### PR TITLE
MINOR: Add coverage for MM2 heartbeats topic detection

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -104,10 +104,16 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testReplicatesHeartbeatsDespiteFilter() {
+        DefaultReplicationPolicy defaultReplicationPolicy = new DefaultReplicationPolicy();
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> false, new DefaultConfigPropertyFilter());
+            defaultReplicationPolicy, x -> false, new DefaultConfigPropertyFilter());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
+
+        Map<String, ?> configs = Collections.singletonMap(DefaultReplicationPolicy.SEPARATOR_CONFIG, "_");
+        defaultReplicationPolicy.configure(configs);
+        assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
+        assertFalse(connector.shouldReplicateTopic("us-west.heartbeats"), "should not consider this topic as a heartbeats topic");
     }
 
     @Test


### PR DESCRIPTION
As IdentityReplicationPolicy extends DefaultReplicationPolicy it relies on replication.policy.separator to identify heartbeats topics. This behaviour should be documented better but this just adds coverage to ensure it is preserved.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
