### PR TITLE
KAFKA-16047: Use REQUEST_TIMEOUT_MS_CONFIG in AdminClient.fenceProducers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4569,7 +4569,7 @@ public class KafkaAdminClient extends AdminClient {
     public FenceProducersResult fenceProducers(Collection<String> transactionalIds, FenceProducersOptions options) {
         AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> future =
             FenceProducersHandler.newFuture(transactionalIds);
-        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        FenceProducersHandler handler = new FenceProducersHandler(logContext, requestTimeoutMs);
         invokeDriver(handler, future, options.timeoutMs);
         return new FenceProducersResult(future.all());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4569,7 +4569,7 @@ public class KafkaAdminClient extends AdminClient {
     public FenceProducersResult fenceProducers(Collection<String> transactionalIds, FenceProducersOptions options) {
         AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> future =
             FenceProducersHandler.newFuture(transactionalIds);
-        FenceProducersHandler handler = new FenceProducersHandler(logContext, requestTimeoutMs);
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext, requestTimeoutMs);
         invokeDriver(handler, future, options.timeoutMs);
         return new FenceProducersResult(future.all());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
+import org.apache.kafka.clients.admin.FenceProducersOptions;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
@@ -38,15 +39,16 @@ import java.util.stream.Collectors;
 public class FenceProducersHandler extends AdminApiHandler.Unbatched<CoordinatorKey, ProducerIdAndEpoch> {
     private final Logger log;
     private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
-    private final int requestTimeoutMs;
+    private final int txnTimeoutMs;
 
     public FenceProducersHandler(
+        FenceProducersOptions options,
         LogContext logContext,
         int requestTimeoutMs
     ) {
         this.log = logContext.logger(FenceProducersHandler.class);
         this.lookupStrategy = new CoordinatorStrategy(FindCoordinatorRequest.CoordinatorType.TRANSACTION, logContext);
-        this.requestTimeoutMs = requestTimeoutMs;
+        this.txnTimeoutMs = options.timeoutMs() != null ? options.timeoutMs() : requestTimeoutMs;
     }
 
     public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> newFuture(
@@ -85,9 +87,8 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
             .setProducerEpoch(ProducerIdAndEpoch.NONE.epoch)
             .setProducerId(ProducerIdAndEpoch.NONE.producerId)
             .setTransactionalId(key.idValue)
-            // Set transaction timeout to requestTimeoutMs since it's only being initialized to fence out older producers with the same transactional ID.
-            // This timeout is used to append the record with the new producer epoch to the transaction log.
-            .setTransactionTimeoutMs(requestTimeoutMs);
+            // This timeout is used by the coordinator to append the record with the new producer epoch to the transaction log.
+            .setTransactionTimeoutMs(txnTimeoutMs);
         return new InitProducerIdRequest.Builder(data);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
@@ -39,10 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class FenceProducersHandlerTest {
     private final LogContext logContext = new LogContext();
     private final Node node = new Node(1, "host", 1234);
+    private final int timeoutMs = 30000;
 
     @Test
     public void testBuildRequest() {
-        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
         mkSet("foo", "bar", "baz").forEach(transactionalId -> assertLookup(handler, transactionalId));
     }
 
@@ -51,7 +52,7 @@ public class FenceProducersHandlerTest {
         String transactionalId = "foo";
         CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
 
-        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
 
         short epoch = 57;
         long producerId = 7;
@@ -73,7 +74,7 @@ public class FenceProducersHandlerTest {
     @Test
     public void testHandleErrorResponse() {
         String transactionalId = "foo";
-        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
         assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.CLUSTER_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);
@@ -140,6 +141,6 @@ public class FenceProducersHandlerTest {
         CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
         InitProducerIdRequest.Builder request = handler.buildSingleRequest(1, key);
         assertEquals(transactionalId, request.data.transactionalId());
-        assertEquals(1, request.data.transactionTimeoutMs());
+        assertEquals(timeoutMs, request.data.transactionTimeoutMs());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
+import org.apache.kafka.clients.admin.FenceProducersOptions;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
@@ -39,12 +40,21 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class FenceProducersHandlerTest {
     private final LogContext logContext = new LogContext();
     private final Node node = new Node(1, "host", 1234);
-    private final int timeoutMs = 30000;
+    private final int requestTimeoutMs = 30000;
+    private final FenceProducersOptions options = new FenceProducersOptions();
 
     @Test
     public void testBuildRequest() {
-        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
-        mkSet("foo", "bar", "baz").forEach(transactionalId -> assertLookup(handler, transactionalId));
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext, requestTimeoutMs);
+        mkSet("foo", "bar", "baz").forEach(transactionalId -> assertLookup(handler, transactionalId, requestTimeoutMs));
+    }
+
+    @Test
+    public void testBuildRequestOptionsTimeout() {
+        final int optionsTimeoutMs = 50000;
+        options.timeoutMs(optionsTimeoutMs);
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext, requestTimeoutMs);
+        mkSet("foo", "bar", "baz").forEach(transactionalId -> assertLookup(handler, transactionalId, optionsTimeoutMs));
     }
 
     @Test
@@ -52,7 +62,7 @@ public class FenceProducersHandlerTest {
         String transactionalId = "foo";
         CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
 
-        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext, requestTimeoutMs);
 
         short epoch = 57;
         long producerId = 7;
@@ -74,7 +84,7 @@ public class FenceProducersHandlerTest {
     @Test
     public void testHandleErrorResponse() {
         String transactionalId = "foo";
-        FenceProducersHandler handler = new FenceProducersHandler(logContext, timeoutMs);
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext, requestTimeoutMs);
         assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.CLUSTER_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);
@@ -137,10 +147,10 @@ public class FenceProducersHandlerTest {
         return result;
     }
 
-    private void assertLookup(FenceProducersHandler handler, String transactionalId) {
+    private void assertLookup(FenceProducersHandler handler, String transactionalId, int txnTimeoutMs) {
         CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
         InitProducerIdRequest.Builder request = handler.buildSingleRequest(1, key);
         assertEquals(transactionalId, request.data.transactionalId());
-        assertEquals(timeoutMs, request.data.transactionTimeoutMs());
+        assertEquals(txnTimeoutMs, request.data.transactionTimeoutMs());
     }
 }


### PR DESCRIPTION
Use REQUEST_TIMEOUT_MS_CONFIG in AdminClient.fenceProducers as transaction timeout.
No transaction will be started with this timeout, but ReplicaManager.appendRecords uses this value as its timeout. Use REQUEST_TIMEOUT_MS_CONFIG like a regular producer append to allow for replication to take place.

Co-Authored-By: Adrian Preston <prestona@uk.ibm.com>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
