### PR TITLE
KAFKA-16257: Improve logical type compatibility in SchemaProjector

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Decimal.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Decimal.java
@@ -84,11 +84,18 @@ public class Decimal {
         return new BigDecimal(new BigInteger(value), scale(schema));
     }
 
-    private static int scale(Schema schema) {
-        String scaleString = schema.parameters().get(SCALE_FIELD);
-        if (scaleString == null)
+    /**
+     * Get the scale factor from the Decimal logical schema
+     * @param schema the schema for the Decimal
+     * @return the scale factor
+     */
+    public static int scale(Schema schema) {
+        if (schema.parameters() == null || !schema.parameters().containsKey(SCALE_FIELD)) {
             throw new DataException("Invalid Decimal schema: scale parameter not found.");
+        }
+
         try {
+            String scaleString = schema.parameters().get(SCALE_FIELD);
             return Integer.parseInt(scaleString);
         } catch (NumberFormatException e) {
             throw new DataException("Invalid scale parameter found in Decimal schema: ", e);

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
@@ -167,7 +167,7 @@ public class SchemaProjector {
                 throw new SchemaProjectorException("Schema logical type mismatch. source type: " + source.name() + " and target type: " + target.name());
             }
 
-            if (Decimal.scale(source) > Decimal.scale(target)) {
+            if (Decimal.scale(source) != Decimal.scale(target)) {
                 throw new SchemaProjectorException("Decimal scale factor mismatch. source scale: " + Decimal.scale(source) + " and target scale: " + Decimal.scale(target));
             }
         } else {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
@@ -63,7 +63,7 @@ public class DecimalTest {
     }
 
     @Test
-    public void setTestScale() {
+    public void testScale() {
         Schema schema = Decimal.schema(2);
         assertEquals(2, Decimal.scale(schema));
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.data;
 
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -24,6 +25,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 public class DecimalTest {
     private static final int TEST_SCALE = 2;
@@ -58,5 +60,13 @@ public class DecimalTest {
 
         converted = Decimal.toLogical(schema, TEST_BYTES_NEGATIVE);
         assertEquals(TEST_DECIMAL_NEGATIVE, converted);
+    }
+
+    @Test
+    public void setTestScale() {
+        Schema schema = Decimal.schema(2);
+        assertEquals(2, Decimal.scale(schema));
+
+        assertThrowsExactly(DataException.class, () -> Decimal.scale(Schema.BYTES_SCHEMA));
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
@@ -320,10 +320,10 @@ public class SchemaProjectorTest {
         BigDecimal testDecimal = new BigDecimal(new BigInteger("156"), 2);
         projected = SchemaProjector.project(Decimal.schema(2), testDecimal, Decimal.schema(2));
         assertEquals(testDecimal, projected);
-        projected = SchemaProjector.project(Decimal.schema(2), testDecimal, Decimal.schema(3));
-        assertEquals(testDecimal, projected);
         assertThrows(SchemaProjectorException.class, () -> SchemaProjector.project(Decimal.schema(2), testDecimal,
-                Decimal.schema(1)), "Cannot project Decimal schema with higher scale to Decimal schema with lower scale.");
+                Decimal.schema(3)), "Cannot project Decimal schema with different scale.");
+        assertThrows(SchemaProjectorException.class, () -> SchemaProjector.project(Decimal.schema(2), testDecimal,
+                Decimal.schema(1)), "Cannot project Decimal schema with different scale.");
 
         projected = SchemaProjector.project(Date.SCHEMA, 1000, Date.SCHEMA);
         assertEquals(1000, projected);


### PR DESCRIPTION
This PR improved logical type compatibility in SchemaProjector.
Decimal type with same scale is compatible with each other.
Timestamp type is compatible with Date and Time type.
Date and Time types are incompatible with each other.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
