### PR TITLE
KAFKA-16840 [WIP]: Add --timeout option for ConfigCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -368,7 +368,7 @@ object ConfigCommand extends Logging {
           throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
 
         val configResource = new ConfigResource(ConfigResource.Type.TOPIC, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(opts.timeoutMs.toInt).validateOnly(false)
         val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
           ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
         ).asJavaCollection
@@ -390,7 +390,7 @@ object ConfigCommand extends Logging {
         val newConfig = new JConfig(newEntries.asJava.values)
 
         val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(opts.timeoutMs.toInt).validateOnly(false)
         adminClient.alterConfigs(Map(configResource -> newConfig).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
 
       case BrokerLoggerConfigType =>
@@ -401,7 +401,7 @@ object ConfigCommand extends Logging {
           throw new InvalidConfigurationException(s"Invalid broker logger(s): ${invalidBrokerLoggers.mkString(",")}")
 
         val configResource = new ConfigResource(ConfigResource.Type.BROKER_LOGGER, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(opts.timeoutMs.toInt).validateOnly(false)
         val alterLogLevelEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
           ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
         ).asJavaCollection
@@ -457,7 +457,7 @@ object ConfigCommand extends Logging {
           throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
 
         val configResource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(opts.timeoutMs.toInt).validateOnly(false)
         val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
           ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
           ).asJavaCollection
@@ -865,6 +865,11 @@ object ConfigCommand extends Logging {
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
         ZkConfigs.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.asScala.keys.toList.sorted.mkString(", ") + " are ignored.")
       .withRequiredArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
+    private val timeoutMsOpt = parser.accepts("timeout", "The maximum amount of time in milliseconds to wait for the command to finish.")
+      .withRequiredArg()
+      .describedAs("timeout (ms)")
+      .ofType(classOf[Long])
+      .defaultsTo(30000L)
     options = parser.parse(args : _*)
 
     private val entityFlags = List((topic, ConfigType.TOPIC),
@@ -895,6 +900,10 @@ object ConfigCommand extends Logging {
       entityDefaultsFlags
         .filter(entity => options.has(entity._1))
         .map(_ => "")
+    }
+
+    private[admin] def timeoutMs: Long = {
+      options.valueOf(timeoutMsOpt)
     }
 
     def checkArgs(): Unit = {
@@ -983,6 +992,12 @@ object ConfigCommand extends Logging {
 
         if (!isAddConfigPresent && !isAddConfigFilePresent && !isDeleteConfigPresent)
           throw new IllegalArgumentException("At least one of --add-config, --add-config-file, or --delete-config must be specified with --alter")
+      }
+
+      if (options.has(timeoutMsOpt)) {
+        val timeoutMs = options.valueOf(timeoutMsOpt)
+        if (timeoutMs <= 0)
+          throw new IllegalArgumentException("--timeout should be a positive value")
       }
     }
   }

--- a/core/src/test/java/kafka/admin/ConfigCommandTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandTest.java
@@ -1915,6 +1915,42 @@ public class ConfigCommandTest {
         assertEquals("client-metrics is not a known entityType. Should be one of List(topics, clients, users, brokers, ips)", exception.getMessage());
     }
 
+    @Test
+    public void testDefaultTimeout() {
+        ConfigCommand.ConfigCommandOptions createOpts = new ConfigCommand.ConfigCommandOptions(toArray("--zookeeper", ZK_CONNECT,
+            "--entity-name", "123",
+            "--entity-type", "brokers",
+            "--alter",
+            "--add-config", "a=b,c=[d,e ,f],g=[h,i]"));
+
+        assertEquals(30000, createOpts.timeoutMs());
+    }
+
+    @Test
+    public void testParseTimeoutOpt() {
+        ConfigCommand.ConfigCommandOptions createOpts = new ConfigCommand.ConfigCommandOptions(toArray("--zookeeper", ZK_CONNECT,
+            "--entity-name", "123",
+            "--entity-type", "brokers",
+            "--alter",
+            "--add-config", "a=b,c=[d,e ,f],g=[h,i]",
+            "--timeout", "12345"));
+
+        assertEquals(12345, createOpts.timeoutMs());
+    }
+
+    @Test
+    public void testShouldNotAllowNegativeTimeoutOpt() {
+        ConfigCommand.ConfigCommandOptions createOpts = new ConfigCommand.ConfigCommandOptions(toArray("--zookeeper", ZK_CONNECT,
+            "--entity-name", "123",
+            "--entity-type", "brokers",
+            "--alter",
+            "--add-config", "a=b,c=[d,e ,f],g=[h,i]",
+            "--timeout", "-123456"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, createOpts::checkArgs);
+        assertEquals("--timeout should be a positive value", exception.getMessage());
+    }
+
     public static String[] toArray(String... first) {
         return first;
     }


### PR DESCRIPTION
The alter config command sometimes takes longer than the default timeout of 30s. Adding a --timeout option helps in thise cases.

Testing
- unit tests (existing and new) passing
- integration tests (existing) passing

This contribution is my original work and I license the work to the project under the project's open source license.