### PR TITLE
KAFKA-16856 : Adding new exception 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/TieredStorageDisablementInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TieredStorageDisablementInProgressException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class TieredStorageDisablementInProgressException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TieredStorageDisablementInProgressException(String message) {
+        super(message);
+    }
+
+    public TieredStorageDisablementInProgressException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -117,6 +117,7 @@ import org.apache.kafka.common.errors.SnapshotNotFoundException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.ThrottlingQuotaExceededException;
+import org.apache.kafka.common.errors.TieredStorageDisablementInProgressException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
@@ -402,7 +403,8 @@ public enum Errors {
     INVALID_RECORD_STATE(121, "The record state is invalid. The acknowledgement of delivery could not be completed.", InvalidRecordStateException::new),
     SHARE_SESSION_NOT_FOUND(122, "The share session was not found.", ShareSessionNotFoundException::new),
     INVALID_SHARE_SESSION_EPOCH(123, "The share session epoch is invalid.", InvalidShareSessionEpochException::new),
-    FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match.", FencedStateEpochException::new);
+    FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match.", FencedStateEpochException::new),
+    TIERED_STORAGE_DISABLEMENT_IN_PROGRESS(125, "The topic is still in the DISABLING state", TieredStorageDisablementInProgressException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 


### PR DESCRIPTION
Resolves : https://issues.apache.org/jira/browse/KAFKA-16856
- Adding new exception TIERED_STORAGE_DISABLEMENT_IN_PROGRESS / TieredStorageDisablementInProgressException

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
