### PR TITLE
KAFKA-16703: Close serverChannel in SocketServer if unable to bind to a port

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -734,6 +734,7 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
       info(s"Awaiting socket connections on ${socketAddress.getHostString}:${serverChannel.socket.getLocalPort}.")
     } catch {
       case e: SocketException =>
+        Utils.closeQuietly(serverChannel, "server socket")
         throw new KafkaException(s"Socket server failed to bind to ${socketAddress.getHostString}:$port: ${e.getMessage}.", e)
     }
     serverChannel

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -725,11 +725,10 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
       else
         new InetSocketAddress(host, port)
     val serverChannel = ServerSocketChannel.open()
-    serverChannel.configureBlocking(false)
-    if (recvBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
-      serverChannel.socket().setReceiveBufferSize(recvBufferSize)
-
     try {
+      serverChannel.configureBlocking(false)
+      if (recvBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
+        serverChannel.socket().setReceiveBufferSize(recvBufferSize)
       serverChannel.socket.bind(socketAddress, listenBacklogSize)
       info(s"Awaiting socket connections on ${socketAddress.getHostString}:${serverChannel.socket.getLocalPort}.")
     } catch {


### PR DESCRIPTION
This was showing up as a leaked socket in KafkaServerTest#testListenerPortAlreadyInUse.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
