### PR TITLE
KAFKA-16807: DescribeLogDirsResponseData#results#topics have unexpected topics having empty partitions

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1262,7 +1262,7 @@ class ReplicaManager(val config: KafkaConfig,
                     .setOffsetLag(getLogEndOffsetLag(log.topicPartition, log.logEndOffset, log.isFuture))
                     .setIsFutureKey(log.isFuture)
                 }.toList.asJava)
-            }.toList.asJava
+            }.filterNot(_.partitions().isEmpty).toList.asJava
 
             new DescribeLogDirsResponseData.DescribeLogDirsResult().setLogDir(absolutePath)
               .setErrorCode(Errors.NONE.code).setTopics(topicInfos)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6450,6 +6450,8 @@ class ReplicaManagerTest {
         assertEquals(Errors.NONE.code, response.errorCode)
         assertTrue(response.totalBytes > 0)
         assertTrue(response.usableBytes >= 0)
+        assertFalse(response.topics().isEmpty)
+        response.topics().forEach(t => assertFalse(t.partitions().isEmpty))
       }
     } finally {
       replicaManager.shutdown(checkpointHW = false)
@@ -6478,6 +6480,8 @@ class ReplicaManagerTest {
       assertEquals(mockLogMgr.liveLogDirs.size, responses.size)
       responses.foreach { response =>
         assertEquals(Errors.NONE.code, response.errorCode)
+        assertTrue(response.totalBytes > 0)
+        assertTrue(response.usableBytes >= 0)
         assertTrue(response.topics().isEmpty)
       }
     } finally {


### PR DESCRIPTION
ReplicaManager will generate a response having unexpected topics with empty patitions, so I add a filter to check partition is empty.