### PR TITLE
MINOR: Add test for KeyValue.toString() method

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/KeyValueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KeyValueTest.java
@@ -71,4 +71,18 @@ public class KeyValueTest {
         assertNotEquals(differentKeyAndValue, kv, "must be false if key and value are different");
     }
 
+    @Test
+    public void shouldReturnCorrectToString() {
+        final KeyValue<String, Long> kv = KeyValue.pair("key1", 1L);
+        assertEquals("KeyValue(key1, 1)", kv.toString());
+
+        final KeyValue<String, Long> kvNullKey = KeyValue.pair(null, 1L);
+        assertEquals("KeyValue(null, 1)", kvNullKey.toString());
+
+        final KeyValue<String, Long> kvNullValue = KeyValue.pair("key1", null);
+        assertEquals("KeyValue(key1, null)", kvNullValue.toString());
+
+        final KeyValue<String, Long> kvNullKeyValue = KeyValue.pair(null, null);
+        assertEquals("KeyValue(null, null)", kvNullKeyValue.toString());
+    }
 }


### PR DESCRIPTION
Added test cases to ensure that the ToString() method works accordingly for KeyValue objects.

This contribution is my original work and I license the work to the project under the project's open source license.
