### PR TITLE
MINOR: Change sys test describe topic parsing to improve extensibility

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1396,18 +1396,13 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 continue
 
             fields = line.split("\t")
-
-            # There are additional fields on the end of the 'describe topic' output related to eligible leader
-            # replicas. We don't want or need those, so drop them before we attempt to parse.
-            assert len(fields) >= 4, "Not enough fields in describe topic output line: %s" % line
-            fields = fields[:4]
-
-            # ["Partition: 4", "Leader: 0"] -> ["4", "0"]
-            fields = list(map(lambda x: x.split(" ")[1], fields))
+            fields = dict([field.split(": ") for field in fields if len(field.split(": ")) == 2])
             partitions.append(
-                {"topic": fields[0],
-                 "partition": int(fields[1]),
-                 "replicas": list(map(int, fields[3].split(',')))})
+                {"topic": fields["Topic"],
+                 "partition": int(fields["Partition"]),
+                 "replicas": list(map(int, fields["Replicas"].split(',')))
+                 })
+
         return {"partitions": partitions}
 
 


### PR DESCRIPTION
Minor change to how the describe topic output is parsed in system tests, to ensure that the output is preserved, even if only some fields are relevant to the test for now (which is what the test used to do before recent changes)

Initial problem: System tests were parsing the describe topic output in kafka.py assuming all fields would include a value. The describe API was recently changed, breaking this logic, because it included new fields for which there may not be values (ex. LastKnownElr). 

Initial fix: The initial fix for this was to drop all fields from the output except for the ones currently used in the test, where in reality only the fields without values are the problematic ones. 

Proposed improvement: A more extensible approach would be to drop only the fields that have no values and preserve the full output, which is what the test did before the initial fix mentioned above. This allows to easily extend the test to include more fields as needed, which could follow as the describe API and tests evolves (it will only require to add the fields to the returned value when needed, without having to change how the `fields` object is stripped). 
