### PR TITLE
KAFKA-16619: add log for de-novo KRaft cluster

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -164,6 +164,8 @@ public class ActivationRecordsGenerator {
                     if (zkMigrationEnabled) {
                         throw new RuntimeException("Should not have ZK migrations enabled on a cluster that was " +
                             "created in KRaft mode.");
+                    } else {
+                        logMessageBuilder.append("This is a de-novo KRaft cluster with ZooKeeper migrations disabled.");
                     }
                     break;
                 case PRE_MIGRATION:

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -191,7 +191,8 @@ public class ActivationRecordsGeneratorTest {
         assertEquals(0, result.records().size());
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
-            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE.", logMsg),
+            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of NONE." +
+                    " This is a de-novo KRaft cluster with ZooKeeper migrations disabled.", logMsg),
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
@@ -202,7 +203,8 @@ public class ActivationRecordsGeneratorTest {
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. Aborting in-progress metadata " +
-                "transaction at offset 42. Loaded ZK migration state of NONE.", logMsg),
+                "transaction at offset 42. Loaded ZK migration state of NONE." +
+                    " This is a de-novo KRaft cluster with ZooKeeper migrations disabled.", logMsg),
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),


### PR DESCRIPTION
Add a log for de-novo KRaft  cluster when zookeeper.metadata.migration.enable=false

Modified test cases for this change.

This contribution is my original work and I license the work to the project under the project's open source license.
