### PR TITLE
improve log description of QuorumController

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -166,7 +166,7 @@ public class ActivationRecordsGenerator {
                             "created in KRaft mode.");
                     }
                     logMessageBuilder
-                            .append("since this is a de-novo KRaft cluster.");
+                            .append("This is expected because this is a de-novo KRaft cluster.");
                     break;
                 case PRE_MIGRATION:
                     if (!metadataVersion.isMetadataTransactionSupported()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -165,6 +165,8 @@ public class ActivationRecordsGenerator {
                         throw new RuntimeException("Should not have ZK migrations enabled on a cluster that was " +
                             "created in KRaft mode.");
                     }
+                    logMessageBuilder
+                            .append("since this is a de-novo KRaft cluster.");
                     break;
                 case PRE_MIGRATION:
                     if (!metadataVersion.isMetadataTransactionSupported()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -165,8 +165,7 @@ public class ActivationRecordsGenerator {
                         throw new RuntimeException("Should not have ZK migrations enabled on a cluster that was " +
                             "created in KRaft mode.");
                     }
-                    logMessageBuilder
-                            .append("This is expected because this is a de-novo KRaft cluster.");
+                    logMessageBuilder.append("This is expected because this is a de-novo KRaft cluster.");
                     break;
                 case PRE_MIGRATION:
                     if (!metadataVersion.isMetadataTransactionSupported()) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -191,7 +191,7 @@ public class ActivationRecordsGeneratorTest {
         assertEquals(0, result.records().size());
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
-            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE.", logMsg),
+            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE. since this is a de-novo KRaft cluster.", logMsg),
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
@@ -202,7 +202,7 @@ public class ActivationRecordsGeneratorTest {
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. Aborting in-progress metadata " +
-                "transaction at offset 42. Loaded ZK migration state of NONE.", logMsg),
+                "transaction at offset 42. Loaded ZK migration state of NONE. since this is a de-novo KRaft cluster.", logMsg),
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -191,7 +191,8 @@ public class ActivationRecordsGeneratorTest {
         assertEquals(0, result.records().size());
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
-            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE. since this is a de-novo KRaft cluster.", logMsg),
+            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE. "
+                                   + "This is expected because this is a de-novo KRaft cluster.", logMsg),
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
@@ -202,7 +203,8 @@ public class ActivationRecordsGeneratorTest {
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. Aborting in-progress metadata " +
-                "transaction at offset 42. Loaded ZK migration state of NONE. since this is a de-novo KRaft cluster.", logMsg),
+                                   "transaction at offset 42. Loaded ZK migration state of NONE. " +
+                                   "This is expected because this is a de-novo KRaft cluster.", logMsg),
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),


### PR DESCRIPTION
### Motivation
- `QuorumController` warn with "Performing controller activation. Loaded ZK migration state of NONE" even if it's `de-novo` KRaft cluster. That message makes operator confused, and operator might waste time investigating that log. If we add some description to log, operator will be more convenient. 

### Modification
- Add a log for `de-novo KRaft ` cluster when `zookeeper.metadata.migration.enable=false` and the broker version supports `KRaft`.

### Result
- Fixes https://issues.apache.org/jira/browse/KAFKA-16619