### PR TITLE
KAFKA-16805: Stop using a ClosureBackedAction to configure Spotbugs reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -743,7 +743,7 @@ subprojects {
   test.dependsOn('spotbugsMain')
 
   tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
-    reports {
+    reports.configure { reports ->
       // Continue supporting `xmlFindBugsReport` for compatibility
       xml.enabled(project.hasProperty('xmlSpotBugsReport') || project.hasProperty('xmlFindBugsReport'))
       html.enabled(!project.hasProperty('xmlSpotBugsReport') && !project.hasProperty('xmlFindBugsReport'))

--- a/build.gradle
+++ b/build.gradle
@@ -742,8 +742,8 @@ subprojects {
   }
   test.dependsOn('spotbugsMain')
 
-  tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
-    reports.configure { reports ->
+  tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+    reports.configure {
       // Continue supporting `xmlFindBugsReport` for compatibility
       xml.enabled(project.hasProperty('xmlSpotBugsReport') || project.hasProperty('xmlFindBugsReport'))
       html.enabled(!project.hasProperty('xmlSpotBugsReport') && !project.hasProperty('xmlFindBugsReport'))


### PR DESCRIPTION
This issue https://issues.apache.org/jira/browse/KAFKA-16805, I change the `reports` method to `reports.configure` to avoid use the ClosureBackedAction interface
