### PR TITLE
KAFKA-16844: Add ByteBuffer support for Connect ByteArrayConverter

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/converters/ByteArrayConverterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/converters/ByteArrayConverterTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
@@ -74,6 +75,29 @@ public class ByteArrayConverterTest {
     @Test
     public void testFromConnectNull() {
         assertNull(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, null));
+    }
+
+    @Test
+    public void testFromConnectByteBufferValue() {
+        ByteBuffer buffer = ByteBuffer.wrap(SAMPLE_BYTES);
+        assertArrayEquals(
+                SAMPLE_BYTES,
+                converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, buffer));
+
+        buffer.rewind();
+        buffer.get(); // Move the position
+        assertArrayEquals(
+                SAMPLE_BYTES,
+                converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, buffer));
+
+        buffer = null;
+        assertNull(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, buffer));
+
+        byte[] emptyBytes = new byte[0];
+        buffer = ByteBuffer.wrap(emptyBytes);
+        assertArrayEquals(
+                emptyBytes,
+                converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, buffer));
     }
 
     @Test


### PR DESCRIPTION
In current Connect schema design, schema type Bytes have 2 representations, byte[] and ByteBuffer. But current ByteArrayConverter can only convert byte[]. 
This PR adds ByteBuffer support in ByteArrayConverter. Also added test for the change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
