### PR TITLE
KAFKA-9228: Restart tasks on runtime-only connector config changes

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -580,7 +580,6 @@
       <!-- for annotations to avoid code duplication -->
       <allow pkg="com.fasterxml.jackson.annotation" />
       <allow pkg="com.fasterxml.jackson.databind" />
-      <allow pkg="com.fasterxml.jackson.databind" />
       <subpackage name="clusters">
         <allow pkg="org.apache.kafka.server.config" />
         <allow pkg="kafka.cluster" />

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -580,6 +580,7 @@
       <!-- for annotations to avoid code duplication -->
       <allow pkg="com.fasterxml.jackson.annotation" />
       <allow pkg="com.fasterxml.jackson.databind" />
+      <allow pkg="com.fasterxml.jackson.databind" />
       <subpackage name="clusters">
         <allow pkg="org.apache.kafka.server.config" />
         <allow pkg="kafka.cluster" />

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -534,6 +534,8 @@
       <allow pkg="javax.crypto"/>
       <allow pkg="org.eclipse.jetty.util" />
       <allow pkg="org.apache.log4j" />
+      <allow pkg="com.fasterxml.jackson.databind" />
+      <allow pkg="javax.ws.rs.core" />
 
       <subpackage name="rest">
         <allow pkg="org.eclipse.jetty" />

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -1051,7 +1051,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             log.debug("Connector {} task count changed from {} to {}", connName, currentNumTasks, taskProps.size());
             result = true;
         } else {
-            for (int index = 0; index < currentNumTasks && !result; index++) {
+            for (int index = 0; index < currentNumTasks; index++) {
                 ConnectorTaskId taskId = new ConnectorTaskId(connName, index);
                 if (!taskProps.get(index).equals(configState.taskConfig(taskId))) {
                     log.debug("Connector {} has change in configuration for task {}-{}", connName, connName, index);
@@ -1066,9 +1066,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 if (storedConnectorConfigHash == null) {
                     log.debug("Connector {} has no config hash stored for its existing tasks", connName);
                 } else if (storedConnectorConfigHash != connectorConfigHash) {
-                    log.debug(
-                            "Connector {} has change in config hash ({}) for tasks ({})",
-                            connName, connectorConfigHash, storedConnectorConfigHash
+                    log.debug("Connector {} has change in config hash for tasks", connName);
+                    log.trace(
+                            "Connector {} previous config hash: {} new config hash: {}",
+                            connName, storedConnectorConfigHash, connectorConfigHash
                     );
                     result = true;
                 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConfigHash.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConfigHash.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.runtime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.util.ConnectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A deterministic hash of a connector configuration. This can be used to detect changes
+ * in connector configurations across worker lifetimes, which is sometimes necessary when
+ * connectors are reconfigured in a way that affects their tasks' runtime behavior but does
+ * not affect their tasks' configurations (for example, changing the key converter class).
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/KAFKA-9228">KAFKA-9228</a>
+ */
+public class ConfigHash {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigHash.class);
+
+    public static final ConfigHash NO_HASH = new ConfigHash(null);
+    public static final String CONNECTOR_CONFIG_HASH_HEADER = "X-Connect-Connector-Config-Hash";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final Integer hash;
+
+    // Visible for testing
+    ConfigHash(Integer hash) {
+        this.hash = hash;
+    }
+
+    /**
+     * Read and parse a hash from the headers of a REST request.
+     *
+     * @param connector the name of the connector; only used for error logging
+     *                  purposes and may be null
+     * @param headers the headers from which to read and parse the hash;
+     *                may be null
+     *
+     * @return the parsed hash; never null, but may be {@link #NO_HASH} if
+     * no hash header is present
+     *
+     * @throws ConnectException if the expected header is present for the hash,
+     * but it cannot be parsed as a 32-bit signed integer
+     */
+    public static ConfigHash fromHeaders(String connector, HttpHeaders headers) {
+        if (headers == null)
+            return NO_HASH;
+
+        String header = headers.getHeaderString(CONNECTOR_CONFIG_HASH_HEADER);
+        if (header == null)
+            return NO_HASH;
+
+        int hash;
+        try {
+            hash = Integer.parseInt(header);
+        } catch (NumberFormatException e) {
+            if (connector == null)
+                connector = "<unknown>";
+
+            if (log.isTraceEnabled()) {
+                log.error("Invalid connector config hash header for connector {}", connector);
+                log.trace("Invalid connector config hash header for connector {}: '{}'", connector, header);
+            } else {
+                log.error(
+                        "Invalid connector config hash header for connector {}. "
+                                + "Please enable TRACE logging to see the invalid value",
+                        connector
+                );
+            }
+            throw new ConnectException("Invalid hash header; expected a 32-bit signed integer");
+        }
+        return new ConfigHash(hash);
+    }
+
+    /**
+     * Generate a deterministic hash from the config. For configurations
+     * with identical key-value pairs, this hash will always be the same, and
+     * {@link #shouldUpdateTasks(ConfigHash, ConfigHash)} will return {@code false}
+     * for any two such configurations. Note that, for security reasons, those
+     * {@link ConfigHash} instances will still not {@link #equals(Object) equal}
+     * each other.
+     *
+     * @param config the configuration to hash; may be null
+     *
+     * @return the resulting hash; may be {@link #NO_HASH} if the configuration
+     * was null
+     *
+     * @throws ConnectException if the configuration cannot be serialized to JSON
+     * for the purposes of hashing
+     */
+    public static ConfigHash fromConfig(Map<String, String> config) {
+        if (config == null)
+            return NO_HASH;
+
+        Map<String, String> toHash = new TreeMap<>(config);
+
+        byte[] serialized;
+        try {
+            serialized = OBJECT_MAPPER.writeValueAsBytes(toHash);
+        } catch (IOException e) {
+            throw new ConnectException(
+                    "Unable to serialize connector config contents for hashing",
+                    e
+            );
+        }
+
+        int hash = Utils.murmur2(serialized);
+        return new ConfigHash(hash);
+    }
+
+    /**
+     * Read and parse the hash from the headers of a REST request.
+     *
+     * @param map the map to read the hash field from; may be null
+     * @param field the field to read and parse; may be null
+     *
+     * @return the parsed hash; never null, but may be {@link #NO_HASH} if
+     * the map is null or the field is not present in the map
+     *
+     * @throws ConnectException if the expected field is present for the hash,
+     * but it cannot be parsed as a 32-bit signed integer
+     */
+    public static ConfigHash fromMap(Map<String, ?> map, String field) {
+        if (map == null)
+            return NO_HASH;
+
+        Object rawHash = map.get(field);
+        if (rawHash == null)
+            return NO_HASH;
+
+        int hash = ConnectUtils.intValue(rawHash);
+        return new ConfigHash(hash);
+    }
+
+    /**
+     * Determine whether tasks should be restarted based on a previously-stored
+     * hash, and the hash for a connector config that was used to generate new task configs
+     *
+     * @param previous the previously-stored config hash for the connector
+     * @param current the hash of the connector config which led to newly-generated
+     *                task configs
+     *
+     * @return whether a restart of the connector's tasks should be forced, possibly to
+     * pick up runtime-controlled configuration changes that would otherwise be dropped
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/KAFKA-9228">KAFKA-9228</a>
+     */
+    public static boolean shouldUpdateTasks(ConfigHash previous, ConfigHash current) {
+        if (previous == null || current == null)
+            return false;
+
+        return previous.exists() && !previous.matches(current);
+    }
+
+    /**
+     * Insert this hash (if it {@link #exists() exists}) into a {@link Struct} with the desired field name.
+     *
+     * @param struct the struct to add the hash to; may be null, in which case
+     *               this method becomes a no-op
+     * @param field the name of the field to add the hash under; may be null,
+     *              in which case this method becomes a no-op
+     */
+    public void addToStruct(Struct struct, String field) {
+        if (hash == null || struct == null || field == null)
+            return;
+        struct.put(field, hash);
+    }
+
+    /**
+     * Add this hash (if it {@link #exists() exists}) to a map of HTTP headers
+     *
+     * @param headers the headers map to add this hash to; may be null, in which case
+     *                this method becomes a no-op
+     */
+    public void addToHeaders(Map<String, String> headers) {
+        if (headers == null || !exists())
+            return;
+
+        headers.put(CONNECTOR_CONFIG_HASH_HEADER, Integer.toString(hash));
+    }
+
+    /**
+     * @return whether a hash for this config was found
+     */
+    public boolean exists() {
+        return hash != null;
+    }
+
+    @Override
+    public String toString() {
+        // DO NOT OVERRIDE THIS METHOD; config hashes should not be logged
+        return "<config hash>";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // DO NOT OVERRIDE THIS METHOD; may leak the hash value and/or break
+        // the hashCode/equals contract
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        // DO NOT OVERRIDE THIS METHOD; may leak the hash value
+        return super.hashCode();
+    }
+
+    /**
+     * Return whether this hash matches another hash. Should be used only in testing code.
+     *
+     * @param that the other hash to test against; may be null
+     *
+     * @return whether the two hashes are identical
+     */
+    // Visible for testing
+    boolean matches(ConfigHash that) {
+        return that != null && this.hash.equals(that.hash);
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -160,8 +160,16 @@ public interface Herder {
      * @param callback callback to invoke upon completion
      * @param requestSignature the signature of the request made for this task (re-)configuration;
      *                         may be null if no signature was provided
+     * @param configHash a hash of the connector config that was used to generate the task configs;
+     *                   never null, but may be {@link ConfigHash#NO_HASH} if no hash is available
      */
-    void putTaskConfigs(String connName, List<Map<String, String>> configs, Callback<Void> callback, InternalRequestSignature requestSignature);
+    void putTaskConfigs(
+            String connName,
+            List<Map<String, String>> configs,
+            Callback<Void> callback,
+            InternalRequestSignature requestSignature,
+            ConfigHash configHash
+    );
 
     /**
      * Fence out any older task generations for a source connector, and then write a record to the config topic

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.runtime.rest.resources;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
+import org.apache.kafka.connect.runtime.ConfigHash;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.distributed.Crypto;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
@@ -77,7 +78,13 @@ public abstract class InternalClusterResource {
             final byte[] requestBody) throws Throwable {
         List<Map<String, String>> taskConfigs = new ObjectMapper().readValue(requestBody, TASK_CONFIGS_TYPE);
         FutureCallback<Void> cb = new FutureCallback<>();
-        herderForRequest().putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(Crypto.SYSTEM, requestBody, headers));
+        herderForRequest().putTaskConfigs(
+                connector,
+                taskConfigs,
+                cb,
+                InternalRequestSignature.fromHeaders(Crypto.SYSTEM, requestBody, headers),
+                ConfigHash.fromHeaders(connector, headers)
+        );
         requestHandler.completeOrForwardRequest(
                 cb,
                 uriInfo.getPath(),

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -519,11 +519,13 @@ public class StandaloneHerder extends AbstractHerder {
         }
 
         List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
+        Map<String, String> connectorConfig = configState.connectorConfig(connName);
+        int configHash = ConnectUtils.configHash(connectorConfig);
 
-        if (taskConfigsChanged(configState, connName, newTaskConfigs)) {
+        if (taskConfigsChanged(configState, connName, newTaskConfigs, configHash)) {
             removeConnectorTasks(connName);
             List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
-            configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
+            configBackingStore.putTaskConfigs(connName, rawTaskConfigs, configHash);
             createConnectorTasks(connName);
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.errors.AlreadyExistsException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.AbstractHerder;
+import org.apache.kafka.connect.runtime.ConfigHash;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.HerderRequest;
@@ -306,7 +307,13 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
-    public void putTaskConfigs(String connName, List<Map<String, String>> configs, Callback<Void> callback, InternalRequestSignature requestSignature) {
+    public void putTaskConfigs(
+            String connName,
+            List<Map<String, String>> configs,
+            Callback<Void> callback,
+            InternalRequestSignature requestSignature,
+            ConfigHash configHash
+    ) {
         throw new UnsupportedOperationException("Kafka Connect in standalone mode does not support externally setting task configurations.");
     }
 
@@ -520,7 +527,7 @@ public class StandaloneHerder extends AbstractHerder {
 
         List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
         Map<String, String> connectorConfig = configState.connectorConfig(connName);
-        int configHash = ConnectUtils.configHash(connectorConfig);
+        ConfigHash configHash = ConfigHash.fromConfig(connectorConfig);
 
         if (taskConfigsChanged(configState, connName, newTaskConfigs, configHash)) {
             removeConnectorTasks(connName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
+import org.apache.kafka.connect.runtime.ConfigHash;
 import org.apache.kafka.connect.runtime.SessionKey;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.TargetState;
@@ -54,7 +55,7 @@ public class ClusterConfigState {
     final Map<String, Map<String, String>> connectorConfigs;
     final Map<String, TargetState> connectorTargetStates;
     final Map<ConnectorTaskId, Map<String, String>> taskConfigs;
-    final Map<String, Integer> taskConfigHashses;
+    final Map<String, ConfigHash> taskConfigHashses;
     final Map<String, Integer> connectorTaskCountRecords;
     final Map<String, Integer> connectorTaskConfigGenerations;
     final Set<String> connectorsPendingFencing;
@@ -66,7 +67,7 @@ public class ClusterConfigState {
                               Map<String, Map<String, String>> connectorConfigs,
                               Map<String, TargetState> connectorTargetStates,
                               Map<ConnectorTaskId, Map<String, String>> taskConfigs,
-                              Map<String, Integer> taskConfigHashses,
+                              Map<String, ConfigHash> taskConfigHashses,
                               Map<String, Integer> connectorTaskCountRecords,
                               Map<String, Integer> connectorTaskConfigGenerations,
                               Set<String> connectorsPendingFencing,
@@ -91,7 +92,7 @@ public class ClusterConfigState {
                               Map<String, Map<String, String>> connectorConfigs,
                               Map<String, TargetState> connectorTargetStates,
                               Map<ConnectorTaskId, Map<String, String>> taskConfigs,
-                              Map<String, Integer> taskConfigHashses,
+                              Map<String, ConfigHash> taskConfigHashses,
                               Map<String, Integer> connectorTaskCountRecords,
                               Map<String, Integer> connectorTaskConfigGenerations,
                               Set<String> connectorsPendingFencing,
@@ -197,11 +198,11 @@ public class ClusterConfigState {
      * Get the hash of the connector config that was used to generate the
      * latest set of task configs for the connector
      * @param connectorName name of the connector
-     * @return the config hash, or null if the connector does not exist or
-     * no config hash for its latest set of tasks has been stored
+     * @return the config hash; never null, but may be {@link ConfigHash#NO_HASH}
+     * if the connector does not exist or no config hash for its latest set of tasks has been stored
      */
-    public Integer taskConfigHash(String connectorName) {
-        return taskConfigHashses.get(connectorName);
+    public ConfigHash taskConfigHash(String connectorName) {
+        return taskConfigHashses.getOrDefault(connectorName, ConfigHash.NO_HASH);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
@@ -43,6 +43,7 @@ public class ClusterConfigState {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             Collections.emptySet(),
             Collections.emptySet());
 
@@ -53,6 +54,7 @@ public class ClusterConfigState {
     final Map<String, Map<String, String>> connectorConfigs;
     final Map<String, TargetState> connectorTargetStates;
     final Map<ConnectorTaskId, Map<String, String>> taskConfigs;
+    final Map<String, Integer> taskConfigHashses;
     final Map<String, Integer> connectorTaskCountRecords;
     final Map<String, Integer> connectorTaskConfigGenerations;
     final Set<String> connectorsPendingFencing;
@@ -64,6 +66,7 @@ public class ClusterConfigState {
                               Map<String, Map<String, String>> connectorConfigs,
                               Map<String, TargetState> connectorTargetStates,
                               Map<ConnectorTaskId, Map<String, String>> taskConfigs,
+                              Map<String, Integer> taskConfigHashses,
                               Map<String, Integer> connectorTaskCountRecords,
                               Map<String, Integer> connectorTaskConfigGenerations,
                               Set<String> connectorsPendingFencing,
@@ -74,6 +77,7 @@ public class ClusterConfigState {
                 connectorConfigs,
                 connectorTargetStates,
                 taskConfigs,
+                taskConfigHashses,
                 connectorTaskCountRecords,
                 connectorTaskConfigGenerations,
                 connectorsPendingFencing,
@@ -87,6 +91,7 @@ public class ClusterConfigState {
                               Map<String, Map<String, String>> connectorConfigs,
                               Map<String, TargetState> connectorTargetStates,
                               Map<ConnectorTaskId, Map<String, String>> taskConfigs,
+                              Map<String, Integer> taskConfigHashses,
                               Map<String, Integer> connectorTaskCountRecords,
                               Map<String, Integer> connectorTaskConfigGenerations,
                               Set<String> connectorsPendingFencing,
@@ -97,6 +102,7 @@ public class ClusterConfigState {
         this.connectorTaskCounts = connectorTaskCounts;
         this.connectorConfigs = connectorConfigs;
         this.connectorTargetStates = connectorTargetStates;
+        this.taskConfigHashses = taskConfigHashses;
         this.taskConfigs = taskConfigs;
         this.connectorTaskCountRecords = connectorTaskCountRecords;
         this.connectorTaskConfigGenerations = connectorTaskConfigGenerations;
@@ -185,6 +191,17 @@ public class ClusterConfigState {
 
     public Map<String, String> rawTaskConfig(ConnectorTaskId task) {
         return taskConfigs.get(task);
+    }
+
+    /**
+     * Get the hash of the connector config that was used to generate the
+     * latest set of task configs for the connector
+     * @param connectorName name of the connector
+     * @return the config hash, or null if the connector does not exist or
+     * no config hash for its latest set of tasks has been stored
+     */
+    public Integer taskConfigHash(String connectorName) {
+        return taskConfigHashses.get(connectorName);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
@@ -72,7 +72,8 @@ public interface ConfigBackingStore {
      * @param connector name of the connector
      * @param configs the new task configs for the connector
      * @param configHash a {@link org.apache.kafka.connect.util.ConnectUtils#configHash(Map)  hash}
-     *                   of the most recent config for the connector
+     *                   of the most recent config for the connector. <strong>NOTE: this value should never be
+     *                   logged above TRACE level</strong>
      */
     void putTaskConfigs(String connector, List<Map<String, String>> configs, int configHash);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.connect.runtime.ConfigHash;
 import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SessionKey;
 import org.apache.kafka.connect.runtime.TargetState;
@@ -71,11 +72,9 @@ public interface ConfigBackingStore {
      * Update the task configurations for a connector.
      * @param connector name of the connector
      * @param configs the new task configs for the connector
-     * @param configHash a {@link org.apache.kafka.connect.util.ConnectUtils#configHash(Map)  hash}
-     *                   of the most recent config for the connector. <strong>NOTE: this value should never be
-     *                   logged above TRACE level</strong>
+     * @param configHash a hash of the connector config that was used to generate the task configs
      */
-    void putTaskConfigs(String connector, List<Map<String, String>> configs, int configHash);
+    void putTaskConfigs(String connector, List<Map<String, String>> configs, ConfigHash configHash);
 
     /**
      * Remove the task configs associated with a connector.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
@@ -71,8 +71,10 @@ public interface ConfigBackingStore {
      * Update the task configurations for a connector.
      * @param connector name of the connector
      * @param configs the new task configs for the connector
+     * @param configHash a {@link org.apache.kafka.connect.util.ConnectUtils#configHash(Map)  hash}
+     *                   of the most recent config for the connector
      */
-    void putTaskConfigs(String connector, List<Map<String, String>> configs);
+    void putTaskConfigs(String connector, List<Map<String, String>> configs, int configHash);
 
     /**
      * Remove the task configs associated with a connector.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -575,7 +575,8 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
      * @param connector the connector to write task configuration
      * @param configs list of task configurations for the connector
      * @param configHash a {@link org.apache.kafka.connect.util.ConnectUtils#configHash(Map)  hash}
-     *                   of the most recent config for the connector
+     *                   of the most recent config for the connector. <strong>NOTE: this value should never be
+     *                   logged above TRACE level</strong>
      * @throws ConnectException if the task configurations do not resolve inconsistencies found in the existing root
      *                          and task configurations.
      * @throws IllegalStateException if {@link #claimWritePrivileges()} is required, but was not successfully invoked before

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -253,6 +253,9 @@ public final class ConnectUtils {
     /**
      * Generate a deterministic hash of the supplied config. For configurations
      * with identical key-value pairs, this hash will always be the same.
+     * <p>
+     * <strong>NOTE: hashes of connector configs should never be logged above
+     * TRACE level</strong>.
      * @param config the config to hash; may be null
      * @return a hash of the config
      */

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -16,11 +16,9 @@
  */
 package org.apache.kafka.connect.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
@@ -30,14 +28,12 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -46,8 +42,6 @@ import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 
 public final class ConnectUtils {
     private static final Logger log = LoggerFactory.getLogger(ConnectUtils.class);
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static Long checkAndConvertTimestamp(Long timestamp) {
         if (timestamp == null || timestamp >= 0)
@@ -250,31 +244,14 @@ public final class ConnectUtils {
         return result;
     }
 
-    /**
-     * Generate a deterministic hash of the supplied config. For configurations
-     * with identical key-value pairs, this hash will always be the same.
-     * <p>
-     * <strong>NOTE: hashes of connector configs should never be logged above
-     * TRACE level</strong>.
-     * @param config the config to hash; may be null
-     * @return a hash of the config
-     */
-    public static int configHash(Map<String, String> config) {
-        if (config == null)
-            return 0;
-
-        Map<String, String> toHash = new TreeMap<>(config);
-
-        byte[] serialized;
-        try {
-            serialized = OBJECT_MAPPER.writeValueAsBytes(toHash);
-        } catch (IOException e) {
-            throw new ConnectException(
-                    "Unable to serialize connector config contents for hashing",
-                    e
-            );
-        }
-
-        return Utils.murmur2(serialized);
+    // Convert an integer value extracted from a schemaless struct to an int. This handles potentially different
+    // encodings by different Converters.
+    public static int intValue(Object value) {
+        if (value instanceof Integer)
+            return (int) value;
+        else if (value instanceof Long)
+            return (int) (long) value;
+        else
+            throw new ConnectException("Expected integer value to be either Integer or Long");
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -17,19 +17,27 @@
 package org.apache.kafka.connect.integration;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.LogCaptureAppender;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffset;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
 import org.apache.kafka.connect.runtime.rest.entities.CreateConnectorRequest;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.KafkaConfigBackingStore;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.SinkUtils;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.connect.util.clusters.WorkerHandle;
 import org.apache.kafka.test.IntegrationTest;
@@ -44,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -53,6 +62,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
@@ -1123,6 +1134,74 @@ public class ConnectWorkerIntegrationTest {
         );
     }
 
+    @Test
+    public void testRuntimePropertyReconfiguration() throws Exception {
+        final int offsetCommitIntervalMs = 1_000;
+        // force fast offset commits
+        workerProps.put(OFFSET_COMMIT_INTERVAL_MS_CONFIG, Integer.toString(offsetCommitIntervalMs));
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
+        connect.assertions().assertAtLeastNumWorkersAreUp(
+                NUM_WORKERS,
+                "Initial group of workers did not start in time."
+        );
+
+        final String topic = "kafka9228";
+        connect.kafka().createTopic(topic, 1);
+        connect.kafka().produce(topic, "non-json-value");
+
+        Map<String, String> connectorConfig = new HashMap<>();
+        connectorConfig.put(CONNECTOR_CLASS_CONFIG, SimpleConnector.class.getName());
+        connectorConfig.put(TASKS_MAX_CONFIG, "1");
+        connectorConfig.put(TOPICS_CONFIG, topic);
+        // Initially configure the connector to use the JSON converter
+        connectorConfig.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        connectorConfig.put(
+                VALUE_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG,
+                "false"
+        );
+
+        connect.configureConnector(CONNECTOR_NAME, connectorConfig);
+        connect.assertions().assertConnectorIsRunningAndTasksHaveFailed(
+                CONNECTOR_NAME,
+                1,
+                "Connector did not start or task did not fail in time"
+        );
+        assertEquals(
+                "Connector should not have any committed offsets when only task fails on first record",
+                new ConnectorOffsets(Collections.emptyList()),
+                connect.connectorOffsets(CONNECTOR_NAME)
+        );
+
+        // Reconfigure the connector to use the string converter
+        connectorConfig.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        connectorConfig.remove(
+                KEY_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG
+        );
+        connect.configureConnector(CONNECTOR_NAME, connectorConfig);
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+                CONNECTOR_NAME,
+                1,
+                "Connector or tasks did not start in time"
+        );
+
+        Map<String, Object> expectedOffsetKey = new HashMap<>();
+        expectedOffsetKey.put(SinkUtils.KAFKA_TOPIC_KEY, topic);
+        expectedOffsetKey.put(SinkUtils.KAFKA_PARTITION_KEY, 0);
+        Map<String, Object> expectedOffsetValue = Collections.singletonMap(SinkUtils.KAFKA_OFFSET_KEY, 1);
+        ConnectorOffset expectedOffset = new ConnectorOffset(expectedOffsetKey, expectedOffsetValue);
+        ConnectorOffsets expectedOffsets = new ConnectorOffsets(Collections.singletonList(expectedOffset));
+
+        // Wait for it to commit offsets, signaling that it has successfully processed the record we produced earlier
+        waitForCondition(
+                () -> expectedOffsets.equals(connect.connectorOffsets(CONNECTOR_NAME)),
+                offsetCommitIntervalMs * 2,
+                "Task did not successfully process record and/or commit offsets in time"
+        );
+    }
+
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup props for the source connector
         Map<String, String> props = new HashMap<>();
@@ -1136,5 +1215,61 @@ public class ConnectWorkerIntegrationTest {
         props.put(DEFAULT_TOPIC_CREATION_PREFIX + REPLICATION_FACTOR_CONFIG, String.valueOf(1));
         props.put(DEFAULT_TOPIC_CREATION_PREFIX + PARTITIONS_CONFIG, String.valueOf(1));
         return props;
+    }
+
+    public static class SimpleConnector extends SinkConnector {
+        @Override
+        public String version() {
+            return "0.0";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            // no-op
+        }
+
+        @Override
+        public Class<? extends Task> taskClass() {
+            return SimpleTask.class;
+        }
+
+        @Override
+        public List<Map<String, String>> taskConfigs(int maxTasks) {
+            return IntStream.range(0, maxTasks)
+                    .mapToObj(i -> Collections.<String, String>emptyMap())
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public void stop() {
+            // no-op
+        }
+
+        @Override
+        public ConfigDef config() {
+            return new ConfigDef();
+        }
+    }
+
+    public static class SimpleTask extends SinkTask {
+        @Override
+        public String version() {
+            return "0.0";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            // no-op
+        }
+
+        @Override
+        public void put(Collection<SinkRecord> records) {
+            // no-op
+        }
+
+        @Override
+        public void stop() {
+            // no-op
+        }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -1156,7 +1156,7 @@ public class ConnectWorkerIntegrationTest {
         connectorConfig.put(CONNECTOR_CLASS_CONFIG, SimpleConnector.class.getName());
         connectorConfig.put(TASKS_MAX_CONFIG, "1");
         connectorConfig.put(TOPICS_CONFIG, topic);
-        // Initially configure the connector to use the JSON converter
+        // Initially configure the connector to use the JSON converter, which should cause task failure(s)
         connectorConfig.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
         connectorConfig.put(
                 VALUE_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG,
@@ -1175,7 +1175,7 @@ public class ConnectWorkerIntegrationTest {
                 connect.connectorOffsets(CONNECTOR_NAME)
         );
 
-        // Reconfigure the connector to use the string converter
+        // Reconfigure the connector to use the string converter, which should not cause any more task failures
         connectorConfig.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         connectorConfig.remove(
                 KEY_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -53,7 +53,6 @@ import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.util.Callback;
-import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 import org.junit.Test;
@@ -139,9 +138,10 @@ public class AbstractHerderTest {
         TASK_CONFIGS_MAP.put(TASK1, TASK_CONFIG);
         TASK_CONFIGS_MAP.put(TASK2, TASK_CONFIG);
     }
-    private static final Map<String, Integer> TASK_CONFIG_HASHES = new HashMap<>();
+    private static final Map<String, ConfigHash> TASK_CONFIG_HASHES = new HashMap<>();
+    private static final int CONN1_CONFIG_HASH = 9228;
     static {
-        TASK_CONFIG_HASHES.put(CONN1, ConnectUtils.configHash(CONN1_CONFIG));
+        TASK_CONFIG_HASHES.put(CONN1, new ConfigHash(CONN1_CONFIG_HASH));
     }
     private static final ClusterConfigState SNAPSHOT = new ClusterConfigState(
             1,
@@ -1156,7 +1156,7 @@ public class AbstractHerderTest {
                         snapshotWithoutConfigHash,
                         CONN1,
                         TASK_CONFIGS,
-                        ConnectUtils.configHash(CONN1_CONFIG)
+                        new ConfigHash(CONN1_CONFIG_HASH)
                 )
         );
 
@@ -1166,7 +1166,7 @@ public class AbstractHerderTest {
                         SNAPSHOT,
                         CONN1,
                         TASK_CONFIGS,
-                        SNAPSHOT.taskConfigHash(CONN1) + 1
+                        new ConfigHash(CONN1_CONFIG_HASH + 1)
                 )
         );
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConfigHashTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConfigHashTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.kafka.connect.runtime.ConfigHash.NO_HASH;
+import static org.apache.kafka.connect.runtime.ConfigHash.fromConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigHashTest {
+
+    private static final ConfigHash HASH_0 = new ConfigHash(0);
+    private static final ConfigHash HASH_1 = new ConfigHash(9228);
+    private static final ConfigHash HASH_2 = new ConfigHash(-468);
+    private static final String CONNECTOR = "connector";
+
+    @Test
+    public void testHandleNullConfig() {
+        ConfigHash configHash = fromConfig(null);
+        assertNotNull(configHash);
+        assertFalse(configHash.exists());
+    }
+
+    @Test
+    public void testShouldUpdateTasks() {
+        // We never expect null ConfigHash objects (should always use NO_HASH instead),
+        // but should still handle them gracefully
+        assertFalse(ConfigHash.shouldUpdateTasks(null, null));
+        assertFalse(ConfigHash.shouldUpdateTasks(null, ConfigHash.NO_HASH));
+        assertFalse(ConfigHash.shouldUpdateTasks(ConfigHash.NO_HASH, null));
+        assertFalse(ConfigHash.shouldUpdateTasks(null, HASH_1));
+        assertFalse(ConfigHash.shouldUpdateTasks(HASH_1, null));
+
+        // We never update when there is no pre-existing hash
+        assertFalse(ConfigHash.shouldUpdateTasks(null, NO_HASH));
+        assertFalse(ConfigHash.shouldUpdateTasks(null, HASH_0));
+        assertFalse(ConfigHash.shouldUpdateTasks(null, HASH_1));
+        assertFalse(ConfigHash.shouldUpdateTasks(null, HASH_2));
+
+        // We do update when hashes differ, including when there is no newer hash
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_0, HASH_1));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_0, HASH_2));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_0, NO_HASH));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_1, HASH_0));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_1, HASH_2));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_1, NO_HASH));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_2, HASH_0));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_2, HASH_1));
+        assertTrue(ConfigHash.shouldUpdateTasks(HASH_2, NO_HASH));
+    }
+
+    @Test
+    public void testDifferentIterationOrder() {
+        Map<String, String> config1 = new LinkedHashMap<>();
+        config1.put("key1", "val1");
+        config1.put("key2", "val2");
+
+        Map<String, String> config2 = new LinkedHashMap<>();
+        config2.put("key2", "val2");
+        config2.put("key1", "val1");
+
+        ConfigHash hash1 = fromConfig(config1);
+        ConfigHash hash2 = fromConfig(config2);
+
+        // Should still return the same value, regardless of iteration order
+        assertTrue(hash1.matches(hash2));
+        // And regardless of argument order
+        assertTrue(hash2.matches(hash1));
+
+        assertFalse(ConfigHash.shouldUpdateTasks(hash1, hash2));
+        assertFalse(ConfigHash.shouldUpdateTasks(hash2, hash1));
+    }
+
+    @Test
+    public void testForCollisions() {
+        Map<String, String> config1 = new HashMap<>();
+        Map<String, String> config2 = new HashMap<>();
+
+        final int iterations = 10_000;
+        int collisions = 0;
+        for (int i = 0; i < iterations; i++) {
+            config1.put("key" + i, "val" + i);
+            config2.put("key_" + i, "val_" + i);
+
+            if (fromConfig(config1).matches(fromConfig(config2)))
+                collisions++;
+        }
+        assertTrue(collisions < iterations * 0.01, "Hash collision rate exceeds 1%");
+    }
+
+    @Test
+    public void testHeaderParsing() {
+        assertFalse(ConfigHash.fromHeaders(CONNECTOR, null).exists());
+        assertFalse(ConfigHash.fromHeaders(CONNECTOR, headers(null)).exists());
+
+        assertTrue(ConfigHash.fromHeaders(CONNECTOR, headers("0")).exists());
+        assertTrue(ConfigHash.fromHeaders(CONNECTOR, headers(Integer.toString(Integer.MAX_VALUE))).exists());
+        assertTrue(ConfigHash.fromHeaders(CONNECTOR, headers(Integer.toString(Integer.MIN_VALUE))).exists());
+    }
+
+    @Test
+    public void testMapParsing() {
+
+    }
+
+    @Test
+    public void testStructInsertion() {
+
+    }
+
+    private static HttpHeaders headers(String configHash) {
+        HttpHeaders result = mock(HttpHeaders.class);
+        when(result.getHeaderString(eq(ConfigHash.CONNECTOR_CONFIG_HASH_HEADER)))
+                .thenReturn(configHash);
+        return result;
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -634,6 +634,7 @@ public class WorkerTest {
                 Collections.singletonMap(TASK_ID, origProps),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet()
         );
@@ -687,6 +688,7 @@ public class WorkerTest {
                 Collections.singletonMap(CONNECTOR_ID, connectorConfigs),
                 Collections.singletonMap(CONNECTOR_ID, TargetState.STARTED),
                 Collections.singletonMap(TASK_ID, origProps),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),
@@ -757,6 +759,7 @@ public class WorkerTest {
                 Collections.singletonMap(CONNECTOR_ID, connectorConfigs),
                 Collections.singletonMap(CONNECTOR_ID, TargetState.STARTED),
                 Collections.singletonMap(TASK_ID, origProps),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),
@@ -2726,6 +2729,7 @@ public class WorkerTest {
                 Collections.singletonMap(connName, connectorConfigs),
                 Collections.singletonMap(connName, TargetState.STARTED),
                 Collections.singletonMap(TASK_ID, origProps),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
@@ -72,6 +72,7 @@ public class WorkerTestUtils {
                 taskConfigs(0, connectorNum, connectorNum * taskNum),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet());
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
@@ -194,4 +194,8 @@ public class WorkerTestUtils {
 
         assertEquals("Wrong rebalance delay in " + assignment, expectedDelay, assignment.delay());
     }
+
+    public static ConfigHash configHash(Integer hash) {
+        return new ConfigHash(hash);
+    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -129,6 +129,7 @@ import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -220,6 +221,7 @@ public class DistributedHerderTest {
             TASK_CONFIGS_MAP,
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             Collections.emptySet(),
             Collections.emptySet());
     private static final ClusterConfigState SNAPSHOT_PAUSED_CONN1 = new ClusterConfigState(
@@ -231,6 +233,7 @@ public class DistributedHerderTest {
             TASK_CONFIGS_MAP,
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             Collections.emptySet(),
             Collections.emptySet());
     private static final ClusterConfigState SNAPSHOT_STOPPED_CONN1 = new ClusterConfigState(
@@ -240,6 +243,7 @@ public class DistributedHerderTest {
             Collections.singletonMap(CONN1, CONN1_CONFIG),
             Collections.singletonMap(CONN1, TargetState.STOPPED),
             Collections.emptyMap(), // Stopped connectors should have an empty set of task configs
+            Collections.emptyMap(),
             Collections.singletonMap(CONN1, 3),
             Collections.singletonMap(CONN1, 10),
             Collections.singleton(CONN1),
@@ -252,6 +256,7 @@ public class DistributedHerderTest {
             Collections.singletonMap(CONN1, CONN1_CONFIG),
             Collections.singletonMap(CONN1, TargetState.STOPPED),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             Collections.singletonMap(CONN1, 0),
             Collections.singletonMap(CONN1, 11),
             Collections.emptySet(),
@@ -263,6 +268,7 @@ public class DistributedHerderTest {
             Collections.singletonMap(CONN1, CONN1_CONFIG_UPDATED),
             Collections.singletonMap(CONN1, TargetState.STARTED),
             TASK_CONFIGS_MAP,
+            Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptySet(),
@@ -630,6 +636,7 @@ public class DistributedHerderTest {
                     Collections.singletonMap(CONN1, CONN1_CONFIG),
                     Collections.singletonMap(CONN1, TargetState.STARTED),
                     TASK_CONFIGS_MAP,
+                    Collections.emptyMap(),
                     Collections.emptyMap(),
                     Collections.emptyMap(),
                     Collections.emptySet(),
@@ -1616,6 +1623,7 @@ public class DistributedHerderTest {
                 TASK_CONFIGS_MAP,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet(),
                 configTransformer
@@ -1797,7 +1805,7 @@ public class DistributedHerderTest {
         // handle stop request
         expectMemberEnsureActive();
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(configBackingStore).putTaskConfigs(CONN1, Collections.emptyList());
+        doNothing().when(configBackingStore).putTaskConfigs(eq(CONN1), eq(Collections.emptyList()), anyInt());
         doNothing().when(configBackingStore).putTargetState(CONN1, TargetState.STOPPED);
 
         FutureCallback<Void> cb = new FutureCallback<>();
@@ -1862,7 +1870,7 @@ public class DistributedHerderTest {
         ConnectException taskConfigsWriteException = new ConnectException("Could not write task configs to config topic");
         // handle stop request
         expectMemberEnsureActive();
-        doThrow(taskConfigsWriteException).when(configBackingStore).putTaskConfigs(CONN1, Collections.emptyList());
+        doThrow(taskConfigsWriteException).when(configBackingStore).putTaskConfigs(eq(CONN1), eq(Collections.emptyList()), anyInt());
         // We do not expect configBackingStore::putTargetState to be invoked, which
         // is intentional since that call should only take place if we are first able to
         // successfully write the empty list of task configs
@@ -2220,6 +2228,7 @@ public class DistributedHerderTest {
                 TASK_CONFIGS_MAP,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet(),
                 configTransformer);
@@ -2351,6 +2360,7 @@ public class DistributedHerderTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet());
         expectConfigRefreshAndSnapshot(clusterConfigState);
@@ -2377,6 +2387,7 @@ public class DistributedHerderTest {
                 Collections.singletonMap(CONN1, 0),
                 Collections.singletonMap(CONN1, CONN1_CONFIG),
                 Collections.singletonMap(CONN1, TargetState.STARTED),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -2417,6 +2428,7 @@ public class DistributedHerderTest {
                 Collections.singletonMap(CONN1, 0),
                 Collections.singletonMap(CONN1, originalConnConfig),
                 Collections.singletonMap(CONN1, TargetState.STARTED),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -2490,6 +2502,7 @@ public class DistributedHerderTest {
                 TASK_CONFIGS_MAP,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet());
         expectConfigRefreshAndSnapshot(snapshotWithKey);
@@ -2534,6 +2547,7 @@ public class DistributedHerderTest {
                 Collections.singletonMap(CONN1, CONN1_CONFIG),
                 Collections.singletonMap(CONN1, TargetState.STARTED),
                 TASK_CONFIGS_MAP,
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),
@@ -2735,6 +2749,7 @@ public class DistributedHerderTest {
                 Collections.singletonMap(CONN1, CONN1_CONFIG),
                 Collections.singletonMap(CONN1, TargetState.STARTED),
                 TASK_CONFIGS_MAP,
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),
@@ -3219,6 +3234,7 @@ public class DistributedHerderTest {
                 Collections.singletonMap(CONN1, CONN1_CONFIG),
                 Collections.singletonMap(CONN1, TargetState.STARTED),
                 TASK_CONFIGS_MAP,
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 taskConfigGenerations,
                 Collections.emptySet(),
@@ -4145,6 +4161,7 @@ public class DistributedHerderTest {
                 connectorConfigs,
                 Collections.singletonMap(CONN1, TargetState.STARTED),
                 taskConfigs,
+                Collections.emptyMap(),
                 taskCountRecords,
                 taskConfigGenerations,
                 pendingFencing,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -1405,6 +1405,7 @@ public class IncrementalCooperativeAssignorTest {
                 taskConfigs,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet());
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
@@ -171,6 +171,7 @@ public class WorkerCoordinatorTest {
                 Collections.singletonMap(taskId1x0, new HashMap<>()),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet()
         );
@@ -195,6 +196,7 @@ public class WorkerCoordinatorTest {
                 configState2ConnectorConfigs,
                 configState2TargetStates,
                 configState2TaskConfigs,
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),
@@ -224,6 +226,7 @@ public class WorkerCoordinatorTest {
                 configStateSingleTaskConnectorsConnectorConfigs,
                 configStateSingleTaskConnectorsTargetStates,
                 configStateSingleTaskConnectorsTaskConfigs,
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptySet(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -95,6 +95,7 @@ public class RestClientTest {
                 url,
                 method,
                 null,
+                null,
                 TEST_DTO,
                 responseFormat,
                 MOCK_SECRET_KEY,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
@@ -87,6 +87,7 @@ public class InternalConnectResourceTest {
                 eq(CONNECTOR_NAME),
                 eq(TASK_CONFIGS),
                 cb.capture(),
+                any(),
                 any()
         );
         expectRequestPath(TASK_CONFIGS_PATH);
@@ -106,7 +107,8 @@ public class InternalConnectResourceTest {
                 eq(CONNECTOR_NAME),
                 eq(TASK_CONFIGS),
                 cb.capture(),
-                signatureCapture.capture()
+                signatureCapture.capture(),
+                any()
         );
 
         HttpHeaders headers = mock(HttpHeaders.class);
@@ -137,6 +139,7 @@ public class InternalConnectResourceTest {
                 eq(CONNECTOR_NAME),
                 eq(TASK_CONFIGS),
                 cb.capture(),
+                any(),
                 any()
         );
         expectRequestPath(TASK_CONFIGS_PATH);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -86,6 +86,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC_CREATION_PREFIX;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerTestUtils.configHash;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -831,7 +832,7 @@ public class StandaloneHerderTest {
         Callback<Void> cb = mock(Callback.class);
 
         assertThrows(UnsupportedOperationException.class, () -> herder.putTaskConfigs(CONNECTOR_NAME,
-                singletonList(singletonMap("config", "value")), cb, null));
+                singletonList(singletonMap("config", "value")), cb, null, configHash(0)));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -387,6 +387,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(taskId, taskConfig(SourceSink.SOURCE)),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 new HashSet<>(),
                 new HashSet<>(),
                 transformer);
@@ -418,6 +419,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(CONNECTOR_NAME, connectorConfig),
                 Collections.singletonMap(CONNECTOR_NAME, TargetState.STARTED),
                 Collections.singletonMap(new ConnectorTaskId(CONNECTOR_NAME, 0), taskConfig(SourceSink.SOURCE)),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 new HashSet<>(),
@@ -555,6 +557,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(taskId, taskConfig(SourceSink.SINK)),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 new HashSet<>(),
                 new HashSet<>(),
                 transformer);
@@ -607,6 +610,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(CONNECTOR_NAME, connectorConfig),
                 Collections.singletonMap(CONNECTOR_NAME, TargetState.STARTED),
                 Collections.singletonMap(taskId, taskConfig(SourceSink.SINK)),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 new HashSet<>(),
@@ -710,7 +714,6 @@ public class StandaloneHerderTest {
     public void testPutConnectorConfig() throws Exception {
         Map<String, String> connConfig = connectorConfig(SourceSink.SOURCE);
         Map<String, String> newConnConfig = new HashMap<>(connConfig);
-        newConnConfig.put("foo", "bar");
 
         Callback<Map<String, String>> connectorConfigCb = mock(Callback.class);
 
@@ -748,7 +751,6 @@ public class StandaloneHerderTest {
                 ConnectorType.SOURCE);
         assertEquals(newConnInfo, newConnectorInfo.result());
 
-        assertEquals("bar", capturedConfig.getValue().get("foo"));
         herder.connectorConfig(CONNECTOR_NAME, connectorConfigCb);
         verifyNoMoreInteractions(connectorConfigCb);
     }
@@ -937,6 +939,7 @@ public class StandaloneHerderTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet()
         );
@@ -972,6 +975,7 @@ public class StandaloneHerderTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                Collections.emptyMap(),
                 Collections.emptySet(),
                 Collections.emptySet()
         );
@@ -998,6 +1002,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(CONNECTOR_NAME, 0),
                 Collections.singletonMap(CONNECTOR_NAME, connectorConfig(SourceSink.SOURCE)),
                 Collections.singletonMap(CONNECTOR_NAME, TargetState.STOPPED),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -1083,6 +1088,7 @@ public class StandaloneHerderTest {
                 Collections.singletonMap(CONNECTOR_NAME, connectorConfig(sourceSink)),
                 Collections.singletonMap(CONNECTOR_NAME, TargetState.STARTED),
                 Collections.singletonMap(new ConnectorTaskId(CONNECTOR_NAME, 0), generatedTaskProps),
+                Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 new HashSet<>(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreMockitoTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreMockitoTest.java
@@ -76,6 +76,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_C
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerTestUtils.configHash;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.INCLUDE_TASKS_FIELD_NAME;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.ONLY_FAILED_FIELD_NAME;
@@ -649,7 +650,7 @@ public class KafkaConfigBackingStoreMockitoTest {
         assertEquals(Collections.singletonList(CONNECTOR_IDS.get(0)), new ArrayList<>(configState.connectors()));
         assertEquals(TargetState.PAUSED, configState.targetState(CONNECTOR_IDS.get(0)));
         assertEquals(TargetState.STOPPED, configState.targetState(CONNECTOR_IDS.get(1)));
-        assertNull(configState.taskConfigHash(CONNECTOR_IDS.get(0)));
+        assertFalse(configState.taskConfigHash(CONNECTOR_IDS.get(0)).exists());
 
         configStorage.stop();
         verify(configLog).stop();
@@ -1093,7 +1094,7 @@ public class KafkaConfigBackingStoreMockitoTest {
 
         // Next, issue a write that has everything that is needed and it should be accepted. Note that in this case
         // we are going to shrink the number of tasks to 1
-        configStorage.putTaskConfigs("connector1", Collections.singletonList(SAMPLE_CONFIGS.get(0)), 0);
+        configStorage.putTaskConfigs("connector1", Collections.singletonList(SAMPLE_CONFIGS.get(0)), configHash(0));
 
         // Validate updated config
         configState = configStorage.snapshot();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -61,6 +61,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.connect.runtime.WorkerTestUtils.configHash;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.INCLUDE_TASKS_FIELD_NAME;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.ONLY_FAILED_FIELD_NAME;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.RESTART_KEY;
@@ -255,7 +256,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
+        configStorage.putTaskConfigs("connector1", taskConfigs, configHash(0));
 
         configState = configStorage.snapshot();
         assertEquals(3, configState.offset());
@@ -324,7 +325,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
+        configStorage.putTaskConfigs("connector1", taskConfigs, configHash(0));
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();
@@ -410,9 +411,9 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
+        configStorage.putTaskConfigs("connector1", taskConfigs, configHash(0));
         taskConfigs = Collections.singletonList(SAMPLE_CONFIGS.get(2));
-        configStorage.putTaskConfigs("connector2", taskConfigs, 0);
+        configStorage.putTaskConfigs("connector2", taskConfigs, configHash(0));
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();
@@ -469,7 +470,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Collections.emptyList();
-        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
+        configStorage.putTaskConfigs("connector1", taskConfigs, configHash(0));
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -130,8 +130,10 @@ public class KafkaConfigBackingStoreTest {
             .put("state", "PAUSED")
             .put("state.v2", "STOPPED");
 
-    private static final Struct TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR
-            = new Struct(KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0).put("tasks", 2);
+    private static final Struct TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR_V1
+            = new Struct(KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1)
+            .put("tasks", 2)
+            .put("connector-config-hash", 3);
 
     private static final Struct ONLY_FAILED_MISSING_STRUCT = new Struct(KafkaConfigBackingStore.RESTART_REQUEST_V0).put(INCLUDE_TASKS_FIELD_NAME, false);
     private static final Struct INCLUDE_TASKS_MISSING_STRUCT = new Struct(KafkaConfigBackingStore.RESTART_REQUEST_V0).put(ONLY_FAILED_FIELD_NAME, true);
@@ -211,7 +213,7 @@ public class KafkaConfigBackingStoreTest {
                 "properties", SAMPLE_CONFIGS.get(1));
         expectReadToEnd(new LinkedHashMap<>());
         expectConvertWriteRead(
-                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0, CONFIGS_SERIALIZED.get(2),
+                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1, CONFIGS_SERIALIZED.get(2),
                 "tasks", 2); // Starts with 0 tasks, after update has 2
         // As soon as root is rewritten, we should see a callback notifying us that we reconfigured some tasks
         configUpdateListener.onTaskConfigUpdate(Arrays.asList(TASK_IDS.get(0), TASK_IDS.get(1)));
@@ -253,7 +255,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs);
+        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
 
         configState = configStorage.snapshot();
         assertEquals(3, configState.offset());
@@ -289,7 +291,7 @@ public class KafkaConfigBackingStoreTest {
                 "properties", SAMPLE_CONFIGS.get(1));
         expectReadToEnd(new LinkedHashMap<>());
         expectConvertWriteRead(
-                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0, CONFIGS_SERIALIZED.get(2),
+                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1, CONFIGS_SERIALIZED.get(2),
                 "tasks", 2); // Starts with 0 tasks, after update has 2
         // As soon as root is rewritten, we should see a callback notifying us that we reconfigured some tasks
         configUpdateListener.onTaskConfigUpdate(Arrays.asList(TASK_IDS.get(0), TASK_IDS.get(1)));
@@ -322,7 +324,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs);
+        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();
@@ -354,7 +356,7 @@ public class KafkaConfigBackingStoreTest {
                 "properties", SAMPLE_CONFIGS.get(1));
         expectReadToEnd(new LinkedHashMap<>());
         expectConvertWriteRead(
-                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0, CONFIGS_SERIALIZED.get(2),
+                COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1, CONFIGS_SERIALIZED.get(2),
                 "tasks", 2); // Starts with 0 tasks, after update has 2
         // As soon as root is rewritten, we should see a callback notifying us that we reconfigured some tasks
         configUpdateListener.onTaskConfigUpdate(Arrays.asList(TASK_IDS.get(0), TASK_IDS.get(1)));
@@ -374,7 +376,7 @@ public class KafkaConfigBackingStoreTest {
                 "properties", SAMPLE_CONFIGS.get(2));
         expectReadToEnd(new LinkedHashMap<>());
         expectConvertWriteRead(
-                COMMIT_TASKS_CONFIG_KEYS.get(1), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0, CONFIGS_SERIALIZED.get(4),
+                COMMIT_TASKS_CONFIG_KEYS.get(1), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1, CONFIGS_SERIALIZED.get(4),
                 "tasks", 1); // Starts with 2 tasks, after update has 3
 
         // As soon as root is rewritten, we should see a callback notifying us that we reconfigured some tasks
@@ -408,9 +410,9 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Arrays.asList(SAMPLE_CONFIGS.get(0), SAMPLE_CONFIGS.get(1));
-        configStorage.putTaskConfigs("connector1", taskConfigs);
+        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
         taskConfigs = Collections.singletonList(SAMPLE_CONFIGS.get(2));
-        configStorage.putTaskConfigs("connector2", taskConfigs);
+        configStorage.putTaskConfigs("connector2", taskConfigs, 0);
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();
@@ -438,7 +440,7 @@ public class KafkaConfigBackingStoreTest {
         // Task configs should read to end, write to the log, read to end, write root.
         expectReadToEnd(new LinkedHashMap<>());
         expectConvertWriteRead(
-            COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V0, CONFIGS_SERIALIZED.get(0),
+            COMMIT_TASKS_CONFIG_KEYS.get(0), KafkaConfigBackingStore.CONNECTOR_TASKS_COMMIT_V1, CONFIGS_SERIALIZED.get(0),
             "tasks", 0); // We have 0 tasks
         // As soon as root is rewritten, we should see a callback notifying us that we reconfigured some tasks
         configUpdateListener.onTaskConfigUpdate(Collections.emptyList());
@@ -467,7 +469,7 @@ public class KafkaConfigBackingStoreTest {
         // Writing task configs should block until all the writes have been performed and the root record update
         // has completed
         List<Map<String, String>> taskConfigs = Collections.emptyList();
-        configStorage.putTaskConfigs("connector1", taskConfigs);
+        configStorage.putTaskConfigs("connector1", taskConfigs, 0);
 
         // Validate root config by listing all connectors and tasks
         configState = configStorage.snapshot();
@@ -500,7 +502,7 @@ public class KafkaConfigBackingStoreTest {
         deserializedOnStartup.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserializedOnStartup.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserializedOnStartup.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
-        deserializedOnStartup.put(CONFIGS_SERIALIZED.get(3), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        deserializedOnStartup.put(CONFIGS_SERIALIZED.get(3), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR_V1);
         logOffset = 5;
 
         expectStart(existingRecords, deserializedOnStartup);
@@ -561,7 +563,7 @@ public class KafkaConfigBackingStoreTest {
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
-        deserialized.put(CONFIGS_SERIALIZED.get(3), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        deserialized.put(CONFIGS_SERIALIZED.get(3), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR_V1);
         logOffset = 5;
 
         expectStart(existingRecords, deserialized);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryConfigBackingStoreTest.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.connect.runtime.WorkerTestUtils.configHash;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -139,16 +139,16 @@ public class MemoryConfigBackingStoreTest {
     public void testPutTaskConfigs() {
         // Can't write task configs for non-existent connector
         assertThrows(IllegalArgumentException.class,
-            () -> configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), 0));
+            () -> configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), configHash(0)));
 
         configStore.putConnectorConfig(CONNECTOR_IDS.get(0), SAMPLE_CONFIGS.get(0), null);
-        configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), 0);
+        configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), configHash(0));
         ClusterConfigState configState = configStore.snapshot();
 
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_IDS.get(0), 0);
         assertEquals(1, configState.taskCount(CONNECTOR_IDS.get(0)));
         assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(taskId));
-        assertEquals(0, (int) configState.taskConfigHash(CONNECTOR_IDS.get(0)));
+        assertTrue(configState.taskConfigHash(CONNECTOR_IDS.get(0)).exists());
 
         verify(configUpdateListener).onConnectorConfigUpdate(eq(CONNECTOR_IDS.get(0)));
         verify(configUpdateListener).onTaskConfigUpdate(eq(Collections.singleton(taskId)));
@@ -170,13 +170,13 @@ public class MemoryConfigBackingStoreTest {
         }).when(configUpdateListener).onTaskConfigUpdate(anySet());
 
         configStore.putConnectorConfig(CONNECTOR_IDS.get(0), SAMPLE_CONFIGS.get(0), null);
-        configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), 0);
+        configStore.putTaskConfigs(CONNECTOR_IDS.get(0), Collections.singletonList(SAMPLE_CONFIGS.get(1)), configHash(0));
         configStore.removeTaskConfigs(CONNECTOR_IDS.get(0));
         ClusterConfigState configState = configStore.snapshot();
 
         assertEquals(0, configState.taskCount(CONNECTOR_IDS.get(0)));
         assertEquals(Collections.emptyList(), configState.tasks(CONNECTOR_IDS.get(0)));
-        assertNull(configState.taskConfigHash(CONNECTOR_IDS.get(0)));
+        assertFalse(configState.taskConfigHash(CONNECTOR_IDS.get(0)).exists());
 
         verify(configUpdateListener).onConnectorConfigUpdate(eq(CONNECTOR_IDS.get(0)));
         verify(configUpdateListener, times(2)).onTaskConfigUpdate(anySet());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -26,15 +26,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
-import static org.apache.kafka.connect.util.ConnectUtils.configHash;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -191,42 +188,5 @@ public class ConnectUtilsTest {
 
         Map<String, String> result = ConnectUtils.patchConfig(config, patch);
         assertEquals(expectedResult, result);
-    }
-
-    @Test
-    public void testConfigHash() {
-        // Should gracefully handle nulls, and always return the same value
-        assertMatchingConfigHash(null, null);
-
-        Map<String, String> config1 = new LinkedHashMap<>();
-        Map<String, String> config2 = new LinkedHashMap<>();
-
-        config1.put("key1", "val1");
-        config1.put("key2", "val2");
-        config2.put("key2", "val2");
-        config2.put("key1", "val1");
-        // Should still return the same value, regardless of iteration order
-        assertMatchingConfigHash(config1, config2);
-
-        config1.clear();
-        config2.clear();
-
-        final int iterations = 1000;
-        int collisions = 0;
-        for (int i = 0; i < iterations; i++) {
-            config1.put("key" + i, "val" + i);
-            config2.put("key_" + i, "val_" + i);
-
-            if (configHash(config1) == configHash(config2))
-                collisions++;
-        }
-        assertTrue("Hash collision rate exceeds 1%", collisions < iterations);
-    }
-
-    private void assertMatchingConfigHash(Map<String, String> config1, Map<String, String> config2) {
-        assertEquals(
-                configHash(config1),
-                configHash(config2)
-        );
     }
 }

--- a/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -18,3 +18,4 @@ org.apache.kafka.connect.integration.BlockingConnectorTest$TaskInitializeBlockin
 org.apache.kafka.connect.integration.ErrantRecordSinkConnector
 org.apache.kafka.connect.integration.MonitorableSinkConnector
 org.apache.kafka.connect.runtime.SampleSinkConnector
+org.apache.kafka.connect.integration.ConnectWorkerIntegrationTest$SimpleConnector


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9228)

Currently, if a connector generates the same set of task configs as the set that already exists in the config topic, then this new set of task configs is not written to the config topic, and the connector's tasks are not (immediately*) restarted.

This is intentional behavior to prevent infinite rebalance loops when using eager rebalancing, and most of the time it comes with no drawbacks. However, if the runtime-controlled properties for a connector (such as its key/value/header converters, or Kafka client overrides) are modified, then this behavior can cause the updates to not be applied (immediately*) to the connector's tasks.

In order to address this, we forcibly rewrite task configs to the config topic when we detect a change in the connector config, even if they are identical to the existing task configs. Changes to the connector config are tracked by taking a hash of the connector config and including it in the config topic when writing task configs.

If no hash has been written to the config topic yet, then we do not compare hashes. This is done in order to prevent upgrades to newer workers from causing all tasks on the cluster to be immediately restarted.

As a final note, this bug should not be very prevalent in the Kafka Connect ecosystem, since most connectors will unintentionally propagate changes in runtime-controlled properties to their tasks. This is because the classic idiom for connectors is to track the properties provided in [Connector::start](https://kafka.apache.org/37/javadoc/org/apache/kafka/connect/connector/Connector.html#start(java.util.Map)) and use either an identical clone or a slightly-modified copy of those properties in the return value of [Connector::taskConfigs](https://kafka.apache.org/37/javadoc/org/apache/kafka/connect/connector/Connector.html#taskConfigs(int)).

\* - Tasks can be restarted later on as a result of workers joining/leaving the cluster, users manually triggering restarts via the REST API, or other causes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
