### PR TITLE
MINOR: Modify doc of advertised.listeners to show supported on KRaft mode.

### DIFF
--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -58,7 +58,7 @@ public class SocketServerConfigs {
 
     public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
     public static final String ADVERTISED_LISTENERS_DOC = String.format(
-            "Listeners to publish to ZooKeeper for clients to use, if different than the <code>%s</code> config property." +
+            "Listeners to publish to ZooKeeper or KRaft for clients to use, if different than the <code>%s</code> config property." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +


### PR DESCRIPTION
`advertised.listeners` is usable on not only ZooKeeper mode but also KRaft mode.
This PR changes related description of doc to explain it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
