### PR TITLE
KAFKA-12399: Deprecate KafkaLog4jAppender

### DIFF
--- a/log4j-appender/src/main/java/org/apache/kafka/log4jappender/KafkaLog4jAppender.java
+++ b/log4j-appender/src/main/java/org/apache/kafka/log4jappender/KafkaLog4jAppender.java
@@ -55,8 +55,11 @@ import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_
 import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
 
 /**
- * A log4j appender that produces log messages to Kafka
+ * A log4j appender that produces log messages to Kafka.
+ * This appender is deprecated and users should migrate to the log4j2 appender
+ * @see <a href="https://logging.apache.org/log4j/2.x/manual/appenders.html#KafkaAppender">KafkaAppender</a>
  */
+@Deprecated
 public class KafkaLog4jAppender extends AppenderSkeleton {
 
     private String brokerList;
@@ -337,6 +340,7 @@ public class KafkaLog4jAppender extends AppenderSkeleton {
         props.put(KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.put(VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         this.producer = getKafkaProducer(props);
+        LogLog.warn("log4j-appender is deprecated and will be removed in Kafka 4.0.");
         LogLog.debug("Kafka producer connected to " + brokerList);
         LogLog.debug("Logging for topic: " + topic);
     }

--- a/log4j-appender/src/test/java/org/apache/kafka/log4jappender/MockKafkaLog4jAppender.java
+++ b/log4j-appender/src/test/java/org/apache/kafka/log4jappender/MockKafkaLog4jAppender.java
@@ -25,6 +25,7 @@ import org.apache.log4j.spi.LoggingEvent;
 import java.util.List;
 import java.util.Properties;
 
+@SuppressWarnings("deprecation")
 public class MockKafkaLog4jAppender extends KafkaLog4jAppender {
     private MockProducer<byte[], byte[]> mockProducer =
             new MockProducer<>(false, new MockSerializer(), new MockSerializer());


### PR DESCRIPTION
As per KIP-719, KafkaLog4jAppender is now deprecated and will be removed in Kafka 4.0. Users should migrate to the log4j2 Kafka Appender

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
