### PR TITLE
KAFKA-16669: Remove extra collection copy when generating DescribeAclsResource

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
@@ -28,12 +28,13 @@ import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -137,15 +138,15 @@ public class DescribeAclsResponse extends AbstractResponse {
         return resources.stream().flatMap(DescribeAclsResponse::aclBindings).collect(Collectors.toList());
     }
 
-    public static List<DescribeAclsResource> aclsResources(Collection<AclBinding> acls) {
-        Map<ResourcePattern, List<AccessControlEntry>> patternToEntries = new HashMap<>();
+    public static List<DescribeAclsResource> aclsResources(Iterable<AclBinding> acls) {
+        Map<ResourcePattern, Set<AccessControlEntry>> patternToEntries = new HashMap<>();
         for (AclBinding acl : acls) {
-            patternToEntries.computeIfAbsent(acl.pattern(), v -> new ArrayList<>()).add(acl.entry());
+            patternToEntries.computeIfAbsent(acl.pattern(), v -> new HashSet<>()).add(acl.entry());
         }
         List<DescribeAclsResource> resources = new ArrayList<>(patternToEntries.size());
-        for (Entry<ResourcePattern, List<AccessControlEntry>> entry : patternToEntries.entrySet()) {
+        for (Entry<ResourcePattern, Set<AccessControlEntry>> entry : patternToEntries.entrySet()) {
             ResourcePattern key = entry.getKey();
-            List<AclDescription> aclDescriptions = new ArrayList<>();
+            List<AclDescription> aclDescriptions = new ArrayList<>(128);
             for (AccessControlEntry ace : entry.getValue()) {
                 AclDescription ad = new AclDescription()
                     .setHost(ace.host())

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
@@ -146,7 +146,7 @@ public class DescribeAclsResponse extends AbstractResponse {
         List<DescribeAclsResource> resources = new ArrayList<>(patternToEntries.size());
         for (Entry<ResourcePattern, Set<AccessControlEntry>> entry : patternToEntries.entrySet()) {
             ResourcePattern key = entry.getKey();
-            List<AclDescription> aclDescriptions = new ArrayList<>(128);
+            List<AclDescription> aclDescriptions = new ArrayList<>(entry.getValue().size());
             for (AccessControlEntry ace : entry.getValue()) {
                 AclDescription ad = new AclDescription()
                     .setHost(ace.host())

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -68,12 +68,10 @@ class AclApis(authHelper: AuthHelper,
           describeAclsRequest.version))
       case Some(auth) =>
         val filter = describeAclsRequest.filter
-        val returnedAcls = new util.HashSet[AclBinding]()
-        returnedAcls.add(auth.acls(filter).iterator().next())
         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
           new DescribeAclsResponse(new DescribeAclsResponseData()
             .setThrottleTimeMs(requestThrottleMs)
-            .setResources(DescribeAclsResponse.aclsResources(returnedAcls)),
+            .setResources(DescribeAclsResponse.aclsResources(auth.acls(filter))),
           describeAclsRequest.version))
     }
     CompletableFuture.completedFuture[Unit](())

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -69,7 +69,7 @@ class AclApis(authHelper: AuthHelper,
       case Some(auth) =>
         val filter = describeAclsRequest.filter
         val returnedAcls = new util.HashSet[AclBinding]()
-        auth.acls(filter).forEach(returnedAcls.add)
+        returnedAcls.add(auth.acls(filter).iterator().next())
         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
           new DescribeAclsResponse(new DescribeAclsResponseData()
             .setThrottleTimeMs(requestThrottleMs)


### PR DESCRIPTION
This pr reduced the occurrence of collection copy when generating DescribeAclsResource.