### PR TITLE
MINOR: Optimize heartbeat to broker in test

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -139,15 +140,19 @@ public class QuorumControllerIntegrationTestUtils {
         if (brokers.isEmpty()) {
             return;
         }
+        List<CompletableFuture<BrokerHeartbeatReply>> replies = new ArrayList<>();
         for (Integer brokerId : brokers) {
-            BrokerHeartbeatReply reply = controller.processBrokerHeartbeat(ANONYMOUS_CONTEXT,
+            CompletableFuture<BrokerHeartbeatReply> reply = controller.processBrokerHeartbeat(ANONYMOUS_CONTEXT,
                 new BrokerHeartbeatRequestData()
                     .setWantFence(false)
                     .setBrokerEpoch(brokerEpochs.get(brokerId))
                     .setBrokerId(brokerId)
                     .setCurrentMetadataOffset(100000)
-            ).get();
-            assertEquals(new BrokerHeartbeatReply(true, false, false, false), reply);
+            );
+            replies.add(reply);
+        }
+        for (CompletableFuture<BrokerHeartbeatReply> reply : replies) {
+            assertEquals(new BrokerHeartbeatReply(true, false, false, false), reply.get());
         }
     }
 


### PR DESCRIPTION
Broker send heartbeats to other brokers async.
It can reduce the time to send heartbeat.
`QuorumControllerTest#testFenceMultipleBrokers` use this method three times.
Hopefully, It can reduce the probability of flaky.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
