### PR TITLE
Fix the config name in `ProducerFailureHandlingTest`

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -45,7 +45,7 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
   val overridingProps = new Properties()
   overridingProps.put(ServerLogConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, false.toString)
   overridingProps.put(KafkaConfig.MessageMaxBytesProp, serverMessageMaxBytes.toString)
-  overridingProps.put(ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_CONFIG, replicaFetchMaxPartitionBytes.toString)
+  overridingProps.put(ReplicationConfigs.REPLICA_FETCH_MAX_BYTES_CONFIG, replicaFetchMaxPartitionBytes.toString)
   overridingProps.put(ReplicationConfigs.REPLICA_FETCH_RESPONSE_MAX_BYTES_DOC, replicaFetchMaxResponseBytes.toString)
   // Set a smaller value for the number of partitions for the offset commit topic (__consumer_offset topic)
   // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long


### PR DESCRIPTION
The following commit (https://github.com/apache/kafka/commit/8c0458861c92d0a85969e99cb3b62c3256ad21e8) had introduced an incorrect name for one of the configs in `ProducerFailureHandlingTest`

When moving from `KafkaConfig.ReplicaFetchMaxBytesProp` we used `ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_CONFIG` instead of `ReplicationConfigs.REPLICA_FETCH_MAX_BYTES_CONFIG`. This PR patches the same.

Thanks!