### PR TITLE
MINOR: Use predetermined dir IDs in ReplicationQuotasTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -139,19 +139,14 @@ class ReplicationQuotasTest extends QuorumTestHarness {
         }
       }
       //Either throttle the six leaders or the two followers
-      if (leaderThrottle) {
-        admin.incrementalAlterConfigs(
-          Map(new ConfigResource(TOPIC, topic) -> Seq(new AlterConfigOp(new ConfigEntry(
-            QuotaConfigs.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:100,1:101,2:102,3:103,4:104,5:105"),
-            SET)).asJavaCollection).asJava
-        ).all().get()
-      } else {
-        admin.incrementalAlterConfigs(
-          Map(new ConfigResource(TOPIC, topic) -> Seq(new AlterConfigOp(new ConfigEntry(
-            QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:106,1:106,2:106,3:107,4:107,5:107"),
-            SET)).asJavaCollection).asJava
-        ).all().get()
-      }
+      val configEntry = if (leaderThrottle)
+        new ConfigEntry(QuotaConfigs.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:100,1:101,2:102,3:103,4:104,5:105")
+      else
+        new ConfigEntry(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:106,1:106,2:106,3:107,4:107,5:107")
+
+      admin.incrementalAlterConfigs(
+        Map(new ConfigResource(TOPIC, topic) -> Seq(new AlterConfigOp(configEntry, SET)).asJavaCollection).asJava
+      ).all().get()
     }
 
     //Add data equally to each partition
@@ -307,7 +302,9 @@ class ReplicationQuotasTest extends QuorumTestHarness {
         .setClusterId(controllerServer.clusterId)
         .setIncarnationId(Uuid.randomUuid())
         .setListeners(listeners)
-        .setLogDirs(Collections.singletonList(Uuid.randomUuid()))
+        .setLogDirs(Collections.singletonList(
+          Uuid.fromString(s"TESTBROKER${Integer.toString(100000 + id).substring(1)}DIRAAAA")
+        ))
         .setFeatures(features)
     ).get()
   }


### PR DESCRIPTION
The registerBroker function in this test file needs to use the directory UUIDs assigned to the broker and not random UUIDs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
