### PR TITLE
KAFKA-14934: KafkaClusterTestKit makes FaultHandler accessible

### DIFF
--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -366,7 +366,13 @@ public class KafkaClusterTestKit implements AutoCloseable {
         this.baseDirectory = baseDirectory;
         this.faultHandlerFactory = faultHandlerFactory;
     }
+    public MockFaultHandler exposedFatalFaultHandler() {
+        return faultHandlerFactory.fatalFaultHandler();
+    }
 
+    public MockFaultHandler exposedNonFatalFaultHandler() {
+        return faultHandlerFactory.nonFatalFaultHandler();
+    }
     public void format() throws Exception {
         List<Future<?>> futures = new ArrayList<>();
         try {

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKitTest.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKitTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KafkaClusterTestKitTest {
     @ParameterizedTest
@@ -68,6 +69,20 @@ public class KafkaClusterTestKitTest {
                 .build())
         );
         assertEquals("Invalid negative value for numBrokerNodes", e.getMessage());
+    }
+    @Test
+    public void testExposedFaultHandlers() {
+        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
+                new TestKitNodes.Builder()
+                        .setNumBrokerNodes(1)
+                        .setNumControllerNodes(1)
+                        .build()).build()) {
+
+            assertNotNull(cluster.exposedFatalFaultHandler(), "Fatal fault handler should not be null");
+            assertNotNull(cluster.exposedNonFatalFaultHandler(), "Non-fatal fault handler should not be null");
+        } catch (Exception e) {
+            fail("Failed to initialize cluster", e);
+        }
     }
 
     @Test


### PR DESCRIPTION
We wrote a function that provide a way to access the MockFaultHandler instances for both fatal and non-fatal faults in the KafkaClusterTestKit class.

We created a KafkaClusterKit instance with one broker node and one controller node then we call the 2 functions that we created and assert that they don't return null which means they've been exposed.