### PR TITLE
KAFKA-16796: Introduce new org.apache.kafka.tools.api.Decoder to replace kafka.serializer.Decoder

### DIFF
--- a/core/src/main/scala/kafka/serializer/Decoder.scala
+++ b/core/src/main/scala/kafka/serializer/Decoder.scala
@@ -27,13 +27,15 @@ import kafka.utils.VerifiableProperties
  * An implementation is required to provide a constructor that
  * takes a VerifiableProperties instance.
  */
-trait Decoder[T] {
+@deprecated(since = "3.8.0")
+trait Decoder[T]  {
   def fromBytes(bytes: Array[Byte]): T
 }
 
 /**
  * The default implementation does nothing, just returns the same byte array it takes in.
  */
+@deprecated(since = "3.8.0")
 class DefaultDecoder(props: VerifiableProperties = null) extends Decoder[Array[Byte]] {
   def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
 }
@@ -42,6 +44,7 @@ class DefaultDecoder(props: VerifiableProperties = null) extends Decoder[Array[B
  * The string decoder translates bytes into strings. It uses UTF8 by default but takes
  * an optional property serializer.encoding to control this.
  */
+@deprecated(since = "3.8.0")
 class StringDecoder(props: VerifiableProperties = null) extends Decoder[String] {
   val encoding: String =
     if (props == null)
@@ -57,6 +60,7 @@ class StringDecoder(props: VerifiableProperties = null) extends Decoder[String] 
 /**
   * The long decoder translates bytes into longs.
   */
+@deprecated(since = "3.8.0")
 class LongDecoder(props: VerifiableProperties = null) extends Decoder[Long] {
   def fromBytes(bytes: Array[Byte]): Long = {
     ByteBuffer.wrap(bytes).getLong
@@ -66,6 +70,7 @@ class LongDecoder(props: VerifiableProperties = null) extends Decoder[Long] {
 /**
   * The integer decoder translates bytes into integers.
   */
+@deprecated(since = "3.8.0")
 class IntegerDecoder(props: VerifiableProperties = null) extends Decoder[Integer] {
   def fromBytes(bytes: Array[Byte]): Integer = {
     ByteBuffer.wrap(bytes).getInt()

--- a/tools/tools-api/src/main/java/org/apache/kafka/tools/api/Decoder.java
+++ b/tools/tools-api/src/main/java/org/apache/kafka/tools/api/Decoder.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.api;
+
+/**
+ * A decoder is a method of turning byte arrays into objects.
+ */
+@FunctionalInterface
+public interface Decoder<T> {
+    T fromBytes(byte[] bytes);
+}

--- a/tools/tools-api/src/main/java/org/apache/kafka/tools/api/DefaultDecoder.java
+++ b/tools/tools-api/src/main/java/org/apache/kafka/tools/api/DefaultDecoder.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.api;
+
+/**
+ * The default implementation does nothing, just returns the same byte array it takes in.
+ */
+public class DefaultDecoder implements Decoder<byte[]> {
+    @Override
+    public byte[] fromBytes(byte[] bytes) {
+        return bytes;
+    }
+}

--- a/tools/tools-api/src/main/java/org/apache/kafka/tools/api/IntegerDecoder.java
+++ b/tools/tools-api/src/main/java/org/apache/kafka/tools/api/IntegerDecoder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.api;
+
+import java.nio.ByteBuffer;
+
+/**
+ * The integer decoder translates bytes into integers.
+ */
+public class IntegerDecoder implements Decoder<Integer> {
+    @Override
+    public Integer fromBytes(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).getInt();
+    }
+}

--- a/tools/tools-api/src/main/java/org/apache/kafka/tools/api/LongDecoder.java
+++ b/tools/tools-api/src/main/java/org/apache/kafka/tools/api/LongDecoder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.api;
+
+import java.nio.ByteBuffer;
+
+/**
+ * The long decoder translates bytes into longs.
+ */
+public class LongDecoder implements Decoder<Long> {
+    @Override
+    public Long fromBytes(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).getLong();
+    }
+}

--- a/tools/tools-api/src/main/java/org/apache/kafka/tools/api/StringDecoder.java
+++ b/tools/tools-api/src/main/java/org/apache/kafka/tools/api/StringDecoder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.api;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The string decoder translates bytes into strings. It uses UTF8 by default.
+ */
+public class StringDecoder implements Decoder<String> {
+    @Override
+    public String fromBytes(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
We need a replacement in order to complete https://issues.apache.org/jira/browse/KAFKA-14579 in kafak 4.0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
