### PR TITLE
KAFKA-15541: Add oldest-iterator-open-since-ms metric

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIterator.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+/**
+ * Common super-interface of all Metered Iterator types.
+ *
+ * This enables tracking the timestamp the Iterator was first created, for the oldest-iterator-open-since-ms metric.
+ */
+public interface MeteredIterator {
+
+    /**
+     * @return The UNIX timestamp, in milliseconds, that this Iterator was created/opened.
+     */
+    long startTimestamp();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.state.VersionedRecordIterator;
 import org.apache.kafka.streams.state.VersionedRecord;
 
-public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterator<V>, MeteredIterator {
+class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterator<V>, MeteredIterator {
 
     private final VersionedRecordIterator<byte[]> iterator;
     private final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import java.util.concurrent.atomic.LongAdder;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.kafka.common.metrics.Sensor;
@@ -24,7 +25,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.state.VersionedRecordIterator;
 import org.apache.kafka.streams.state.VersionedRecord;
 
-public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterator<V> {
+public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterator<V>, MeteredIterator {
 
     private final VersionedRecordIterator<byte[]> iterator;
     private final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue;
@@ -32,21 +33,31 @@ public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecord
     private final Sensor sensor;
     private final Time time;
     private final long startNs;
+    private final long startTimestampMs;
+    private final Set<MeteredIterator> openIterators;
 
     public MeteredMultiVersionedKeyQueryIterator(final VersionedRecordIterator<byte[]> iterator,
                                                  final Sensor sensor,
                                                  final Time time,
                                                  final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue,
-                                                 final LongAdder numOpenIterators) {
+                                                 final LongAdder numOpenIterators,
+                                                 final Set<MeteredIterator> openIterators) {
         this.iterator = iterator;
         this.deserializeValue = deserializeValue;
         this.numOpenIterators = numOpenIterators;
+        this.openIterators = openIterators;
         this.sensor = sensor;
         this.time = time;
         this.startNs = time.nanoseconds();
+        this.startTimestampMs = time.milliseconds();
         numOpenIterators.increment();
+        openIterators.add(this);
     }
 
+    @Override
+    public long startTimestamp() {
+        return startTimestampMs;
+    }
 
     @Override
     public void close() {
@@ -55,6 +66,7 @@ public class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecord
         } finally {
             sensor.record(time.nanoseconds() - startNs);
             numOpenIterators.decrement();
+            openIterators.remove(this);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -307,11 +307,12 @@ public class MeteredTimestampedKeyValueStore<K, V>
     }
 
     @SuppressWarnings("unchecked")
-    private class MeteredTimestampedKeyValueStoreIterator implements KeyValueIterator<K, V> {
+    private class MeteredTimestampedKeyValueStoreIterator implements KeyValueIterator<K, V>, MeteredIterator {
 
         private final KeyValueIterator<Bytes, byte[]> iter;
         private final Sensor sensor;
         private final long startNs;
+        private final long startTimestampMs;
         private final Function<byte[], ValueAndTimestamp<V>> valueAndTimestampDeserializer;
 
         private final boolean returnPlainValue;
@@ -324,8 +325,15 @@ public class MeteredTimestampedKeyValueStore<K, V>
             this.sensor = sensor;
             this.valueAndTimestampDeserializer = valueAndTimestampDeserializer;
             this.startNs = time.nanoseconds();
+            this.startTimestampMs = time.milliseconds();
             this.returnPlainValue = returnPlainValue;
             numOpenIterators.increment();
+            openIterators.add(this);
+        }
+
+        @Override
+        public long startTimestamp() {
+            return startTimestampMs;
         }
 
         @Override
@@ -354,6 +362,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
                 sensor.record(duration);
                 iteratorDurationSensor.record(duration);
                 numOpenIterators.decrement();
+                openIterators.remove(this);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -269,7 +269,8 @@ public class MeteredVersionedKeyValueStore<K, V>
                             iteratorDurationSensor,
                             time,
                             StoreQueryUtils.getDeserializeValue(plainValueSerdes),
-                            numOpenIterators
+                            numOpenIterators,
+                            openIterators
                         );
                 final QueryResult<MeteredMultiVersionedKeyQueryIterator<V>> typedQueryResult =
                         InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
@@ -25,9 +25,10 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import java.util.concurrent.atomic.LongAdder;
+import java.util.Set;
 import java.util.function.Function;
 
-class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed<K>, V> {
+class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed<K>, V>, MeteredIterator {
 
     private final KeyValueIterator<Windowed<Bytes>, byte[]> iter;
     private final Sensor operationSensor;
@@ -36,8 +37,10 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
     private final Function<byte[], K> deserializeKey;
     private final Function<byte[], V> deserializeValue;
     private final long startNs;
+    private final long startTimestampMs;
     private final Time time;
     private final LongAdder numOpenIterators;
+    private final Set<MeteredIterator> openIterators;
 
     MeteredWindowedKeyValueIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> iter,
                                     final Sensor operationSensor,
@@ -46,7 +49,8 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
                                     final Function<byte[], K> deserializeKey,
                                     final Function<byte[], V> deserializeValue,
                                     final Time time,
-                                    final LongAdder numOpenIterators) {
+                                    final LongAdder numOpenIterators,
+                                    final Set<MeteredIterator> openIterators) {
         this.iter = iter;
         this.operationSensor = operationSensor;
         this.iteratorSensor = iteratorSensor;
@@ -54,9 +58,17 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
         this.deserializeKey = deserializeKey;
         this.deserializeValue = deserializeValue;
         this.startNs = time.nanoseconds();
+        this.startTimestampMs = time.milliseconds();
         this.time = time;
         this.numOpenIterators = numOpenIterators;
+        this.openIterators = openIterators;
         numOpenIterators.increment();
+        openIterators.add(this);
+    }
+
+    @Override
+    public long startTimestamp() {
+        return this.startTimestampMs;
     }
 
     @Override
@@ -84,6 +96,7 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
             operationSensor.record(duration);
             iteratorSensor.record(duration);
             numOpenIterators.decrement();
+            openIterators.remove(this);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -157,6 +157,10 @@ public class StateStoreMetrics {
     private static final String ITERATOR_DURATION_MAX_DESCRIPTION =
             MAX_DESCRIPTION_PREFIX + ITERATOR_DURATION_DESCRIPTION;
 
+    private static final String OLDEST_ITERATOR_OPEN_SINCE_MS = "oldest-iterator-open-since-ms";
+    private static final String OLDEST_ITERATOR_OPEN_SINCE_MS_DESCRIPTION =
+            "The UNIX timestamp the oldest still open iterator was created, in milliseconds";
+
     public static Sensor putSensor(final String taskId,
                                    final String storeType,
                                    final String storeName,
@@ -449,6 +453,22 @@ public class StateStoreMetrics {
                 numOpenIteratorsGauge
         );
 
+    }
+
+    public static void addOldestOpenIteratorGauge(final String taskId,
+                                                  final String storeType,
+                                                  final String storeName,
+                                                  final StreamsMetricsImpl streamsMetrics,
+                                                  final Gauge<Long> oldestOpenIteratorGauge) {
+        streamsMetrics.addStoreLevelMutableMetric(
+                taskId,
+                storeType,
+                storeName,
+                OLDEST_ITERATOR_OPEN_SINCE_MS,
+                OLDEST_ITERATOR_OPEN_SINCE_MS_DESCRIPTION,
+                RecordingLevel.INFO,
+                oldestOpenIteratorGauge
+        );
     }
 
     private static Sensor sizeOrCountSensor(final String taskId,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -490,6 +490,42 @@ public class MeteredKeyValueStoreTest {
         assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
     }
 
+    @Test
+    public void shouldTrackOldestOpenIteratorTimestamp() {
+        when(inner.all()).thenReturn(KeyValueIterators.emptyIterator());
+        init();
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+
+        assertThat(oldestIteratorTimestampMetric.metricValue(), nullValue());
+
+        KeyValueIterator<String, String> second = null;
+        final long secondTimestamp;
+        try {
+            try (final KeyValueIterator<String, String> first = metered.all()) {
+                final long oldestTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+
+                // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
+                second = metered.all();
+                secondTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+            }
+
+            // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
+            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+        } finally {
+            if (second != null) {
+                second.close();
+            }
+        }
+
+        assertThat((Integer) oldestIteratorTimestampMetric.metricValue(), nullValue());
+    }
+
     private KafkaMetric metric(final MetricName metricName) {
         return this.metrics.metric(metricName);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -654,6 +654,42 @@ public class MeteredSessionStoreTest {
         assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
     }
 
+    @Test
+    public void shouldTrackOldestOpenIteratorTimestamp() {
+        when(innerStore.backwardFetch(KEY_BYTES)).thenReturn(KeyValueIterators.emptyIterator());
+        init();
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+
+        assertThat(oldestIteratorTimestampMetric.metricValue(), nullValue());
+
+        KeyValueIterator<Windowed<String>, String> second = null;
+        final long secondTimestamp;
+        try {
+            try (final KeyValueIterator<Windowed<String>, String> first = store.backwardFetch(KEY)) {
+                final long oldestTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+
+                // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
+                second = store.backwardFetch(KEY);
+                secondTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+            }
+
+            // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
+            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+        } finally {
+            if (second != null) {
+                second.close();
+            }
+        }
+
+        assertThat((Integer) oldestIteratorTimestampMetric.metricValue(), nullValue());
+    }
+
     private KafkaMetric metric(final String name) {
         return this.metrics.metric(new MetricName(name, STORE_LEVEL_GROUP, "", this.tags));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -487,4 +487,40 @@ public class MeteredTimestampedKeyValueStoreTest {
         assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
         assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
     }
+
+    @Test
+    public void shouldTrackOldestOpenIteratorTimestamp() {
+        when(inner.all()).thenReturn(KeyValueIterators.emptyIterator());
+        init();
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+
+        assertThat(oldestIteratorTimestampMetric.metricValue(), nullValue());
+
+        KeyValueIterator<String, ValueAndTimestamp<String>> second = null;
+        final long secondTimestamp;
+        try {
+            try (final KeyValueIterator<String, ValueAndTimestamp<String>> first = metered.all()) {
+                final long oldestTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+
+                // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
+                second = metered.all();
+                secondTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+            }
+
+            // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
+            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+        } finally {
+            if (second != null) {
+                second.close();
+            }
+        }
+
+        assertThat((Integer) oldestIteratorTimestampMetric.metricValue(), nullValue());
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
@@ -426,6 +426,48 @@ public class MeteredVersionedKeyValueStoreTest {
         assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
     }
 
+    @Test
+    public void shouldTrackOldestOpenIteratorTimestamp() {
+        final MultiVersionedKeyQuery<String, String> query = MultiVersionedKeyQuery.withKey(KEY);
+        final PositionBound bound = PositionBound.unbounded();
+        final QueryConfig config = new QueryConfig(false);
+        when(inner.query(any(), any(), any())).thenReturn(
+                QueryResult.forResult(new LogicalSegmentIterator(Collections.emptyListIterator(), RAW_KEY, 0L, 0L, ResultOrder.ANY)));
+
+        final KafkaMetric oldestIteratorTimestampMetric = getMetric("oldest-iterator-open-since-ms");
+        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+
+        assertThat(oldestIteratorTimestampMetric.metricValue(), nullValue());
+
+        final QueryResult<VersionedRecordIterator<String>> first = store.query(query, bound, config);
+        VersionedRecordIterator<String> secondIterator = null;
+        final long secondTime;
+        try {
+            try (final VersionedRecordIterator<String> iterator = first.getResult()) {
+                final long oldestTimestamp = mockTime.milliseconds();
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+
+                // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
+                final QueryResult<VersionedRecordIterator<String>> second = store.query(query, bound, config);
+                secondIterator = second.getResult();
+                secondTime = mockTime.milliseconds();
+
+                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                mockTime.sleep(100);
+            }
+
+            // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
+            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTime));
+        } finally {
+            if (secondIterator != null) {
+                secondIterator.close();
+            }
+        }
+
+        assertThat((Integer) oldestIteratorTimestampMetric.metricValue(), nullValue());
+    }
+
     private KafkaMetric getMetric(final String name) {
         return metrics.metric(new MetricName(name, STORE_LEVEL_GROUP, "", tags));
     }


### PR DESCRIPTION
Part of [KIP-989](https://cwiki.apache.org/confluence/x/9KCzDw)

This new `StateStore` metric tracks the timestamp that the oldest surviving Iterator was created.

This timestamp should continue to climb, and closely track the current time, as old iterators are closed and new ones created. If the timestamp remains very low (i.e. old), that suggests an Iterator has leaked, which should enable users to isolate the affected store.

It will report no data when there are no currently open Iterators.