### PR TITLE
MINOR: Fix TargetAssignmentBuilderBenchmark

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
@@ -105,6 +105,7 @@ public class TargetAssignmentBuilderBenchmark {
             .withMembers(members)
             .withSubscriptionMetadata(subscriptionMetadata)
             .withTargetAssignment(existingTargetAssignment)
+            .withSubscriptionType(HOMOGENEOUS)
             .addOrUpdateMember(newMember.memberId(), newMember);
     }
 


### PR DESCRIPTION
We forgot adding the subscription type to the benchmark in https://github.com/apache/kafka/commit/ee16eee5debe653b005afc5a3f4e0bf5486b09b0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
