### PR TITLE
MINOR: Disable JDK 11 and 17 tests on PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,45 +118,48 @@ pipeline {
           }
         }
 
-        // Only run the oldest and newest JDKs on PR builds
-        if (!isChangeRequest(env)) {
-            stage('JDK 11 and Scala 2.13') {
-              agent { label 'ubuntu' }
-              tools {
-                jdk 'jdk_11_latest'
-              }
-              options {
-                timeout(time: 8, unit: 'HOURS')
-                timestamps()
-              }
-              environment {
-                SCALA_VERSION=2.13
-              }
-              steps {
-                doValidation()
-                doTest(env)
-                echo 'Skipping Kafka Streams archetype test for Java 11'
-              }
-            }
+        stage('JDK 11 and Scala 2.13') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_11_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          when {
+            expression !isChangeRequest(env)
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            echo 'Skipping Kafka Streams archetype test for Java 11'
+          }
+        }
 
-            stage('JDK 17 and Scala 2.13') {
-              agent { label 'ubuntu' }
-              tools {
-                jdk 'jdk_17_latest'
-              }
-              options {
-                timeout(time: 8, unit: 'HOURS')
-                timestamps()
-              }
-              environment {
-                SCALA_VERSION=2.13
-              }
-              steps {
-                doValidation()
-                doTest(env)
-                echo 'Skipping Kafka Streams archetype test for Java 17'
-              }
-            }
+        stage('JDK 17 and Scala 2.13') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_17_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          when {
+            expression !isChangeRequest(env)
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            echo 'Skipping Kafka Streams archetype test for Java 17'
+          }
         }
 
         stage('JDK 21 and Scala 2.13') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def doTest(env, target = "test") {
 }
 
 def runTestOnDevBranch(env) {
-  if (isChangeRequest(env)) {
+  if (!isChangeRequest(env)) {
     doTest(env)
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,42 +118,45 @@ pipeline {
           }
         }
 
-        stage('JDK 11 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_11_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 11'
-          }
-        }
+        // Only run the oldest and newest JDKs on PR builds
+        if (!isChangeRequest(env)) {
+            stage('JDK 11 and Scala 2.13') {
+              agent { label 'ubuntu' }
+              tools {
+                jdk 'jdk_11_latest'
+              }
+              options {
+                timeout(time: 8, unit: 'HOURS')
+                timestamps()
+              }
+              environment {
+                SCALA_VERSION=2.13
+              }
+              steps {
+                doValidation()
+                doTest(env)
+                echo 'Skipping Kafka Streams archetype test for Java 11'
+              }
+            }
 
-        stage('JDK 17 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_17_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 17'
-          }
+            stage('JDK 17 and Scala 2.13') {
+              agent { label 'ubuntu' }
+              tools {
+                jdk 'jdk_17_latest'
+              }
+              options {
+                timeout(time: 8, unit: 'HOURS')
+                timestamps()
+              }
+              environment {
+                SCALA_VERSION=2.13
+              }
+              steps {
+                doValidation()
+                doTest(env)
+                echo 'Skipping Kafka Streams archetype test for Java 17'
+              }
+            }
         }
 
         stage('JDK 21 and Scala 2.13') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,12 @@ def doTest(env, target = "test") {
   junit '**/build/test-results/**/TEST-*.xml'
 }
 
+def runTestOnDevBranch(env) {
+  if (isChangeRequest(env)) {
+    doTest(env)
+  }
+}
+
 def doStreamsArchetype() {
   echo 'Verify that Kafka Streams archetype compiles'
 
@@ -127,15 +133,12 @@ pipeline {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
           }
-          when {
-            expression { !isChangeRequest(env) }
-          }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
             doValidation()
-            doTest(env)
+            runTestOnDevBranch(env)
             echo 'Skipping Kafka Streams archetype test for Java 11'
           }
         }
@@ -149,15 +152,12 @@ pipeline {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
           }
-          when {
-            expression { !isChangeRequest(env) }
-          }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
             doValidation()
-            doTest(env)
+            runTestOnDevBranch(env)
             echo 'Skipping Kafka Streams archetype test for Java 17'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ pipeline {
             timestamps()
           }
           when {
-            expression !isChangeRequest(env)
+            expression { !isChangeRequest(env) }
           }
           environment {
             SCALA_VERSION=2.13
@@ -150,7 +150,7 @@ pipeline {
             timestamps()
           }
           when {
-            expression !isChangeRequest(env)
+            expression { !isChangeRequest(env) }
           }
           environment {
             SCALA_VERSION=2.13


### PR DESCRIPTION
Testing these JDK versions in PRs is low value, and has a high cost in CI workload. At least temporarily we should disable these, and only run the full JDK suites for branch builds.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
