### PR TITLE
KAFKA-16766: offset fetch timeout exception in new consumer consistent with legacy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1076,12 +1076,16 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                 return listOffsetsEvent.emptyResults();
             }
 
-            return applicationEventHandler.addAndGet(listOffsetsEvent)
+            try {
+                return applicationEventHandler.addAndGet(listOffsetsEvent)
                     .entrySet()
                     .stream()
                     .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            entry -> entry.getValue().buildOffsetAndTimestamp()));
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().buildOffsetAndTimestamp()));
+            } catch (TimeoutException e) {
+                throw new TimeoutException("Failed to get offsets by times in " + timeout.toMillis() + "ms");
+            }
         } finally {
             release();
         }
@@ -1136,12 +1140,16 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             }
 
             Map<TopicPartition, OffsetAndTimestampInternal> offsetAndTimestampMap;
-            offsetAndTimestampMap = applicationEventHandler.addAndGet(listOffsetsEvent);
-            return offsetAndTimestampMap.entrySet()
+            try {
+                offsetAndTimestampMap = applicationEventHandler.addAndGet(listOffsetsEvent);
+                return offsetAndTimestampMap.entrySet()
                     .stream()
                     .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            entry -> entry.getValue().offset()));
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().offset()));
+            } catch (TimeoutException e) {
+                throw new TimeoutException("Failed to get offsets by times in " + timeout.toMillis() + "ms");
+            }
         } finally {
             release();
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1032,6 +1032,47 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsEvent.class));
     }
 
+    @Test
+    public void testOffsetsForTimesTimeoutException() {
+        consumer = newConsumer();
+        long timeout = 100;
+        doThrow(new TimeoutException("Event did not complete in time and was expired by the reaper"))
+            .when(applicationEventHandler).addAndGet(any());
+
+        Throwable t = assertThrows(
+            TimeoutException.class,
+            () -> consumer.offsetsForTimes(mockTimestampToSearch(), Duration.ofMillis(timeout)));
+        assertEquals("Failed to get offsets by times in " + timeout + "ms", t.getMessage());
+    }
+
+    @Test
+    public void testBeginningOffsetsTimeoutException() {
+        consumer = newConsumer();
+        long timeout = 100;
+        doThrow(new TimeoutException("Event did not complete in time and was expired by the reaper"))
+            .when(applicationEventHandler).addAndGet(any());
+
+        Throwable t = assertThrows(
+            TimeoutException.class,
+            () -> consumer.beginningOffsets(Collections.singleton(new TopicPartition("topic", 5)),
+                Duration.ofMillis(timeout)));
+        assertEquals("Failed to get offsets by times in " + timeout + "ms", t.getMessage());
+    }
+
+    @Test
+    public void testEndOffsetsTimeoutException() {
+        consumer = newConsumer();
+        long timeout = 100;
+        doThrow(new TimeoutException("Event did not complete in time and was expired by the reaper"))
+            .when(applicationEventHandler).addAndGet(any());
+
+        Throwable t = assertThrows(
+            TimeoutException.class,
+            () -> consumer.endOffsets(Collections.singleton(new TopicPartition("topic", 5)),
+                Duration.ofMillis(timeout)));
+        assertEquals("Failed to get offsets by times in " + timeout + "ms", t.getMessage());
+    }
+
     // This test ensures same behaviour as the current consumer when offsetsForTimes is called
     // with 0 timeout. It should return map with all requested partitions as keys, with null
     // OffsetAndTimestamp as value.


### PR DESCRIPTION
Fix to ensure that a sensible error message is shown in TimeoutExceptions that may be thrown in offsetsForTimes, beginningOffsets and endOffsets, consistent with the message that the legacy consumer throws in these cases.
 
Before this fix, those functions timing out would throw a org.apache.kafka.common.errors.TimeoutException with message "java.util.concurrent.TimeoutException". This PR ensures a clear message is included (same message used by the LegacyKafkaConsumer)