### PR TITLE
MINOR: fix incorrect formatter package in streams quickstart

### DIFF
--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -200,7 +200,6 @@ and inspect the output of the WordCount demo application by reading from its out
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -223,7 +222,6 @@ This message will be processed by the Wordcount application and the following ou
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -252,7 +250,6 @@ In your other terminal in which the console consumer is running, you will observ
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -283,7 +280,6 @@ The <b>streams-wordcount-output</b> topic will subsequently show the correspondi
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -200,7 +200,7 @@ and inspect the output of the WordCount demo application by reading from its out
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter kafka.tools.DefaultMessageFormatter \
+    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -223,7 +223,7 @@ This message will be processed by the Wordcount application and the following ou
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter kafka.tools.DefaultMessageFormatter \
+    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -252,7 +252,7 @@ In your other terminal in which the console consumer is running, you will observ
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter kafka.tools.DefaultMessageFormatter \
+    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
@@ -283,7 +283,7 @@ The <b>streams-wordcount-output</b> topic will subsequently show the correspondi
 <pre class="line-numbers"><code class="language-bash">&gt; bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
     --topic streams-wordcount-output \
     --from-beginning \
-    --formatter kafka.tools.DefaultMessageFormatter \
+    --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter \
     --property print.key=true \
     --property print.value=true \
     --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \


### PR DESCRIPTION
https://github.com/apache/kafka/commit/0bf830fc9c3915bc99b6e487e6083dabd593c5d3 moved DefaultMessageFormatter package from `kafka.tools` to `org.apache.kafka.tools.consumer`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
