### PR TITLE
MINOR: fix streams_broker_compatibility test

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until


### PR DESCRIPTION
The system test was broken in ccf4bd5f4621b80f5b1d3700df30e3b444381927
which failed to import the matrix symbol. The test was failing silently, not
discovering any tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
