### PR TITLE
KAFKA-15541: Add num-open-iterators metric

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -39,8 +39,11 @@ public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecord
 
     @Override
     public void close() {
-        iterator.close();
-        numOpenIterators.decrementAndGet();
+        try {
+            iterator.close();
+        } finally {
+            numOpenIterators.decrementAndGet();
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.kafka.streams.state.VersionedRecordIterator;
 import org.apache.kafka.streams.state.VersionedRecord;
@@ -24,18 +25,22 @@ public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecord
 
     private final VersionedRecordIterator<byte[]> iterator;
     private final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue;
-
+    private final AtomicInteger numOpenIterators;
 
     public MeteredMultiVersionedKeyQueryIterator(final VersionedRecordIterator<byte[]> iterator,
-                                                 final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue) {
+                                                 final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue,
+                                                 final AtomicInteger numOpenIterators) {
         this.iterator = iterator;
         this.deserializeValue = deserializeValue;
+        this.numOpenIterators = numOpenIterators;
+        numOpenIterators.incrementAndGet();
     }
 
 
     @Override
     public void close() {
         iterator.close();
+        numOpenIterators.decrementAndGet();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -47,6 +47,7 @@ import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -69,6 +70,8 @@ public class MeteredSessionStore<K, V>
     private Sensor e2eLatencySensor;
     private InternalProcessorContext<?, ?> context;
     private TaskId taskId;
+
+    private AtomicInteger numOpenIterators = new AtomicInteger(0);
 
     @SuppressWarnings("rawtypes")
     private final Map<Class, QueryHandler> queryHandlers =
@@ -131,6 +134,8 @@ public class MeteredSessionStore<K, V>
         flushSensor = StateStoreMetrics.flushSensor(taskId.toString(), metricsScope, name(), streamsMetrics);
         removeSensor = StateStoreMetrics.removeSensor(taskId.toString(), metricsScope, name(), streamsMetrics);
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId.toString(), metricsScope, name(), streamsMetrics);
+        StateStoreMetrics.addNumOpenIteratorsGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
+                (config, now) -> numOpenIterators.get());
     }
 
 
@@ -248,7 +253,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time);
+            time,
+            numOpenIterators);
     }
 
     @Override
@@ -260,7 +266,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time
+            time,
+            numOpenIterators
         );
     }
 
@@ -273,7 +280,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time);
+            time,
+            numOpenIterators);
     }
 
     @Override
@@ -285,7 +293,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time
+            time,
+            numOpenIterators
         );
     }
 
@@ -304,7 +313,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time);
+            time,
+            numOpenIterators);
     }
 
     @Override
@@ -323,7 +333,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time
+            time,
+            numOpenIterators
         );
     }
 
@@ -344,7 +355,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time);
+            time,
+            numOpenIterators);
     }
 
     @Override
@@ -356,7 +368,8 @@ public class MeteredSessionStore<K, V>
                 streamsMetrics,
                 serdes::keyFrom,
                 serdes::valueFrom,
-                time);
+                time,
+                numOpenIterators);
     }
 
     @Override
@@ -377,7 +390,8 @@ public class MeteredSessionStore<K, V>
             streamsMetrics,
             serdes::keyFrom,
             serdes::valueFrom,
-            time
+            time,
+            numOpenIterators
         );
     }
 
@@ -447,7 +461,8 @@ public class MeteredSessionStore<K, V>
                         streamsMetrics,
                         serdes::keyFrom,
                         StoreQueryUtils.getDeserializeValue(serdes, wrapped()),
-                        time
+                        time,
+                        numOpenIterators
                     );
                 final QueryResult<MeteredWindowedKeyValueIterator<K, V>> typedQueryResult =
                     InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -325,6 +325,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
             this.valueAndTimestampDeserializer = valueAndTimestampDeserializer;
             this.startNs = time.nanoseconds();
             this.returnPlainValue = returnPlainValue;
+            numOpenIterators.incrementAndGet();
         }
 
         @Override
@@ -350,6 +351,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
                 iter.close();
             } finally {
                 sensor.record(time.nanoseconds() - startNs);
+                numOpenIterators.decrementAndGet();
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -264,7 +264,7 @@ public class MeteredVersionedKeyValueStore<K, V>
             final QueryResult<VersionedRecordIterator<byte[]>> rawResult = wrapped().query(rawKeyQuery, positionBound, config);
             if (rawResult.isSuccess()) {
                 final MeteredMultiVersionedKeyQueryIterator<V> typedResult =
-                        new MeteredMultiVersionedKeyQueryIterator<V>(rawResult.getResult(), StoreQueryUtils.getDeserializeValue(plainValueSerdes));
+                        new MeteredMultiVersionedKeyQueryIterator<V>(rawResult.getResult(), StoreQueryUtils.getDeserializeValue(plainValueSerdes), numOpenIterators);
                 final QueryResult<MeteredMultiVersionedKeyQueryIterator<V>> typedQueryResult =
                         InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);
                 result = (QueryResult<R>) typedQueryResult;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals.metrics;
 
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -143,6 +144,10 @@ public class StateStoreMetrics {
         AVG_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_SIZE_DESCRIPTION;
     private static final String SUPPRESSION_BUFFER_SIZE_MAX_DESCRIPTION =
         MAX_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_SIZE_DESCRIPTION;
+
+    private static final String NUM_OPEN_ITERATORS = "num-open-iterators";
+    private static final String NUM_OPEN_ITERATORS_DESCRIPTION =
+            "The current number of Iterators on the store that have been created, but not yet closed";
 
     public static Sensor putSensor(final String taskId,
                                    final String storeType,
@@ -402,6 +407,23 @@ public class StateStoreMetrics {
             RECORD_E2E_LATENCY_MAX_DESCRIPTION
         );
         return sensor;
+    }
+
+    public static void addNumOpenIteratorsGauge(final String taskId,
+                                                final String storeType,
+                                                final String storeName,
+                                                final StreamsMetricsImpl streamsMetrics,
+                                                final Gauge<Integer> numOpenIteratorsGauge) {
+        streamsMetrics.addStoreLevelMutableMetric(
+                taskId,
+                storeType,
+                storeName,
+                NUM_OPEN_ITERATORS,
+                NUM_OPEN_ITERATORS_DESCRIPTION,
+                RecordingLevel.INFO,
+                numOpenIteratorsGauge
+        );
+
     }
 
     private static Sensor sizeOrCountSensor(final String taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -147,7 +147,7 @@ public class StateStoreMetrics {
 
     private static final String NUM_OPEN_ITERATORS = "num-open-iterators";
     private static final String NUM_OPEN_ITERATORS_DESCRIPTION =
-            "The current number of Iterators on the store that have been created, but not yet closed";
+            "The current number of iterators on the store that have been created, but not yet closed";
 
     public static Sensor putSensor(final String taskId,
                                    final String storeType,


### PR DESCRIPTION
Part of [KIP-989](https://cwiki.apache.org/confluence/x/9KCzDw).

This new `StateStore` metric tracks the number of `Iterator` instances that have been created, but not yet closed (via
`AutoCloseable#close()`).

This will aid users in detecting leaked iterators, which can cause major performance problems.