### PR TITLE
KAFKA-9401 Reduce contention for Fetch requests

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -386,9 +386,17 @@ class BrokerServer(
       authorizer = config.createNewAuthorizer()
       authorizer.foreach(_.configure(config.originals))
 
-      val fetchManager = new FetchManager(Time.SYSTEM,
-        new FetchSessionCache(config.maxIncrementalFetchSessionCacheSlots,
-          KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS))
+      // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
+      // for Math.max(1, shardNum * sessionIdRange) <= sessionId < (shardNum + 1) * sessionIdRange
+      val sessionIdRange = Int.MaxValue / NumFetchSessionCacheShards
+      val fetchSessionCacheShards = (0 until NumFetchSessionCacheShards)
+        .map(shardNum => new FetchSessionCacheShard(
+          config.maxIncrementalFetchSessionCacheSlots / NumFetchSessionCacheShards,
+          KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
+          sessionIdRange,
+          shardNum
+        ))
+      val fetchManager = new FetchManager(Time.SYSTEM, new FetchSessionCache(fetchSessionCacheShards))
 
       // Create the request processor objects.
       val raftSupport = RaftSupport(forwardingManager, metadataCache)

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -26,10 +26,11 @@ import org.apache.kafka.common.requests.FetchMetadata.{FINAL_EPOCH, INITIAL_EPOC
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, FetchMetadata => JFetchMetadata}
 import org.apache.kafka.common.utils.{ImplicitLinkedHashCollection, Time, Utils}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
-import java.util
-import java.util.{Collections, Optional}
-import java.util.concurrent.{ThreadLocalRandom, TimeUnit}
 
+import java.util
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ThreadLocalRandom, TimeUnit}
 import scala.collection.mutable
 import scala.math.Ordered.orderingToOrdered
 
@@ -408,6 +409,14 @@ class FullFetchContext(private val time: Time,
                        private val usesTopicIds: Boolean,
                        private val isFromFollower: Boolean) extends FetchContext {
 
+  def this(time: Time,
+           cacheShard: FetchSessionCacheShard,
+           reqMetadata: JFetchMetadata,
+           fetchData: util.Map[TopicIdPartition, FetchRequest.PartitionData],
+           usesTopicIds: Boolean,
+           isFromFollower: Boolean
+          ) = this(time, new FetchSessionCache(Seq(cacheShard)), reqMetadata, fetchData, usesTopicIds, isFromFollower)
+
   override lazy val logger = FullFetchContext.logger
 
   override def getFetchOffset(part: TopicIdPartition): Option[Long] =
@@ -430,7 +439,8 @@ class FullFetchContext(private val time: Time,
       }
       cachedPartitions
     }
-    val responseSessionId = cache.maybeCreateSession(time.milliseconds(), isFromFollower,
+    val cacheShard = cache.getNextCacheShard
+    val responseSessionId = cacheShard.maybeCreateSession(time.milliseconds(), isFromFollower,
         updates.size, usesTopicIds, () => createNewSession)
     debug(s"Full fetch context with session id $responseSessionId returning " +
       s"${partitionsToLogString(updates.keySet)}")
@@ -571,6 +581,7 @@ case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Compara
     (privileged, size, id) compare (other.privileged, other.size, other.id)
 }
 
+
 /**
   * Caches fetch sessions.
   *
@@ -583,10 +594,15 @@ case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Compara
   *
   * @param maxEntries The maximum number of entries that can be in the cache.
   * @param evictionMs The minimum time that an entry must be unused in order to be evictable.
-  */
-class FetchSessionCache(private val maxEntries: Int,
-                        private val evictionMs: Long) extends Logging {
-  private val metricsGroup = new KafkaMetricsGroup(this.getClass)
+  * @param sessionIdRange The number of sessionIds each cache shard handles. For a given instance, Math.max(1, shardNum * sessionIdRange) <= sessionId < (shardNum + 1) * sessionIdRange always holds.
+  * @param shardNum Identifier for this shard.
+ */
+class FetchSessionCacheShard(private val maxEntries: Int,
+                             private val evictionMs: Long,
+                             val sessionIdRange: Int = Int.MaxValue,
+                             private val shardNum: Int = 0) extends Logging {
+
+  this.logIdent = s"[Shard $shardNum] "
 
   private var numPartitions: Long = 0
 
@@ -603,14 +619,10 @@ class FetchSessionCache(private val maxEntries: Int,
   // A map containing sessions which can be evicted by privileged sessions.
   private val evictableByPrivileged = new util.TreeMap[EvictableKey, FetchSession]
 
-  // Set up metrics.
-  metricsGroup.removeMetric(FetchSession.NUM_INCREMENTAL_FETCH_SESSIONS)
-  metricsGroup.newGauge(FetchSession.NUM_INCREMENTAL_FETCH_SESSIONS, () => FetchSessionCache.this.size)
-  metricsGroup.removeMetric(FetchSession.NUM_INCREMENTAL_FETCH_PARTITIONS_CACHED)
-  metricsGroup.newGauge(FetchSession.NUM_INCREMENTAL_FETCH_PARTITIONS_CACHED, () => FetchSessionCache.this.totalPartitions)
-  metricsGroup.removeMetric(FetchSession.INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC)
-  private[server] val evictionsMeter = metricsGroup.newMeter(FetchSession.INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC,
-    FetchSession.EVICTIONS, TimeUnit.SECONDS, Collections.emptyMap())
+  // This metric is shared across all shards because newMeter returns an existing metric
+  // if one exists with the same name. It's safe for concurrent use because Meter is thread-safe.
+  private[server] val evictionsMeter = FetchSessionCache.metricsGroup.newMeter(FetchSession.INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC,
+    FetchSession.EVICTIONS, TimeUnit.SECONDS)
 
   /**
     * Get a session by session ID.
@@ -644,7 +656,7 @@ class FetchSessionCache(private val maxEntries: Int,
   def newSessionId(): Int = synchronized {
     var id = 0
     do {
-      id = ThreadLocalRandom.current().nextInt(1, Int.MaxValue)
+      id = ThreadLocalRandom.current().nextInt(Math.max(1, shardNum * sessionIdRange), (shardNum + 1) * sessionIdRange)
     } while (sessions.contains(id) || id == INVALID_SESSION_ID)
     id
   }
@@ -689,6 +701,10 @@ class FetchSessionCache(private val maxEntries: Int,
     * 1. A is privileged and B is not, or
     * 2. B is considered "stale" because it has been inactive for a long time, or
     * 3. A contains more partitions than B, and B is not recently created.
+    *
+    * Prior to KAFKA-9401, the session cache was not sharded and we looked at all
+    * entries while considering those eligible for eviction. Now eviction is done
+    * by considering entries on a per-shard basis.
     *
     * @param privileged True if the new entry we would like to add is privileged.
     * @param key        The EvictableKey for the new entry we would like to add.
@@ -787,9 +803,38 @@ class FetchSessionCache(private val maxEntries: Int,
     }
   }
 }
+object FetchSessionCache {
+  private[server] val metricsGroup = new KafkaMetricsGroup(classOf[FetchSessionCache])
+  private[server] val counter = new AtomicInteger(0)
+}
+
+class FetchSessionCache(private val cacheShards: Seq[FetchSessionCacheShard]) {
+  // Set up metrics.
+  FetchSessionCache.metricsGroup.newGauge(FetchSession.NUM_INCREMENTAL_FETCH_SESSIONS, () => cacheShards.map(_.size).sum)
+  FetchSessionCache.metricsGroup.newGauge(FetchSession.NUM_INCREMENTAL_FETCH_PARTITIONS_CACHED, () => cacheShards.map(_.totalPartitions).sum)
+
+  def getCacheShard(sessionId: Int): FetchSessionCacheShard = {
+    val shard = sessionId / cacheShards.head.sessionIdRange
+    // This assumes that cacheShards is sorted by shardNum
+    cacheShards(shard)
+  }
+
+  // Returns the shard in round-robin
+  def getNextCacheShard: FetchSessionCacheShard = {
+    val shardNum = Utils.toPositive(FetchSessionCache.counter.getAndIncrement()) % size
+    cacheShards(shardNum)
+  }
+
+  def size: Int = {
+    cacheShards.size
+  }
+}
 
 class FetchManager(private val time: Time,
                    private val cache: FetchSessionCache) extends Logging {
+
+  def this(time: Time, cacheShard: FetchSessionCacheShard) = this(time, new FetchSessionCache(Seq(cacheShard)))
+
   def newContext(reqVersion: Short,
                  reqMetadata: JFetchMetadata,
                  isFollower: Boolean,
@@ -799,8 +844,9 @@ class FetchManager(private val time: Time,
     val context = if (reqMetadata.isFull) {
       var removedFetchSessionStr = ""
       if (reqMetadata.sessionId != INVALID_SESSION_ID) {
+        val cacheShard = cache.getCacheShard(reqMetadata.sessionId())
         // Any session specified in a FULL fetch request will be closed.
-        if (cache.remove(reqMetadata.sessionId).isDefined) {
+        if (cacheShard.remove(reqMetadata.sessionId).isDefined) {
           removedFetchSessionStr = s" Removed fetch session ${reqMetadata.sessionId}."
         }
       }
@@ -816,8 +862,9 @@ class FetchManager(private val time: Time,
         s"$removedFetchSessionStr$suffix")
       context
     } else {
-      cache.synchronized {
-        cache.get(reqMetadata.sessionId) match {
+      val cacheShard = cache.getCacheShard(reqMetadata.sessionId())
+      cacheShard.synchronized {
+        cacheShard.get(reqMetadata.sessionId) match {
           case None => {
             debug(s"Session error for ${reqMetadata.sessionId}: no such session ID found.")
             new SessionErrorContext(Errors.FETCH_SESSION_ID_NOT_FOUND, reqMetadata)
@@ -838,10 +885,10 @@ class FetchManager(private val time: Time,
                 debug(s"Created a new sessionless FetchContext and closing session id ${session.id}, " +
                   s"epoch ${session.epoch}: after removing ${partitionsToLogString(removed)}, " +
                   s"there are no more partitions left.")
-                cache.remove(session)
+                cacheShard.remove(session)
                 new SessionlessFetchContext(fetchData)
               } else {
-                cache.touch(session, time.milliseconds())
+                cacheShard.touch(session, time.milliseconds())
                 session.epoch = JFetchMetadata.nextEpoch(session.epoch)
                 debug(s"Created a new incremental FetchContext for session id ${session.id}, " +
                   s"epoch ${session.epoch}: added ${partitionsToLogString(added)}, " +

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -72,6 +72,9 @@ object KafkaBroker {
 }
 
 trait KafkaBroker extends Logging {
+  // Number of shards to split FetchSessionCache into. This is to reduce contention when trying to
+  // acquire lock while handling Fetch requests.
+  val NumFetchSessionCacheShards: Int = 8
 
   def authorizer: Option[Authorizer]
   def brokerState: BrokerState

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1065,7 +1065,7 @@ object KafkaConfig {
   val ProducerIdExpirationCheckIntervalMsDoc = "The interval at which to remove producer IDs that have expired due to <code>producer.id.expiration.ms</code> passing."
 
   /** ********* Fetch Configuration **************/
-  val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of incremental fetch sessions that we will maintain."
+  val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of total incremental fetch sessions that we will maintain. FetchSessionCache is sharded into 8 shards and the limit is equally divided among all shards. Sessions are allocated to each shard in round-robin. Only entries within a shard are considered eligible for eviction."
   val FetchMaxBytesDoc = "The maximum number of bytes we will return for a fetch request. Must be at least 1024."
 
   /** ********* Quota Configuration ***********/

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -541,9 +541,17 @@ class KafkaServer(
             }.toMap
         }
 
-        val fetchManager = new FetchManager(Time.SYSTEM,
-          new FetchSessionCache(config.maxIncrementalFetchSessionCacheSlots,
-            KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS))
+        // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
+        // for Math.max(1, shardNum * sessionIdRange) <= sessionId < (shardNum + 1) * sessionIdRange
+        val sessionIdRange = Int.MaxValue / NumFetchSessionCacheShards
+        val fetchSessionCacheShards = (0 until NumFetchSessionCacheShards)
+          .map(shardNum => new FetchSessionCacheShard(
+            config.maxIncrementalFetchSessionCacheSlots / NumFetchSessionCacheShards,
+            KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
+            sessionIdRange,
+            shardNum
+          ))
+        val fetchManager = new FetchManager(Time.SYSTEM, new FetchSessionCache(fetchSessionCacheShards))
 
         // Start RemoteLogManager before broker start serving the requests.
         remoteLogManagerOpt.foreach { rlm =>

--- a/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, FetchMetad
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.util.MockTime
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.api.{AfterEach, Test, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource, ValueSource}
 
@@ -39,23 +39,31 @@ import scala.collection.mutable.ArrayBuffer
 @Timeout(120)
 class FetchSessionTest {
 
+  @AfterEach
+  def afterEach(): Unit = {
+    FetchSessionCache.metricsGroup.removeMetric(FetchSession.NUM_INCREMENTAL_FETCH_SESSIONS)
+    FetchSessionCache.metricsGroup.removeMetric(FetchSession.NUM_INCREMENTAL_FETCH_PARTITIONS_CACHED)
+    FetchSessionCache.metricsGroup.removeMetric(FetchSession.INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC)
+    FetchSessionCache.counter.set(0)
+  }
+
   @Test
   def testNewSessionId(): Unit = {
-    val cache = new FetchSessionCache(3, 100)
+    val cacheShard = new FetchSessionCacheShard(3, 100)
     for (_ <- 0 to 10000) {
-      val id = cache.newSessionId()
+      val id = cacheShard.newSessionId()
       assertTrue(id > 0)
     }
   }
 
-  def assertCacheContains(cache: FetchSessionCache, sessionIds: Int*) = {
+  def assertCacheContains(cacheShard: FetchSessionCacheShard, sessionIds: Int*): Unit = {
     var i = 0
     for (sessionId <- sessionIds) {
       i = i + 1
-      assertTrue(cache.get(sessionId).isDefined,
-        "Missing session " + i + " out of " + sessionIds.size + "(" + sessionId + ")")
+      assertTrue(cacheShard.get(sessionId).isDefined,
+        s"Missing session $i out of ${sessionIds.size} ($sessionId)")
     }
-    assertEquals(sessionIds.size, cache.size)
+    assertEquals(sessionIds.size, cacheShard.size)
   }
 
   private def dummyCreate(size: Int): FetchSession.CACHE_MAP = {
@@ -68,68 +76,68 @@ class FetchSessionTest {
 
   @Test
   def testSessionCache(): Unit = {
-    val cache = new FetchSessionCache(3, 100)
-    assertEquals(0, cache.size)
-    val id1 = cache.maybeCreateSession(0, false, 10, true, () => dummyCreate(10))
-    val id2 = cache.maybeCreateSession(10, false, 20, true, () => dummyCreate(20))
-    val id3 = cache.maybeCreateSession(20, false, 30, true, () => dummyCreate(30))
-    assertEquals(INVALID_SESSION_ID, cache.maybeCreateSession(30, false, 40, true, () => dummyCreate(40)))
-    assertEquals(INVALID_SESSION_ID, cache.maybeCreateSession(40, false, 5, true, () => dummyCreate(5)))
-    assertCacheContains(cache, id1, id2, id3)
-    cache.touch(cache.get(id1).get, 200)
-    val id4 = cache.maybeCreateSession(210, false, 11, true, () => dummyCreate(11))
-    assertCacheContains(cache, id1, id3, id4)
-    cache.touch(cache.get(id1).get, 400)
-    cache.touch(cache.get(id3).get, 390)
-    cache.touch(cache.get(id4).get, 400)
-    val id5 = cache.maybeCreateSession(410, false, 50, true, () => dummyCreate(50))
-    assertCacheContains(cache, id3, id4, id5)
-    assertEquals(INVALID_SESSION_ID, cache.maybeCreateSession(410, false, 5, true, () => dummyCreate(5)))
-    val id6 = cache.maybeCreateSession(410, true, 5, true, () => dummyCreate(5))
-    assertCacheContains(cache, id3, id5, id6)
+    val cacheShard = new FetchSessionCacheShard(3, 100)
+    assertEquals(0, cacheShard.size)
+    val id1 = cacheShard.maybeCreateSession(0, privileged = false, 10, usesTopicIds = true, () => dummyCreate(10))
+    val id2 = cacheShard.maybeCreateSession(10, privileged = false, 20, usesTopicIds = true, () => dummyCreate(20))
+    val id3 = cacheShard.maybeCreateSession(20, privileged = false, 30, usesTopicIds = true, () => dummyCreate(30))
+    assertEquals(INVALID_SESSION_ID, cacheShard.maybeCreateSession(30, privileged = false, 40, usesTopicIds = true, () => dummyCreate(40)))
+    assertEquals(INVALID_SESSION_ID, cacheShard.maybeCreateSession(40, privileged = false, 5, usesTopicIds = true, () => dummyCreate(5)))
+    assertCacheContains(cacheShard, id1, id2, id3)
+    cacheShard.touch(cacheShard.get(id1).get, 200)
+    val id4 = cacheShard.maybeCreateSession(210, privileged = false, 11, usesTopicIds = true, () => dummyCreate(11))
+    assertCacheContains(cacheShard, id1, id3, id4)
+    cacheShard.touch(cacheShard.get(id1).get, 400)
+    cacheShard.touch(cacheShard.get(id3).get, 390)
+    cacheShard.touch(cacheShard.get(id4).get, 400)
+    val id5 = cacheShard.maybeCreateSession(410, privileged = false, 50, usesTopicIds = true, () => dummyCreate(50))
+    assertCacheContains(cacheShard, id3, id4, id5)
+    assertEquals(INVALID_SESSION_ID, cacheShard.maybeCreateSession(410, privileged = false, 5, usesTopicIds = true, () => dummyCreate(5)))
+    val id6 = cacheShard.maybeCreateSession(410, privileged = true, 5, usesTopicIds = true, () => dummyCreate(5))
+    assertCacheContains(cacheShard, id3, id5, id6)
   }
 
   @Test
   def testResizeCachedSessions(): Unit = {
-    val cache = new FetchSessionCache(2, 100)
-    assertEquals(0, cache.totalPartitions)
-    assertEquals(0, cache.size)
-    assertEquals(0, cache.evictionsMeter.count)
-    val id1 = cache.maybeCreateSession(0, false, 2, true, () => dummyCreate(2))
+    val cacheShard = new FetchSessionCacheShard(2, 100)
+    assertEquals(0, cacheShard.totalPartitions)
+    assertEquals(0, cacheShard.size)
+    assertEquals(0, cacheShard.evictionsMeter.count)
+    val id1 = cacheShard.maybeCreateSession(0, privileged = false, 2, usesTopicIds = true, () => dummyCreate(2))
     assertTrue(id1 > 0)
-    assertCacheContains(cache, id1)
-    val session1 = cache.get(id1).get
+    assertCacheContains(cacheShard, id1)
+    val session1 = cacheShard.get(id1).get
     assertEquals(2, session1.size)
-    assertEquals(2, cache.totalPartitions)
-    assertEquals(1, cache.size)
-    assertEquals(0, cache.evictionsMeter.count)
-    val id2 = cache.maybeCreateSession(0, false, 4, true, () => dummyCreate(4))
-    val session2 = cache.get(id2).get
+    assertEquals(2, cacheShard.totalPartitions)
+    assertEquals(1, cacheShard.size)
+    assertEquals(0, cacheShard.evictionsMeter.count)
+    val id2 = cacheShard.maybeCreateSession(0, privileged = false, 4, usesTopicIds = true, () => dummyCreate(4))
+    val session2 = cacheShard.get(id2).get
     assertTrue(id2 > 0)
-    assertCacheContains(cache, id1, id2)
-    assertEquals(6, cache.totalPartitions)
-    assertEquals(2, cache.size)
-    assertEquals(0, cache.evictionsMeter.count)
-    cache.touch(session1, 200)
-    cache.touch(session2, 200)
-    val id3 = cache.maybeCreateSession(200, false, 5, true, () => dummyCreate(5))
+    assertCacheContains(cacheShard, id1, id2)
+    assertEquals(6, cacheShard.totalPartitions)
+    assertEquals(2, cacheShard.size)
+    assertEquals(0, cacheShard.evictionsMeter.count)
+    cacheShard.touch(session1, 200)
+    cacheShard.touch(session2, 200)
+    val id3 = cacheShard.maybeCreateSession(200, privileged = false, 5, usesTopicIds = true, () => dummyCreate(5))
     assertTrue(id3 > 0)
-    assertCacheContains(cache, id2, id3)
-    assertEquals(9, cache.totalPartitions)
-    assertEquals(2, cache.size)
-    assertEquals(1, cache.evictionsMeter.count)
-    cache.remove(id3)
-    assertCacheContains(cache, id2)
-    assertEquals(1, cache.size)
-    assertEquals(1, cache.evictionsMeter.count)
-    assertEquals(4, cache.totalPartitions)
+    assertCacheContains(cacheShard, id2, id3)
+    assertEquals(9, cacheShard.totalPartitions)
+    assertEquals(2, cacheShard.size)
+    assertEquals(1, cacheShard.evictionsMeter.count)
+    cacheShard.remove(id3)
+    assertCacheContains(cacheShard, id2)
+    assertEquals(1, cacheShard.size)
+    assertEquals(1, cacheShard.evictionsMeter.count)
+    assertEquals(4, cacheShard.totalPartitions)
     val iter = session2.partitionMap.iterator
     iter.next()
     iter.remove()
     assertEquals(3, session2.size)
     assertEquals(4, session2.cachedSize)
-    cache.touch(session2, session2.lastUsedMs)
-    assertEquals(3, cache.totalPartitions)
+    cacheShard.touch(session2, session2.lastUsedMs)
+    assertEquals(3, cacheShard.totalPartitions)
   }
 
   private val EMPTY_PART_LIST = Collections.unmodifiableList(new util.ArrayList[TopicIdPartition]())
@@ -152,8 +160,8 @@ class FetchSessionTest {
   @Test
   def testCachedLeaderEpoch(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
 
     val topicIds = Map("foo" -> Uuid.randomUuid(), "bar" -> Uuid.randomUuid()).asJava
     val tp0 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 0))
@@ -246,8 +254,8 @@ class FetchSessionTest {
   @Test
   def testLastFetchedEpoch(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
 
     val topicIds = Map("foo" -> Uuid.randomUuid(), "bar" -> Uuid.randomUuid()).asJava
     val topicNames = topicIds.asScala.map(_.swap).asJava
@@ -345,8 +353,8 @@ class FetchSessionTest {
   @Test
   def testFetchRequests(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = Map(Uuid.randomUuid() -> "foo", Uuid.randomUuid() -> "bar").asJava
     val topicIds = topicNames.asScala.map(_.swap).asJava
     val tp0 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 0))
@@ -510,7 +518,7 @@ class FetchSessionTest {
         topicNames
       )
       assertEquals(classOf[SessionlessFetchContext], context8.getClass)
-      assertEquals(0, cache.size)
+      assertEquals(0, cacheShard.size)
       val respData8 = new util.LinkedHashMap[TopicIdPartition, FetchResponseData.PartitionData]
       respData8.put(tp2,
         new FetchResponseData.PartitionData()
@@ -534,8 +542,8 @@ class FetchSessionTest {
   @ValueSource(booleans = Array(true, false))
   def testIncrementalFetchSession(usesTopicIds: Boolean): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = if (usesTopicIds) Map(Uuid.randomUuid() -> "foo", Uuid.randomUuid() -> "bar").asJava else Map[Uuid, String]().asJava
     val topicIds = topicNames.asScala.map(_.swap).asJava
     val version = if (usesTopicIds) ApiKeys.FETCH.latestVersion else 12.toShort
@@ -623,8 +631,8 @@ class FetchSessionTest {
   @Test
   def testFetchSessionWithUnknownIdOldRequestVersion(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = Map(Uuid.randomUuid() -> "foo", Uuid.randomUuid() -> "bar").asJava
     val topicIds = topicNames.asScala.map(_.swap).asJava
     val tp0 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 0))
@@ -671,8 +679,8 @@ class FetchSessionTest {
   @Test
   def testFetchSessionWithUnknownId(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val fooId = Uuid.randomUuid()
     val barId = Uuid.randomUuid()
     val zarId = Uuid.randomUuid()
@@ -780,8 +788,8 @@ class FetchSessionTest {
   @Test
   def testIncrementalFetchSessionWithIdsWhenSessionDoesNotUseIds() : Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = new util.HashMap[Uuid, String]()
     val foo0 = new TopicIdPartition(Uuid.ZERO_UUID, new TopicPartition("foo", 0))
 
@@ -834,8 +842,8 @@ class FetchSessionTest {
   @Test
   def testIncrementalFetchSessionWithoutIdsWhenSessionUsesIds() : Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val fooId = Uuid.randomUuid()
     val topicNames = new util.HashMap[Uuid, String]()
     topicNames.put(fooId, "foo")
@@ -891,8 +899,8 @@ class FetchSessionTest {
   @Test
   def testFetchSessionUpdateTopicIdsBrokerSide(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = Map(Uuid.randomUuid() -> "foo", Uuid.randomUuid() -> "bar").asJava
     val topicIds = topicNames.asScala.map(_.swap).asJava
     val tp0 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 0))
@@ -983,8 +991,8 @@ class FetchSessionTest {
   @Test
   def testResolveUnknownPartitions(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
 
     def newContext(
       metadata: JFetchMetadata,
@@ -1105,8 +1113,8 @@ class FetchSessionTest {
   @MethodSource(Array("idUsageCombinations"))
   def testToForgetPartitions(fooStartsResolved: Boolean, fooEndsResolved: Boolean): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
 
     def newContext(
       metadata: JFetchMetadata,
@@ -1205,8 +1213,8 @@ class FetchSessionTest {
   @Test
   def testUpdateAndGenerateResponseData(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
 
     def newContext(
       metadata: JFetchMetadata,
@@ -1316,8 +1324,8 @@ class FetchSessionTest {
   def testFetchSessionExpiration(): Unit = {
     val time = new MockTime()
     // set maximum entries to 2 to allow for eviction later
-    val cache = new FetchSessionCache(2, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(2, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val fooId = Uuid.randomUuid()
     val topicNames = Map(fooId -> "foo").asJava
     val foo0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0))
@@ -1356,7 +1364,7 @@ class FetchSessionTest {
     assertEquals(2, session1resp.responseData(topicNames, session1request1.version).size)
 
     // check session entered into case
-    assertTrue(cache.get(session1resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session1resp.sessionId()).isDefined)
     time.sleep(500)
 
     // Create a second new fetch session
@@ -1393,8 +1401,8 @@ class FetchSessionTest {
     assertEquals(2, session2resp.responseData(topicNames, session2request1.version()).size())
 
     // both newly created entries are present in cache
-    assertTrue(cache.get(session1resp.sessionId()).isDefined)
-    assertTrue(cache.get(session2resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session1resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session2resp.sessionId()).isDefined)
     time.sleep(500)
 
     // Create an incremental fetch request for session 1
@@ -1450,17 +1458,17 @@ class FetchSessionTest {
     assertTrue(session3resp.sessionId() != INVALID_SESSION_ID)
     assertEquals(2, session3resp.responseData(topicNames, session3request1.version).size)
 
-    assertTrue(cache.get(session1resp.sessionId()).isDefined)
-    assertFalse(cache.get(session2resp.sessionId()).isDefined, "session 2 should have been evicted by latest session, as session 1 was used more recently")
-    assertTrue(cache.get(session3resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session1resp.sessionId()).isDefined)
+    assertFalse(cacheShard.get(session2resp.sessionId()).isDefined, "session 2 should have been evicted by latest session, as session 1 was used more recently")
+    assertTrue(cacheShard.get(session3resp.sessionId()).isDefined)
   }
 
   @Test
   def testPrivilegedSessionHandling(): Unit = {
     val time = new MockTime()
     // set maximum entries to 2 to allow for eviction later
-    val cache = new FetchSessionCache(2, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(2, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val fooId = Uuid.randomUuid()
     val topicNames = Map(fooId -> "foo").asJava
     val foo0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0))
@@ -1497,7 +1505,7 @@ class FetchSessionTest {
     assertEquals(Errors.NONE, session1resp.error())
     assertTrue(session1resp.sessionId() != INVALID_SESSION_ID)
     assertEquals(2, session1resp.responseData(topicNames, session1request.version).size)
-    assertEquals(1, cache.size)
+    assertEquals(1, cacheShard.size)
 
     // move time forward to age session 1 a little compared to session 2
     time.sleep(500)
@@ -1537,9 +1545,9 @@ class FetchSessionTest {
     assertEquals(2, session2resp.responseData(topicNames, session2request.version).size)
 
     // both newly created entries are present in cache
-    assertTrue(cache.get(session1resp.sessionId()).isDefined)
-    assertTrue(cache.get(session2resp.sessionId()).isDefined)
-    assertEquals(2, cache.size)
+    assertTrue(cacheShard.get(session1resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session2resp.sessionId()).isDefined)
+    assertEquals(2, cacheShard.size)
     time.sleep(500)
 
     // create a session to test session1 privileges mean that session 1 is retained and session 2 is evicted
@@ -1576,12 +1584,12 @@ class FetchSessionTest {
     assertTrue(session3resp.sessionId() != INVALID_SESSION_ID)
     assertEquals(2, session3resp.responseData(topicNames, session3request.version).size)
 
-    assertTrue(cache.get(session1resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session1resp.sessionId()).isDefined)
     // even though session 2 is more recent than session 1, and has not reached expiry time, it is less
     // privileged than session 2, and thus session 3 should be entered and session 2 evicted.
-    assertFalse(cache.get(session2resp.sessionId()).isDefined, "session 2 should have been evicted by session 3")
-    assertTrue(cache.get(session3resp.sessionId()).isDefined)
-    assertEquals(2, cache.size)
+    assertFalse(cacheShard.get(session2resp.sessionId()).isDefined, "session 2 should have been evicted by session 3")
+    assertTrue(cacheShard.get(session3resp.sessionId()).isDefined)
+    assertEquals(2, cacheShard.size)
 
     time.sleep(501)
 
@@ -1619,17 +1627,17 @@ class FetchSessionTest {
     assertTrue(session4resp.sessionId() != INVALID_SESSION_ID)
     assertEquals(2, session4resp.responseData(topicNames, session4request.version).size)
 
-    assertFalse(cache.get(session1resp.sessionId()).isDefined, "session 1 should have been evicted by session 4 even though it is privileged as it has hit eviction time")
-    assertTrue(cache.get(session3resp.sessionId()).isDefined)
-    assertTrue(cache.get(session4resp.sessionId()).isDefined)
-    assertEquals(2, cache.size)
+    assertFalse(cacheShard.get(session1resp.sessionId()).isDefined, "session 1 should have been evicted by session 4 even though it is privileged as it has hit eviction time")
+    assertTrue(cacheShard.get(session3resp.sessionId()).isDefined)
+    assertTrue(cacheShard.get(session4resp.sessionId()).isDefined)
+    assertEquals(2, cacheShard.size)
   }
 
   @Test
   def testZeroSizeFetchSession(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val fooId = Uuid.randomUuid()
     val topicNames = Map(fooId -> "foo").asJava
     val foo0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0))
@@ -1687,14 +1695,14 @@ class FetchSessionTest {
     val resp2 = context2.updateAndGenerateResponseData(respData2)
     assertEquals(INVALID_SESSION_ID, resp2.sessionId)
     assertTrue(resp2.responseData(topicNames, request2.version).isEmpty)
-    assertEquals(0, cache.size)
+    assertEquals(0, cacheShard.size)
   }
 
   @Test
   def testDivergingEpoch(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicNames = Map(Uuid.randomUuid() -> "foo", Uuid.randomUuid() -> "bar").asJava
     val topicIds = topicNames.asScala.map(_.swap).asJava
     val tp1 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 1))
@@ -1778,8 +1786,8 @@ class FetchSessionTest {
   @Test
   def testDeprioritizesPartitionsWithRecordsOnly(): Unit = {
     val time = new MockTime()
-    val cache = new FetchSessionCache(10, 1000)
-    val fetchManager = new FetchManager(time, cache)
+    val cacheShard = new FetchSessionCacheShard(10, 1000)
+    val fetchManager = new FetchManager(time, cacheShard)
     val topicIds = Map("foo" -> Uuid.randomUuid(), "bar" -> Uuid.randomUuid(), "zar" -> Uuid.randomUuid()).asJava
     val topicNames = topicIds.asScala.map(_.swap).asJava
     val tp1 = new TopicIdPartition(topicIds.get("foo"), new TopicPartition("foo", 1))
@@ -1931,6 +1939,55 @@ class FetchSessionTest {
       partitionsInContext += tp
     }
     assertEquals(partitions, partitionsInContext.toSeq)
+  }
+
+  @Test
+  def testFetchSessionCache_getShardedCache_retrievesCacheFromCorrectSegment(): Unit = {
+    // Given
+    val numShards = 8
+    val sessionIdRange = Int.MaxValue / numShards
+    val cacheShards = (0 until numShards).map(shardNum => new FetchSessionCacheShard(10, 1000, sessionIdRange, shardNum))
+    val cache = new FetchSessionCache(cacheShards)
+
+    // When
+    val cache0 = cache.getCacheShard(sessionIdRange - 1)
+    val cache1 = cache.getCacheShard(sessionIdRange)
+    val cache2 = cache.getCacheShard(sessionIdRange * 2)
+
+    // Then
+    assertEquals(cache0, cacheShards(0))
+    assertEquals(cache1, cacheShards(1))
+    assertEquals(cache2, cacheShards(2))
+    assertThrows(classOf[IndexOutOfBoundsException], () => cache.getCacheShard(sessionIdRange * numShards))
+  }
+
+  @Test
+  def testFetchSessionCache_RoundRobinsIntoShards(): Unit = {
+    // Given
+    val numShards = 8
+    val sessionIdRange = Int.MaxValue / numShards
+    val cacheShards = (0 until numShards).map(shardNum => new FetchSessionCacheShard(10, 1000, sessionIdRange, shardNum))
+    val cache = new FetchSessionCache(cacheShards)
+
+    // When / Then
+    (0 until numShards*2).foreach { shardNum =>
+      assertEquals(cacheShards(shardNum % numShards), cache.getNextCacheShard)
+    }
+  }
+
+  @Test
+  def testFetchSessionCache_RoundRobinsIntoShards_WhenIntegerOverflows(): Unit = {
+    // Given
+    FetchSessionCache.counter.set(Int.MaxValue+1)
+    val numShards = 8
+    val sessionIdRange = Int.MaxValue / numShards
+    val cacheShards = (0 until numShards).map(shardNum => new FetchSessionCacheShard(10, 1000, sessionIdRange, shardNum))
+    val cache = new FetchSessionCache(cacheShards)
+
+    // When / Then
+    (0 until numShards*2).foreach { shardNum =>
+      assertEquals(cacheShards(shardNum % numShards), cache.getNextCacheShard)
+    }
   }
 }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4177,7 +4177,7 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, false, false)
     when(fetchManager.newContext(
       any[Short],
@@ -4229,7 +4229,7 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(foo.topicPartition -> new FetchRequest.PartitionData(foo.topicId, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, true, replicaId >= 0)
     // We expect to have the resolved partition, but we will simulate an unknown one with the fetchContext we return.
     when(fetchManager.newContext(
@@ -4300,8 +4300,8 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
-      fetchMetadata, fetchData, false, false)
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
+      fetchMetadata, fetchData, true, false)
     when(fetchManager.newContext(
       any[Short],
       any[JFetchMetadata],
@@ -5543,7 +5543,7 @@ class KafkaApisTest extends Logging {
     })
 
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, true, true)
     when(fetchManager.newContext(
       any[Short],


### PR DESCRIPTION
Cherry picks  #15836 to 3.7.

Note:
There were merge conflicts in the following files which were resolved

```
 both modified:   core/src/main/scala/kafka/server/FetchSession.scala
both modified:   core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
both modified:   core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
```