### PR TITLE
KAFKA-16675: Refactored and new rebalance callbacks integration tests

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerCallbackTest.scala
@@ -16,7 +16,7 @@ import kafka.api.{AbstractConsumerTest, BaseConsumerTest}
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRebalanceListener}
 import org.apache.kafka.common.TopicPartition
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
@@ -35,7 +35,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerAssignOnPartitionsAssigned(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsAssigned { (consumer, _) =>
       val e: Exception = assertThrows(classOf[IllegalStateException], () => consumer.assign(Collections.singletonList(tp)))
       assertEquals(e.getMessage, "Subscription to topics, partitions and pattern are mutually exclusive")
@@ -45,7 +45,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerAssignmentOnPartitionsAssigned(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsAssigned { (consumer, _) =>
       assertTrue(consumer.assignment().contains(tp));
     }
@@ -54,7 +54,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerBeginningOffsetsOnPartitionsAssigned(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsAssigned { (consumer, _) =>
       val map = consumer.beginningOffsets(Collections.singletonList(tp))
       assertTrue(map.containsKey(tp))
@@ -65,7 +65,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerAssignOnPartitionsRevoked(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsRevoked { (consumer, _) =>
       val e: Exception = assertThrows(classOf[IllegalStateException], () => consumer.assign(Collections.singletonList(tp)))
       assertEquals(e.getMessage, "Subscription to topics, partitions and pattern are mutually exclusive")
@@ -75,7 +75,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerAssignmentOnPartitionsRevoked(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsRevoked { (consumer, _) =>
       assertTrue(consumer.assignment().contains(tp))
     }
@@ -84,7 +84,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testConsumerRebalanceListenerBeginningOffsetsOnPartitionsRevoked(quorum: String, groupProtocol: String): Unit = {
-    val tp = new TopicPartition(topic, 0);
+    val tp = new TopicPartition(topic, 0)
     triggerOnPartitionsRevoked { (consumer, _) =>
       val map = consumer.beginningOffsets(Collections.singletonList(tp))
       assertTrue(map.containsKey(tp))
@@ -92,13 +92,53 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
     }
   }
 
-  private def triggerOnPartitionsAssigned(execute: (Consumer[Array[Byte], Array[Byte]], util.Collection[TopicPartition]) => Unit): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testGetPositionOfNewlyAssignedPartitionOnPartitionsAssignedCallback(quorum: String, groupProtocol: String): Unit = {
+    val tp = new TopicPartition(topic, 0)
+    triggerOnPartitionsAssigned { (consumer, _) => assertDoesNotThrow(() => consumer.position(tp)) }
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testSeekPositionOfNewlyAssignedPartitionOnPartitionsAssignedCallback(quorum: String, groupProtocol: String): Unit = {
     val consumer = createConsumer()
-    val partitionsAssigned = new AtomicBoolean(false);
+    val startingOffset = 100L
+    val totalRecords = 120L
+
+    val producer = createProducer()
+    val startingTimestamp = 0
+    sendRecords(producer, totalRecords.toInt, tp, startingTimestamp)
+
     consumer.subscribe(asList(topic), new ConsumerRebalanceListener {
       override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
-        execute(consumer, partitions);
-        partitionsAssigned.set(true);
+        consumer.seek(tp, startingOffset)
+      }
+
+      override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
+        // noop
+      }
+    })
+    consumeAndVerifyRecords(consumer, numRecords = (totalRecords - startingOffset).toInt,
+      startingOffset = startingOffset.toInt, startingKeyAndValueIndex = startingOffset.toInt,
+      startingTimestamp = startingOffset)
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testPauseOnPartitionsAssignedCallback(quorum: String, groupProtocol: String): Unit = {
+    val consumer = createConsumer()
+    val totalRecords = 100L
+    val partitionsAssigned = new AtomicBoolean(false)
+
+    val producer = createProducer()
+    val startingTimestamp = 0
+    sendRecords(producer, totalRecords.toInt, tp, startingTimestamp)
+
+    consumer.subscribe(asList(topic), new ConsumerRebalanceListener {
+      override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+        consumer.pause(asList(tp))
+        partitionsAssigned.set(true)
       }
 
       override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
@@ -106,7 +146,25 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
       }
     })
     TestUtils.pollUntilTrue(consumer, () => partitionsAssigned.get(), "Timed out before expected rebalance completed")
-    consumer.close()
+    assertTrue(consumer.paused().contains(tp))
+    consumer.resume(asList(tp))
+    consumeAndVerifyRecords(consumer, numRecords = totalRecords.toInt, startingOffset = 0, startingTimestamp)
+  }
+
+  private def triggerOnPartitionsAssigned(execute: (Consumer[Array[Byte], Array[Byte]], util.Collection[TopicPartition]) => Unit): Unit = {
+    val consumer = createConsumer()
+    val partitionsAssigned = new AtomicBoolean(false)
+    consumer.subscribe(asList(topic), new ConsumerRebalanceListener {
+      override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+        execute(consumer, partitions)
+        partitionsAssigned.set(true)
+      }
+
+      override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
+        // noop
+      }
+    })
+    TestUtils.pollUntilTrue(consumer, () => partitionsAssigned.get(), "Timed out before expected rebalance completed")
   }
 
   private def triggerOnPartitionsRevoked(execute: (Consumer[Array[Byte], Array[Byte]], util.Collection[TopicPartition]) => Unit): Unit = {
@@ -125,7 +183,7 @@ class PlaintextConsumerCallbackTest extends AbstractConsumerTest {
     })
     TestUtils.pollUntilTrue(consumer, () => partitionsAssigned.get(), "Timed out before expected rebalance completed")
     consumer.close()
-    assertTrue(partitionsRevoked.get());
+    assertTrue(partitionsRevoked.get())
   }
 }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -907,28 +907,4 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     assertThrows(classOf[WakeupException], () => consumer.position(topicPartition, Duration.ofSeconds(100)))
   }
-
-  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
-  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
-  def testGetPositionOfNewlyAssignedPartitionFromPartitionsAssignedCallback(quorum: String,
-                                                                            groupProtocol: String): Unit = {
-    val consumer = createConsumer()
-    val listener = new TestConsumerReassignmentListener {
-      override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
-        super.onPartitionsRevoked(partitions)
-      }
-
-      override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
-        super.onPartitionsAssigned(partitions)
-        partitions.forEach(tp => {
-          assertDoesNotThrow(() => consumer.position(tp))
-        })
-
-      }
-    }
-    consumer.subscribe(List(topic).asJava, listener)
-    awaitRebalance(consumer, listener)
-    assertEquals(1, listener.callsToAssigned)
-    assertEquals(0, listener.callsToRevoked)
-  }
 }


### PR DESCRIPTION
- Move existing rebalance callback + consumer.position test to the PlaintextConsumerCallbackTest file (refactored to reuse the new helper funcs available)
- Add new integration tests for callbacks interaction with seek and pause
- Minor cleanup in the callbacks test file
