### PR TITLE
Minor fix invalid name REPLICA_LAG_TIME_MAX_MS_CONFIG

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -45,7 +45,7 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
   val overridingProps = new Properties()
   overridingProps.put(ServerLogConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, false.toString)
   overridingProps.put(KafkaConfig.MessageMaxBytesProp, serverMessageMaxBytes.toString)
-  overridingProps.put(ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_CONFIG, replicaFetchMaxPartitionBytes.toString)
+  overridingProps.put(ReplicationConfigs.REPLICA_FETCH_MAX_BYTES_CONFIG, replicaFetchMaxPartitionBytes.toString)
   overridingProps.put(ReplicationConfigs.REPLICA_FETCH_RESPONSE_MAX_BYTES_DOC, replicaFetchMaxResponseBytes.toString)
   // Set a smaller value for the number of partitions for the offset commit topic (__consumer_offset topic)
   // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long


### PR DESCRIPTION
**Summary**
Fixed minor naming error introduced as part of https://github.com/apache/kafka/pull/15575/files#diff-f4c48da6e1d079a4579514d7b2102804e805f16cd172dfe8bddf866f7028d333L46 