### PR TITLE
MINOR: ensure KafkaServerTestHarness::tearDown is always invoked

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -220,16 +220,18 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
 
   @AfterEach
   override def tearDown(): Unit = {
-    producers.foreach(_.close(Duration.ZERO))
-    consumers.foreach(_.wakeup())
-    consumers.foreach(_.close(Duration.ZERO))
-    adminClients.foreach(_.close(Duration.ZERO))
+    try {
+      producers.foreach(_.close(Duration.ZERO))
+      consumers.foreach(_.wakeup())
+      consumers.foreach(_.close(Duration.ZERO))
+      adminClients.foreach(_.close(Duration.ZERO))
 
-    producers.clear()
-    consumers.clear()
-    adminClients.clear()
-
-    super.tearDown()
+      producers.clear()
+      consumers.clear()
+      adminClients.clear()
+    } finally {
+      super.tearDown()
+    }
   }
 
 }


### PR DESCRIPTION
An exception thrown while closing the client instances in `IntegrationTestHarness::tearDown` may result in
`KafkaServerTestHarness::tearDown` not being invoked. This would result in thread leaks of the broker and controller threads spawned in the failing test.

An example of this is the [CI
run](https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-15994/1/tests) for #15994 where
`Build / JDK 8 and Scala 2.12 / testCoordinatorFailover(String, String).quorum=kraft+kip848.groupProtocol=consumer – kafka.api.PlaintextConsumerTest` failing results in `consumers.foreach(_.close(Duration.ZERO))` in `IntegrationTestHarness::tearDown` throwing an exception.

A side effect of this is it poisons Gradle test runner JVM and prevents tests in other unrelated classes from executing as `@BeforeAll` check in QuorumTestHarness would cause them to fail immediately.

This PR encloses the client closure in try-finally to ensure `KafkaServerTestHarness::tearDown` is always invoked.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
