### PR TITLE
MINOR: Add classic member session timeout to ClassicMemberMetadata

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1467,6 +1467,7 @@ public class GroupMetadataManager {
         final List<Record> records = new ArrayList<>();
         final String groupId = request.groupId();
         final String instanceId = request.groupInstanceId();
+        final int sessionTimeoutMs = request.sessionTimeoutMs();
         final JoinGroupRequestProtocolCollection protocols = request.protocols();
 
         String memberId = request.memberId();
@@ -1545,6 +1546,7 @@ public class GroupMetadataManager {
             .setClientId(context.clientId())
             .setClientHost(context.clientAddress.toString())
             .setSupportedClassicProtocols(protocols)
+            .setSessionTimeoutMs(sessionTimeoutMs)
             .build();
 
         boolean bumpGroupEpoch = hasMemberSubscriptionChanged(
@@ -1620,7 +1622,7 @@ public class GroupMetadataManager {
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.whenComplete((__, t) -> {
             if (t == null) {
-                scheduleConsumerGroupSessionTimeout(groupId, response.memberId(), request.sessionTimeoutMs());
+                scheduleConsumerGroupSessionTimeout(groupId, response.memberId(), sessionTimeoutMs);
                 // The sync timeout ensures that the member send sync request within the rebalance timeout.
                 scheduleConsumerGroupSyncTimeout(groupId, response.memberId(), request.rebalanceTimeoutMs());
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1545,8 +1545,11 @@ public class GroupMetadataManager {
             .maybeUpdateSubscribedTopicNames(Optional.ofNullable(subscription.topics()))
             .setClientId(context.clientId())
             .setClientHost(context.clientAddress.toString())
-            .setSupportedClassicProtocols(protocols)
-            .setSessionTimeoutMs(sessionTimeoutMs)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(sessionTimeoutMs)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols))
+            )
             .build();
 
         boolean bumpGroupEpoch = hasMemberSubscriptionChanged(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -833,7 +833,6 @@ public class GroupMetadataManager {
                 logContext,
                 time,
                 metrics,
-                consumerGroupSessionTimeoutMs,
                 metadataImage
             );
         } catch (SchemaException e) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1400,7 +1400,7 @@ public class ClassicGroup implements Group {
                         Optional.ofNullable(member.instanceId()),
                         member.clientId(),
                         member.clientHost(),
-                        member.rebalanceTimeoutMs(),
+                        member.classicProtocolSessionTimeout().get(),
                         consumerGroupSessionTimeoutMs,
                         ConsumerProtocol.PROTOCOL_TYPE,
                         member.supportedJoinGroupRequestProtocols(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1366,7 +1366,6 @@ public class ClassicGroup implements Group {
      * @param leavingMemberId               The member that will not be converted in the ClassicGroup.
      * @param logContext                    The logContext to create the ClassicGroup.
      * @param time                          The time to create the ClassicGroup.
-     * @param consumerGroupSessionTimeoutMs The consumerGroupSessionTimeoutMs.
      * @param metadataImage                 The MetadataImage.
      * @return  The created ClassicGroup.
      */
@@ -1376,7 +1375,6 @@ public class ClassicGroup implements Group {
         LogContext logContext,
         Time time,
         GroupCoordinatorMetricsShard metrics,
-        int consumerGroupSessionTimeoutMs,
         MetadataImage metadataImage
     ) {
         ClassicGroup classicGroup = new ClassicGroup(
@@ -1400,8 +1398,8 @@ public class ClassicGroup implements Group {
                         Optional.ofNullable(member.instanceId()),
                         member.clientId(),
                         member.clientHost(),
+                        member.rebalanceTimeoutMs(),
                         member.classicProtocolSessionTimeout().get(),
-                        consumerGroupSessionTimeoutMs,
                         ConsumerProtocol.PROTOCOL_TYPE,
                         member.supportedJoinGroupRequestProtocols(),
                         null

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -32,6 +32,7 @@ import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
 import org.apache.kafka.coordinator.group.Record;
 import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.TopicImage;
@@ -1145,7 +1146,13 @@ public class ConsumerGroup implements Group {
                 .setClientHost(classicGroupMember.clientHost())
                 .setSubscribedTopicNames(subscription.topics())
                 .setAssignedPartitions(partitions)
-                .setSupportedClassicProtocols(classicGroupMember.supportedProtocols())
+                .setClassicMemberMetadata(
+                    new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                        .setSessionTimeoutMs(classicGroupMember.sessionTimeoutMs())
+                        .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                            classicGroupMember.supportedProtocols()
+                        ))
+                )
                 .build();
             consumerGroup.updateTargetAssignment(newMember.memberId(), new Assignment(partitions));
             consumerGroup.updateMember(newMember);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -200,31 +200,6 @@ public class ConsumerGroupMember {
             return this;
         }
 
-        public Builder setSupportedClassicProtocols(JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols) {
-            List<ConsumerGroupMemberMetadataValue.ClassicProtocol> newSupportedProtocols = new ArrayList<>();
-            protocols.forEach(protocol ->
-                newSupportedProtocols.add(
-                    new ConsumerGroupMemberMetadataValue.ClassicProtocol()
-                        .setName(protocol.name())
-                        .setMetadata(protocol.metadata())
-                )
-            );
-
-            if (this.classicMemberMetadata == null) {
-                this.classicMemberMetadata = new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata();
-            }
-            this.classicMemberMetadata.setSupportedProtocols(newSupportedProtocols);
-            return this;
-        }
-
-        public Builder setSessionTimeoutMs(int sessionTimeoutMs) {
-            if (this.classicMemberMetadata == null) {
-                this.classicMemberMetadata = new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata();
-            }
-            this.classicMemberMetadata.setSessionTimeoutMs(sessionTimeoutMs);
-            return this;
-        }
-
         public Builder updateWith(ConsumerGroupMemberMetadataValue record) {
             setInstanceId(record.instanceId());
             setRackId(record.rackId());
@@ -507,6 +482,17 @@ public class ConsumerGroupMember {
     }
 
     /**
+     * @return The session timeout if the member uses the classic protocol.
+     */
+    public Optional<Integer> classicProtocolSessionTimeout() {
+        if (classicMemberMetadata != null) {
+            return Optional.ofNullable(classicMemberMetadata.sessionTimeoutMs());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * @return The classicMemberMetadata if the consumer uses the classic protocol.
      */
     public Optional<ConsumerGroupMemberMetadataValue.ClassicMemberMetadata> classicMemberMetadata() {
@@ -578,6 +564,26 @@ public class ConsumerGroupMember {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Converts the JoinGroupRequestProtocolCollection to a list of ClassicProtocol.
+     *
+     * @param protocols The JoinGroupRequestProtocolCollection.
+     * @return The converted list of ClassicProtocol.
+     */
+    public static List<ConsumerGroupMemberMetadataValue.ClassicProtocol> classicProtocolListFromJoinRequestProtocolCollection(
+        JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols
+    ) {
+        List<ConsumerGroupMemberMetadataValue.ClassicProtocol> newSupportedProtocols = new ArrayList<>();
+        protocols.forEach(protocol ->
+            newSupportedProtocols.add(
+                new ConsumerGroupMemberMetadataValue.ClassicProtocol()
+                    .setName(protocol.name())
+                    .setMetadata(protocol.metadata())
+            )
+        );
+        return newSupportedProtocols;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -88,7 +88,7 @@ public class ConsumerGroupMember {
             this.state = member.state;
             this.assignedPartitions = member.assignedPartitions;
             this.partitionsPendingRevocation = member.partitionsPendingRevocation;
-            this.classicMemberMetadata = member.classicMemberMetadata;
+            this.classicMemberMetadata = member.classicMemberMetadata == null ? null : member.classicMemberMetadata.duplicate();
         }
 
         public Builder updateMemberEpoch(int memberEpoch) {
@@ -209,8 +209,19 @@ public class ConsumerGroupMember {
                         .setMetadata(protocol.metadata())
                 )
             );
-            this.classicMemberMetadata = new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(newSupportedProtocols);
+
+            if (this.classicMemberMetadata == null) {
+                this.classicMemberMetadata = new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata();
+            }
+            this.classicMemberMetadata.setSupportedProtocols(newSupportedProtocols);
+            return this;
+        }
+
+        public Builder setSessionTimeoutMs(int sessionTimeoutMs) {
+            if (this.classicMemberMetadata == null) {
+                this.classicMemberMetadata = new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata();
+            }
+            this.classicMemberMetadata.setSessionTimeoutMs(sessionTimeoutMs);
             return this;
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -88,7 +88,7 @@ public class ConsumerGroupMember {
             this.state = member.state;
             this.assignedPartitions = member.assignedPartitions;
             this.partitionsPendingRevocation = member.partitionsPendingRevocation;
-            this.classicMemberMetadata = member.classicMemberMetadata == null ? null : member.classicMemberMetadata.duplicate();
+            this.classicMemberMetadata = member.classicMemberMetadata;
         }
 
         public Builder updateMemberEpoch(int memberEpoch) {
@@ -485,7 +485,7 @@ public class ConsumerGroupMember {
      * @return The session timeout if the member uses the classic protocol.
      */
     public Optional<Integer> classicProtocolSessionTimeout() {
-        if (classicMemberMetadata != null) {
+        if (useClassicProtocol()) {
             return Optional.ofNullable(classicMemberMetadata.sessionTimeoutMs());
         } else {
             return Optional.empty();

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
@@ -40,7 +40,7 @@
       "default": null, "taggedVersions": "0+", "tag": 0,
       "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
       "fields": [
-        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+",
           "about": "The session timeout if the consumer uses the classic protocol." },
         { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
           "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
@@ -40,6 +40,8 @@
       "default": null, "taggedVersions": "0+", "tag": 0,
       "about": "The classic member metadata which includes the supported protocols of the consumer if it uses the classic protocol. The metadata is null if the consumer uses the consumer protocol.",
       "fields": [
+        { "name": "SessionTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+          "about": "The session timeout if the consumer uses the classic protocol." },
         { "name": "SupportedProtocols", "type": "[]ClassicProtocol", "versions": "0+",
           "about": "The list of protocols that the member supports if the consumer uses the classic protocol.",
           "fields": [

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -10967,6 +10967,7 @@ public class GroupMetadataManagerTest {
                 .setRebalanceTimeoutMs(500)
                 .setAssignedPartitions(assignor.targetPartitions(newMemberId))
                 .setSupportedClassicProtocols(request.protocols())
+                .setSessionTimeoutMs(request.sessionTimeoutMs())
                 .build();
 
             List<Record> expectedRecords = Arrays.asList(
@@ -11133,6 +11134,7 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(500)
             .setSupportedClassicProtocols(request.protocols())
+            .setSessionTimeoutMs(request.sessionTimeoutMs())
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11233,6 +11235,7 @@ public class GroupMetadataManagerTest {
                 mkTopicAssignment(fooTopicId, 0, 1)))
             .setRebalanceTimeoutMs(500)
             .setSupportedClassicProtocols(request.protocols())
+            .setSessionTimeoutMs(request.sessionTimeoutMs())
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11369,6 +11372,7 @@ public class GroupMetadataManagerTest {
             .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
                 Arrays.asList(fooTopicName, barTopicName, zarTopicName),
                 Collections.emptyList()))
+            .setSessionTimeoutMs(request.sessionTimeoutMs())
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11576,6 +11580,7 @@ public class GroupMetadataManagerTest {
             .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
                 Arrays.asList(fooTopicName, barTopicName, zarTopicName),
                 Collections.emptyList()))
+            .setSessionTimeoutMs(request.sessionTimeoutMs())
             .build();
 
         List<Record> expectedRecords1 = Arrays.asList(
@@ -11761,6 +11766,7 @@ public class GroupMetadataManagerTest {
             .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
                 Arrays.asList(fooTopicName, barTopicName, zarTopicName),
                 Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))))
+            .setSessionTimeoutMs(request1.sessionTimeoutMs())
             .build();
 
         List<Record> expectedRecords1 = Arrays.asList(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -10382,8 +10382,8 @@ public class GroupMetadataManagerTest {
                 Optional.ofNullable(member1.instanceId()),
                 member1.clientId(),
                 member1.clientHost(),
+                member1.rebalanceTimeoutMs(),
                 member1.classicProtocolSessionTimeout().get(),
-                45000,
                 ConsumerProtocol.PROTOCOL_TYPE,
                 member1.supportedJoinGroupRequestProtocols(),
                 assignment
@@ -10410,7 +10410,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedListEquals(expectedRecords.subList(2, 4), result.records().subList(2, 4));
         assertRecordEquals(expectedRecords.get(4), result.records().get(4));
         assertUnorderedListEquals(expectedRecords.subList(5, 7), result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 9), result.records().subList(7, 9));
+        assertRecordsEquals(expectedRecords.subList(7, 10), result.records().subList(7, 10));
 
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
@@ -10580,7 +10580,7 @@ public class GroupMetadataManagerTest {
                 member1.clientId(),
                 member1.clientHost(),
                 member1.rebalanceTimeoutMs(),
-                45000,
+                member1.classicProtocolSessionTimeout().get(),
                 ConsumerProtocol.PROTOCOL_TYPE,
                 member1.supportedJoinGroupRequestProtocols(),
                 assignment
@@ -10606,7 +10606,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedListEquals(expectedRecords.subList(2, 4), timeout.result.records().subList(2, 4));
         assertRecordEquals(expectedRecords.get(4), timeout.result.records().get(4));
         assertUnorderedListEquals(expectedRecords.subList(5, 7), timeout.result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 9), timeout.result.records().subList(7, 9));
+        assertRecordsEquals(expectedRecords.subList(7, 10), timeout.result.records().subList(7, 10));
 
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
@@ -10796,7 +10796,7 @@ public class GroupMetadataManagerTest {
                 member1.clientId(),
                 member1.clientHost(),
                 member1.rebalanceTimeoutMs(),
-                45000,
+                member1.classicProtocolSessionTimeout().get(),
                 ConsumerProtocol.PROTOCOL_TYPE,
                 member1.supportedJoinGroupRequestProtocols(),
                 assignment
@@ -10823,7 +10823,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedListEquals(expectedRecords.subList(2, 4), timeout.result.records().subList(2, 4));
         assertRecordEquals(expectedRecords.get(4), timeout.result.records().get(4));
         assertUnorderedListEquals(expectedRecords.subList(5, 7), timeout.result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 9), timeout.result.records().subList(7, 9));
+        assertRecordsEquals(expectedRecords.subList(7, 10), timeout.result.records().subList(7, 10));
 
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.RECONCILING, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -9562,7 +9562,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("client-host")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(10000)
-            .setSupportedClassicProtocols(protocols)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols))
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0),
                 mkTopicAssignment(barTopicId, 0)))
@@ -9780,7 +9784,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("client-host")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(10000)
-            .setSupportedClassicProtocols(protocols1)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols1))
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1)))
             .build();
@@ -9792,7 +9800,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("client-host")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(10000)
-            .setSupportedClassicProtocols(protocols2)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols2))
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(barTopicId, 0)))
             .build();
@@ -10037,7 +10049,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("client-host")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(10000)
-            .setSupportedClassicProtocols(protocols1)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols1))
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1)))
             .build();
@@ -10049,7 +10065,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("client-host")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(10000)
-            .setSupportedClassicProtocols(protocols2)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols2))
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(barTopicId, 0)))
             .build();
@@ -10265,8 +10285,11 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
-            .setClassicMemberMetadata(new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(protocols))
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(protocols)
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2),
                 mkTopicAssignment(barTopicId, 0, 1)))
@@ -10359,7 +10382,7 @@ public class GroupMetadataManagerTest {
                 Optional.ofNullable(member1.instanceId()),
                 member1.clientId(),
                 member1.clientHost(),
-                member1.rebalanceTimeoutMs(),
+                member1.classicProtocolSessionTimeout().get(),
                 45000,
                 ConsumerProtocol.PROTOCOL_TYPE,
                 member1.supportedJoinGroupRequestProtocols(),
@@ -10454,8 +10477,11 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
-            .setClassicMemberMetadata(new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(protocols))
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(protocols)
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2),
                 mkTopicAssignment(barTopicId, 0, 1)))
@@ -10641,8 +10667,11 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(30000)
-            .setClassicMemberMetadata(new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(protocols))
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(protocols)
+            )
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2),
                 mkTopicAssignment(barTopicId, 0, 1)))
@@ -10849,7 +10878,13 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toProtocols("roundrobin"))
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                                GroupMetadataManagerTestContext.toProtocols("roundrobin")
+                            ))
+                    )
                     .build()))
             .build();
 
@@ -10966,8 +11001,11 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                 .setRebalanceTimeoutMs(500)
                 .setAssignedPartitions(assignor.targetPartitions(newMemberId))
-                .setSupportedClassicProtocols(request.protocols())
-                .setSessionTimeoutMs(request.sessionTimeoutMs())
+                .setClassicMemberMetadata(
+                    new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                        .setSessionTimeoutMs(request.sessionTimeoutMs())
+                        .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(request.protocols()))
+                )
                 .build();
 
             List<Record> expectedRecords = Arrays.asList(
@@ -11133,8 +11171,11 @@ public class GroupMetadataManagerTest {
             .setClientHost("localhost/127.0.0.1")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(500)
-            .setSupportedClassicProtocols(request.protocols())
-            .setSessionTimeoutMs(request.sessionTimeoutMs())
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(request.protocols()))
+            )
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11234,8 +11275,11 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1)))
             .setRebalanceTimeoutMs(500)
-            .setSupportedClassicProtocols(request.protocols())
-            .setSessionTimeoutMs(request.sessionTimeoutMs())
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(request.protocols()))
+            )
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11307,9 +11351,16 @@ public class GroupMetadataManagerTest {
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
                         mkTopicAssignment(barTopicId, 0)))
-                    .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                        Arrays.asList(fooTopicName, barTopicName),
-                        Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(fooTopicName, 1))))
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                                GroupMetadataManagerTestContext.toConsumerProtocol(
+                                    Arrays.asList(fooTopicName, barTopicName),
+                                    Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(fooTopicName, 1))
+                                )
+                            ))
+                    )
                     .build())
                 .withMember(new ConsumerGroupMember.Builder(memberId2)
                     .setState(MemberState.STABLE)
@@ -11369,10 +11420,16 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0),
                 mkTopicAssignment(zarTopicId, 0)))
-            .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                Arrays.asList(fooTopicName, barTopicName, zarTopicName),
-                Collections.emptyList()))
-            .setSessionTimeoutMs(request.sessionTimeoutMs())
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                        GroupMetadataManagerTestContext.toConsumerProtocol(
+                            Arrays.asList(fooTopicName, barTopicName, zarTopicName),
+                            Collections.emptyList()
+                        )
+                    ))
+            )
             .build();
 
         List<Record> expectedRecords = Arrays.asList(
@@ -11422,7 +11479,11 @@ public class GroupMetadataManagerTest {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(new ConsumerGroupMember.Builder(memberId1)
-                    .setSupportedClassicProtocols(protocols)
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols))
+                    )
                     .build())
                 .withMember(new ConsumerGroupMember.Builder(memberId2)
                     .build()))
@@ -11457,7 +11518,11 @@ public class GroupMetadataManagerTest {
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(new ConsumerGroupMember.Builder(memberId1)
                     .setInstanceId(instanceId)
-                    .setSupportedClassicProtocols(protocols)
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(protocols))
+                    )
                     .build())
                 .withMember(new ConsumerGroupMember.Builder(memberId2)
                     .build()))
@@ -11514,9 +11579,16 @@ public class GroupMetadataManagerTest {
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
                         mkTopicAssignment(barTopicId, 0)))
-                    .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                        Arrays.asList(fooTopicName, barTopicName),
-                        Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))))
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                                GroupMetadataManagerTestContext.toConsumerProtocol(
+                                    Arrays.asList(fooTopicName, barTopicName),
+                                    Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))
+                                )
+                            ))
+                    )
                     .build())
                 .withMember(new ConsumerGroupMember.Builder(memberId2)
                     .setState(MemberState.STABLE)
@@ -11577,10 +11649,16 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0),
                 mkTopicAssignment(zarTopicId, 0)))
-            .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                Arrays.asList(fooTopicName, barTopicName, zarTopicName),
-                Collections.emptyList()))
-            .setSessionTimeoutMs(request.sessionTimeoutMs())
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                        GroupMetadataManagerTestContext.toConsumerProtocol(
+                            Arrays.asList(fooTopicName, barTopicName, zarTopicName),
+                            Collections.emptyList()
+                        )
+                    ))
+            )
             .build();
 
         List<Record> expectedRecords1 = Arrays.asList(
@@ -11700,9 +11778,16 @@ public class GroupMetadataManagerTest {
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
                         mkTopicAssignment(barTopicId, 0)))
-                    .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                        Arrays.asList(fooTopicName, barTopicName),
-                        Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))))
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(5000)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                                GroupMetadataManagerTestContext.toConsumerProtocol(
+                                    Arrays.asList(fooTopicName, barTopicName),
+                                    Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))
+                                )
+                            ))
+                    )
                     .build())
                 .withMember(new ConsumerGroupMember.Builder(memberId2)
                     .setState(MemberState.STABLE)
@@ -11763,10 +11848,16 @@ public class GroupMetadataManagerTest {
                 mkTopicAssignment(fooTopicId, 0)))
             .setPartitionsPendingRevocation(mkAssignment(
                 mkTopicAssignment(barTopicId, 0)))
-            .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                Arrays.asList(fooTopicName, barTopicName, zarTopicName),
-                Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))))
-            .setSessionTimeoutMs(request1.sessionTimeoutMs())
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request1.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                        GroupMetadataManagerTestContext.toConsumerProtocol(
+                            Arrays.asList(fooTopicName, barTopicName, zarTopicName),
+                            Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(barTopicName, 0))
+                        )
+                    ))
+            )
             .build();
 
         List<Record> expectedRecords1 = Arrays.asList(
@@ -11825,9 +11916,16 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0),
                 mkTopicAssignment(zarTopicId, 0)))
-            .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                Arrays.asList(fooTopicName, barTopicName, zarTopicName),
-                Collections.singletonList(new TopicPartition(fooTopicName, 0))))
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request2.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                        GroupMetadataManagerTestContext.toConsumerProtocol(
+                            Arrays.asList(fooTopicName, barTopicName, zarTopicName),
+                            Collections.singletonList(new TopicPartition(fooTopicName, 0))
+                        )
+                    ))
+            )
             .build();
 
         assertRecordsEquals(
@@ -11876,9 +11974,16 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1),
                 mkTopicAssignment(zarTopicId, 0)))
-            .setSupportedClassicProtocols(GroupMetadataManagerTestContext.toConsumerProtocol(
-                Arrays.asList(fooTopicName, barTopicName, zarTopicName),
-                Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(zarTopicName, 0))))
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(request3.sessionTimeoutMs())
+                    .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                        GroupMetadataManagerTestContext.toConsumerProtocol(
+                            Arrays.asList(fooTopicName, barTopicName, zarTopicName),
+                            Arrays.asList(new TopicPartition(fooTopicName, 0), new TopicPartition(zarTopicName, 0))
+                        )
+                    ))
+            )
             .build();
 
         assertRecordsEquals(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
-import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
@@ -40,7 +39,6 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerGroupMemberTest {
 
@@ -351,40 +349,6 @@ public class ConsumerGroupMemberTest {
                 .build().topics()
         );
         assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testSetSupportedClassicProtocolsWithJoinGroupRequestProtocolCollections() {
-        Uuid topicId1 = Uuid.randomUuid();
-        Uuid topicId2 = Uuid.randomUuid();
-
-        JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestData.JoinGroupRequestProtocolCollection();
-        protocols.addAll(Arrays.asList(
-            new JoinGroupRequestData.JoinGroupRequestProtocol()
-                .setName("range")
-                .setMetadata(new byte[]{1, 2, 3})
-        ));
-
-        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
-            .setMemberEpoch(10)
-            .setPreviousMemberEpoch(9)
-            .setInstanceId("instance-id")
-            .setRackId("rack-id")
-            .setRebalanceTimeoutMs(5000)
-            .setClientId("client-id")
-            .setClientHost("hostname")
-            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-            .setSubscribedTopicRegex("regex")
-            .setServerAssignorName("range")
-            .setAssignedPartitions(mkAssignment(
-                mkTopicAssignment(topicId1, 1, 2, 3)))
-            .setPartitionsPendingRevocation(mkAssignment(
-                mkTopicAssignment(topicId2, 4, 5, 6)))
-            .setSupportedClassicProtocols(protocols)
-            .build();
-
-        assertEquals(toClassicProtocolCollection("range"), member.supportedClassicProtocols().get());
-        assertTrue(member.useClassicProtocol());
     }
 
     private List<ConsumerGroupMemberMetadataValue.ClassicProtocol> toClassicProtocolCollection(String name) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsumerGroupMemberTest {
@@ -349,6 +351,21 @@ public class ConsumerGroupMemberTest {
                 .build().topics()
         );
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testClassicProtocolListFromJoinRequestProtocolCollection() {
+        JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestData.JoinGroupRequestProtocolCollection();
+        protocols.addAll(Arrays.asList(
+            new JoinGroupRequestData.JoinGroupRequestProtocol()
+                .setName("range")
+                .setMetadata(new byte[]{1, 2, 3})
+        ));
+
+        assertEquals(
+            toClassicProtocolCollection("range"),
+            classicProtocolListFromJoinRequestProtocolCollection(protocols)
+        );
     }
 
     private List<ConsumerGroupMemberMetadataValue.ClassicProtocol> toClassicProtocolCollection(String name) {


### PR DESCRIPTION
The heartbeat api to the consumer group with classic protocol members schedules the session timeout. At present, there's no way to get the classic member session timeout in heartbeat to consumer group.

This patch stores the session timeout into the ClassicMemberMetadata in ConsumerGroupMemberMetadataValue and update it when it's provided in the join request.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
