### PR TITLE
HOTFIX: remove unnecessary list creation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -78,9 +78,7 @@ public class StickyTaskAssignor implements TaskAssignor {
             finalAssignments.put(clientId, previousAssignment.withFollowupRebalance(Instant.ofEpochMilli(0)));
         }
 
-        final Collection<KafkaStreamsAssignment> taskAssignments = finalAssignments.entrySet().stream()
-            .map(Map.Entry::getValue).collect(Collectors.toList());
-        return new TaskAssignment(taskAssignments);
+        return new TaskAssignment(finalAssignments.values());
     }
 
     private void optimizeActive(final ApplicationState applicationState,


### PR DESCRIPTION
Removing a redundant list declaration in the new StickyTaskAssignor implementation