### PR TITLE
KAFKA-16738: Returns BaseRecords instead of MemoryRecords

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 
 import java.nio.ByteBuffer;
@@ -53,7 +54,7 @@ public interface Readable {
         return unknowns;
     }
 
-    default MemoryRecords readRecords(int length) {
+    default BaseRecords readRecords(int length) {
         if (length < 0) {
             // no records
             return null;

--- a/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
@@ -31,4 +31,13 @@ public interface BaseRecords {
      * @return Initialized {@link RecordsSend} object
      */
     RecordsSend<? extends BaseRecords> toSend();
+
+    /**
+     * Make a copy of this {@link BaseRecords}.
+     *
+     * @return A copy of this {@link BaseRecords} which does not share any mutable fields.
+     */
+    default BaseRecords duplicate() {
+        throw new UnsupportedOperationException("Duplication is not supported");
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -71,6 +71,11 @@ public class MemoryRecords extends AbstractRecords {
     }
 
     @Override
+    public MemoryRecords duplicate() {
+        return new MemoryRecords(buffer.duplicate());
+    }
+
+    @Override
     public int writeTo(TransferableChannel channel, int position, int length) throws IOException {
         if (((long) position) + length > buffer.limit())
             throw new IllegalArgumentException("position+length should not be greater than buffer.limit(), position: "

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1537,12 +1537,9 @@ public final class MessageDataGenerator implements MessageClassGenerator {
                     });
                 }
             } else if (field.type().isRecords()) {
-                cond.ifShouldNotBeNull(() -> {
-                    headerGenerator.addImport(MessageGenerator.MEMORY_RECORDS_CLASS);
+                cond.ifShouldNotBeNull(() ->
                     buffer.printf("%s;%n", target.assignmentStatement(
-                        String.format("MemoryRecords.readableRecords(((MemoryRecords) %s).buffer().duplicate())",
-                            target.sourceVariable())));
-                });
+                        String.format("%s.duplicate()", target.sourceVariable()))));
             } else if (field.type().isStruct()) {
                 cond.ifShouldNotBeNull(() ->
                     buffer.printf("%s;%n", target.assignmentStatement(


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/KAFKA-16738

We can write a record which is a subtype of [BaseRecords](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java), but we can not read a record which is a subtype of [BaseRecords](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java). If we change the return type of [Readable#readRecords](https://github.com/apache/kafka/blob/5439914c32fa00d634efa7219699f1bc21add839/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java#L56) from MemoryRecords to BaseRecords, we can override the implementation of readRecords and returns a subtype of BaseRecords easily.

We known that the MemoryRecords is based on JDK's ByteBuffer. We are developing a netty project([kroxylicious](https://github.com/kroxylicious/kroxylicious/)) and we want to create a subtype of BaseRecords like MemoryRecords based on netty's ByteBuf.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
