### PR TITLE
KAFKA-16544 DescribeTopicsResult#allTopicIds and DescribeTopicsResult#allTopicNames should return null instead of throwing NPE

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
@@ -128,6 +128,7 @@ public class DescribeTopicsResult {
      * Return a future which succeeds only if all the topic descriptions succeed.
      */
     private static <T> KafkaFuture<Map<T, TopicDescription>> all(Map<T, KafkaFuture<TopicDescription>> futures) {
+        if (futures == null) return null;
         KafkaFuture<Void> future = KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
         return future.
             thenApply(v -> {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/DescribeTopicsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/DescribeTopicsResultTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class DescribeTopicsResultTest {
+
+    @Test
+    public void testNullAllTopicNames() {
+        DescribeTopicsResult result = DescribeTopicsResult.ofTopicIds(Collections.singletonMap(
+                Uuid.randomUuid(), KafkaFuture.completedFuture(
+                        new TopicDescription("foo", false, Collections.emptyList()))));
+
+        Assertions.assertNull(result.allTopicNames());
+    }
+
+    @Test
+    public void testNullAllTopicIds() {
+        DescribeTopicsResult result = DescribeTopicsResult.ofTopicNames(Collections.singletonMap(
+                "foo", KafkaFuture.completedFuture(
+                        new TopicDescription("foo", false, Collections.emptyList()))));
+
+        Assertions.assertNull(result.allTopicIds());
+    }
+}


### PR DESCRIPTION
related to https://issues.apache.org/jira/browse/KAFKA-16544

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
