### PR TITLE
MINOR: fix flaky testRecordThreadIdleRatio

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -112,9 +112,6 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      */
     private class EventProcessorThread extends Thread {
         private final Logger log;
-        private long pollStartMs;
-        private long timeSinceLastPollMs;
-        private long lastPollMs;
 
         EventProcessorThread(
             String name

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -62,9 +62,7 @@ public class MultiThreadedEventProcessorTest {
         @Override
         public CoordinatorEvent take() {
             CoordinatorEvent event = super.take();
-            if (event != null) {
-                time.sleep(takeDelayMs);
-            }
+            time.sleep(takeDelayMs);
             return event;
         }
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -61,8 +61,11 @@ public class MultiThreadedEventProcessorTest {
 
         @Override
         public CoordinatorEvent take() {
-            time.sleep(takeDelayMs);
-            return super.take();
+            CoordinatorEvent event = super.take();
+            if (event != null) {
+                time.sleep(takeDelayMs);
+            }
+            return event;
         }
     }
 
@@ -475,9 +478,7 @@ public class MultiThreadedEventProcessorTest {
             doAnswer(invocation -> {
                 long threadIdleTime = idleTimeCaptured.getValue();
                 assertEquals(100, threadIdleTime);
-                synchronized (recordedIdleTimesMs) {
-                    recordedIdleTimesMs.add(threadIdleTime);
-                }
+                recordedIdleTimesMs.add(threadIdleTime);
                 return null;
             }).when(mockRuntimeMetrics).recordThreadIdleTime(idleTimeCaptured.capture());
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -478,6 +478,8 @@ public class MultiThreadedEventProcessorTest {
             doAnswer(invocation -> {
                 long threadIdleTime = idleTimeCaptured.getValue();
                 assertEquals(100, threadIdleTime);
+
+                // No synchronization required as the test uses a single event processor thread.
                 recordedIdleTimesMs.add(threadIdleTime);
                 return null;
             }).when(mockRuntimeMetrics).recordThreadIdleTime(idleTimeCaptured.capture());


### PR DESCRIPTION
DelayEventAccumulator should return immediately if there are no events in the queue. Also removed some unused fields inside EventProcessorThread

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
