### PR TITLE
Adding standalone parameter to kafka-storage.sh [KAFKA-16518]

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -166,6 +166,55 @@ Found problem:
   }
 
   @Test
+  def testStandaloneCommandOnEmptyDirectory(): Unit = {
+    val stream = new ByteArrayOutputStream()
+    val tempDir = TestUtils.tempDir()
+    val metaPropertiesFile = tempDir + "/" + MetaPropertiesEnsemble.META_PROPERTIES_NAME
+    try {
+      assertEquals(0, StorageTool.
+        standaloneCommand(new PrintStream(stream), tempDir.toString))
+
+      assertEquals(
+        s"""Found metadata log directory:
+  ${tempDir.toString}
+
+directory.id written to file : ${metaPropertiesFile}
+""", stream.toString())
+    } finally Utils.delete(tempDir)
+  }
+
+  @Test
+  def testStorageCommandOnMissingDirectory(): Unit = {
+    val stream = new ByteArrayOutputStream()
+    val tempDir = TestUtils.tempDir()
+    tempDir.delete()
+    try {
+      assertEquals(1, StorageTool.
+        standaloneCommand(new PrintStream(stream), tempDir.toString))
+      assertEquals(
+        s"""Found problem:
+  ${tempDir.toString} does not exist
+
+""", stream.toString())
+    } finally Utils.delete(tempDir)
+  }
+
+  @Test
+  def testStorageCommandOnDirectoryAsFile(): Unit = {
+    val stream = new ByteArrayOutputStream()
+    val tempFile = TestUtils.tempFile()
+    try {
+      assertEquals(1, StorageTool.
+        standaloneCommand(new PrintStream(stream), tempFile.toString))
+      assertEquals(
+        s"""Found problem:
+  ${tempFile.toString} is not a directory
+
+""", stream.toString())
+    } finally tempFile.delete()
+  }
+
+  @Test
   def testFormatEmptyDirectory(): Unit = {
     val tempDir = TestUtils.tempDir()
     try {


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

- kafka-storage.sh with a new parameter 'standalone' which creates a meta.properties file in metadata log dir
- random id directory.id written to file

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
