### PR TITLE
KAFKA-16684: Remove cache in responseData

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -99,26 +99,21 @@ public class FetchResponse extends AbstractResponse {
     }
 
     public LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData(Map<Uuid, String> topicNames, short version) {
-        synchronized (this) {
-            // Assigning the lazy-initialized `responseData` in the last step
-            // to avoid other threads accessing a half-initialized object.
-            final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
-                    new LinkedHashMap<>();
-            data.responses().forEach(topicResponse -> {
-                String name;
-                if (version < 13) {
-                    name = topicResponse.topic();
-                } else {
-                    name = topicNames.get(topicResponse.topicId());
-                }
-                if (name != null) {
-                    topicResponse.partitions().forEach(partition ->
-                        responseDataTmp.put(new TopicPartition(name, partition.partitionIndex()), partition));
-                }
-            });
-            responseData = responseDataTmp;
-        }
-        return responseData;
+        final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
+                new LinkedHashMap<>();
+        data.responses().forEach(topicResponse -> {
+            String name;
+            if (version < 13) {
+                name = topicResponse.topic();
+            } else {
+                name = topicNames.get(topicResponse.topicId());
+            }
+            if (name != null) {
+                topicResponse.partitions().forEach(partition ->
+                    responseDataTmp.put(new TopicPartition(name, partition.partitionIndex()), partition));
+            }
+        });
+        return responseDataTmp;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -99,28 +99,24 @@ public class FetchResponse extends AbstractResponse {
     }
 
     public LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData(Map<Uuid, String> topicNames, short version) {
-        if (responseData == null) {
-            synchronized (this) {
-                if (responseData == null) {
-                    // Assigning the lazy-initialized `responseData` in the last step
-                    // to avoid other threads accessing a half-initialized object.
-                    final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
-                            new LinkedHashMap<>();
-                    data.responses().forEach(topicResponse -> {
-                        String name;
-                        if (version < 13) {
-                            name = topicResponse.topic();
-                        } else {
-                            name = topicNames.get(topicResponse.topicId());
-                        }
-                        if (name != null) {
-                            topicResponse.partitions().forEach(partition ->
-                                responseDataTmp.put(new TopicPartition(name, partition.partitionIndex()), partition));
-                        }
-                    });
-                    responseData = responseDataTmp;
+        synchronized (this) {
+            // Assigning the lazy-initialized `responseData` in the last step
+            // to avoid other threads accessing a half-initialized object.
+            final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
+                    new LinkedHashMap<>();
+            data.responses().forEach(topicResponse -> {
+                String name;
+                if (version < 13) {
+                    name = topicResponse.topic();
+                } else {
+                    name = topicNames.get(topicResponse.topicId());
                 }
-            }
+                if (name != null) {
+                    topicResponse.partitions().forEach(partition ->
+                        responseDataTmp.put(new TopicPartition(name, partition.partitionIndex()), partition));
+                }
+            });
+            responseData = responseDataTmp;
         }
         return responseData;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -73,8 +73,6 @@ public class FetchResponse extends AbstractResponse {
     public static final int INVALID_PREFERRED_REPLICA_ID = -1;
 
     private final FetchResponseData data;
-    // we build responseData when needed.
-    private volatile LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData = null;
 
     @Override
     public FetchResponseData data() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -99,7 +99,7 @@ public class FetchResponse extends AbstractResponse {
     }
 
     public LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData(Map<Uuid, String> topicNames, short version) {
-        final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
+        final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData =
                 new LinkedHashMap<>();
         data.responses().forEach(topicResponse -> {
             String name;
@@ -110,10 +110,10 @@ public class FetchResponse extends AbstractResponse {
             }
             if (name != null) {
                 topicResponse.partitions().forEach(partition ->
-                    responseDataTmp.put(new TopicPartition(name, partition.partitionIndex()), partition));
+                    responseData.put(new TopicPartition(name, partition.partitionIndex()), partition));
             }
         });
-        return responseDataTmp;
+        return responseData;
     }
 
     @Override


### PR DESCRIPTION
## Context
The response data should change accordingly to the input, however with the current design, it will not change even if the input changes. We should remove this cache logic to avoid returning wrong data.
Jira: https://issues.apache.org/jira/browse/KAFKA-16684

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
