### PR TITLE
KAFKA-16764: New consumer should throw InvalidTopicException on poll when invalid topic in metadata.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManager.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
+import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
+
+public class MetadataErrorManager implements RequestManager {
+    private final Metadata metadata;
+    private final BackgroundEventHandler backgroundEventHandler;
+
+    public MetadataErrorManager(Metadata metadata, BackgroundEventHandler backgroundEventHandler) {
+        this.metadata = metadata;
+        this.backgroundEventHandler = backgroundEventHandler;
+    }
+
+    @Override
+    public PollResult poll(long currentTimeMs) {
+        try {
+            metadata.maybeThrowAnyException();
+        } catch (Exception ex) {
+            backgroundEventHandler.add(new ErrorEvent(ex));
+        }
+
+        return PollResult.EMPTY;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManager.java
@@ -26,18 +26,25 @@ public class MetadataErrorManager implements RequestManager {
     private final BackgroundEventHandler backgroundEventHandler;
 
     public MetadataErrorManager(Metadata metadata, BackgroundEventHandler backgroundEventHandler) {
+        assert metadata != null;
+        assert backgroundEventHandler != null;
+
         this.metadata = metadata;
         this.backgroundEventHandler = backgroundEventHandler;
     }
 
     @Override
     public PollResult poll(long currentTimeMs) {
-        try {
-            metadata.maybeThrowAnyException();
-        } catch (Exception ex) {
-            backgroundEventHandler.add(new ErrorEvent(ex));
-        }
+        maybePropagateMetadataError();
 
         return PollResult.EMPTY;
+    }
+
+    private void maybePropagateMetadataError() {
+        try {
+            metadata.maybeThrowAnyException();
+        } catch (Exception e) {
+            backgroundEventHandler.add(new ErrorEvent(e));
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -259,8 +259,8 @@ public class ConsumerTestBuilder implements Closeable {
                 metricsManager,
                 networkClientDelegate,
                 apiVersions));
-        this.metadataErrorManager = new MetadataErrorManager(metadata,
-                backgroundEventHandler);
+        this.metadataErrorManager = spy(new MetadataErrorManager(metadata,
+                backgroundEventHandler));
         this.requestManagers = new RequestManagers(logContext,
                 offsetsRequestManager,
                 topicMetadataRequestManager,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -91,6 +91,7 @@ public class ConsumerTestBuilder implements Closeable {
     final Optional<HeartbeatRequestManager.HeartbeatRequestState> heartbeatRequestState;
     final TopicMetadataRequestManager topicMetadataRequestManager;
     final FetchRequestManager fetchRequestManager;
+    final MetadataErrorManager metadataErrorManager;
     final RequestManagers requestManagers;
     public final ApplicationEventProcessor applicationEventProcessor;
     public final BackgroundEventHandler backgroundEventHandler;
@@ -258,10 +259,13 @@ public class ConsumerTestBuilder implements Closeable {
                 metricsManager,
                 networkClientDelegate,
                 apiVersions));
+        this.metadataErrorManager = new MetadataErrorManager(metadata,
+                backgroundEventHandler);
         this.requestManagers = new RequestManagers(logContext,
                 offsetsRequestManager,
                 topicMetadataRequestManager,
                 fetchRequestManager,
+                metadataErrorManager,
                 coordinatorRequestManager,
                 commitRequestManager,
                 heartbeatRequestManager,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MetadataErrorManagerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent.Type;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
+import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MetadataErrorManagerTest {
+    private Metadata metadata;
+    private BackgroundEventHandler backgroundEventHandler;
+    private Queue<BackgroundEvent> backgroundEventQueue;
+    private MetadataErrorManager metadataErrorManager;
+
+    @BeforeEach
+    void setUp() {
+        this.metadata = new Metadata(50,
+                50,
+                5000,
+                new LogContext(),
+                new ClusterResourceListeners());
+        this.backgroundEventQueue = new LinkedList<>();
+        this.backgroundEventHandler = new BackgroundEventHandler(backgroundEventQueue);
+        this.metadataErrorManager = new MetadataErrorManager(metadata, backgroundEventHandler);
+    }
+
+    @Test
+    void testNoMetadataError() {
+        PollResult empty = metadataErrorManager.poll(0);
+        BackgroundEvent event = backgroundEventQueue.poll();
+
+        assertEquals(PollResult.EMPTY, empty);
+        assertNull(event);
+    }
+
+    @Test
+    void testMetadataError() {
+        Time time = new MockTime();
+        String invalidTopic = "invalid topic";
+        MetadataResponse invalidTopicResponse = RequestTestUtils.metadataUpdateWith("clusterId", 1,
+                Collections.singletonMap(invalidTopic, Errors.INVALID_TOPIC_EXCEPTION), Collections.emptyMap());
+        metadata.updateWithCurrentRequestVersion(invalidTopicResponse, false, time.milliseconds());
+
+        PollResult empty = metadataErrorManager.poll(0);
+        BackgroundEvent event = backgroundEventQueue.poll();
+
+        assertEquals(PollResult.EMPTY, empty);
+        assertNotNull(event);
+        assertEquals(Type.ERROR, event.type());
+        assertEquals(InvalidTopicException.class, ((ErrorEvent) event).error().getClass());
+        assertEquals(String.format("Invalid topics: [%s]", invalidTopic),
+                ((ErrorEvent) event).error().getMessage());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.internals.CoordinatorRequestManager;
 import org.apache.kafka.clients.consumer.internals.FetchRequestManager;
 import org.apache.kafka.clients.consumer.internals.HeartbeatRequestManager;
 import org.apache.kafka.clients.consumer.internals.MembershipManager;
+import org.apache.kafka.clients.consumer.internals.MetadataErrorManager;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate;
 import org.apache.kafka.clients.consumer.internals.OffsetsRequestManager;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
@@ -62,6 +63,7 @@ public class ApplicationEventProcessorTest {
         TopicMetadataRequestManager topicMetadataRequestManager = mock(TopicMetadataRequestManager.class);
         FetchRequestManager fetchRequestManager = mock(FetchRequestManager.class);
         CoordinatorRequestManager coordinatorRequestManager = mock(CoordinatorRequestManager.class);
+        MetadataErrorManager metadataErrorManager = mock(MetadataErrorManager.class);
         commitRequestManager = mock(CommitRequestManager.class);
         heartbeatRequestManager = mock(HeartbeatRequestManager.class);
         membershipManager = mock(MembershipManager.class);
@@ -70,6 +72,7 @@ public class ApplicationEventProcessorTest {
             offsetsRequestManager,
             topicMetadataRequestManager,
             fetchRequestManager,
+            metadataErrorManager,
             Optional.of(coordinatorRequestManager),
             Optional.of(commitRequestManager),
             Optional.of(heartbeatRequestManager),


### PR DESCRIPTION
- Add ErrorPropagateMetadataUpdater
   - Just proxy but propagates error though BackgroundEventHandler

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
