### PR TITLE
KAFKA-16664: Re-add EventAccumulator.poll(long, TimeUnit)

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
@@ -163,8 +163,18 @@ public class EventAccumulator<K, T extends EventAccumulator.Event<K>> implements
     }
 
     /**
+     * Immediately returns the next {{@link Event}} available or null
+     * if the accumulator is empty.
+     *
+     * @return The next event available or null.
+     */
+    public T poll() {
+        return poll(0, TimeUnit.MILLISECONDS);
+    }
+
+    /**
      * Returns the next {{@link Event}} available. This method blocks for the provided
-     * time and returns null of not event is available.
+     * time and returns null of no event is available.
      *
      * @param timeout   The timeout.
      * @param unit      The timeout unit.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
@@ -162,16 +162,6 @@ public class EventAccumulator<K, T extends EventAccumulator.Event<K>> implements
         }
     }
 
-//    /**
-//     * Returns the next {{@link Event}} available. This method block indefinitely until
-//     * one event is ready or the accumulator is closed.
-//     *
-//     * @return The next event.
-//     */
-//    public T poll() {
-//        return poll(Long.MAX_VALUE, TimeUnit.SECONDS);
-//    }
-
     /**
      * Returns the next {{@link Event}} available. This method blocks for the provided
      * time and returns null of not event is available.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -38,7 +38,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
     /**
      * The poll timeout to wait for an event by the EventProcessorThread.
      */
-    public static final long POLL_TIMEOUT_MS = 300L;
+    private static final long POLL_TIMEOUT_MS = 300L;
 
     /**
      * The logger.
@@ -157,8 +157,8 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
         }
 
         private void drainEvents() {
-            CoordinatorEvent event = accumulator.poll(0, TimeUnit.MILLISECONDS);
-            while (event != null) {
+            CoordinatorEvent event;
+            while ((event = accumulator.poll()) != null) {
                 try {
                     log.debug("Draining event: {}.", event);
                     metrics.recordEventQueueTime(time.milliseconds() - event.createdTimeMs());
@@ -168,8 +168,6 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                 } finally {
                     accumulator.done(event);
                 }
-
-                event = accumulator.poll(0, TimeUnit.MILLISECONDS);
             }
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -36,9 +36,9 @@ import java.util.stream.IntStream;
 public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
 
     /**
-     * The poll timeout to wait for an event in EventProcessorThread.
+     * The poll timeout to wait for an event by the EventProcessorThread.
      */
-    private static long POLL_TIMEOUT = 300;
+    public static final long POLL_TIMEOUT_MS = 300L;
 
     /**
      * The logger.
@@ -135,7 +135,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                 // time should be discounted by # threads.
 
                 long idleStartTimeMs = time.milliseconds();
-                CoordinatorEvent event = accumulator.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
+                CoordinatorEvent event = accumulator.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 long idleEndTimeMs = time.milliseconds();
                 long idleTimeMs = idleEndTimeMs - idleStartTimeMs;
                 metrics.recordThreadIdleTime(idleTimeMs / threads.size());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/EventAccumulatorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/EventAccumulatorTest.java
@@ -80,7 +80,7 @@ public class EventAccumulatorTest {
         EventAccumulator<Integer, MockEvent> accumulator = new EventAccumulator<>();
 
         assertEquals(0, accumulator.size());
-        assertNull(accumulator.poll(0, TimeUnit.MILLISECONDS));
+        assertNull(accumulator.poll());
 
         List<MockEvent> events = Arrays.asList(
             new MockEvent(1, 0),
@@ -99,14 +99,14 @@ public class EventAccumulatorTest {
 
         Set<MockEvent> polledEvents = new HashSet<>();
         for (int i = 0; i < events.size(); i++) {
-            MockEvent event = accumulator.poll(0, TimeUnit.MILLISECONDS);
+            MockEvent event = accumulator.poll();
             assertNotNull(event);
             polledEvents.add(event);
             assertEquals(events.size() - 1 - i, accumulator.size());
             accumulator.done(event);
         }
 
-        assertNull(accumulator.poll(0, TimeUnit.MILLISECONDS));
+        assertNull(accumulator.poll());
         assertEquals(new HashSet<>(events), polledEvents);
         assertEquals(0, accumulator.size());
 
@@ -128,7 +128,7 @@ public class EventAccumulatorTest {
 
         List<MockEvent> polledEvents = new ArrayList<>(3);
         for (int i = 0; i < events.size(); i++) {
-            MockEvent event = accumulator.poll(0, TimeUnit.MILLISECONDS);
+            MockEvent event = accumulator.poll();
             assertNotNull(event);
             polledEvents.add(event);
             assertEquals(events.size() - 1 - i, accumulator.size());
@@ -156,27 +156,27 @@ public class EventAccumulatorTest {
         MockEvent event = null;
 
         // Poll event0.
-        event = accumulator.poll(0, TimeUnit.MILLISECONDS);
+        event = accumulator.poll();
         assertEquals(event0, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MILLISECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         // Poll event1.
-        event = accumulator.poll(0, TimeUnit.MILLISECONDS);
+        event = accumulator.poll();
         assertEquals(event1, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MILLISECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         // Poll event2.
-        event = accumulator.poll(0, TimeUnit.MILLISECONDS);
+        event = accumulator.poll();
         assertEquals(event2, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MILLISECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         accumulator.close();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -60,8 +60,8 @@ public class MultiThreadedEventProcessorTest {
         }
 
         @Override
-        public CoordinatorEvent take() {
-            CoordinatorEvent event = super.take();
+        public CoordinatorEvent poll(long timeout, TimeUnit unit) {
+            CoordinatorEvent event = super.poll(timeout, unit);
             time.sleep(takeDelayMs);
             return event;
         }


### PR DESCRIPTION
We have revamped the thread idle ratio metric in https://github.com/apache/kafka/pull/15835. https://github.com/apache/kafka/pull/15835#discussion_r1588068337 describes a case where the metric loses accuracy and in order to set a lower bound to the accuracy, this patch re-adds a poll with a timeout that was removed as part of https://github.com/apache/kafka/pull/15430.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
