### PR TITLE
KAFKA-16797: A bit cleanup of FeatureControlManager

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -59,12 +59,12 @@ public class FeatureControlManager {
         private ClusterFeatureSupportDescriber clusterSupportDescriber = new ClusterFeatureSupportDescriber() {
             @Override
             public Iterator<Entry<Integer, Map<String, VersionRange>>> brokerSupported() {
-                return Collections.<Integer, Map<String, VersionRange>>emptyMap().entrySet().iterator();
+                return Collections.emptyIterator();
             }
 
             @Override
             public Iterator<Entry<Integer, Map<String, VersionRange>>> controllerSupported() {
-                return Collections.<Integer, Map<String, VersionRange>>emptyMap().entrySet().iterator();
+                return Collections.emptyIterator();
             }
         };
 


### PR DESCRIPTION
Clean up `brokerSupported` and `controllerSupported` method by using `Collections.emptyIterator()`