### PR TITLE
KAFKA-15045: (KIP-924 pt. 16) TaskAssignor.onAssignmentComputed handling

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
@@ -46,7 +46,7 @@ public interface ApplicationState {
     AssignmentConfigs assignmentConfigs();
 
     /**
-     * @return the set of all tasks in this topology which must be assigned
+     * @return a map of task ids to all tasks in this topology to be assigned
      */
     Map<TaskId, TaskInfo> allTasks();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.assignment;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -29,8 +30,8 @@ public class AssignmentConfigs {
     private final int numStandbyReplicas;
     private final long probingRebalanceIntervalMs;
     private final List<String> rackAwareAssignmentTags;
-    private final int rackAwareTrafficCost;
-    private final int rackAwareNonOverlapCost;
+    private final Optional<Integer> rackAwareTrafficCost;
+    private final Optional<Integer> rackAwareNonOverlapCost;
     private final String rackAwareAssignmentStrategy;
 
     public AssignmentConfigs(final StreamsConfig configs) {
@@ -40,8 +41,8 @@ public class AssignmentConfigs {
             configs.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG),
             configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG),
             configs.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG),
-            configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG),
-            configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG),
+            Optional.ofNullable(configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG)),
+            Optional.ofNullable(configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG)),
             configs.getString(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG)
         );
     }
@@ -51,10 +52,9 @@ public class AssignmentConfigs {
                              final int numStandbyReplicas,
                              final long probingRebalanceIntervalMs,
                              final List<String> rackAwareAssignmentTags,
-                             final int rackAwareTrafficCost,
-                             final int rackAwareNonOverlapCost,
-                             final String rackAwareAssignmentStrategy
-    ) {
+                             final Optional<Integer> rackAwareTrafficCost,
+                             final Optional<Integer>  rackAwareNonOverlapCost,
+                             final String rackAwareAssignmentStrategy) {
         this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
         this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
         this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
@@ -115,7 +115,7 @@ public class AssignmentConfigs {
      * The rack-aware assignment traffic cost as configured via
      * {@link StreamsConfig#RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG}
      */
-    public int rackAwareTrafficCost() {
+    public Optional<Integer> rackAwareTrafficCost() {
         return rackAwareTrafficCost;
     }
 
@@ -123,7 +123,7 @@ public class AssignmentConfigs {
      * The rack-aware assignment non-overlap cost as configured via
      * {@link StreamsConfig#RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG}
      */
-    public int rackAwareNonOverlapCost() {
+    public Optional<Integer> rackAwareNonOverlapCost() {
         return rackAwareNonOverlapCost;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -57,10 +57,10 @@ public class AssignmentConfigs {
         } else if (HighAvailabilityTaskAssignor.class.getName().equals(assignorClassName)) {
             // TODO KAFKA-16869: replace with the HighAvailabilityTaskAssignor class once it implements the new TaskAssignor interface
             if (rackAwareTrafficCost == null) {
-                rackAwareTrafficCost = HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST;
+                rackAwareTrafficCost = HighAvailabilityTaskAssignor.DEFAULT_HIGH_AVAILABILITY_TRAFFIC_COST;
             }
             if (rackAwareNonOverlapCost == null) {
-                rackAwareNonOverlapCost = HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_NON_OVERLAP_COST;
+                rackAwareNonOverlapCost = HighAvailabilityTaskAssignor.DEFAULT_HIGH_AVAILABILITY_NON_OVERLAP_COST;
             }
         }
 
@@ -70,8 +70,8 @@ public class AssignmentConfigs {
             numStandbyReplicas,
             probingRebalanceIntervalMs,
             rackAwareAssignmentTags,
-            OptionalInt.of(rackAwareTrafficCost),
-            OptionalInt.of(rackAwareNonOverlapCost),
+            rackAwareTrafficCost != null ? OptionalInt.of(rackAwareTrafficCost) : OptionalInt.empty(),
+            rackAwareNonOverlapCost != null ? OptionalInt.of(rackAwareNonOverlapCost) : OptionalInt.empty(),
             rackAwareAssignmentStrategy
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.assignment;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.streams.StreamsConfig;
@@ -44,23 +43,23 @@ public class AssignmentConfigs {
         final long probingRebalanceIntervalMs = configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG);
         final List<String> rackAwareAssignmentTags = configs.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
         final String rackAwareAssignmentStrategy = configs.getString(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG);
-        Optional<Integer> rackAwareTrafficCost = Optional.ofNullable(configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG));
-        Optional<Integer> rackAwareNonOverlapCost = Optional.ofNullable(configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG));
+        Integer rackAwareTrafficCost = configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG);
+        Integer rackAwareNonOverlapCost = configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG);
 
         final String assignorClassName = configs.getString(StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG);
         if (StickyTaskAssignor.class.getName().equals(assignorClassName)) {
-            if (!rackAwareTrafficCost.isPresent()) {
-                rackAwareTrafficCost = Optional.of(StickyTaskAssignor.DEFAULT_STICKY_TRAFFIC_COST);
+            if (rackAwareTrafficCost == null) {
+                rackAwareTrafficCost = StickyTaskAssignor.DEFAULT_STICKY_TRAFFIC_COST;
             }
-            if (!rackAwareNonOverlapCost.isPresent()) {
-                rackAwareNonOverlapCost = Optional.of(StickyTaskAssignor.DEFAULT_STICKY_NON_OVERLAP_COST);
+            if (rackAwareNonOverlapCost == null) {
+                rackAwareNonOverlapCost = StickyTaskAssignor.DEFAULT_STICKY_NON_OVERLAP_COST;
             }
         } else if (HighAvailabilityTaskAssignor.class.getName().equals(assignorClassName)) {
-            if (!rackAwareTrafficCost.isPresent()) {
-                rackAwareTrafficCost = Optional.of(HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST);
+            if (rackAwareTrafficCost == null) {
+                rackAwareTrafficCost = HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST;
             }
-            if (!rackAwareNonOverlapCost.isPresent()) {
-                rackAwareNonOverlapCost = Optional.of(HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_NON_OVERLAP_COST);
+            if (rackAwareNonOverlapCost == null) {
+                rackAwareNonOverlapCost = HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_NON_OVERLAP_COST;
             }
         }
 
@@ -70,8 +69,8 @@ public class AssignmentConfigs {
             numStandbyReplicas,
             probingRebalanceIntervalMs,
             rackAwareAssignmentTags,
-            rackAwareTrafficCost.map(OptionalInt::of).orElseGet(OptionalInt::empty),
-            rackAwareNonOverlapCost.map(OptionalInt::of).orElseGet(OptionalInt::empty),
+            OptionalInt.of(rackAwareTrafficCost),
+            OptionalInt.of(rackAwareNonOverlapCost),
             rackAwareAssignmentStrategy
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.assignment;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor;
@@ -32,8 +33,8 @@ public class AssignmentConfigs {
     private final int numStandbyReplicas;
     private final long probingRebalanceIntervalMs;
     private final List<String> rackAwareAssignmentTags;
-    private final Optional<Integer> rackAwareTrafficCost;
-    private final Optional<Integer> rackAwareNonOverlapCost;
+    private final OptionalInt rackAwareTrafficCost;
+    private final OptionalInt rackAwareNonOverlapCost;
     private final String rackAwareAssignmentStrategy;
 
     public static AssignmentConfigs of(final StreamsConfig configs) {
@@ -71,8 +72,8 @@ public class AssignmentConfigs {
             numStandbyReplicas,
             probingRebalanceIntervalMs,
             rackAwareAssignmentTags,
-            rackAwareTrafficCost,
-            rackAwareNonOverlapCost,
+            rackAwareTrafficCost.map(OptionalInt::of).orElseGet(OptionalInt::empty),
+            rackAwareNonOverlapCost.map(OptionalInt::of).orElseGet(OptionalInt::empty),
             rackAwareAssignmentStrategy
         );
     }
@@ -82,8 +83,8 @@ public class AssignmentConfigs {
                              final int numStandbyReplicas,
                              final long probingRebalanceIntervalMs,
                              final List<String> rackAwareAssignmentTags,
-                             final Optional<Integer> rackAwareTrafficCost,
-                             final Optional<Integer>  rackAwareNonOverlapCost,
+                             final OptionalInt rackAwareTrafficCost,
+                             final OptionalInt  rackAwareNonOverlapCost,
                              final String rackAwareAssignmentStrategy) {
         this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
         this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
@@ -146,7 +147,7 @@ public class AssignmentConfigs {
      * The rack-aware assignment traffic cost as configured via
      * {@link StreamsConfig#RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG}
      */
-    public Optional<Integer> rackAwareTrafficCost() {
+    public OptionalInt rackAwareTrafficCost() {
         return rackAwareTrafficCost;
     }
 
@@ -154,7 +155,7 @@ public class AssignmentConfigs {
      * The rack-aware assignment non-overlap cost as configured via
      * {@link StreamsConfig#RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG}
      */
-    public Optional<Integer> rackAwareNonOverlapCost() {
+    public OptionalInt rackAwareNonOverlapCost() {
         return rackAwareNonOverlapCost;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -55,6 +55,7 @@ public class AssignmentConfigs {
                 rackAwareNonOverlapCost = StickyTaskAssignor.DEFAULT_STICKY_NON_OVERLAP_COST;
             }
         } else if (HighAvailabilityTaskAssignor.class.getName().equals(assignorClassName)) {
+            // TODO KAFKA-16869: replace with the HighAvailabilityTaskAssignor class once it implements the new TaskAssignor interface
             if (rackAwareTrafficCost == null) {
                 rackAwareTrafficCost = HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -50,14 +50,12 @@ public class AssignmentConfigs {
         final String assignorClassName = configs.getString(StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG);
         if (StickyTaskAssignor.class.getName().equals(assignorClassName)) {
             if (!rackAwareTrafficCost.isPresent()) {
-                rackAwareTrafficCost = Optional.of(StickyTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST);
+                rackAwareTrafficCost = Optional.of(StickyTaskAssignor.DEFAULT_STICKY_TRAFFIC_COST);
             }
             if (!rackAwareNonOverlapCost.isPresent()) {
-                rackAwareNonOverlapCost = Optional.of(StickyTaskAssignor.DEFAULT_STATEFUL_NON_OVERLAP_COST);
+                rackAwareNonOverlapCost = Optional.of(StickyTaskAssignor.DEFAULT_STICKY_NON_OVERLAP_COST);
             }
-        }
-
-        if (HighAvailabilityTaskAssignor.class.getName().equals(assignorClassName)) {
+        } else if (HighAvailabilityTaskAssignor.class.getName().equals(assignorClassName)) {
             if (!rackAwareTrafficCost.isPresent()) {
                 rackAwareTrafficCost = Optional.of(HighAvailabilityTaskAssignor.DEFAULT_STATEFUL_TRAFFIC_COST);
             }
@@ -78,7 +76,7 @@ public class AssignmentConfigs {
         );
     }
 
-    private AssignmentConfigs(final long acceptableRecoveryLag,
+    public AssignmentConfigs(final long acceptableRecoveryLag,
                              final int maxWarmupReplicas,
                              final int numStandbyReplicas,
                              final long probingRebalanceIntervalMs,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -154,6 +154,7 @@ public final class TaskAssignmentUtils {
             final UUID uuid = entry.getKey().id();
             clientIds.add(uuid);
             clientRacks.put(uuid, kafkaStreamsStates.get(entry.getKey()).rackId());
+            assignmentsByUuid.put(uuid, entry.getValue());
         }
 
         final long initialCost = computeTotalAssignmentCost(
@@ -254,6 +255,7 @@ public final class TaskAssignmentUtils {
             final UUID uuid = entry.getKey().id();
             clientIds.add(uuid);
             clientRacks.put(uuid, kafkaStreamsStates.get(entry.getKey()).rackId());
+            assignmentsByUuid.put(uuid, entry.getValue());
         }
 
         final long initialCost = computeTotalAssignmentCost(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -136,8 +136,8 @@ public final class TaskAssignmentUtils {
             return kafkaStreamsAssignments;
         }
 
-        final int crossRackTrafficCost = applicationState.assignmentConfigs().rackAwareTrafficCost().get();
-        final int nonOverlapCost = applicationState.assignmentConfigs().rackAwareNonOverlapCost().get();
+        final int crossRackTrafficCost = applicationState.assignmentConfigs().rackAwareTrafficCost().getAsInt();
+        final int nonOverlapCost = applicationState.assignmentConfigs().rackAwareNonOverlapCost().getAsInt();
 
         final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates = applicationState.kafkaStreamsStates(false);
         final List<TaskId> taskIds = new ArrayList<>(tasks);
@@ -234,8 +234,8 @@ public final class TaskAssignmentUtils {
             return kafkaStreamsAssignments;
         }
 
-        final int crossRackTrafficCost = applicationState.assignmentConfigs().rackAwareTrafficCost().get();
-        final int nonOverlapCost = applicationState.assignmentConfigs().rackAwareNonOverlapCost().get();
+        final int crossRackTrafficCost = applicationState.assignmentConfigs().rackAwareTrafficCost().getAsInt();
+        final int nonOverlapCost = applicationState.assignmentConfigs().rackAwareNonOverlapCost().getAsInt();
 
         final Map<TaskId, Set<TaskTopicPartition>> topicPartitionsByTaskId =
             applicationState.allTasks().values().stream().collect(Collectors.toMap(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -92,9 +92,7 @@ public final class TaskAssignmentUtils {
      */
     public static Map<ProcessId, KafkaStreamsAssignment> defaultStandbyTaskAssignment(final ApplicationState applicationState,
                                                                                       final Map<ProcessId, KafkaStreamsAssignment> kafkaStreamsAssignments) {
-        if (!applicationState.assignmentConfigs().rackAwareAssignmentTags().isEmpty()) {
-            return tagBasedStandbyTaskAssignment(applicationState, kafkaStreamsAssignments);
-        } else if (canPerformRackAwareOptimization(applicationState, AssignedTask.Type.STANDBY)) {
+        if (applicationState.assignmentConfigs().rackAwareAssignmentTags().isEmpty()) {
             return tagBasedStandbyTaskAssignment(applicationState, kafkaStreamsAssignments);
         } else {
             return loadBasedStandbyTaskAssignment(applicationState, kafkaStreamsAssignments);
@@ -330,8 +328,8 @@ public final class TaskAssignmentUtils {
                         topicPartitionsByTaskId,
                         crossRackTrafficCost,
                         nonOverlapCost,
-                        false,
-                        false,
+                        true,
+                        true,
                         graphConstructor
                     );
                     assignmentGraph.graph.solveMinCostFlow();
@@ -574,7 +572,7 @@ public final class TaskAssignmentUtils {
         final Map<TaskId, ProcessId> pendingStandbyTasksToClientId = new HashMap<>();
         for (final TaskId statefulTaskId : statefulTaskIds) {
             for (final KafkaStreamsAssignment assignment : clientsByUuid.values()) {
-                if (assignment.tasks().containsKey(statefulTaskId)) {
+                if (assignment.tasks().containsKey(statefulTaskId) && assignment.tasks().get(statefulTaskId).type() == AssignedTask.Type.ACTIVE) {
                     assignStandbyTasksToClientsWithDifferentTags(
                         numStandbyReplicas,
                         standbyTaskClientsByTaskLoad,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -488,12 +488,12 @@ public final class TaskAssignmentUtils {
         }
 
         if (!assignmentConfigs.rackAwareTrafficCost().isPresent()) {
-            LOG.warn("Rack aware task assignment optimization unavailable: the traffic cost configuration was not set.");
+            LOG.warn("Rack aware task assignment optimization unavailable: must configure {}", StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG);
             return false;
         }
 
         if (!assignmentConfigs.rackAwareNonOverlapCost().isPresent()) {
-            LOG.warn("Rack aware task assignment optimization unavailable: the non-overlap cost configuration was not set.");
+            LOG.warn("Rack aware task assignment optimization unavailable: must configure {}", StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG);
             return false;
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
@@ -68,10 +68,15 @@ public interface TaskAssignor extends Configurable {
      * will be returned and a StreamsException will be thrown after this callback returns. The StreamsException will
      * be thrown up to kill the StreamThread and can be handled as any other uncaught exception would if the application
      * has registered a {@link StreamsUncaughtExceptionHandler}.
+     * <p>
+     * Note: some kinds of errors will make it impossible for the StreamsPartitionAssignor to parse the TaskAssignment
+     * that was returned from the TaskAssignor's {@link #assign}. If this occurs, the {@link GroupAssignment} passed
+     * in to this callback will contain an empty map instead of the consumer assignments.
      *
-     * @param assignment    the final assignment returned to the kafka broker
-     * @param subscription  the original subscription passed into the assignor
-     * @param error         the corresponding error type if one was detected while processing the returned assignment,
+     * @param assignment:   the final consumer assignments returned to the kafka broker, or an empty assignment map if
+     *                      an error prevented the assignor from converting the TaskAssignment into a GroupAssignment
+     * @param subscription: the original consumer subscriptions passed into the assignor
+     * @param error:        the corresponding error type if one was detected while processing the returned assignment,
      *                      or AssignmentError.NONE if the returned assignment was valid
      */
     default void onAssignmentComputed(GroupAssignment assignment, GroupSubscription subscription, AssignmentError error) {}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
@@ -35,7 +35,6 @@ public interface TaskAssignor extends Configurable {
     /**
      * NONE: no error detected
      * ACTIVE_TASK_ASSIGNED_MULTIPLE_TIMES: multiple KafkaStreams clients assigned with the same active task
-     * ACTIVE_AND_STANDBY_TASK_ASSIGNED_TO_SAME_KAFKASTREAMS: active task and standby task assigned to the same KafkaStreams client
      * INVALID_STANDBY_TASK: stateless task assigned as a standby task
      * MISSING_PROCESS_ID: ProcessId present in the input ApplicationState was not present in the output TaskAssignment
      * UNKNOWN_PROCESS_ID: unrecognized ProcessId not matching any of the participating consumers
@@ -44,7 +43,6 @@ public interface TaskAssignor extends Configurable {
     enum AssignmentError {
         NONE,
         ACTIVE_TASK_ASSIGNED_MULTIPLE_TIMES,
-        ACTIVE_AND_STANDBY_TASK_ASSIGNED_TO_SAME_KAFKASTREAMS,
         INVALID_STANDBY_TASK,
         MISSING_PROCESS_ID,
         UNKNOWN_PROCESS_ID,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 public class StickyTaskAssignor implements TaskAssignor {
     private static final Logger LOG = LoggerFactory.getLogger(StickyTaskAssignor.class);
 
-    public static final int DEFAULT_STATEFUL_TRAFFIC_COST = 1;
-    public static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 10;
+    public static final int DEFAULT_STICKY_TRAFFIC_COST = 1;
+    public static final int DEFAULT_STICKY_NON_OVERLAP_COST = 10;
 
     private final boolean mustPreserveActiveTaskAssignment;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -48,6 +48,9 @@ import org.slf4j.LoggerFactory;
 public class StickyTaskAssignor implements TaskAssignor {
     private static final Logger LOG = LoggerFactory.getLogger(StickyTaskAssignor.class);
 
+    public static final int DEFAULT_STATEFUL_TRAFFIC_COST = 1;
+    public static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 10;
+
     private final boolean mustPreserveActiveTaskAssignment;
 
     public StickyTaskAssignor() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -262,7 +262,7 @@ public class StickyTaskAssignor implements TaskAssignor {
             taskPairs.addPairs(taskId, newAssignmentsForClient);
 
             newAssignments.get(client).assignTask(new AssignedTask(taskId, type));
-            newTaskLocations.get(taskId).add(client);
+            newTaskLocations.computeIfAbsent(taskId, k -> new HashSet<>()).add(client);
         }
 
         public Map<ProcessId, KafkaStreamsAssignment> newAssignments() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -212,7 +212,7 @@ public class StickyTaskAssignor implements TaskAssignor {
     private static Map<TaskId, Set<ProcessId>> mapPreviousStandbyTasks(final Map<ProcessId, KafkaStreamsState> clients) {
         final Map<TaskId, Set<ProcessId>> previousStandbyTasks = new HashMap<>();
         for (final KafkaStreamsState client : clients.values()) {
-            for (final TaskId taskId : client.previousActiveTasks()) {
+            for (final TaskId taskId : client.previousStandbyTasks()) {
                 previousStandbyTasks.computeIfAbsent(taskId, k -> new HashSet<>());
                 previousStandbyTasks.get(taskId).add(client.processId());
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.assignment.TaskAssignmentUtils;
 import org.apache.kafka.streams.processor.assignment.TaskAssignor;
 import org.apache.kafka.streams.processor.assignment.TaskInfo;
+import org.apache.kafka.streams.processor.assignment.TaskTopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,6 +178,7 @@ public class StickyTaskAssignor implements TaskAssignor {
                                       final AssignmentState assignmentState) {
         final Set<TaskInfo> statefulTasks = applicationState.allTasks().values().stream()
             .filter(TaskInfo::isStateful)
+            .filter(taskInfo -> taskInfo.topicPartitions().stream().anyMatch(TaskTopicPartition::isChangelog))
             .collect(Collectors.toSet());
         final int numStandbyReplicas = applicationState.assignmentConfigs().numStandbyReplicas();
         for (final TaskInfo task : statefulTasks) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -277,7 +277,7 @@ public class StickyTaskAssignor implements TaskAssignor {
                 final Set<AssignedTask> assignedTasks = new HashSet<>(optimizedAssignments.get(processId).tasks().values());
 
                 for (final AssignedTask task : assignedTasks) {
-                    newTaskLocations.get(task.id()).add(processId);
+                    newTaskLocations.computeIfAbsent(task.id(), k -> new HashSet<>()).add(processId);
                 }
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
@@ -43,6 +43,7 @@ import java.util.Set;
 public class PartitionGrouper {
 
     private static final Logger log = LoggerFactory.getLogger(PartitionGrouper.class);
+
     /**
      * Generate tasks with the assigned topic partitions.
      *
@@ -51,28 +52,57 @@ public class PartitionGrouper {
      * @return The map from generated task ids to the assigned partitions
      */
     public Map<TaskId, Set<TopicPartition>> partitionGroups(final Map<Subtopology, Set<String>> topicGroups, final Cluster metadata) {
-        final Map<TaskId, Set<TopicPartition>> groups = new HashMap<>();
+        return partitionGroups(topicGroups, new HashMap<>(), new HashMap<>(), metadata);
+    }
 
-        for (final Map.Entry<Subtopology, Set<String>> entry : topicGroups.entrySet()) {
+    /**
+     * Generate tasks with the assigned topic partitions.
+     *
+     * @param sourceTopicGroups        group of source topics that need to be joined together
+     * @param changelogTopicGroups     group of changelog topics that need to be joined together
+     * @param changelogPartitionGroups the output grouping of the changelog topic partitions by task
+     *                                 id. This input will be mutated.
+     * @param metadata                 metadata of the consuming cluster
+     * @return The map from generated task ids to the assigned partitions
+     */
+    public Map<TaskId, Set<TopicPartition>> partitionGroups(final Map<Subtopology, Set<String>> sourceTopicGroups,
+                                                            final Map<Subtopology, Set<String>> changelogTopicGroups,
+                                                            final Map<TaskId, Set<TopicPartition>> changelogPartitionGroups,
+                                                            final Cluster metadata) {
+        final Map<TaskId, Set<TopicPartition>> sourcePartitionGroups = new HashMap<>();
+
+        for (final Map.Entry<Subtopology, Set<String>> entry : sourceTopicGroups.entrySet()) {
             final Subtopology subtopology = entry.getKey();
-            final Set<String> topicGroup = entry.getValue();
+            final Set<String> sourceTopicGroup = entry.getValue();
+            final Set<String> changelogTopicGroup = changelogTopicGroups.getOrDefault(subtopology, new HashSet<>());
 
-            final int maxNumPartitions = maxNumPartitions(metadata, topicGroup);
+            final int maxNumPartitions = maxNumPartitions(metadata, sourceTopicGroup);
 
             for (int partitionId = 0; partitionId < maxNumPartitions; partitionId++) {
-                final Set<TopicPartition> group = new HashSet<>(topicGroup.size());
+                final Set<TopicPartition> sourcePartitionGroup = new HashSet<>(sourceTopicGroup.size());
+                final Set<TopicPartition> changelogPartitionGroup = new HashSet<>(changelogTopicGroup.size());
 
-                for (final String topic : topicGroup) {
+                for (final String topic : sourceTopicGroup) {
                     final List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
                     if (partitionId < partitions.size()) {
-                        group.add(new TopicPartition(topic, partitionId));
+                        sourcePartitionGroup.add(new TopicPartition(topic, partitionId));
                     }
                 }
-                groups.put(new TaskId(subtopology.nodeGroupId, partitionId, subtopology.namedTopology), Collections.unmodifiableSet(group));
+
+                for (final String topic : changelogTopicGroup) {
+                    final List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
+                    if (partitionId < partitions.size()) {
+                        changelogPartitionGroup.add(new TopicPartition(topic, partitionId));
+                    }
+                }
+
+                final TaskId taskId = new TaskId(subtopology.nodeGroupId, partitionId, subtopology.namedTopology);
+                sourcePartitionGroups.put(taskId, Collections.unmodifiableSet(sourcePartitionGroup));
+                changelogPartitionGroups.put(taskId, Collections.unmodifiableSet(changelogPartitionGroup));
             }
         }
 
-        return Collections.unmodifiableMap(groups);
+        return Collections.unmodifiableMap(sourcePartitionGroups);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
@@ -90,10 +90,7 @@ public class PartitionGrouper {
                 }
 
                 for (final String topic : changelogTopicGroup) {
-                    final List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
-                    if (partitionId < partitions.size()) {
-                        changelogPartitionGroup.add(new TopicPartition(topic, partitionId));
-                    }
+                    changelogPartitionGroup.add(new TopicPartition(topic, partitionId));
                 }
 
                 final TaskId taskId = new TaskId(subtopology.nodeGroupId, partitionId, subtopology.namedTopology);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -559,9 +559,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 final boolean isChangelog = true;
                 final DefaultTaskTopicPartition racklessTopicPartition = new DefaultTaskTopicPartition(
                     topicPartition, isSource, isChangelog, fetchRackInformation);
-                if (publicAssignmentConfigs.numStandbyReplicas() > 0) {
-                    topicsRequiringRackInfo.add(racklessTopicPartition);
-                }
+                topicsRequiringRackInfo.add(racklessTopicPartition);
                 topicPartitions.add(racklessTopicPartition);
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -206,6 +206,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     private String userEndPoint;
     private AssignmentConfigs assignmentConfigs;
+    private org.apache.kafka.streams.processor.assignment.AssignmentConfigs publicAssignmentConfigs;
 
     // for the main consumer, we need to use a supplier to break a cyclic setup dependency
     private Supplier<Consumer<byte[], byte[]>> mainConsumerSupplier;
@@ -255,6 +256,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         nonFatalExceptionsToHandle = referenceContainer.nonFatalExceptionsToHandle;
         time = Objects.requireNonNull(referenceContainer.time, "Time was not specified");
         assignmentConfigs = assignorConfiguration.assignmentConfigs();
+        publicAssignmentConfigs = assignorConfiguration.publicAssignmentConfigs();
         partitionGrouper = new PartitionGrouper();
         userEndPoint = assignorConfiguration.userEndPoint();
         internalTopicManager = assignorConfiguration.internalTopicManager();
@@ -582,7 +584,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         ));
 
         return new DefaultApplicationState(
-            assignmentConfigs.toPublicAssignmentConfigs(),
+            publicAssignmentConfigs,
             logicalTasks,
             clientMetadataMap
         );
@@ -1585,6 +1587,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
     }
 
+    // Visible for testing only.
     AssignmentError validateTaskAssignment(final ApplicationState applicationState,
                                            final TaskAssignment taskAssignment) {
         final Collection<KafkaStreamsAssignment> assignments = taskAssignment.assignment();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -535,8 +535,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final AtomicBoolean rackInformationFetched = new AtomicBoolean(false);
         final Runnable fetchRackInformation = () -> {
             if (!rackInformationFetched.get()) {
-                RackUtils.annotateTopicPartitionsWithRackInfo(cluster,
-                    internalTopicManager, topicsRequiringRackInfo);
+                RackUtils.annotateTopicPartitionsWithRackInfo(cluster, internalTopicManager, topicsRequiringRackInfo);
                 rackInformationFetched.set(true);
             }
         };
@@ -599,7 +598,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                                    final GroupSubscription groupSubscription) {
         if (assignmentError == AssignmentError.UNKNOWN_PROCESS_ID || assignmentError == AssignmentError.UNKNOWN_TASK_ID) {
             assignor.onAssignmentComputed(new GroupAssignment(Collections.emptyMap()), groupSubscription, assignmentError);
-            log.error("Task assignment returning empty GroupAssignment and failing due to error {}", assignmentError);
+            log.error("Rebalance failed due to task assignor returning assignment with error {}, " +
+                      "assignor callback will receive empty GroupAssignment due to this error", assignmentError);
             throw new StreamsException("Task assignment with " + assignor.getClass().getName() +
                                        " returned a fatal error: " + assignmentError);
         }
@@ -818,7 +818,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             customTaskAssignmentListener = (assignment, subscription) -> {
                 assignor.onAssignmentComputed(assignment, subscription, assignmentError);
                 if (assignmentError != AssignmentError.NONE) {
-                    log.error("Task assignment returning empty GroupAssignment and failing due to error {}", assignmentError);
+                    log.error("Rebalance failed due to task assignor returning assignment with error {}", assignmentError);
                     throw new StreamsException("Task assignment with " + assignor.getClass().getName() +
                                                " returned an error: " + assignmentError);
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -263,6 +263,8 @@ public final class AssignorConfiguration {
             final org.apache.kafka.streams.processor.assignment.TaskAssignor assignor = Utils.newInstance(userTaskAssignorClassname,
                 org.apache.kafka.streams.processor.assignment.TaskAssignor.class);
             log.info("Instantiated {} as the task assignor.", userTaskAssignorClassname);
+            assignor.configure(streamsConfig.originals());
+            log.info("Configured task assignor {} with the StreamsConfig.", userTaskAssignorClassname);
             return Optional.of(assignor);
         } catch (final ClassNotFoundException e) {
             throw new IllegalArgumentException(
@@ -367,8 +369,8 @@ public final class AssignorConfiguration {
                 numStandbyReplicas,
                 probingRebalanceIntervalMs,
                 rackAwareAssignmentTags,
-                rackAwareAssignmentTrafficCost,
-                rackAwareAssignmentNonOverlapCost,
+                Optional.ofNullable(rackAwareAssignmentTrafficCost),
+                Optional.ofNullable(rackAwareAssignmentNonOverlapCost),
                 rackAwareAssignmentStrategy
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -268,7 +268,6 @@ public final class AssignorConfiguration {
                 org.apache.kafka.streams.processor.assignment.TaskAssignor.class);
             log.info("Instantiated {} as the task assignor.", userTaskAssignorClassname);
             assignor.configure(streamsConfig.originals());
-            log.info("Configured task assignor {} with the StreamsConfig.", userTaskAssignorClassname);
             return Optional.of(assignor);
         } catch (final ClassNotFoundException e) {
             throw new IllegalArgumentException(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.internals.UpgradeFromValues;
+import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
 import org.apache.kafka.streams.processor.internals.ClientUtils;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 import org.slf4j.Logger;
@@ -243,6 +244,10 @@ public final class AssignorConfiguration {
         return new AssignmentConfigs(streamsConfig);
     }
 
+    public org.apache.kafka.streams.processor.assignment.AssignmentConfigs publicAssignmentConfigs() {
+        return org.apache.kafka.streams.processor.assignment.AssignmentConfigs.of(streamsConfig);
+    }
+
     public TaskAssignor taskAssignor() {
         try {
             return Utils.newInstance(taskAssignorClass, TaskAssignor.class);
@@ -360,19 +365,6 @@ public final class AssignorConfiguration {
                 "\n  probingRebalanceIntervalMs=" + probingRebalanceIntervalMs +
                 "\n  rackAwareAssignmentTags=" + rackAwareAssignmentTags +
                 "\n}";
-        }
-
-        public org.apache.kafka.streams.processor.assignment.AssignmentConfigs toPublicAssignmentConfigs() {
-            return new org.apache.kafka.streams.processor.assignment.AssignmentConfigs(
-                acceptableRecoveryLag,
-                maxWarmupReplicas,
-                numStandbyReplicas,
-                probingRebalanceIntervalMs,
-                rackAwareAssignmentTags,
-                Optional.ofNullable(rackAwareAssignmentTrafficCost),
-                Optional.ofNullable(rackAwareAssignmentNonOverlapCost),
-                rackAwareAssignmentStrategy
-            );
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.internals.UpgradeFromValues;
-import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
 import org.apache.kafka.streams.processor.internals.ClientUtils;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 import org.slf4j.Logger;
@@ -41,7 +40,7 @@ import static org.apache.kafka.streams.StreamsConfig.InternalConfig.INTERNAL_TAS
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 
 public final class AssignorConfiguration {
-    private final String taskAssignorClass;
+    private final String internalTaskAssignorClass;
 
     private final String logPrefix;
     private final Logger log;
@@ -84,9 +83,9 @@ public final class AssignorConfiguration {
         {
             final String o = (String) configs.get(INTERNAL_TASK_ASSIGNOR_CLASS);
             if (o == null) {
-                taskAssignorClass = HighAvailabilityTaskAssignor.class.getName();
+                internalTaskAssignorClass = HighAvailabilityTaskAssignor.class.getName();
             } else {
-                taskAssignorClass = o;
+                internalTaskAssignorClass = o;
             }
         }
     }
@@ -250,7 +249,7 @@ public final class AssignorConfiguration {
 
     public TaskAssignor taskAssignor() {
         try {
-            return Utils.newInstance(taskAssignorClass, TaskAssignor.class);
+            return Utils.newInstance(internalTaskAssignorClass, TaskAssignor.class);
         } catch (final ClassNotFoundException e) {
             throw new IllegalArgumentException(
                 "Expected an instantiable class name for " + INTERNAL_TASK_ASSIGNOR_CLASS,
@@ -259,7 +258,7 @@ public final class AssignorConfiguration {
         }
     }
 
-    public Optional<org.apache.kafka.streams.processor.assignment.TaskAssignor> userTaskAssignor() {
+    public Optional<org.apache.kafka.streams.processor.assignment.TaskAssignor> customTaskAssignor() {
         final String userTaskAssignorClassname = streamsConfig.getString(StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG);
         if (userTaskAssignorClassname == null) {
             return Optional.empty();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultTaskTopicPartition.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultTaskTopicPartition.java
@@ -95,8 +95,7 @@ public class DefaultTaskTopicPartition implements TaskTopicPartition {
         final TaskTopicPartition other = (TaskTopicPartition) obj;
         return topicPartition.equals(other.topicPartition()) &&
                isSourceTopic == other.isSource() &&
-               isChangelogTopic == other.isChangelog() &&
-               rackIds.equals(other.rackIds());
+               isChangelogTopic == other.isChangelog();
     }
 
     public void annotateWithRackIds(final Set<String> rackIds) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
@@ -45,8 +45,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.TaskMoveme
 
 public class HighAvailabilityTaskAssignor implements TaskAssignor {
     private static final Logger log = LoggerFactory.getLogger(HighAvailabilityTaskAssignor.class);
-    public static final int DEFAULT_STATEFUL_TRAFFIC_COST = 10;
-    public static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 1;
+    public static final int DEFAULT_HIGH_AVAILABILITY_TRAFFIC_COST = 10;
+    public static final int DEFAULT_HIGH_AVAILABILITY_NON_OVERLAP_COST = 1;
 
     @Override
     public boolean assign(final Map<UUID, ClientState> clients,
@@ -135,9 +135,9 @@ public class HighAvailabilityTaskAssignor implements TaskAssignor {
 
         if (rackAwareTaskAssignor.canEnableRackAwareAssignor()) {
             final int trafficCost = configs.rackAwareAssignmentTrafficCost == null ?
-                DEFAULT_STATEFUL_TRAFFIC_COST : configs.rackAwareAssignmentTrafficCost;
+                DEFAULT_HIGH_AVAILABILITY_TRAFFIC_COST : configs.rackAwareAssignmentTrafficCost;
             final int nonOverlapCost = configs.rackAwareAssignmentNonOverlapCost == null ?
-                DEFAULT_STATEFUL_NON_OVERLAP_COST : configs.rackAwareAssignmentNonOverlapCost;
+                DEFAULT_HIGH_AVAILABILITY_NON_OVERLAP_COST : configs.rackAwareAssignmentNonOverlapCost;
             rackAwareTaskAssignor.optimizeActiveTasks(statefulTasks, clientStates, trafficCost, nonOverlapCost);
         }
     }
@@ -165,9 +165,9 @@ public class HighAvailabilityTaskAssignor implements TaskAssignor {
 
         if (rackAwareTaskAssignor.canEnableRackAwareAssignor()) {
             final int trafficCost = configs.rackAwareAssignmentTrafficCost == null ?
-                DEFAULT_STATEFUL_TRAFFIC_COST : configs.rackAwareAssignmentTrafficCost;
+                DEFAULT_HIGH_AVAILABILITY_TRAFFIC_COST : configs.rackAwareAssignmentTrafficCost;
             final int nonOverlapCost = configs.rackAwareAssignmentNonOverlapCost == null ?
-                DEFAULT_STATEFUL_NON_OVERLAP_COST : configs.rackAwareAssignmentNonOverlapCost;
+                DEFAULT_HIGH_AVAILABILITY_NON_OVERLAP_COST : configs.rackAwareAssignmentNonOverlapCost;
             rackAwareTaskAssignor.optimizeStandbyTasks(clientStates, trafficCost, nonOverlapCost, standbyTaskAssignor::isAllowedTaskMovement);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
@@ -45,8 +45,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.TaskMoveme
 
 public class HighAvailabilityTaskAssignor implements TaskAssignor {
     private static final Logger log = LoggerFactory.getLogger(HighAvailabilityTaskAssignor.class);
-    private static final int DEFAULT_STATEFUL_TRAFFIC_COST = 10;
-    private static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 1;
+    public static final int DEFAULT_STATEFUL_TRAFFIC_COST = 10;
+    public static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 1;
 
     @Override
     public boolean assign(final Map<UUID, ClientState> clients,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackUtils.java
@@ -44,7 +44,7 @@ public final class RackUtils {
                                                            final Set<DefaultTaskTopicPartition> topicPartitions) {
         // First we add all the changelog topics to the set of topics to describe.
         final Set<String> topicsToDescribe = topicPartitions.stream()
-            .filter(DefaultTaskTopicPartition::isChangelog)
+            .filter(tp -> !tp.isSource())
             .map(topicPartition -> topicPartition.topicPartition().topic())
             .collect(Collectors.toSet());
 
@@ -142,6 +142,7 @@ public final class RackUtils {
             return new HashMap<>();
         }
 
+        LOG.info("Describing topics for rack information: {}", Arrays.toString(topicsToDescribe.toArray()));
         try {
             final Map<String, List<TopicPartitionInfo>> topicPartitionInfo = internalTopicManager.getTopicPartitionInfo(topicsToDescribe);
             if (topicsToDescribe.size() > topicPartitionInfo.size()) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -153,7 +153,7 @@ public class TaskAssignorIntegrationTest {
             assignmentListenerField.setAccessible(true);
             final AssignmentListener actualAssignmentListener = (AssignmentListener) assignmentListenerField.get(streamsPartitionAssignor);
 
-            final Field taskAssignorSupplierField = StreamsPartitionAssignor.class.getDeclaredField("taskAssignorSupplier");
+            final Field taskAssignorSupplierField = StreamsPartitionAssignor.class.getDeclaredField("internalTaskAssignorSupplier");
             taskAssignorSupplierField.setAccessible(true);
             final Supplier<TaskAssignor> taskAssignorSupplier =
                 (Supplier<TaskAssignor>) taskAssignorSupplierField.get(streamsPartitionAssignor);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -58,11 +58,19 @@ import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilder;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ApplicationState;
+import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
+import org.apache.kafka.streams.processor.assignment.TaskInfo;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ClientState;
+import org.apache.kafka.streams.processor.internals.assignment.DefaultApplicationState;
+import org.apache.kafka.streams.processor.internals.assignment.DefaultTaskInfo;
+import org.apache.kafka.streams.processor.internals.assignment.DefaultTaskTopicPartition;
 import org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
@@ -2551,6 +2559,101 @@ public class StreamsPartitionAssignorTest {
         assertEquals(singletonList("input"), subscription.topics());
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
         assertEquals(clientTags, partitionAssignor.clientTags());
+    }
+
+    @Test
+    public void testValidateTaskAssignment() {
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor();
+
+        final StreamsConfig streamsConfig = new StreamsConfig(configProps());
+        final AssignmentConfigs assignmentConfigs = AssignmentConfigs.of(streamsConfig);
+        final Set<TaskInfo> tasks = mkSet(
+            new DefaultTaskInfo(
+                new TaskId(1, 1),
+                false,
+                mkSet(),
+                mkSet(
+                    new DefaultTaskTopicPartition(
+                        new TopicPartition("t1", 1),
+                        true,
+                        false,
+                        () -> { }
+                    )
+                )
+            )
+        );
+
+        final UUID clientUuid1 = UUID.randomUUID();
+        final UUID clientUuid2 = UUID.randomUUID();
+        final Map<UUID, StreamsPartitionAssignor.ClientMetadata> clients = mkMap(
+            mkEntry(clientUuid1, new StreamsPartitionAssignor.ClientMetadata(clientUuid1, "endpoint1:80", mkMap(), Optional.empty())),
+            mkEntry(clientUuid2, new StreamsPartitionAssignor.ClientMetadata(clientUuid1, "endpoint2:80", mkMap(), Optional.empty()))
+        );
+        final ApplicationState applicationState = new DefaultApplicationState(
+            assignmentConfigs,
+            tasks.stream().collect(Collectors.toMap(
+                TaskInfo::id,
+                t -> t
+            )),
+            clients
+        );
+
+        // ****
+        final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment noError = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
+            mkSet(
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
+                )),
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet())
+            )
+        );
+        org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError error = partitionAssignor.validateTaskAssignment(applicationState, noError);
+        assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.NONE, error);
+
+        // ****
+        final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment missingProcessId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
+            mkSet(
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
+                ))
+            )
+        );
+        error = partitionAssignor.validateTaskAssignment(applicationState, missingProcessId);
+        assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.MISSING_PROCESS_ID, error);
+
+        // ****
+        final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment unknownProcessId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
+            mkSet(
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
+                )),
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet()),
+                KafkaStreamsAssignment.of(new ProcessId(UUID.randomUUID()), mkSet())
+            )
+        );
+        error = partitionAssignor.validateTaskAssignment(applicationState, unknownProcessId);
+        assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.UNKNOWN_PROCESS_ID, error);
+
+        // ****
+        final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment unknownTaskId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
+            mkSet(
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE)
+                )),
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(new TaskId(13, 13), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE)
+                ))
+            )
+        );
+        error = partitionAssignor.validateTaskAssignment(applicationState, unknownTaskId);
+        assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.UNKNOWN_TASK_ID, error);
     }
 
     private static class CorruptedInternalTopologyBuilder extends InternalTopologyBuilder {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2645,15 +2645,37 @@ public class StreamsPartitionAssignorTest {
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment unknownTaskId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
                 KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
-                    new KafkaStreamsAssignment.AssignedTask(new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE)
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
                 )),
                 KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet(
-                    new KafkaStreamsAssignment.AssignedTask(new TaskId(13, 13), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE)
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(13, 13), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
                 ))
             )
         );
         error = partitionAssignor.validateTaskAssignment(applicationState, unknownTaskId);
         assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.UNKNOWN_TASK_ID, error);
+
+        // ****
+        final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment activeTaskDuplicated = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
+            mkSet(
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
+                )),
+                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet(
+                    new KafkaStreamsAssignment.AssignedTask(
+                        new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
+                    )
+                ))
+            )
+        );
+        error = partitionAssignor.validateTaskAssignment(applicationState, activeTaskDuplicated);
+        assertEquals(org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError.ACTIVE_TASK_ASSIGNED_MULTIPLE_TIMES, error);
     }
 
     private static class CorruptedInternalTopologyBuilder extends InternalTopologyBuilder {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -647,7 +647,7 @@ public class StreamsPartitionAssignorTest {
             singletonList(3))
         );
 
-        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(
@@ -2393,7 +2393,7 @@ public class StreamsPartitionAssignorTest {
                           ));
 
         configureDefault();
-        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(
@@ -2446,7 +2446,7 @@ public class StreamsPartitionAssignorTest {
             ));
 
         configureDefault();
-        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -351,9 +351,9 @@ public class StreamsPartitionAssignorTest {
             new Object[]{StickyTaskAssignor.class, true, null},
             new Object[]{StickyTaskAssignor.class, false, null},
             new Object[]{FallbackPriorTaskAssignor.class, true, null},
-            new Object[]{FallbackPriorTaskAssignor.class, false, null}
-            // new Object[]{HighAvailabilityTaskAssignor.class, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
-            // new Object[]{null, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class}
+            new Object[]{FallbackPriorTaskAssignor.class, false, null},
+            new Object[]{null, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
+            new Object[]{HighAvailabilityTaskAssignor.class, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class}
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -84,6 +84,7 @@ import org.apache.kafka.test.MockInternalTopicManager;
 import org.apache.kafka.test.MockKeyValueStoreBuilder;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
@@ -182,6 +183,8 @@ public class StreamsPartitionAssignorTest {
     // We need this rule because we would like to combine Parameterised tests with strict Mockito stubs.
     @Rule
     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    @Rule
+    public Timeout timeout = new Timeout(10_000);
 
     private static final String CONSUMER_1 = "consumer1";
     private static final String CONSUMER_2 = "consumer2";
@@ -353,6 +356,7 @@ public class StreamsPartitionAssignorTest {
             new Object[]{FallbackPriorTaskAssignor.class, true, null},
             new Object[]{FallbackPriorTaskAssignor.class, false, null},
             new Object[]{null, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
+            new Object[]{null, true, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
             new Object[]{HighAvailabilityTaskAssignor.class, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class}
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -351,9 +351,9 @@ public class StreamsPartitionAssignorTest {
             new Object[]{StickyTaskAssignor.class, true, null},
             new Object[]{StickyTaskAssignor.class, false, null},
             new Object[]{FallbackPriorTaskAssignor.class, true, null},
-            new Object[]{FallbackPriorTaskAssignor.class, false, null},
-            new Object[]{HighAvailabilityTaskAssignor.class, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
-            new Object[]{null, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class}
+            new Object[]{FallbackPriorTaskAssignor.class, false, null}
+            // new Object[]{HighAvailabilityTaskAssignor.class, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class},
+            // new Object[]{null, false, org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor.class}
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -184,7 +184,7 @@ public class StreamsPartitionAssignorTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     @Rule
-    public Timeout timeout = new Timeout(10_000);
+    public Timeout timeout = new Timeout(30_000);
 
     private static final String CONSUMER_1 = "consumer1";
     private static final String CONSUMER_2 = "consumer2";

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -646,7 +646,20 @@ public class StreamsPartitionAssignorTest {
             singletonList(APPLICATION_ID + "-store-changelog"),
             singletonList(3))
         );
-        configureDefaultPartitionAssignor();
+
+        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+                "stream-partition-assignor-test-store-changelog",
+                singletonList(
+                    new TopicPartitionInfo(
+                        0,
+                        new Node(1, "h1", 80),
+                        singletonList(new Node(1, "h1", 80)),
+                        emptyList()
+                    )
+                )
+            )
+        ));
+        configurePartitionAssignorWith(emptyMap(), partitionInfo);
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -2380,7 +2393,19 @@ public class StreamsPartitionAssignorTest {
                           ));
 
         configureDefault();
-        overwriteInternalTopicManagerWithMock(true);
+        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+                "stream-partition-assignor-test-store-changelog",
+                singletonList(
+                    new TopicPartitionInfo(
+                        0,
+                        new Node(1, "h1", 80),
+                        singletonList(new Node(1, "h1", 80)),
+                        emptyList()
+                    )
+                )
+            )
+        ));
+        overwriteInternalTopicManagerWithMock(true, partitionInfo);
 
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions));
     }
@@ -2421,7 +2446,19 @@ public class StreamsPartitionAssignorTest {
             ));
 
         configureDefault();
-        overwriteInternalTopicManagerWithMock(false);
+        List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+                "stream-partition-assignor-test-store-changelog",
+                singletonList(
+                    new TopicPartitionInfo(
+                        0,
+                        new Node(1, "h1", 80),
+                        singletonList(new Node(1, "h1", 80)),
+                        emptyList()
+                    )
+                )
+            )
+        ));
+        overwriteInternalTopicManagerWithMock(false, partitionInfo);
 
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/CustomStickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/CustomStickyTaskAssignorTest.java
@@ -1,0 +1,765 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.assignment;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment.AssignedTask.Type.ACTIVE;
+import static org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment.AssignedTask.Type.STANDBY;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_4;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_5;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_3_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_3_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_3_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment.AssignedTask;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsState;
+import org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor;
+import org.apache.kafka.streams.processor.assignment.TaskAssignor;
+import org.apache.kafka.streams.processor.assignment.ApplicationState;
+import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
+import org.apache.kafka.streams.processor.assignment.TaskInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class CustomStickyTaskAssignorTest {
+
+    private TaskAssignor assignor;
+
+    @Parameterized.Parameter
+    public String rackAwareStrategy;
+
+    @Parameterized.Parameters(name = "rackAwareStrategy={0}")
+    public static Collection<Object[]> getParamStoreType() {
+        return asList(new Object[][] {
+            {StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_NONE},
+            {StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_MIN_TRAFFIC},
+            {StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_BALANCE_SUBTOPOLOGY},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        assignor = new StickyTaskAssignor();
+    }
+
+    @Test
+    public void shouldAssignOneActiveTaskToEachProcessWhenTaskCountSameAsProcessCount() {
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty())
+        );
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        for (final KafkaStreamsAssignment assignment : assignments.values()) {
+            assertThat(assignment.tasks().size(), equalTo(1));
+        }
+    }
+
+    @Test
+    public void shouldAssignTopicGroupIdEvenlyAcrossClientsWithNoStandByTasks() {
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 2, Optional.empty()),
+            mkStreamState(2, 2, Optional.empty()),
+            mkStreamState(3, 2, Optional.empty())
+        );
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_1_0, false),
+            mkTaskInfo(TASK_1_1, false),
+            mkTaskInfo(TASK_2_2, false),
+            mkTaskInfo(TASK_2_0, false),
+            mkTaskInfo(TASK_2_1, false),
+            mkTaskInfo(TASK_1_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertActiveTaskTopicGroupIdsEvenlyDistributed(assignments);
+    }
+
+    @Test
+    public void shouldAssignTopicGroupIdEvenlyAcrossClientsWithStandByTasks() {
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 2, Optional.empty()),
+            mkStreamState(2, 2, Optional.empty()),
+            mkStreamState(3, 2, Optional.empty())
+        );
+
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_2_0, false),
+            mkTaskInfo(TASK_1_1, false),
+            mkTaskInfo(TASK_1_2, false),
+            mkTaskInfo(TASK_1_0, false),
+            mkTaskInfo(TASK_2_1, false),
+            mkTaskInfo(TASK_2_2, false)
+        );
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 1);
+        assertActiveTaskTopicGroupIdsEvenlyDistributed(assignments);
+    }
+
+
+    @Test
+    public void shouldNotMigrateActiveTaskToOtherProcess() {
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_1), mkSet())
+        );
+
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertHasAssignment(assignments, 1, TASK_0_0, ACTIVE);
+        assertHasAssignment(assignments, 2, TASK_0_1, ACTIVE);
+
+        final Map<ProcessId, KafkaStreamsState> streamStates2 = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_0), mkSet())
+        );
+        final Map<ProcessId, KafkaStreamsAssignment> assignments2 = assign(streamStates2, tasks);
+        assertHasAssignment(assignments2, 1, TASK_0_1, ACTIVE);
+        assertHasAssignment(assignments2, 2, TASK_0_0, ACTIVE);
+    }
+
+    @Test
+    public void shouldMigrateActiveTasksToNewProcessWithoutChangingAllAssignments() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0, TASK_0_2), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(3, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(assignments.get(processId(1)).tasks().values().size(), equalTo(1));
+        assertThat(assignments.get(processId(2)).tasks().values().size(), equalTo(1));
+        assertThat(assignments.get(processId(3)).tasks().values().size(), equalTo(1));
+
+        assertHasAssignment(assignments, 2, TASK_0_1, ACTIVE);
+    }
+
+    @Test
+    public void shouldAssignBasedOnCapacity() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 2, Optional.empty())
+        );
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(assignments.get(processId(1)).tasks().values().size(), equalTo(1));
+        assertThat(assignments.get(processId(2)).tasks().values().size(), equalTo(2));
+    }
+
+    @Test
+    public void shouldAssignTasksEvenlyWithUnequalTopicGroupSizes() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_1_0, false),
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false),
+            mkTaskInfo(TASK_0_3, false),
+            mkTaskInfo(TASK_0_4, false),
+            mkTaskInfo(TASK_0_5, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_0_4, TASK_0_5, TASK_1_0), mkSet()),
+            mkStreamState(2, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        final Set<TaskId> client1Tasks = assignments.get(processId(1)).tasks().values().stream()
+            .filter(t -> t.type() == ACTIVE)
+            .map(AssignedTask::id)
+            .collect(Collectors.toSet());
+        final Set<TaskId> client2Tasks = assignments.get(processId(2)).tasks().values().stream()
+            .filter(t -> t.type() == ACTIVE)
+            .map(AssignedTask::id)
+            .collect(Collectors.toSet());
+
+        final Set<TaskId> allTasks = tasks.keySet();
+
+        // one client should get 3 tasks and the other should have 4
+        assertThat(
+            (client1Tasks.size() == 3 && client2Tasks.size() == 4) ||
+            (client1Tasks.size() == 4 && client2Tasks.size() == 3),
+            is(true));
+        allTasks.removeAll(client1Tasks);
+        // client2 should have all the remaining tasks not assigned to client 1
+        assertThat(client2Tasks, equalTo(allTasks));
+    }
+
+    @Test
+    public void shouldKeepActiveTaskStickinessWhenMoreClientThanActiveTasks() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_2), mkSet()),
+            mkStreamState(3, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(4, 1, Optional.empty()),
+            mkStreamState(5, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(assignments.get(processId(1)).tasks().size(), is(1));
+        assertThat(assignments.get(processId(2)).tasks().size(), is(1));
+        assertThat(assignments.get(processId(3)).tasks().size(), is(1));
+        assertThat(assignments.get(processId(4)).tasks().size(), is(0));
+        assertThat(assignments.get(processId(5)).tasks().size(), is(0));
+
+        assertHasAssignment(assignments, 1, TASK_0_0, ACTIVE);
+        assertHasAssignment(assignments, 2, TASK_0_2, ACTIVE);
+        assertHasAssignment(assignments, 3, TASK_0_1, ACTIVE);
+
+
+        final Map<ProcessId, KafkaStreamsState> streamStates2 = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(4, 1, Optional.empty(), mkSet(TASK_0_0), mkSet()),
+            mkStreamState(5, 1, Optional.empty(), mkSet(TASK_0_2), mkSet())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments2 = assign(streamStates2, tasks);
+        assertThat(assignments2.get(processId(1)).tasks().size(), is(0));
+        assertThat(assignments2.get(processId(2)).tasks().size(), is(0));
+        assertThat(assignments2.get(processId(3)).tasks().size(), is(1));
+        assertThat(assignments2.get(processId(4)).tasks().size(), is(1));
+        assertThat(assignments2.get(processId(5)).tasks().size(), is(1));
+
+        assertHasAssignment(assignments2, 3, TASK_0_1, ACTIVE);
+        assertHasAssignment(assignments2, 4, TASK_0_0, ACTIVE);
+        assertHasAssignment(assignments2, 5, TASK_0_2, ACTIVE);
+    }
+
+    @Test
+    public void shouldAssignTasksToClientWithPreviousStandbyTasks() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(), mkSet(TASK_0_2)),
+            mkStreamState(2, 1, Optional.empty(), mkSet(), mkSet(TASK_0_1)),
+            mkStreamState(3, 1, Optional.empty(), mkSet(), mkSet(TASK_0_0))
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertHasAssignment(assignments, 1, TASK_0_2, ACTIVE);
+        assertHasAssignment(assignments, 2, TASK_0_1, ACTIVE);
+        assertHasAssignment(assignments, 3, TASK_0_0, ACTIVE);
+    }
+
+    @Test
+    public void shouldAssignBasedOnCapacityWhenMultipleClientHaveStandbyTasks() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet(TASK_0_1)),
+            mkStreamState(2, 2, Optional.empty(), mkSet(TASK_0_2), mkSet(TASK_0_1))
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(assignments.get(processId(1)).tasks().size(), is(1));
+        assertThat(assignments.get(processId(2)).tasks().size(), is(2));
+        assertHasAssignment(assignments, 1, TASK_0_0, ACTIVE);
+        assertHasAssignment(assignments, 2, TASK_0_1, ACTIVE);
+        assertHasAssignment(assignments, 2, TASK_0_2, ACTIVE);
+    }
+
+    @Test
+    public void shouldAssignStandbyTasksToDifferentClientThanCorrespondingActiveTaskIsAssignedTo() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true),
+            mkTaskInfo(TASK_0_1, true),
+            mkTaskInfo(TASK_0_2, true),
+            mkTaskInfo(TASK_0_3, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(3, 1, Optional.empty(), mkSet(TASK_0_2), mkSet()),
+            mkStreamState(4, 1, Optional.empty(), mkSet(TASK_0_3), mkSet())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 1);
+        assertThat(standbyTasks(assignments, 1).size(), lessThanOrEqualTo(2));
+        assertThat(standbyTasks(assignments, 2).size(), lessThanOrEqualTo(2));
+        assertThat(standbyTasks(assignments, 3).size(), lessThanOrEqualTo(2));
+        assertThat(standbyTasks(assignments, 4).size(), lessThanOrEqualTo(2));
+
+        assertThat(standbyTasks(assignments, 1), not(hasItems(TASK_0_0)));
+        assertThat(standbyTasks(assignments, 2), not(hasItems(TASK_0_1)));
+        assertThat(standbyTasks(assignments, 3), not(hasItems(TASK_0_2)));
+        assertThat(standbyTasks(assignments, 4), not(hasItems(TASK_0_3)));
+
+        assertThat(activeTasks(assignments, 1), hasItems(TASK_0_0));
+        assertThat(activeTasks(assignments, 2), hasItems(TASK_0_1));
+        assertThat(activeTasks(assignments, 3), hasItems(TASK_0_2));
+        assertThat(activeTasks(assignments, 4), hasItems(TASK_0_3));
+
+        int nonEmptyStandbyTaskCount = 0;
+        for (int i = 1; i <= 4; i++) {
+            nonEmptyStandbyTaskCount += standbyTasks(assignments, i).isEmpty() ? 0 : 1;
+        }
+
+        assertThat(nonEmptyStandbyTaskCount, greaterThanOrEqualTo(3));
+
+        final Set<TaskId> allStandbyTasks = allTasks(assignments).stream()
+            .filter(t -> t.type() == STANDBY)
+            .map(AssignedTask::id)
+            .collect(Collectors.toSet());
+        assertThat(allStandbyTasks, equalTo(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)));
+    }
+
+
+    @Test
+    public void shouldAssignMultipleReplicasOfStandbyTask() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true),
+            mkTaskInfo(TASK_0_1, true),
+            mkTaskInfo(TASK_0_2, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet()),
+            mkStreamState(2, 1, Optional.empty(), mkSet(TASK_0_1), mkSet()),
+            mkStreamState(3, 1, Optional.empty(), mkSet(TASK_0_2), mkSet())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 2);
+        assertThat(activeTasks(assignments, 1), equalTo(mkSet(TASK_0_0)));
+        assertThat(activeTasks(assignments, 2), equalTo(mkSet(TASK_0_1)));
+        assertThat(activeTasks(assignments, 3), equalTo(mkSet(TASK_0_2)));
+
+        assertThat(standbyTasks(assignments, 1), equalTo(mkSet(TASK_0_1, TASK_0_2)));
+        assertThat(standbyTasks(assignments, 2), equalTo(mkSet(TASK_0_0, TASK_0_2)));
+        assertThat(standbyTasks(assignments, 3), equalTo(mkSet(TASK_0_0, TASK_0_1)));
+    }
+
+    @Test
+    public void shouldNotAssignStandbyTaskReplicasWhenNoClientAvailableWithoutHavingTheTaskAssigned() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty(), mkSet(TASK_0_0), mkSet())
+        );
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 2);
+        assertThat(activeTasks(assignments, 1), equalTo(mkSet(TASK_0_0)));
+        assertThat(standbyTasks(assignments, 1), equalTo(mkSet()));
+    }
+
+    @Test
+    public void shouldAssignActiveAndStandbyTasks() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true),
+            mkTaskInfo(TASK_0_1, true),
+            mkTaskInfo(TASK_0_2, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 1);
+        final Set<AssignedTask> allTasks = allTasks(assignments);
+        assertThat(allTasks.stream().filter(t -> t.type() == ACTIVE).map(AssignedTask::id).collect(
+            Collectors.toSet()), equalTo(mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
+        assertThat(allTasks.stream().filter(t -> t.type() == STANDBY).map(AssignedTask::id).collect(
+            Collectors.toSet()), equalTo(mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
+    }
+
+    @Test
+    public void shouldAssignAtLeastOneTaskToEachClientIfPossible() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 3, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(activeTasks(assignments, 1).size(), is(1));
+        assertThat(activeTasks(assignments, 2).size(), is(1));
+        assertThat(activeTasks(assignments, 3).size(), is(1));
+    }
+
+    @Test
+    public void shouldAssignEachActiveTaskToOneClientWhenMoreClientsThanTasks() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty()),
+            mkStreamState(4, 1, Optional.empty()),
+            mkStreamState(5, 1, Optional.empty()),
+            mkStreamState(6, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        final Set<AssignedTask> allTasks = allTasks(assignments);
+        assertThat(allTasks.stream().filter(t -> t.type() == ACTIVE).map(AssignedTask::id).collect(
+            Collectors.toSet()), equalTo(mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
+        assertThat(allTasks.stream().filter(t -> t.type() == STANDBY).map(AssignedTask::id).collect(
+            Collectors.toSet()), equalTo(mkSet()));
+
+        final int clientsWithATask = assignments.values().stream().mapToInt(assignment -> assignment.tasks().isEmpty() ? 0 : 1).sum();
+        assertThat(clientsWithATask, greaterThanOrEqualTo(3));
+    }
+
+    @Test
+    public void shouldBalanceActiveAndStandbyTasksAcrossAvailableClients() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true),
+            mkTaskInfo(TASK_0_1, true),
+            mkTaskInfo(TASK_0_2, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty()),
+            mkStreamState(4, 1, Optional.empty()),
+            mkStreamState(5, 1, Optional.empty()),
+            mkStreamState(6, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 1);
+        for (final KafkaStreamsAssignment assignment : assignments.values()) {
+            assertThat(assignment.tasks().values(), not(hasSize(0)));
+        }
+    }
+
+    @Test
+    public void shouldAssignMoreTasksToClientWithMoreCapacity() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, false),
+            mkTaskInfo(TASK_0_1, false),
+            mkTaskInfo(TASK_0_2, false),
+            mkTaskInfo(TASK_1_0, false),
+            mkTaskInfo(TASK_1_1, false),
+            mkTaskInfo(TASK_1_2, false),
+            mkTaskInfo(TASK_2_0, false),
+            mkTaskInfo(TASK_2_1, false),
+            mkTaskInfo(TASK_2_2, false),
+            mkTaskInfo(TASK_3_0, false),
+            mkTaskInfo(TASK_3_1, false),
+            mkTaskInfo(TASK_3_2, false)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 2, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks);
+        assertThat(activeTasks(assignments, 1).size(), equalTo(4));
+        assertThat(activeTasks(assignments, 2).size(), equalTo(8));
+    }
+
+    @Test
+    public void shouldEvenlyDistributeByTaskIdAndPartition() {
+        // TODO: port shouldEvenlyDistributeByTaskIdAndPartition from StickyTaskAssignorTest
+    }
+
+    @Test
+    public void shouldNotHaveSameAssignmentOnAnyTwoHosts() {
+        final Map<TaskId, TaskInfo> tasks = mkMap(
+            mkTaskInfo(TASK_0_0, true),
+            mkTaskInfo(TASK_0_1, true),
+            mkTaskInfo(TASK_0_2, true),
+            mkTaskInfo(TASK_0_3, true)
+        );
+
+        final Map<ProcessId, KafkaStreamsState> streamStates = mkMap(
+            mkStreamState(1, 1, Optional.empty()),
+            mkStreamState(2, 1, Optional.empty()),
+            mkStreamState(3, 1, Optional.empty()),
+            mkStreamState(4, 1, Optional.empty())
+        );
+
+        final Map<ProcessId, KafkaStreamsAssignment> assignments = assign(streamStates, tasks, 1);
+
+        for (final KafkaStreamsState client1: streamStates.values()) {
+            for (final KafkaStreamsState client2: streamStates.values()) {
+                if (!client1.processId().equals(client2.processId())) {
+                    final Set<TaskId> assignedTasks1 = assignments.get(client1.processId()).tasks().keySet();
+                    final Set<TaskId> assignedTasks2 = assignments.get(client2.processId()).tasks().keySet();
+                    assertThat("clients shouldn't have same task assignment", assignedTasks1,
+                        not(equalTo(assignedTasks2)));
+                }
+            }
+        }
+    }
+
+    // **************************
+    private Map.Entry<ProcessId, KafkaStreamsState> mkStreamState(final int id,
+                                                                  final int numProcessingThreads,
+                                                                  final Optional<String> rackId) {
+        return mkStreamState(id, numProcessingThreads, rackId, new HashSet<>(), new HashSet<>());
+    }
+
+    private Map.Entry<ProcessId, KafkaStreamsState> mkStreamState(final int id,
+                                                                  final int numProcessingThreads,
+                                                                  final Optional<String> rackId,
+                                                                  final Set<TaskId> previousActiveTasks,
+                                                                  final Set<TaskId> previousStandbyTasks) {
+        final ProcessId processId = new ProcessId(uuidForInt(id));
+        return mkEntry(processId, new KafkaStreamsStateImpl(
+            processId,
+            numProcessingThreads,
+            mkMap(),
+            new TreeSet<>(previousActiveTasks),
+            new TreeSet<>(previousStandbyTasks),
+            new TreeMap<>(),
+            Optional.empty(),
+            Optional.empty(),
+            rackId
+        ));
+    }
+
+    private Map.Entry<TaskId, TaskInfo> mkTaskInfo(final TaskId taskId, final boolean isStateful) {
+        if (!isStateful) {
+            return mkEntry(
+                taskId,
+                new DefaultTaskInfo(taskId, false, mkSet(), mkSet())
+            );
+        }
+        return mkEntry(
+            taskId,
+            new DefaultTaskInfo(
+                taskId,
+                true,
+                mkSet("test-statestore-1"),
+                mkSet(
+                    new DefaultTaskTopicPartition(
+                        new TopicPartition("test-topic-1", taskId.partition()),
+                        true,
+                        true,
+                        () -> { }
+                    )
+                )
+            )
+        );
+    }
+
+    private AssignmentConfigs defaultAssignmentConfigs(final int numStandbys) {
+        return new AssignmentConfigs(
+            0L,
+            1,
+            numStandbys,
+            60_000L,
+            Collections.emptyList(),
+            OptionalInt.empty(),
+            OptionalInt.empty(),
+            rackAwareStrategy
+        );
+    }
+
+    private Map<ProcessId, KafkaStreamsAssignment> assign(final Map<ProcessId, KafkaStreamsState> streamStates,
+                                                      final Map<TaskId, TaskInfo> tasks) {
+        return assign(streamStates, tasks, 0);
+    }
+
+    private Map<ProcessId, KafkaStreamsAssignment> assign(final Map<ProcessId, KafkaStreamsState> streamStates,
+                                                      final Map<TaskId, TaskInfo> tasks,
+                                                      final int numStandbys) {
+        final ApplicationState applicationState = new TestApplicationState(
+            defaultAssignmentConfigs(numStandbys),
+            streamStates,
+            tasks
+        );
+        return indexAssignment(assignor.assign(applicationState).assignment());
+    }
+
+    private ProcessId processId(final int id) {
+        return new ProcessId(uuidForInt(id));
+    }
+
+    private Map<ProcessId, KafkaStreamsAssignment> indexAssignment(final Collection<KafkaStreamsAssignment> assignments) {
+        return assignments.stream().collect(Collectors.toMap(KafkaStreamsAssignment::processId, assignment -> assignment));
+    }
+
+    private Set<TaskId> activeTasks(final Map<ProcessId, KafkaStreamsAssignment> assignments,
+                                    final int client) {
+        final KafkaStreamsAssignment assignment = assignments.getOrDefault(processId(client), null);
+        if (assignment == null) {
+            return mkSet();
+        }
+        return assignment.tasks().values().stream().filter(t -> t.type() == ACTIVE)
+            .map(AssignedTask::id)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<TaskId> standbyTasks(final Map<ProcessId, KafkaStreamsAssignment> assignments,
+                                    final int client) {
+        final KafkaStreamsAssignment assignment = assignments.getOrDefault(processId(client), null);
+        if (assignment == null) {
+            return mkSet();
+        }
+        return assignment.tasks().values().stream().filter(t -> t.type() == STANDBY)
+            .map(AssignedTask::id)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<AssignedTask> allTasks(final Map<ProcessId, KafkaStreamsAssignment> assignments) {
+        final Set<AssignedTask> allTasks = new HashSet<>();
+        assignments.values().forEach(assignment -> allTasks.addAll(assignment.tasks().values()));
+        return allTasks;
+    }
+
+    private void assertHasAssignment(final Map<ProcessId, KafkaStreamsAssignment> assignments,
+                                     final int client,
+                                     final TaskId taskId,
+                                     final AssignedTask.Type taskType) {
+        final KafkaStreamsAssignment assignment = assignments.getOrDefault(processId(client), null);
+        assertThat(assignment, notNullValue());
+        final AssignedTask assignedTask = assignment.tasks().getOrDefault(taskId, null);
+        assertThat(assignedTask, notNullValue());
+        assertThat(assignedTask.id().equals(taskId), is(true));
+        assertThat(assignedTask.type().equals(taskType), is(true));
+    }
+
+    private void assertActiveTaskTopicGroupIdsEvenlyDistributed(final Map<ProcessId, KafkaStreamsAssignment> assignments) {
+        for (final KafkaStreamsAssignment assignment : assignments.values()) {
+            final List<Integer> topicGroupIds = new ArrayList<>();
+            final Set<TaskId> activeTasks = assignment.tasks().values().stream()
+                .map(AssignedTask::id)
+                .collect(Collectors.toSet());
+            for (final TaskId activeTask : activeTasks) {
+                topicGroupIds.add(activeTask.subtopology());
+            }
+            Collections.sort(topicGroupIds);
+            assertThat(topicGroupIds, equalTo(asList(1, 2)));
+        }
+    }
+
+    private static class TestApplicationState implements ApplicationState {
+
+        private final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates;
+        private final AssignmentConfigs assignmentConfigs;
+        private final Map<TaskId, TaskInfo> tasks;
+
+        private TestApplicationState(final AssignmentConfigs assignmentConfigs,
+                                     final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates,
+                                     final Map<TaskId, TaskInfo> tasks) {
+            this.kafkaStreamsStates = kafkaStreamsStates;
+            this.assignmentConfigs = assignmentConfigs;
+            this.tasks = tasks;
+        }
+
+        @Override
+        public Map<ProcessId, KafkaStreamsState> kafkaStreamsStates(final boolean computeTaskLags) {
+            return kafkaStreamsStates;
+        }
+
+        @Override
+        public AssignmentConfigs assignmentConfigs() {
+            return assignmentConfigs;
+        }
+
+        @Override
+        public Map<TaskId, TaskInfo> allTasks() {
+            return tasks;
+        }
+    }
+}


### PR DESCRIPTION
This PR takes care of making the call back to`TaskAssignor.onAssignmentComputed`.

It also contains a change to the public AssignmentConfigs API, as well as some simplifications of the StickyTaskAssignor.

This PR also changes the rack information fetching to happen lazily in the case where the TaskAssignor makes its decisions without said rack information.
