### PR TITLE
KAFKA-16414: Inconsistent active segment expiration behavior between retention.ms and retention.bytes

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1585,7 +1585,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     if (retentionSize < 0 || size < retentionSize) return 0
     var diff = size - retentionSize
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
-      if (diff - segment.size >= 0) {
+      if (diff - segment.size >= 0 || segment.size() > retentionSize) {
         diff -= segment.size
         true
       } else {


### PR DESCRIPTION
Approach 1: make `retention.bytes` roll active segment when active segment size > `retention.bytes`

Leave this draft and evaluate the scope of CI affected by this commit.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
