### PR TITLE
MINOR: fix flaky testRecordThreadIdleRatioTwoThreads test

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -516,7 +516,8 @@ public class MultiThreadedEventProcessorTest {
 
             long sum = recordedIdleTimesMs.stream().mapToLong(Long::longValue).sum();
             double idleRatio = (double) sum / diff;
-            assertTrue(idleRatio >= 0.5 && idleRatio <= 1.0);
+            assertTrue(idleRatio >= 0.5 && idleRatio <= 1.0, "idle ratio should be " +
+                "greater than or equal to 0.5 and smaller than or equal to 1.0 but was " + idleRatio);
         }
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -457,14 +457,14 @@ public class MultiThreadedEventProcessorTest {
     }
 
     @Test
-    public void testRecordThreadIdleRatioTwoThreads() throws Exception {
+    public void testRecordThreadIdleRatio() throws Exception {
         GroupCoordinatorRuntimeMetrics mockRuntimeMetrics = mock(GroupCoordinatorRuntimeMetrics.class);
-        Time time = Time.SYSTEM;
+        Time time = new MockTime();
 
         try (CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            2,
+            1,
             time,
             mockRuntimeMetrics,
             new DelayEventAccumulator(time, 100L)
@@ -474,10 +474,7 @@ public class MultiThreadedEventProcessorTest {
             ArgumentCaptor<Long> idleTimeCaptured = ArgumentCaptor.forClass(Long.class);
             doAnswer(invocation -> {
                 long threadIdleTime = idleTimeCaptured.getValue();
-
-                // As each thread sleeps for 100ms before returning from take(),
-                // we know that each recorded idle time must be at least 50 (100/2)ms.
-                assertTrue(threadIdleTime >= 50);
+                assertEquals(100, threadIdleTime);
                 synchronized (recordedIdleTimesMs) {
                     recordedIdleTimesMs.add(threadIdleTime);
                 }
@@ -508,16 +505,15 @@ public class MultiThreadedEventProcessorTest {
                 assertFalse(event.future.isCompletedExceptionally());
             });
 
-            long diff = time.milliseconds() - startMs;
-
             assertEquals(events.size(), numEventsExecuted.get());
             verify(mockRuntimeMetrics, times(8)).recordThreadIdleTime(anyLong());
             assertEquals(8, recordedIdleTimesMs.size());
 
+            long diff = time.milliseconds() - startMs;
             long sum = recordedIdleTimesMs.stream().mapToLong(Long::longValue).sum();
             double idleRatio = (double) sum / diff;
-            assertTrue(idleRatio >= 0.5 && idleRatio <= 1.0, "idle ratio should be " +
-                "greater than or equal to 0.5 and smaller than or equal to 1.0 but was " + idleRatio);
+
+            assertEquals(1.0, idleRatio, "idle ratio should be 1.0 but was: " + idleRatio);
         }
     }
 }


### PR DESCRIPTION
This patch makes testRecordThreadIdleRatioTwoThreads, now testRecordThreadIdleRatio, a single threaded test and a test that relies on MockTime instead of Time.SYSTEM.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
