### PR TITLE
KAFKA-15045: (KIP-924 pt. 14) Callback to TaskAssignor::onAssignmenComputed

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
@@ -17,8 +17,8 @@
 package org.apache.kafka.streams.processor.assignment;
 
 import java.util.Map;
-import java.util.Set;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.processor.TaskId;
 
 /**
  * A read-only metadata class representing the state of the application and the current rebalance.
@@ -48,5 +48,5 @@ public interface ApplicationState {
     /**
      * @return the set of all tasks in this topology which must be assigned
      */
-    Set<TaskInfo> allTasks();
+    Map<TaskId, TaskInfo> allTasks();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -89,14 +89,14 @@ public class StickyTaskAssignor implements TaskAssignor {
 
         final Map<ProcessId, KafkaStreamsAssignment> currentAssignments = assignmentState.buildKafkaStreamsAssignments();
 
-        final Set<TaskId> statefulTasks = applicationState.allTasks().stream()
+        final Set<TaskId> statefulTasks = applicationState.allTasks().values().stream()
             .filter(TaskInfo::isStateful)
             .map(TaskInfo::id)
             .collect(Collectors.toSet());
         final Map<ProcessId, KafkaStreamsAssignment> optimizedAssignmentsForStatefulTasks = TaskAssignmentUtils.optimizeRackAwareActiveTasks(
             applicationState, currentAssignments, new TreeSet<>(statefulTasks));
 
-        final Set<TaskId> statelessTasks = applicationState.allTasks().stream()
+        final Set<TaskId> statelessTasks = applicationState.allTasks().values().stream()
             .filter(task -> !task.isStateful())
             .map(TaskInfo::id)
             .collect(Collectors.toSet());
@@ -126,8 +126,7 @@ public class StickyTaskAssignor implements TaskAssignor {
                                      final AssignmentState assignmentState,
                                      final boolean mustPreserveActiveTaskAssignment) {
         final int totalCapacity = computeTotalProcessingThreads(clients);
-        final Set<TaskId> allTaskIds = applicationState.allTasks().stream()
-            .map(TaskInfo::id).collect(Collectors.toSet());
+        final Set<TaskId> allTaskIds = applicationState.allTasks().keySet();
         final int taskCount = allTaskIds.size();
         final int activeTasksPerThread = taskCount / totalCapacity;
         final Set<TaskId> unassigned = new HashSet<>(allTaskIds);
@@ -172,7 +171,7 @@ public class StickyTaskAssignor implements TaskAssignor {
 
     private static void assignStandby(final ApplicationState applicationState,
                                       final AssignmentState assignmentState) {
-        final Set<TaskInfo> statefulTasks = applicationState.allTasks().stream()
+        final Set<TaskInfo> statefulTasks = applicationState.allTasks().values().stream()
             .filter(TaskInfo::isStateful)
             .collect(Collectors.toSet());
         final int numStandbyReplicas = applicationState.assignmentConfigs().numStandbyReplicas();


### PR DESCRIPTION
This PR adds the logic and wiring necessary to make the callback to `TaskAssignor::onAssignmentComputed` with the necessary parameters.

We also fixed some log statements in the actual assignment error computation, as well as modified the `ApplicationState::allTasks` method to return a `Map` instead of a `Set` of `TaskInfos`.