### PR TITLE
SMT InsertField current timestamp

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Field;
@@ -54,6 +55,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         String TIMESTAMP_FIELD = "timestamp.field";
         String STATIC_FIELD = "static.field";
         String STATIC_VALUE = "static.value";
+        String CURRENT_TIMESTAMP_FIELD = "current.timestamp.field";
     }
 
     private static final String OPTIONALITY_DOC = "Suffix with <code>!</code> to make this a required field, or <code>?</code> to keep it optional (the default).";
@@ -70,7 +72,9 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
             .define(ConfigName.STATIC_FIELD, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
                     "Field name for static data field. " + OPTIONALITY_DOC)
             .define(ConfigName.STATIC_VALUE, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
-                    "Static field value, if field name configured.");
+                    "Static field value, if field name configured.")
+            .define(ConfigName.CURRENT_TIMESTAMP_FIELD, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
+                    "Field name for current timestamp value.");
 
     private static final String PURPOSE = "field insertion";
 
@@ -103,8 +107,15 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
     private InsertionSpec timestampField;
     private InsertionSpec staticField;
     private String staticValue;
+    private InsertionSpec currentTimestampField;
 
     private Cache<Schema, Schema> schemaUpdateCache;
+
+    private final Time time;
+
+    protected InsertField(Time time) {
+        this.time = time;
+    }
 
     @Override
     public String version() {
@@ -120,8 +131,9 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         timestampField = InsertionSpec.parse(config.getString(ConfigName.TIMESTAMP_FIELD));
         staticField = InsertionSpec.parse(config.getString(ConfigName.STATIC_FIELD));
         staticValue = config.getString(ConfigName.STATIC_VALUE);
+        currentTimestampField = InsertionSpec.parse(config.getString(ConfigName.CURRENT_TIMESTAMP_FIELD));
 
-        if (topicField == null && partitionField == null && offsetField == null && timestampField == null && staticField == null) {
+        if (topicField == null && partitionField == null && offsetField == null && timestampField == null && staticField == null && currentTimestampField == null) {
             throw new ConfigException("No field insertion configured");
         }
 
@@ -163,6 +175,9 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         if (staticField != null && staticValue != null) {
             updatedValue.put(staticField.name, staticValue);
         }
+        if (currentTimestampField != null) {
+            updatedValue.put(currentTimestampField.name, currentTimestamp());
+        }
 
         return newRecord(record, null, updatedValue);
     }
@@ -182,23 +197,50 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
             updatedValue.put(field.name(), value.get(field));
         }
 
+        putTopic(record, updatedValue);
+        putParition(record, updatedValue);
+        putOffsetValue(record, updatedValue);
+        putTimestamp(record, updatedValue);
+        putStaticValue(updatedValue);
+        putCurrentTimestamp(updatedValue);
+
+        return newRecord(record, updatedSchema, updatedValue);
+    }
+
+    private void putTopic(R record, Struct updatedValue) {
         if (topicField != null) {
             updatedValue.put(topicField.name, record.topic());
         }
+    }
+
+    private void putParition(R record, Struct updatedValue) {
         if (partitionField != null && record.kafkaPartition() != null) {
             updatedValue.put(partitionField.name, record.kafkaPartition());
         }
+    }
+
+    private void putOffsetValue(R record, Struct updatedValue) {
         if (offsetField != null) {
             updatedValue.put(offsetField.name, requireSinkRecord(record, PURPOSE).kafkaOffset());
         }
+    }
+
+    private void putTimestamp(R record, Struct updatedValue) {
         if (timestampField != null && record.timestamp() != null) {
             updatedValue.put(timestampField.name, new Date(record.timestamp()));
         }
+    }
+
+    private void putStaticValue(Struct updatedValue) {
         if (staticField != null && staticValue != null) {
             updatedValue.put(staticField.name, staticValue);
         }
+    }
 
-        return newRecord(record, updatedSchema, updatedValue);
+    private void putCurrentTimestamp(Struct updatedValue) {
+        if (currentTimestampField != null) {
+            updatedValue.put(currentTimestampField.name, new Date(currentTimestamp()));
+        }
     }
 
     private Schema makeUpdatedSchema(Schema schema) {
@@ -208,23 +250,24 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
             builder.field(field.name(), field.schema());
         }
 
-        if (topicField != null) {
-            builder.field(topicField.name, topicField.optional ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
-        }
-        if (partitionField != null) {
-            builder.field(partitionField.name, partitionField.optional ? Schema.OPTIONAL_INT32_SCHEMA : Schema.INT32_SCHEMA);
-        }
-        if (offsetField != null) {
-            builder.field(offsetField.name, offsetField.optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA);
-        }
-        if (timestampField != null) {
-            builder.field(timestampField.name, timestampField.optional ? OPTIONAL_TIMESTAMP_SCHEMA : Timestamp.SCHEMA);
-        }
-        if (staticField != null) {
-            builder.field(staticField.name, staticField.optional ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
-        }
+        addField(topicField, builder, Schema.OPTIONAL_STRING_SCHEMA, Schema.STRING_SCHEMA);
+        addField(partitionField, builder, Schema.OPTIONAL_INT32_SCHEMA, Schema.INT32_SCHEMA);
+        addField(offsetField, builder, Schema.OPTIONAL_INT64_SCHEMA, Schema.INT64_SCHEMA);
+        addField(timestampField, builder, OPTIONAL_TIMESTAMP_SCHEMA, Timestamp.SCHEMA);
+        addField(staticField, builder, Schema.OPTIONAL_STRING_SCHEMA, Schema.STRING_SCHEMA);
+        addField(currentTimestampField, builder, OPTIONAL_TIMESTAMP_SCHEMA, Timestamp.SCHEMA);
 
         return builder.build();
+    }
+
+    private void addField(InsertionSpec spec, SchemaBuilder builder, Schema optionalStringSchema, Schema stringSchema) {
+        if (spec != null) {
+            builder.field(spec.name, spec.optional ? optionalStringSchema : stringSchema);
+        }
+    }
+
+    private long currentTimestamp() {
+        return time.milliseconds();
     }
 
     @Override
@@ -245,6 +288,14 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
 
     public static class Key<R extends ConnectRecord<R>> extends InsertField<R> {
 
+        public Key() {
+            this(Time.SYSTEM);
+        }
+
+        public Key(Time time) {
+            super(time);
+        }
+
         @Override
         protected Schema operatingSchema(R record) {
             return record.keySchema();
@@ -263,6 +314,14 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
     }
 
     public static class Value<R extends ConnectRecord<R>> extends InsertField<R> {
+
+        public Value() {
+            this(Time.SYSTEM);
+        }
+
+        public Value(Time time) {
+            super(time);
+        }
 
         @Override
         protected Schema operatingSchema(R record) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -260,9 +260,9 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         return builder.build();
     }
 
-    private void addField(InsertionSpec spec, SchemaBuilder builder, Schema optionalStringSchema, Schema stringSchema) {
+    private void addField(InsertionSpec spec, SchemaBuilder builder, Schema optionalSchema, Schema schema) {
         if (spec != null) {
-            builder.field(spec.name, spec.optional ? optionalStringSchema : stringSchema);
+            builder.field(spec.name, spec.optional ? optionalSchema : schema);
         }
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -16,7 +16,21 @@
  */
 package org.apache.kafka.connect.transforms;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -26,19 +40,30 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class InsertFieldTest {
-    private final InsertField<SourceRecord> xformKey = new InsertField.Key<>();
-    private final InsertField<SourceRecord> xformValue = new InsertField.Value<>();
+    private final Time mockTime = new Time() {
+        private final Clock fixedClock = Clock.fixed(Instant.now(), ZoneId.of("UTC"));
+        @Override
+        public long milliseconds() {
+            return fixedClock.millis();
+        }
+
+        @Override
+        public long nanoseconds() {
+            return fixedClock.instant().getNano();
+        }
+
+        @Override
+        public void sleep(long ms) {
+        }
+
+        @Override
+        public void waitObject(Object obj, Supplier<Boolean> condition, long deadlineMs) {
+        }
+    };
+
+    private final InsertField<SourceRecord> xformKey = new InsertField.Key<>(mockTime);
+    private final InsertField<SourceRecord> xformValue = new InsertField.Value<>(mockTime);
 
     @AfterEach
     public void teardown() {
@@ -60,6 +85,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformValue.configure(props);
 
@@ -88,6 +114,9 @@ public class InsertFieldTest {
         assertEquals(Schema.OPTIONAL_STRING_SCHEMA, transformedRecord.valueSchema().field("instance_id").schema());
         assertEquals("my-instance-id", ((Struct) transformedRecord.value()).getString("instance_id"));
 
+        assertEquals(Timestamp.builder().optional().build(), transformedRecord.valueSchema().field("current_timestamp_field").schema());
+        assertEquals(mockTime.milliseconds(), ((Date) ((Struct) transformedRecord.value()).get("current_timestamp_field")).getTime());
+
         // Exercise caching
         final SourceRecord transformedRecord2 = xformValue.apply(
                 new SourceRecord(null, null, "test", 1, simpleStructSchema, new Struct(simpleStructSchema)));
@@ -102,6 +131,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformValue.configure(props);
 
@@ -115,6 +145,7 @@ public class InsertFieldTest {
         assertEquals(0, ((Map<?, ?>) transformedRecord.value()).get("partition_field"));
         assertEquals(123L, ((Map<?, ?>) transformedRecord.value()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map<?, ?>) transformedRecord.value()).get("instance_id"));
+        assertEquals(mockTime.milliseconds(), ((Map<?, ?>) transformedRecord.value()).get("current_timestamp_field"));
     }
 
     @Test
@@ -125,6 +156,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformValue.configure(props);
 
@@ -145,6 +177,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformValue.configure(props);
 
@@ -167,6 +200,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformKey.configure(props);
 
@@ -180,6 +214,7 @@ public class InsertFieldTest {
         assertEquals(0, ((Map<?, ?>) transformedRecord.key()).get("partition_field"));
         assertNull(((Map<?, ?>) transformedRecord.key()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map<?, ?>) transformedRecord.key()).get("instance_id"));
+        assertEquals(mockTime.milliseconds(), ((Map<?, ?>) transformedRecord.key()).get("current_timestamp_field"));
         assertNull(transformedRecord.value());
     }
 
@@ -191,6 +226,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
+        props.put("current.timestamp.field", "current_timestamp_field?");
 
         xformKey.configure(props);
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -16,19 +16,6 @@
  */
 package org.apache.kafka.connect.transforms;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
@@ -39,6 +26,20 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InsertFieldTest {
     private final Time mockTime = new Time() {


### PR DESCRIPTION
Kafka Connect single message transform for inserting field with current system timestamp value.
```
  "transforms": "insertCurrentTimestamp",
  "transforms.insertCurrentTimestamp.type": "org.apache.kafka.connect.transforms.InsertField$Value",
  "transforms.insertCurrentTimestamp.current.timestamp.field": "LOAD_TIMESTAMP_UTC"
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
