### PR TITLE
Adds a test case to test that an exception is thrown in invalid ports

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -78,6 +78,11 @@ public class ClientUtilsTest {
     }
 
     @Test
+    public void testInvalidPort() {
+        assertThrows(ConfigException.class, () -> checkWithoutLookup("localhost:70000"));
+    }
+
+    @Test
     public void testOnlyBadHostname() {
         assertThrows(ConfigException.class, () -> checkWithoutLookup("some.invalid.hostname.foo.bar.local:9999"));
     }


### PR DESCRIPTION
The testInvalidPort() test is designed to verify that the checkWithoutLookup method correctly handles invalid port numbers.  In this case, the port number "70000" is invalid because port numbers in TCP/IP are 16 bit so they can only range from 0 to 65535. Therefore, when the checkWithoutLookup method is called with "localhost:70000" as an argument, it should throw a ConfigException.  The assertThrows method is used to assert that a specific type of exception is thrown. It takes two arguments: the type of exception expected and a lambda expression that executes the code that is expected to throw the exception.  In this test, assertThrows is expected to catch a ConfigException when checkWithoutLookup("localhost:70000") is called. If a ConfigException is thrown, the test passes. If not, the test fails. This ensures that the method is correctly validating port numbers and throwing an exception when an invalid port is encountered.
