### PR TITLE
KAFKA-16826: Integrate Native Docker Image with github actions

### DIFF
--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -23,6 +23,7 @@ on:
         description: Docker image type to build and test
         options: 
           - "jvm"
+          - "native"
       kafka_url:
         description: Kafka url to be used to build the docker image
         required: true

--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -19,10 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       rc_docker_image:
-        description: RC docker image that needs to be promoted (Example:- apache/kafka:3.6.0-rc0, apache/kafka-native:3.6.0-rc0)
+        description: RC docker image that needs to be promoted (Example:- apache/kafka:3.8.0-rc0 (OR) apache/kafka-native:3.8.0-rc0)
         required: true
       promoted_docker_image:
-        description: Docker image name of the promoted image (Example:- apache/kafka:3.6.0, apache/kafka-native:3.6.0)
+        description: Docker image name of the promoted image (Example:- apache/kafka:3.8.0 (OR) apache/kafka-native:3.8.0)
         required: true
 
 jobs:

--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -19,10 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       rc_docker_image:
-        description: RC docker image that needs to be promoted (Example:- apache/kafka:3.6.0-rc0)
+        description: RC docker image that needs to be promoted (Example:- apache/kafka:3.6.0-rc0, apache/kafka-native:3.6.0-rc0)
         required: true
       promoted_docker_image:
-        description: Docker image name of the promoted image (Example:- apache/kafka:3.6.0)
+        description: Docker image name of the promoted image (Example:- apache/kafka:3.6.0, apache/kafka-native:3.6.0)
         required: true
 
 jobs:

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -25,7 +25,7 @@ on:
           - "jvm"
           - "native"
       rc_docker_image:
-        description: RC docker image that needs to be built and pushed to Dockerhub (Example:- apache/kafka:3.6.0-rc0, apache/kafka-native:3.6.0-rc0)
+        description: RC docker image that needs to be built and pushed to Dockerhub (Example:- apache/kafka:3.8.0-rc0 (OR) apache/kafka-native:3.8.0-rc0)
         required: true
       kafka_url:
         description: Kafka url to be used to build the docker image

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -23,8 +23,9 @@ on:
         description: Docker image type to be built and pushed
         options: 
           - "jvm"
+          - "native"
       rc_docker_image:
-        description: RC docker image that needs to be built and pushed to Dockerhub (Example:- apache/kafka:3.6.0-rc0)
+        description: RC docker image that needs to be built and pushed to Dockerhub (Example:- apache/kafka:3.6.0-rc0, apache/kafka-native:3.6.0-rc0)
         required: true
       kafka_url:
         description: Kafka url to be used to build the docker image


### PR DESCRIPTION
Followup of https://github.com/apache/kafka/pull/15927
This PR integrates the Native docker image with the existing github action jobs for the jvm docker image of AK.

The integration is done to the following actions:
1. `docker_build_and_test.yml`: Builds the docker image and runs sanity tests and CVE scan
2. `docker_rc_release.yml`: Builds the RC docker image for both amd and arm platform and pushes it to the dockerhub.
3. `docker_promote.yml`: Promotes the RC docker image to the released image tag

NOTE: I will add this image to the `docker_scan.yml` once the image is released as this job runs on the released images.

**TESTING**
I ran these actions for both native and JVM images and and they are working fine
1. [Native Build and test](https://github.com/kagarwal06/github-actions/actions/runs/9207002337)
2. [Native Build and push RC](https://github.com/kagarwal06/github-actions/actions/runs/9207131145)
3. [Native Promote](https://github.com/kagarwal06/github-actions/actions/runs/9207980290)
4. [JVM Build and test](https://github.com/kagarwal06/github-actions/actions/runs/9208078411)
5. [JVM Build and push RC](https://github.com/kagarwal06/github-actions/actions/runs/9208156672)
6. [JVM Promote](https://github.com/kagarwal06/github-actions/actions/runs/9208496484)

I used [my Dockerhub account](https://hub.docker.com/repository/docker/krishnaconfluent/kafka-native/general) for the testing

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
