### PR TITLE
MINOR: use try-with resources in ClientMetricsManagerTest

### DIFF
--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -35,6 +35,9 @@ import org.apache.kafka.server.metrics.ClientMetricsConfigs;
 import org.apache.kafka.server.metrics.ClientMetricsInstance;
 import org.apache.kafka.server.metrics.ClientMetricsReceiverPlugin;
 import org.apache.kafka.server.metrics.ClientMetricsTestUtils;
+import org.apache.kafka.server.util.timer.SystemTimer;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,10 +47,10 @@ import org.slf4j.LoggerFactory;
 
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -73,6 +76,17 @@ public class ClientMetricsManagerTest {
     private Metrics kafkaMetrics;
     private ClientMetricsReceiverPlugin clientMetricsReceiverPlugin;
     private ClientMetricsManager clientMetricsManager;
+
+    @AfterAll
+    public static void ensureNoThreadLeak() throws InterruptedException {
+        TestUtils.waitForCondition(
+                () -> Thread.getAllStackTraces().keySet().stream()
+                    .map(Thread::getName)
+                    .noneMatch(t -> t.contains(ClientMetricsManager.CLIENT_METRICS_REAPER_THREAD_NAME) || t.contains(SystemTimer.SYSTEM_TIMER_THREAD_PREFIX)),
+                "Thread leak detected"
+        );
+
+    }
 
     @BeforeEach
     public void setUp() {
@@ -339,33 +353,34 @@ public class ClientMetricsManagerTest {
         // Create new client metrics manager which simulates a new server as it will not have any
         // last request information but request should succeed as subscription id should match
         // the one with new client instance.
-        Metrics kafkaMetrics = new Metrics();
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics)
+        ) {
 
-        PushTelemetryRequest pushRequest = new Builder(
-            new PushTelemetryRequestData()
-                .setClientInstanceId(response.data().clientInstanceId())
-                .setSubscriptionId(response.data().subscriptionId())
-                .setCompressionType(CompressionType.NONE.id)
-                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
+            PushTelemetryRequest pushRequest = new Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(response.data().clientInstanceId())
+                            .setSubscriptionId(response.data().subscriptionId())
+                            .setCompressionType(CompressionType.NONE.id)
+                            .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
-        PushTelemetryResponse pushResponse = newClientMetricsManager.processPushTelemetryRequest(
-            pushRequest, ClientMetricsTestUtils.requestContext());
+            PushTelemetryResponse pushResponse = newClientMetricsManager.processPushTelemetryRequest(
+                    pushRequest, ClientMetricsTestUtils.requestContext());
 
-        assertEquals(Errors.NONE, pushResponse.error());
+            assertEquals(Errors.NONE, pushResponse.error());
 
-        request = new GetTelemetrySubscriptionsRequest.Builder(
-            new GetTelemetrySubscriptionsRequestData().setClientInstanceId(clientInstanceId), true).build();
+            request = new GetTelemetrySubscriptionsRequest.Builder(
+                    new GetTelemetrySubscriptionsRequestData().setClientInstanceId(clientInstanceId), true).build();
 
-        response = newClientMetricsManager.processGetTelemetrySubscriptionRequest(
-            request, ClientMetricsTestUtils.requestContext());
+            response = newClientMetricsManager.processGetTelemetrySubscriptionRequest(
+                    request, ClientMetricsTestUtils.requestContext());
 
-        assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED, response.error());
-        // Should register 1 throttle metric.
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
-        assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-rate").metricValue() > 0);
-        newClientMetricsManager.close();
-        kafkaMetrics.close();
+            assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED, response.error());
+            // Should register 1 throttle metric.
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
+            assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-rate").metricValue() > 0);
+        }
     }
 
     @Test
@@ -578,33 +593,34 @@ public class ClientMetricsManagerTest {
         // Create new client metrics manager which simulates a new server as it will not have any
         // client instance information but request should succeed as subscription id should match
         // the one with new client instance.
-        Metrics kafkaMetrics = new Metrics();
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics)
+        ) {
 
-        PushTelemetryRequest request = new PushTelemetryRequest.Builder(
-            new PushTelemetryRequestData()
-                .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
-                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
+            PushTelemetryRequest request = new PushTelemetryRequest.Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                            .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
-        PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
-            request, ClientMetricsTestUtils.requestContext());
+            PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
+                    request, ClientMetricsTestUtils.requestContext());
 
-        assertEquals(Errors.NONE, response.error());
-        // Validate metrics should have instance count metric, kafka metrics count and 4 sensors with 10 metrics
-        // registered i.e. 12 metrics.
-        assertEquals(12, kafkaMetrics.metrics().size());
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "-count").metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
-        // Should have 1 successful export and 0 error metrics.
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
-        // Should not have default NaN value, must register actual export time metrics.
-        assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
-        assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
-        newClientMetricsManager.close();
-        kafkaMetrics.close();
+            assertEquals(Errors.NONE, response.error());
+            // Validate metrics should have instance count metric, kafka metrics count and 4 sensors with 10 metrics
+            // registered i.e. 12 metrics.
+            assertEquals(12, kafkaMetrics.metrics().size());
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "-count").metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
+            // Should have 1 successful export and 0 error metrics.
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
+            // Should not have default NaN value, must register actual export time metrics.
+            assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
+            assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
+        }
     }
 
     @Test
@@ -870,37 +886,38 @@ public class ClientMetricsManagerTest {
 
     @Test
     public void testPushTelemetryMetricsTooLarge() throws Exception {
-        Metrics kafkaMetrics = new Metrics();
-        ClientMetricsManager clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 1, time, kafkaMetrics);
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 1, time, kafkaMetrics)
+        ) {
 
-        GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
-            new GetTelemetrySubscriptionsRequestData(), true).build();
+            GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
+                    new GetTelemetrySubscriptionsRequestData(), true).build();
 
-        GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
-            subscriptionsRequest, ClientMetricsTestUtils.requestContext());
+            GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
+                    subscriptionsRequest, ClientMetricsTestUtils.requestContext());
 
-        ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
-        assertNotNull(instance);
+            ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
+            assertNotNull(instance);
 
-        byte[] metrics = "ab".getBytes(StandardCharsets.UTF_8);
-        assertEquals(2, metrics.length);
+            byte[] metrics = "ab".getBytes(StandardCharsets.UTF_8);
+            assertEquals(2, metrics.length);
 
-        PushTelemetryRequest request = new PushTelemetryRequest.Builder(
-            new PushTelemetryRequestData()
-                .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
-                .setMetrics(metrics), true).build();
+            PushTelemetryRequest request = new PushTelemetryRequest.Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                            .setMetrics(metrics), true).build();
 
-        // Set the max bytes 1 to force the error.
-        PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
-            request, ClientMetricsTestUtils.requestContext());
+            // Set the max bytes 1 to force the error.
+            PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
+                    request, ClientMetricsTestUtils.requestContext());
 
-        // Should not report any error though no metrics will be exported.
-        assertEquals(Errors.TELEMETRY_TOO_LARGE, response.error());
-        assertFalse(instance.terminating());
-        assertEquals(Errors.TELEMETRY_TOO_LARGE, instance.lastKnownError());
-        clientMetricsManager.close();
-        kafkaMetrics.close();
+            // Should not report any error though no metrics will be exported.
+            assertEquals(Errors.TELEMETRY_TOO_LARGE, response.error());
+            assertFalse(instance.terminating());
+            assertEquals(Errors.TELEMETRY_TOO_LARGE, instance.lastKnownError());
+        }
     }
 
     @Test
@@ -924,58 +941,59 @@ public class ClientMetricsManagerTest {
         CountDownLatch lock = new CountDownLatch(2);
         List<PushTelemetryResponse> responses = Collections.synchronizedList(new ArrayList<>());
 
-        Metrics kafkaMetrics = new Metrics();
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
+        ) {
 
-        Thread thread = new Thread(() -> {
-            try {
-                PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
-                    request, ClientMetricsTestUtils.requestContext());
-                responses.add(response);
-            } catch (UnknownHostException e) {
-                LOG.error("Error processing request", e);
-            } finally {
-                lock.countDown();
+            Thread thread = new Thread(() -> {
+                try {
+                    PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
+                            request, ClientMetricsTestUtils.requestContext());
+                    responses.add(response);
+                } catch (UnknownHostException e) {
+                    LOG.error("Error processing request", e);
+                } finally {
+                    lock.countDown();
+                }
+            });
+
+            Thread thread1 = new Thread(() -> {
+                try {
+                    PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
+                            request, ClientMetricsTestUtils.requestContext());
+                    responses.add(response);
+                } catch (UnknownHostException e) {
+                    LOG.error("Error processing request", e);
+                } finally {
+                    lock.countDown();
+                }
+            });
+
+            thread.start();
+            thread1.start();
+
+            assertTrue(lock.await(2000, TimeUnit.MILLISECONDS));
+            assertEquals(2, responses.size());
+
+            int throttlingErrorCount = 0;
+            for (PushTelemetryResponse response : responses) {
+                if (response.error() == Errors.THROTTLING_QUOTA_EXCEEDED) {
+                    throttlingErrorCount++;
+                } else {
+                    assertEquals(Errors.NONE, response.error());
+                }
             }
-        });
-
-        Thread thread1 = new Thread(() -> {
-            try {
-                PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
-                    request, ClientMetricsTestUtils.requestContext());
-                responses.add(response);
-            } catch (UnknownHostException e) {
-                LOG.error("Error processing request", e);
-            } finally {
-                lock.countDown();
-            }
-        });
-
-        thread.start();
-        thread1.start();
-
-        assertTrue(lock.await(2000, TimeUnit.MILLISECONDS));
-        assertEquals(2, responses.size());
-
-        int throttlingErrorCount = 0;
-        for (PushTelemetryResponse response : responses) {
-            if (response.error() == Errors.THROTTLING_QUOTA_EXCEEDED) {
-                throttlingErrorCount++;
-            } else {
-                assertEquals(Errors.NONE, response.error());
-            }
+            // 1 request should fail with throttling error.
+            assertEquals(1, throttlingErrorCount);
+            // Metrics should report 1 export and 1 throttle error.
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
+            assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-rate").metricValue() > 0);
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
+            assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
+            assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
         }
-        // 1 request should fail with throttling error.
-        assertEquals(1, throttlingErrorCount);
-        // Metrics should report 1 export and 1 throttle error.
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
-        assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-rate").metricValue() > 0);
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
-        assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
-        assertNotEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
-        newClientMetricsManager.close();
-        kafkaMetrics.close();
     }
 
     @Test
@@ -1059,45 +1077,46 @@ public class ClientMetricsManagerTest {
         ClientMetricsReceiverPlugin receiverPlugin = Mockito.mock(ClientMetricsReceiverPlugin.class);
         Mockito.doThrow(new RuntimeException("test exception")).when(receiverPlugin).exportMetrics(Mockito.any(), Mockito.any());
 
-        Metrics kafkaMetrics = new Metrics();
-        ClientMetricsManager clientMetricsManager = new ClientMetricsManager(receiverPlugin, 100, time, 100, kafkaMetrics);
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager clientMetricsManager = new ClientMetricsManager(receiverPlugin, 100, time, 100, kafkaMetrics)
+        ) {
 
-        clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultProperties());
-        assertEquals(1, clientMetricsManager.subscriptions().size());
+            clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultProperties());
+            assertEquals(1, clientMetricsManager.subscriptions().size());
 
-        GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
-            new GetTelemetrySubscriptionsRequestData(), true).build();
+            GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
+                    new GetTelemetrySubscriptionsRequestData(), true).build();
 
-        GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
-            subscriptionsRequest, ClientMetricsTestUtils.requestContext());
+            GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
+                    subscriptionsRequest, ClientMetricsTestUtils.requestContext());
 
-        ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
-        assertNotNull(instance);
+            ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
+            assertNotNull(instance);
 
-        PushTelemetryRequest request = new Builder(
-            new PushTelemetryRequestData()
-                .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
-                .setCompressionType(CompressionType.NONE.id)
-                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
+            PushTelemetryRequest request = new Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                            .setCompressionType(CompressionType.NONE.id)
+                            .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
-        PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
-            request, ClientMetricsTestUtils.requestContext());
+            PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
+                    request, ClientMetricsTestUtils.requestContext());
 
-        assertEquals(Errors.INVALID_RECORD, response.error());
-        assertFalse(instance.terminating());
-        assertEquals(Errors.INVALID_RECORD, instance.lastKnownError());
-        // Metrics should report 1 plugin export error and 0 successful export.
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "-count").metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
-        assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
-        assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
-        assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-rate").metricValue() > 0);
-        // Should have default NaN value, must not register export time.
-        assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
-        assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
-        clientMetricsManager.close();
-        kafkaMetrics.close();
+            assertEquals(Errors.INVALID_RECORD, response.error());
+            assertFalse(instance.terminating());
+            assertEquals(Errors.INVALID_RECORD, instance.lastKnownError());
+            // Metrics should report 1 plugin export error and 0 successful export.
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "-count").metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.THROTTLE + "-count").metricValue());
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
+            assertTrue((double) getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-rate").metricValue() > 0);
+            // Should have default NaN value, must not register export time.
+            assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
+            assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
+        }
     }
 
     @Test


### PR DESCRIPTION
Ensures we close resources even if an exception is thrown within a test. Also added an `@AfterAll` to ensure threads aren't leaked from the test class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
