### PR TITLE
KAFKA-16843: Remove preAppendErrors from createPutCacheCallback

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 import com.yammer.metrics.core.Gauge
 import kafka.common.OffsetAndMetadata
 import kafka.coordinator.group.GroupMetadataManager.maybeConvertOffsetCommitError
-import kafka.server.{LogAppendResult, ReplicaManager, RequestLocal}
+import kafka.server.{ReplicaManager, RequestLocal}
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Implicits._
 import kafka.utils._
@@ -377,14 +377,13 @@ class GroupMetadataManager(brokerId: Int,
   }
 
   private def createPutCacheCallback(isTxnOffsetCommit: Boolean,
-                             group: GroupMetadata,
-                             consumerId: String,
-                             offsetMetadata: immutable.Map[TopicIdPartition, OffsetAndMetadata],
-                             filteredOffsetMetadata: Map[TopicIdPartition, OffsetAndMetadata],
-                             responseCallback: immutable.Map[TopicIdPartition, Errors] => Unit,
-                             producerId: Long,
-                             records: Map[TopicPartition, MemoryRecords],
-                             preAppendErrors: Map[TopicPartition, LogAppendResult] = Map.empty): Map[TopicPartition, PartitionResponse] => Unit = {
+                                     group: GroupMetadata,
+                                     consumerId: String,
+                                     offsetMetadata: immutable.Map[TopicIdPartition, OffsetAndMetadata],
+                                     filteredOffsetMetadata: Map[TopicIdPartition, OffsetAndMetadata],
+                                     responseCallback: immutable.Map[TopicIdPartition, Errors] => Unit,
+                                     producerId: Long,
+                                     records: Map[TopicPartition, MemoryRecords]): Map[TopicPartition, PartitionResponse] => Unit = {
     val offsetTopicPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, partitionFor(group.groupId))
     // set the callback function to insert offsets into cache after log append completed
     def putCacheCallback(responseStatus: Map[TopicPartition, PartitionResponse]): Unit = {
@@ -435,8 +434,6 @@ class GroupMetadataManager(brokerId: Int,
       val commitStatus = offsetMetadata.map { case (topicIdPartition, offsetAndMetadata) =>
         if (!validateOffsetMetadataLength(offsetAndMetadata.metadata))
           (topicIdPartition, Errors.OFFSET_METADATA_TOO_LARGE)
-        else if (preAppendErrors.contains(topicIdPartition.topicPartition))
-          (topicIdPartition, preAppendErrors(topicIdPartition.topicPartition).error)
         else
           (topicIdPartition, responseError)
       }


### PR DESCRIPTION
The method `createPutCacheCallback` has a input argument [`preAppendErrors`](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala#L387). It is used to keep the "error" happens before appending. However, it is always empty. Also, the pre-append error is handled before `createPutCacheCallback` by calling [`responseCallback`](https://github.com/apache/kafka/blob/4f55786a8a86fe228a0b10a2f28529f5128e5d6f/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala#L927C15-L927C84). Hence, we can remove `preAppendErrors`.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
