### PR TITLE
KAFKA-15045: (KIP-924 pt. 7) Simplify requirements for rack aware graphs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/MinTrafficGraphConstructor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/MinTrafficGraphConstructor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -25,7 +26,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssignor.CostFunction;
 
 public class MinTrafficGraphConstructor<T> implements RackAwareGraphConstructor<T> {
@@ -34,7 +34,7 @@ public class MinTrafficGraphConstructor<T> implements RackAwareGraphConstructor<
     public int getSinkNodeID(
         final List<TaskId> taskIdList,
         final List<UUID> clientList,
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup
+        final Collection<Set<TaskId>> taskSetsPerTopicGroup
     ) {
         return clientList.size() + taskIdList.size();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssignor.CostFunction;
 
 /**
@@ -36,7 +36,7 @@ import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssi
 public interface RackAwareGraphConstructor<T> {
     int SOURCE_ID = -1;
 
-    int getSinkNodeID(final List<TaskId> taskIdList, final List<UUID> clientList, final Map<Subtopology, Set<TaskId>> tasksForTopicGroup);
+    int getSinkNodeID(final List<TaskId> taskIdList, final List<UUID> clientList, final Collection<Set<TaskId>> taskSetsPerTopicGroup);
 
     int getClientNodeId(final int clientIndex, final List<TaskId> taskIdList, final List<UUID> clientList, final int topicGroupIndex);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorFactory.java
@@ -16,8 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
@@ -25,12 +28,18 @@ import org.apache.kafka.streams.processor.internals.assignment.AssignorConfigura
 
 public class RackAwareGraphConstructorFactory {
 
-    static <T> RackAwareGraphConstructor<T> create(final AssignmentConfigs assignmentConfigs, final Map<Subtopology, Set<TaskId>> tasksForTopicGroup) {
+    static <T> RackAwareGraphConstructor<T> create(final AssignmentConfigs assignmentConfigs,
+                                                   final Map<Subtopology, Set<TaskId>> tasksForTopicGroup) {
+        return create(assignmentConfigs, new ArrayList<>(new TreeMap<>(tasksForTopicGroup).values()));
+    }
+
+    static <T> RackAwareGraphConstructor<T> create(final AssignmentConfigs assignmentConfigs,
+                                                   final List<Set<TaskId>> taskSetsPerTopicGroup) {
         switch (assignmentConfigs.rackAwareAssignmentStrategy) {
             case StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_MIN_TRAFFIC:
                 return new MinTrafficGraphConstructor<T>();
             case StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_BALANCE_SUBTOPOLOGY:
-                return new BalanceSubtopologyGraphConstructor<T>(tasksForTopicGroup);
+                return new BalanceSubtopologyGraphConstructor<T>(taskSetsPerTopicGroup);
             default:
                 throw new IllegalArgumentException("Rack aware assignment is disabled");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorTest.java
@@ -35,6 +35,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.UUID;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
@@ -88,7 +89,8 @@ public class RackAwareGraphConstructorTest {
         if (constructorType.equals(MIN_COST)) {
             constructor = new MinTrafficGraphConstructor<>();
         } else if (constructorType.equals(BALANCE_SUBTOPOLOGY)) {
-            constructor = new BalanceSubtopologyGraphConstructor<>(tasksForTopicGroup);
+            final List<Set<TaskId>> taskSetsPerTopicGroup = new ArrayList<>(new TreeMap<>(tasksForTopicGroup).values());
+            constructor = new BalanceSubtopologyGraphConstructor<>(taskSetsPerTopicGroup);
         }
         graph = constructor.constructTaskGraph(
             clientList, taskIdList, clientStateMap, taskClientMap, originalAssignedTaskNumber, ClientState::hasAssignedTask, this::getCost, 10, 1, false, false);


### PR DESCRIPTION
Rack aware graphs don't actually need any topology information about the system, but rather require a simple ordered (not sorted) grouping of tasks.

This PR changes the internal constructors and some interface signatures of RackAwareGraphConstructor and its implementations to allow reuse by future components that may not have access to the actual subtopology information.
