### PR TITLE
MINOR: Log client idle disconnect events at DEBUG level

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -995,12 +995,13 @@ public class NetworkClient implements KafkaClient {
     private void handleDisconnections(List<ClientResponse> responses, long now) {
         for (Map.Entry<String, ChannelState> entry : this.selector.disconnected().entrySet()) {
             String node = entry.getKey();
-            if (null != entry.getValue() && entry.getValue() == ChannelState.EXPIRED) {
+            ChannelState channelState = entry.getValue();
+            if (channelState == ChannelState.EXPIRED) {
                 log.debug("Idle connection to node {} disconnected.", node);
             } else {
                 log.info("Node {} disconnected.", node);
             }
-            processDisconnection(responses, node, now, entry.getValue());
+            processDisconnection(responses, node, now, channelState);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -995,7 +995,11 @@ public class NetworkClient implements KafkaClient {
     private void handleDisconnections(List<ClientResponse> responses, long now) {
         for (Map.Entry<String, ChannelState> entry : this.selector.disconnected().entrySet()) {
             String node = entry.getKey();
-            log.info("Node {} disconnected.", node);
+            if (null != entry.getValue() && entry.getValue() == ChannelState.EXPIRED) {
+                log.debug("Idle connection to node {} disconnected.", node);
+            } else {
+                log.info("Node {} disconnected.", node);
+            }
             processDisconnection(responses, node, now, entry.getValue());
         }
     }


### PR DESCRIPTION
We recently increased that log verbosity from INFO to DEBUG, but this is causing some confusion among users when an idle connection is disconnected, which is a normal activity. This is a proposal to make it clear that the connection being disconnect has expired, thank you

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
