### PR TITLE
KAFKA-16535: Implement AddVoter, RemoveVoter, UpdateVoter RPCs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AddRaftVoterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AddRaftVoterOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#addRaftVoter}.
+ */
+@InterfaceStability.Stable
+public class AddRaftVoterOptions extends AbstractOptions<AddRaftVoterOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AddRaftVoterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AddRaftVoterResult.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link org.apache.kafka.clients.admin.Admin#addRaftVoter(int, org.apache.kafka.common.Uuid, java.util.Set, org.apache.kafka.clients.admin.AddRaftVoterOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Stable
+public class AddRaftVoterResult {
+    private final KafkaFuture<Void> result;
+
+    AddRaftVoterResult(KafkaFuture<Void> result) {
+        this.result = result;
+    }
+
+    /**
+     * Returns a future that completes when the voter has been added.
+     */
+    public KafkaFuture<Void> all() {
+        return result;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1712,6 +1712,62 @@ public interface Admin extends AutoCloseable {
     Uuid clientInstanceId(Duration timeout);
 
     /**
+     * Add a new voter node to the KRaft metadata quorum.
+     *
+     * @param voterId           The node ID of the voter.
+     * @param voterDirectoryId  The directory ID of the voter.
+     * @param endpoints         The endpoints that the new voter has.
+     */
+    default AddRaftVoterResult addRaftVoter(
+        int voterId,
+        Uuid voterDirectoryId,
+        Set<RaftVoterEndpoint> endpoints
+    ) {
+        return addRaftVoter(voterId, voterDirectoryId, endpoints, new AddRaftVoterOptions());
+    }
+
+    /**
+     * Add a new voter node to the KRaft metadata quorum.
+     *
+     * @param voterId           The node ID of the voter.
+     * @param voterDirectoryId  The directory ID of the voter.
+     * @param endpoints         The endpoints that the new voter has.
+     * @param options           The options to use when adding the new voter node.
+     */
+    AddRaftVoterResult addRaftVoter(
+        int voterId,
+        Uuid voterDirectoryId,
+        Set<RaftVoterEndpoint> endpoints,
+        AddRaftVoterOptions options
+    );
+
+    /**
+     * Remove a voter node from the KRaft metadata quorum.
+     *
+     * @param voterId           The node ID of the voter.
+     * @param voterDirectoryId  The directory ID of the voter.
+     */
+    default RemoveRaftVoterResult removeRaftVoter(
+        int voterId,
+        Uuid voterDirectoryId
+    ) {
+        return removeRaftVoter(voterId, voterDirectoryId, new RemoveRaftVoterOptions());
+    }
+
+    /**
+     * Remove a voter node from the KRaft metadata quorum.
+     *
+     * @param voterId           The node ID of the voter.
+     * @param voterDirectoryId  The directory ID of the voter.
+     * @param options           The options to use when removing the voter node.
+     */
+    RemoveRaftVoterResult removeRaftVoter(
+        int voterId,
+        Uuid voterDirectoryId,
+        RemoveRaftVoterOptions options
+    );
+
+    /**
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -289,6 +289,16 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public AddRaftVoterResult addRaftVoter(int voterId, Uuid voterDirectoryId, Set<RaftVoterEndpoint> endpoints, AddRaftVoterOptions options) {
+        return delegate.addRaftVoter(voterId, voterDirectoryId, endpoints, options);
+    }
+
+    @Override
+    public RemoveRaftVoterResult removeRaftVoter(int voterId, Uuid voterDirectoryId, RemoveRaftVoterOptions options) {
+        return delegate.removeRaftVoter(voterId, voterDirectoryId, options);
+    }
+
+    @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return delegate.metrics();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RaftVoterEndpoint.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RaftVoterEndpoint.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * An endpoint for a raft quorum voter.
+ */
+@InterfaceStability.Stable
+public class RaftVoterEndpoint {
+    private final String name;
+    private final String host;
+    private final int port;
+
+    static String requireNonNullAllCapsNonEmpty(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("Null argument not allowed.");
+        }
+        if (!input.trim().equals(input)) {
+            throw new IllegalArgumentException("Leading or trailing whitespace is not allowed.");
+        }
+        if (input.isEmpty()) {
+            throw new IllegalArgumentException("Empty string is not allowed.");
+        }
+        if (!input.toUpperCase(Locale.ROOT).equals(input)) {
+            throw new IllegalArgumentException("String must be UPPERCASE.");
+        }
+        return input;
+    }
+
+    /**
+     * Create an endpoint for a metadata quorum voter.
+     *
+     * @param name              The human-readable name for this endpoint. For example, CONTROLLER.
+     * @param host              The DNS hostname for this endpoint.
+     * @param port              The network port for this endpoint.
+     */
+    public RaftVoterEndpoint(
+        String name,
+        String host,
+        int port
+    ) {
+        this.name = requireNonNullAllCapsNonEmpty(name);
+        this.host = Objects.requireNonNull(host);
+        this.port = port;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String host() {
+        return host;
+    }
+
+    public int port() {
+        return port;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || (!o.getClass().equals(getClass()))) return false;
+        RaftVoterEndpoint other = (RaftVoterEndpoint) o;
+        return name.equals(other.name) &&
+            host.equals(other.host) &&
+            port == other.port;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, host, port);
+    }
+
+    @Override
+    public String toString() {
+        return "RaftVoterEndpoint" +
+            "(name=" + name +
+            ", host=" + host +
+            ", port=" + port +
+            ")";
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RemoveRaftVoterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RemoveRaftVoterOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#removeRaftVoter}.
+ */
+@InterfaceStability.Stable
+public class RemoveRaftVoterOptions extends AbstractOptions<RemoveRaftVoterOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RemoveRaftVoterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RemoveRaftVoterResult.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link org.apache.kafka.clients.admin.Admin#removeRaftVoter(int, org.apache.kafka.common.Uuid, org.apache.kafka.clients.admin.RemoveRaftVoterOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Stable
+public class RemoveRaftVoterResult {
+    private final KafkaFuture<Void> result;
+
+    RemoveRaftVoterResult(KafkaFuture<Void> result) {
+        this.result = result;
+    }
+
+    /**
+     * Returns a future that completes when the voter has been removed.
+     */
+    public KafkaFuture<Void> all() {
+        return result;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -122,7 +122,10 @@ public enum ApiKeys {
     SHARE_GROUP_HEARTBEAT(ApiMessageType.SHARE_GROUP_HEARTBEAT),
     SHARE_GROUP_DESCRIBE(ApiMessageType.SHARE_GROUP_DESCRIBE),
     SHARE_FETCH(ApiMessageType.SHARE_FETCH),
-    SHARE_ACKNOWLEDGE(ApiMessageType.SHARE_ACKNOWLEDGE);
+    SHARE_ACKNOWLEDGE(ApiMessageType.SHARE_ACKNOWLEDGE),
+    ADD_RAFT_VOTER(ApiMessageType.ADD_RAFT_VOTER),
+    REMOVE_RAFT_VOTER(ApiMessageType.REMOVE_RAFT_VOTER),
+    UPDATE_RAFT_VOTER(ApiMessageType.UPDATE_RAFT_VOTER);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -334,6 +334,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return ShareFetchRequest.parse(buffer, apiVersion);
             case SHARE_ACKNOWLEDGE:
                 return ShareAcknowledgeRequest.parse(buffer, apiVersion);
+            case ADD_RAFT_VOTER:
+                return AddRaftVoterRequest.parse(buffer, apiVersion);
+            case REMOVE_RAFT_VOTER:
+                return RemoveRaftVoterRequest.parse(buffer, apiVersion);
+            case UPDATE_RAFT_VOTER:
+                return UpdateRaftVoterRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -271,6 +271,12 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return ShareFetchResponse.parse(responseBuffer, version);
             case SHARE_ACKNOWLEDGE:
                 return ShareAcknowledgeResponse.parse(responseBuffer, version);
+            case ADD_RAFT_VOTER:
+                return AddRaftVoterResponse.parse(responseBuffer, version);
+            case REMOVE_RAFT_VOTER:
+                return RemoveRaftVoterResponse.parse(responseBuffer, version);
+            case UPDATE_RAFT_VOTER:
+                return UpdateRaftVoterResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AddRaftVoterRequestData;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class AddRaftVoterRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<AddRaftVoterRequest> {
+        private final AddRaftVoterRequestData data;
+
+        public Builder(AddRaftVoterRequestData data) {
+            super(ApiKeys.ADD_RAFT_VOTER);
+            this.data = data;
+        }
+
+        @Override
+        public AddRaftVoterRequest build(short version) {
+            return new AddRaftVoterRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+
+    }
+
+    private final AddRaftVoterRequestData data;
+
+    public AddRaftVoterRequest(AddRaftVoterRequestData data, short version) {
+        super(ApiKeys.ADD_RAFT_VOTER, version);
+        this.data = data;
+    }
+
+    @Override
+    public AddRaftVoterRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        return new AddRaftVoterResponse(new AddRaftVoterResponseData().
+            setErrorCode(error.code()).
+            setErrorMessage(error.message()).
+            setThrottleTimeMs(throttleTimeMs));
+    }
+
+    public static AddRaftVoterRequest parse(ByteBuffer buffer, short version) {
+        return new AddRaftVoterRequest(
+            new AddRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
+public class AddRaftVoterResponse extends AbstractResponse {
+    private final AddRaftVoterResponseData data;
+
+    public AddRaftVoterResponse(AddRaftVoterResponseData data) {
+        super(ApiKeys.ADD_RAFT_VOTER);
+        this.data = data;
+    }
+
+    @Override
+    public AddRaftVoterResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        // not supported
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        if (data.errorCode() != Errors.NONE.code()) {
+            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static AddRaftVoterResponse parse(ByteBuffer buffer, short version) {
+        return new AddRaftVoterResponse(
+            new AddRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class RemoveRaftVoterRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<RemoveRaftVoterRequest> {
+        private final RemoveRaftVoterRequestData data;
+
+        public Builder(RemoveRaftVoterRequestData data) {
+            super(ApiKeys.REMOVE_RAFT_VOTER);
+            this.data = data;
+        }
+
+        @Override
+        public RemoveRaftVoterRequest build(short version) {
+            return new RemoveRaftVoterRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+
+    }
+
+    private final RemoveRaftVoterRequestData data;
+
+    public RemoveRaftVoterRequest(RemoveRaftVoterRequestData data, short version) {
+        super(ApiKeys.REMOVE_RAFT_VOTER, version);
+        this.data = data;
+    }
+
+    @Override
+    public RemoveRaftVoterRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        return new RemoveRaftVoterResponse(new RemoveRaftVoterResponseData().
+            setErrorCode(error.code()).
+            setErrorMessage(error.message()).
+            setThrottleTimeMs(throttleTimeMs));
+    }
+
+    public static RemoveRaftVoterRequest parse(ByteBuffer buffer, short version) {
+        return new RemoveRaftVoterRequest(
+            new RemoveRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
+public class RemoveRaftVoterResponse extends AbstractResponse {
+    private final RemoveRaftVoterResponseData data;
+
+    public RemoveRaftVoterResponse(RemoveRaftVoterResponseData data) {
+        super(ApiKeys.REMOVE_RAFT_VOTER);
+        this.data = data;
+    }
+
+    @Override
+    public RemoveRaftVoterResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        // not supported
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        if (data.errorCode() != Errors.NONE.code()) {
+            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static RemoveRaftVoterResponse parse(ByteBuffer buffer, short version) {
+        return new RemoveRaftVoterResponse(
+            new RemoveRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
+import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class UpdateRaftVoterRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<UpdateRaftVoterRequest> {
+        private final UpdateRaftVoterRequestData data;
+
+        public Builder(UpdateRaftVoterRequestData data) {
+            super(ApiKeys.UPDATE_RAFT_VOTER);
+            this.data = data;
+        }
+
+        @Override
+        public UpdateRaftVoterRequest build(short version) {
+            return new UpdateRaftVoterRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+
+    }
+
+    private final UpdateRaftVoterRequestData data;
+
+    public UpdateRaftVoterRequest(UpdateRaftVoterRequestData data, short version) {
+        super(ApiKeys.UPDATE_RAFT_VOTER, version);
+        this.data = data;
+    }
+
+    @Override
+    public UpdateRaftVoterRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        return new UpdateRaftVoterResponse(new UpdateRaftVoterResponseData().
+            setErrorCode(Errors.forException(e).code()).
+            setThrottleTimeMs(throttleTimeMs));
+    }
+
+    public static UpdateRaftVoterRequest parse(ByteBuffer buffer, short version) {
+        return new UpdateRaftVoterRequest(
+            new UpdateRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
+public class UpdateRaftVoterResponse extends AbstractResponse {
+    private final UpdateRaftVoterResponseData data;
+
+    public UpdateRaftVoterResponse(UpdateRaftVoterResponseData data) {
+        super(ApiKeys.UPDATE_RAFT_VOTER);
+        this.data = data;
+    }
+
+    @Override
+    public UpdateRaftVoterResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        // not supported
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        if (data.errorCode() != Errors.NONE.code()) {
+            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static UpdateRaftVoterResponse parse(ByteBuffer buffer, short version) {
+        return new UpdateRaftVoterResponse(
+            new UpdateRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/resources/common/message/AddRaftVoterRequest.json
+++ b/clients/src/main/resources/common/message/AddRaftVoterRequest.json
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 80,
+  "type": "request",
+  "listeners": ["controller", "broker"],
+  "name": "AddRaftVoterRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterId", "type": "string", "versions": "0+" },
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+" },
+    { "name": "VoterId", "type": "int32", "versions": "0+",
+      "about": "The replica id of the voter getting added to the topic partition" },
+    { "name": "VoterDirectoryId", "type": "uuid", "versions": "0+",
+      "about": "The directory id of the voter getting added to the topic partition" },
+    { "name": "Listeners", "type": "[]Listener", "versions": "0+",
+      "about": "The endpoints that can be used to communicate with the voter", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The name of the endpoint" },
+      { "name": "Host", "type": "string", "versions": "0+",
+        "about": "The hostname" },
+      { "name": "Port", "type": "uint16", "versions": "0+",
+        "about": "The port" }
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/AddRaftVoterResponse.json
+++ b/clients/src/main/resources/common/message/AddRaftVoterResponse.json
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 80,
+  "type": "response",
+  "name": "AddRaftVoterResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error" },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/RemoveRaftVoterRequest.json
+++ b/clients/src/main/resources/common/message/RemoveRaftVoterRequest.json
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 81,
+  "type": "request",
+  "listeners": ["controller", "broker"],
+  "name": "RemoveRaftVoterRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterId", "type": "string", "versions": "0+" },
+    { "name": "VoterId", "type": "int32", "versions": "0+",
+      "about": "The replica id of the voter getting removed from the topic partition" },
+    { "name": "VoterDirectoryId", "type": "uuid", "versions": "0+",
+      "about": "The directory id of the voter getting removed from the topic partition" }
+  ]
+}

--- a/clients/src/main/resources/common/message/RemoveRaftVoterResponse.json
+++ b/clients/src/main/resources/common/message/RemoveRaftVoterResponse.json
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 81,
+  "type": "response",
+  "name": "RemoveRaftVoterResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error" },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
+++ b/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 82,
+  "type": "request",
+  "listeners": ["controller"],
+  "name": "UpdateRaftVoterRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterId", "type": "string", "versions": "0+" },
+    { "name": "VoterId", "type": "int32", "versions": "0+",
+      "about": "The replica id of the voter getting updated in the topic partition" },
+    { "name": "VoterDirectoryId", "type": "uuid", "versions": "0+",
+      "about": "The directory id of the voter getting updated in the topic partition" },
+    { "name": "Listeners", "type": "[]Listener", "versions": "0+",
+      "about": "The endpoint that can be used to communicate with the leader", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The name of the endpoint" },
+      { "name": "Host", "type": "string", "versions": "0+",
+        "about": "The hostname" },
+      { "name": "Port", "type": "uint16", "versions": "0+",
+        "about": "The port" }
+    ]},
+    { "name": "KRaftVersionFeature", "type": "KRaftVersionFeature", "versions": "0+",
+      "about": "The range of versions of the protocol that the replica supports", "fields": [
+      { "name": "MinSupportedVersion", "type": "int16", "versions": "0+",
+        "about": "The minimum supported KRaft protocol version" },
+      { "name": "MaxSupportedVersion", "type": "int16", "versions": "0+",
+        "about": "The maximum supported KRaft protocol version" }
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/UpdateRaftVoterResponse.json
+++ b/clients/src/main/resources/common/message/UpdateRaftVoterResponse.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 82,
+  "type": "response",
+  "name": "UpdateRaftVoterResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error" }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1321,6 +1321,16 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public AddRaftVoterResult addRaftVoter(int voterId, Uuid voterDirectoryId, Set<RaftVoterEndpoint> endpoints, AddRaftVoterOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public RemoveRaftVoterResult removeRaftVoter(int voterId, Uuid voterDirectoryId, RemoveRaftVoterOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -44,6 +44,8 @@ import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.AddPartitio
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.AddPartitionsToTxnTopicCollection;
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.AddPartitionsToTxnTransaction;
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.AddPartitionsToTxnTransactionCollection;
+import org.apache.kafka.common.message.AddRaftVoterRequestData;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
 import org.apache.kafka.common.message.AllocateProducerIdsRequestData;
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData;
 import org.apache.kafka.common.message.AlterClientQuotasResponseData;
@@ -205,6 +207,8 @@ import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.PushTelemetryRequestData;
 import org.apache.kafka.common.message.PushTelemetryResponseData;
+import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.message.SaslAuthenticateRequestData;
@@ -233,6 +237,8 @@ import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataB
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataEndpoint;
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataPartitionState;
 import org.apache.kafka.common.message.UpdateMetadataResponseData;
+import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
+import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.network.ListenerName;
@@ -1098,6 +1104,9 @@ public class RequestResponseTest {
             case SHARE_GROUP_DESCRIBE: return createShareGroupDescribeRequest(version);
             case SHARE_FETCH: return createShareFetchRequest(version);
             case SHARE_ACKNOWLEDGE: return createShareAcknowledgeRequest(version);
+            case ADD_RAFT_VOTER: return createAddRaftVoterRequest(version);
+            case REMOVE_RAFT_VOTER: return createRemoveRaftVoterRequest(version);
+            case UPDATE_RAFT_VOTER: return createUpdateRaftVoterRequest(version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1184,6 +1193,9 @@ public class RequestResponseTest {
             case SHARE_GROUP_DESCRIBE: return createShareGroupDescribeResponse();
             case SHARE_FETCH: return createShareFetchResponse();
             case SHARE_ACKNOWLEDGE: return createShareAcknowledgeResponse();
+            case ADD_RAFT_VOTER: return createAddRaftVoterResponse();
+            case REMOVE_RAFT_VOTER: return createRemoveRaftVoterResponse();
+            case UPDATE_RAFT_VOTER: return createUpdateRaftVoterResponse();
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1282,6 +1294,58 @@ public class RequestResponseTest {
                 .setTopics(Arrays.asList(new DescribeTopicPartitionsRequestData.TopicRequest().setName("foo")))
                 .setCursor(new DescribeTopicPartitionsRequestData.Cursor().setTopicName("foo").setPartitionIndex(1));
         return new DescribeTopicPartitionsRequest.Builder(data).build(version);
+    }
+
+    private AddRaftVoterRequest createAddRaftVoterRequest(short version) {
+        return new AddRaftVoterRequest(new AddRaftVoterRequestData().
+            setClusterId("FmRMoH-iTCSFNnzgpkWT2A").
+            setTimeoutMs(60_000).
+            setVoterId(1).
+            setVoterDirectoryId(Uuid.fromString("DZG26STKRxaelDpg2wqsXw")).
+            setListeners(new AddRaftVoterRequestData.ListenerCollection(
+                Collections.singletonList(new AddRaftVoterRequestData.Listener().
+                    setName("CONTROLLER").
+                    setHost("localhost").
+                    setPort(8080)).iterator())
+            ), version);
+    }
+
+    private AddRaftVoterResponse createAddRaftVoterResponse() {
+        return new AddRaftVoterResponse(new AddRaftVoterResponseData().
+            setErrorCode((short) 0).
+            setErrorMessage(null));
+    }
+
+    private RemoveRaftVoterRequest createRemoveRaftVoterRequest(short version) {
+        return new RemoveRaftVoterRequest(new RemoveRaftVoterRequestData().
+                setClusterId("FmRMoH-iTCSFNnzgpkWT2A").
+                setVoterId(1).
+                setVoterDirectoryId(Uuid.fromString("DZG26STKRxaelDpg2wqsXw")),
+                version);
+    }
+
+    private RemoveRaftVoterResponse createRemoveRaftVoterResponse() {
+        return new RemoveRaftVoterResponse(new RemoveRaftVoterResponseData().
+            setErrorCode((short) 0).
+            setErrorMessage(null));
+    }
+
+    private UpdateRaftVoterRequest createUpdateRaftVoterRequest(short version) {
+        return new UpdateRaftVoterRequest(new UpdateRaftVoterRequestData().
+                setClusterId("FmRMoH-iTCSFNnzgpkWT2A").
+                setVoterId(1).
+                setVoterDirectoryId(Uuid.fromString("DZG26STKRxaelDpg2wqsXw")).
+                setListeners(new UpdateRaftVoterRequestData.ListenerCollection(
+                    Collections.singletonList(new UpdateRaftVoterRequestData.Listener().
+                        setName("CONTROLLER").
+                        setHost("localhost").
+                        setPort(8080)).iterator())),
+                version);
+    }
+
+    private UpdateRaftVoterResponse createUpdateRaftVoterResponse() {
+        return new UpdateRaftVoterResponse(new UpdateRaftVoterResponseData().
+            setErrorCode((short) 0));
     }
 
     private DescribeTopicPartitionsResponse createDescribeTopicPartitionsResponse() {

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -107,6 +107,9 @@ object RequestConvertToJson {
       case req: UpdateMetadataRequest => UpdateMetadataRequestDataJsonConverter.write(req.data, request.version)
       case req: VoteRequest => VoteRequestDataJsonConverter.write(req.data, request.version)
       case req: WriteTxnMarkersRequest => WriteTxnMarkersRequestDataJsonConverter.write(req.data, request.version)
+      case req: AddRaftVoterRequest => AddRaftVoterRequestDataJsonConverter.write(req.data, request.version)
+      case req: RemoveRaftVoterRequest => RemoveRaftVoterRequestDataJsonConverter.write(req.data, request.version)
+      case req: UpdateRaftVoterRequest => UpdateRaftVoterRequestDataJsonConverter.write(req.data, request.version)
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.")
     }
@@ -194,6 +197,9 @@ object RequestConvertToJson {
       case res: UpdateMetadataResponse => UpdateMetadataResponseDataJsonConverter.write(res.data, version)
       case res: VoteResponse => VoteResponseDataJsonConverter.write(res.data, version)
       case res: WriteTxnMarkersResponse => WriteTxnMarkersResponseDataJsonConverter.write(res.data, version)
+      case res: AddRaftVoterResponse => AddRaftVoterResponseDataJsonConverter.write(res.data, version)
+      case res: RemoveRaftVoterResponse => RemoveRaftVoterResponseDataJsonConverter.write(res.data, version)
+      case res: UpdateRaftVoterResponse => UpdateRaftVoterResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.")
     }

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -31,7 +31,10 @@ import kafka.utils.CoreUtils
 import kafka.utils.FileLock
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, NetworkClient}
-import org.apache.kafka.common.{KafkaException, Node, TopicPartition, Uuid}
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{ChannelBuilders, ListenerName, NetworkReceive, Selectable, Selector}

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -129,6 +129,9 @@ class ControllerApis(
         case ApiKeys.DESCRIBE_CLUSTER => handleDescribeCluster(request)
         case ApiKeys.CONTROLLER_REGISTRATION => handleControllerRegistration(request)
         case ApiKeys.ASSIGN_REPLICAS_TO_DIRS => handleAssignReplicasToDirs(request)
+        case ApiKeys.ADD_RAFT_VOTER => handleAddRaftVoter(request)
+        case ApiKeys.REMOVE_RAFT_VOTER => handleRemoveRaftVoter(request)
+        case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -1079,5 +1082,20 @@ class ControllerApis(
       requestHelper.sendResponseMaybeThrottle(request,
         requestThrottleMs => new AssignReplicasToDirsResponse(reply.setThrottleTimeMs(requestThrottleMs)))
     }
+  }
+
+  def handleAddRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, ALTER)
+    throw new UnsupportedVersionException("handleAddRaftVoter is not supported yet.")
+  }
+
+  def handleRemoveRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, ALTER)
+    throw new UnsupportedVersionException("handleRemoveRaftVoter is not supported yet.")
+  }
+
+  def handleUpdateRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    throw new UnsupportedVersionException("handleUpdateRaftVoter is not supported yet.")
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -256,6 +256,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS => handleGetTelemetrySubscriptionsRequest(request)
         case ApiKeys.PUSH_TELEMETRY => handlePushTelemetryRequest(request)
         case ApiKeys.LIST_CLIENT_METRICS_RESOURCES => handleListClientMetricsResources(request)
+        case ApiKeys.ADD_RAFT_VOTER => forwardToControllerOrFail(request)
+        case ApiKeys.REMOVE_RAFT_VOTER => forwardToControllerOrFail(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -730,6 +730,15 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.SHARE_ACKNOWLEDGE =>
           new ShareAcknowledgeRequest.Builder(new ShareAcknowledgeRequestData(), true)
 
+        case ApiKeys.ADD_RAFT_VOTER =>
+          new AddRaftVoterRequest.Builder(new AddRaftVoterRequestData())
+
+        case ApiKeys.REMOVE_RAFT_VOTER =>
+          new RemoveRaftVoterRequest.Builder(new RemoveRaftVoterRequestData())
+
+        case ApiKeys.UPDATE_RAFT_VOTER =>
+          new UpdateRaftVoterRequest.Builder(new UpdateRaftVoterRequestData())
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
Implement the add voter, remove voter, and update voter RPCs for
KIP-853. This is just adding the RPC handling; the current
implementation in RaftManager just throws UnsupportedVersionException