### PR TITLE
MINOR: reduce the test suits of consumer group tools 

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
@@ -43,11 +43,37 @@ import java.util.stream.Stream;
 
 import static kafka.test.annotation.Type.CO_KRAFT;
 import static kafka.test.annotation.Type.KRAFT;
+import static kafka.test.annotation.Type.ZK;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 
+/**
+ * The old test framework {@link kafka.api.BaseConsumerTest#getTestQuorumAndGroupProtocolParametersAll} test for the following cases:
+ * <ul>
+ *     <li>(ZK / KRAFT servers) with (group.coordinator.new.enable=false) with (classic group protocol) = 2 cases</li>
+ *     <li>(KRAFT server) with (group.coordinator.new.enable=true) with (classic group protocol) = 1 case</li>
+ *     <li>(KRAFT server) with (group.coordinator.new.enable=true) with (consumer group protocol) = 1 case</li>
+ * </ul>
+ * <p>
+ * The new test framework run seven cases for the following cases:
+ * <ul>
+ *     <li>(ZK / KRAFT / CO_KRAFT servers) with (group.coordinator.new.enable=false) with (classic group protocol) = 3 cases</li>
+ *     <li>(KRAFT / CO_KRAFT servers) with (group.coordinator.new.enable=true) with (classic group protocol) = 2 cases</li>
+ *     <li>(KRAFT / CO_KRAFT servers) with (group.coordinator.new.enable=true) with (consumer group protocol) = 2 cases</li>
+ * </ul>
+ * <p>
+ * We can reduce the number of cases as same as the old test framework by using the following methods:
+ * <ul>
+ *     <li>{@link #forConsumerGroupCoordinator} for the case of (consumer group protocol)</li>
+ *     <li>(CO_KRAFT servers) with (group.coordinator.new.enable=true) with (classic / consumer group protocols) = 2 cases</li>
+ * </ul>
+ * <ul>
+ *     <li>{@link #forClassicGroupCoordinator} for the case of (classic group protocol)</li>
+ *     <li>(ZK / KRAFT servers) with (group.coordinator.new.enable=false) with (classic group protocol) = 2 cases</li>
+ * </ul>
+ */
 class ConsumerGroupCommandTestUtils {
 
     private ConsumerGroupCommandTestUtils() {
@@ -66,8 +92,8 @@ class ConsumerGroupCommandTestUtils {
         serverProperties.put(GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer");
 
         return Collections.singletonList(ClusterConfig.defaultBuilder()
-                .setTypes(Stream.of(KRAFT, CO_KRAFT).collect(Collectors.toSet()))
                 .setFeatures(Collections.singletonMap(Features.GROUP_VERSION, GroupVersion.GV_1.featureLevel()))
+                .setTypes(Collections.singleton(CO_KRAFT))
                 .setServerProperties(serverProperties)
                 .setTags(Collections.singletonList("consumerGroupCoordinator"))
                 .build());
@@ -80,6 +106,7 @@ class ConsumerGroupCommandTestUtils {
         serverProperties.put(NEW_GROUP_COORDINATOR_ENABLE_CONFIG, "false");
 
         return Collections.singletonList(ClusterConfig.defaultBuilder()
+                .setTypes(Stream.of(ZK, KRAFT).collect(Collectors.toSet()))
                 .setServerProperties(serverProperties)
                 .setTags(Collections.singletonList("classicGroupCoordinator"))
                 .build());


### PR DESCRIPTION
Because `ConsumerGroupOffsetTest` test for a long time, so I think that we should reduce the test time.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
