### PR TITLE
MINOR: Add a constructor to accept cause in ConfigException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigException.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigException.java
@@ -33,6 +33,10 @@ public class ConfigException extends KafkaException {
         this(name, value, null);
     }
 
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public ConfigException(String name, Object value, String message) {
         super("Invalid value " + value + " for configuration " + name + (message == null ? "" : ": " + message));
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -185,7 +185,7 @@ public class SslFactory implements Reconfigurable, Closeable {
             return newSslEngineFactory;
         } catch (Exception e) {
             log.debug("Validation of dynamic config update of SSLFactory failed.", e);
-            throw new ConfigException("Validation of dynamic config update of SSLFactory failed: " + e);
+            throw new ConfigException("Validation of dynamic config update of SSLFactory failed", e);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -279,7 +279,7 @@ public class RetryWithToleranceOperator<T> implements AutoCloseable {
             case ALL:
                 return true;
             default:
-                throw new ConfigException("Unknown tolerance type: {}", errorToleranceType);
+                throw new ConfigException("errorToleranceType", errorToleranceType, "Unknown tolerance type");
         }
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
@@ -216,7 +216,7 @@ public class QuorumConfig {
         @Override
         public void ensureValid(String name, Object value) {
             if (value == null) {
-                throw new ConfigException(name, null);
+                throw new ConfigException(name, null, null);
             }
 
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
ConfigException's constructor doesn't follow the usual convention of accepting a `Throwable` as a cause. Instead, the constructor accepts an Object type for the config's value and crafts a message using it.

This makes it difficult to debug cases where the cause would prove useful. As an example, consider the flakey test in `DynamicBrokerReconfigurationTest::testTrustStoreAlter` [[0]] which masks the cause of the certificate validation failure.

Since the existing constructor is public, this change introduces another constructor which accepts a `Throwable` as the second argument. JLS §15.12.2.5 [[1]] ensures the more specific constructor is chosen. Caution must be taken when passing `null` as the value of the second argument as the constructor with `Throwable` as the second argument would be invoked since it's more specific [[2]].

[0]: https://ge.apache.org/s/bhdpknkevz37g/tests/task/:core:test/details/kafka.server.DynamicBrokerReconfigurationTest/testTrustStoreAlter(String)%5B2%5D?expanded-stacktrace=WyIwIl0&top-execution=1
[1]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.5
[2]: https://stackoverflow.com/a/1572499

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
