### PR TITLE
MINOR: update all-latency-avg documentation

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3143,7 +3143,7 @@ for built-in state stores, currently we have:
       </tr>
       <tr>
         <td>all-latency-avg</td>
-        <td>The average all operation execution time in ns.</td>
+        <td>The average execution time in ns, for iterating over the results of the all operation.</td>
         <td>kafka.streams:type=stream-state-metrics,thread-id=([-.\w]+),task-id=([-.\w]+),[store-scope]-id=([-.\w]+)</td>
       </tr>
       <tr>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3143,7 +3143,7 @@ for built-in state stores, currently we have:
       </tr>
       <tr>
         <td>all-latency-avg</td>
-        <td>The average execution time in ns, for iterating over the results of the all operation.</td>
+        <td>The average execution time in ns, from iterator create to close time.</td>
         <td>kafka.streams:type=stream-state-metrics,thread-id=([-.\w]+),task-id=([-.\w]+),[store-scope]-id=([-.\w]+)</td>
       </tr>
       <tr>


### PR DESCRIPTION
This change update the documentation for the all-latency-avg. It specifies that the execution time of the all operation is in fact the time the iterator is in use.
