### PR TITLE
KAFKA-16858: Throw DataException from validateValue on array and map schemas without inner schemas

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -251,17 +251,28 @@ public class ConnectSchema implements Schema {
                 break;
             case ARRAY:
                 List<?> array = (List<?>) value;
-                for (Object entry : array)
-                    validateValue(schema.valueSchema(), entry);
+                Schema arrayValueSchema = assertSchemaNotNull(name, "elements", schema.valueSchema());
+                for (Object entry : array) {
+                    validateValue("entry", arrayValueSchema, entry);
+                }
                 break;
             case MAP:
                 Map<?, ?> map = (Map<?, ?>) value;
+                Schema mapKeySchema = assertSchemaNotNull(name, "keys", schema.keySchema());
+                Schema mapValueSchema = assertSchemaNotNull(name, "values", schema.valueSchema());
                 for (Map.Entry<?, ?> entry : map.entrySet()) {
-                    validateValue(schema.keySchema(), entry.getKey());
-                    validateValue(schema.valueSchema(), entry.getValue());
+                    validateValue("key", mapKeySchema, entry.getKey());
+                    validateValue("value", mapValueSchema, entry.getValue());
                 }
                 break;
         }
+    }
+
+    private static Schema assertSchemaNotNull(String fieldName, String innerName, Schema schema) {
+        if (schema == null) {
+            throw new DataException("No schema defined for " + innerName + " of field: \"" + fieldName + "\"");
+        }
+        return schema;
     }
 
     private static List<Class<?>> expectedClassesFor(Schema schema) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -340,8 +340,8 @@ public class ConnectSchemaTest {
         String fieldName = "field";
         assertInvalidValueForSchema(fieldName, new FakeSchema(), new Object(),
                 "Invalid Java object for schema \"fake\" with type null: class java.lang.Object for field: \"field\"");
-        assertInvalidValueForSchema(fieldName, Schema.INT8_SCHEMA, new Object(),
-                "Invalid Java object for schema with type INT8: class java.lang.Object for field: \"field\"");
+        assertInvalidValueForSchema(null, Schema.INT8_SCHEMA, new Object(),
+                "Invalid Java object for schema with type INT8: class java.lang.Object for value");
         assertInvalidValueForSchema(fieldName, Schema.INT8_SCHEMA, new Object(),
                 "Invalid Java object for schema with type INT8: class java.lang.Object for field: \"field\"");
     }
@@ -371,38 +371,38 @@ public class ConnectSchemaTest {
         ConnectSchema.validateValue(fieldName, optionalStrings, Arrays.asList("hello", null));
         ConnectSchema.validateValue(fieldName, optionalStrings, Arrays.asList(null, "world"));
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonList(true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"entry\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for element of array field: \"field\"");
 
         // Required element schema
         Schema requiredStrings = SchemaBuilder.array(Schema.STRING_SCHEMA);
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.emptyList());
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.singletonList("hello"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonList(null),
-                "Invalid value: null used for required field: \"entry\", schema type: STRING");
+                "Invalid value: null used for required element of array field: \"field\", schema type: STRING");
         ConnectSchema.validateValue(fieldName, requiredStrings, Arrays.asList("hello", "world"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Arrays.asList("hello", null),
-                "Invalid value: null used for required field: \"entry\", schema type: STRING");
+                "Invalid value: null used for required element of array field: \"field\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Arrays.asList(null, "world"),
-                "Invalid value: null used for required field: \"entry\", schema type: STRING");
+                "Invalid value: null used for required element of array field: \"field\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonList(true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"entry\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for element of array field: \"field\"");
 
         // Null element schema
         Schema nullElements = SchemaBuilder.type(Schema.Type.ARRAY);
         assertInvalidValueForSchema(fieldName, nullElements, Collections.emptyList(),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList("hello"),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList(null),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList("hello", "world"),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList("hello", null),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList(null, "world"),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
         assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList(true),
-                "No schema defined for elements of field: \"field\"");
+                "No schema defined for element of array field: \"field\"");
     }
 
     @Test
@@ -417,40 +417,57 @@ public class ConnectSchemaTest {
         ConnectSchema.validateValue(fieldName, optionalStrings, Collections.singletonMap(null, "value"));
         ConnectSchema.validateValue(fieldName, optionalStrings, Collections.singletonMap(null, null));
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonMap("key", true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"value\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for value of map field: \"field\"");
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonMap(true, "value"),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"key\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for key of map field: \"field\"");
 
         // Required element schema
         Schema requiredStrings = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.emptyMap());
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.singletonMap("key", "value"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap("key", null),
-                "Invalid value: null used for required field: \"value\", schema type: STRING");
+                "Invalid value: null used for required value of map field: \"field\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(null, "value"),
-                "Invalid value: null used for required field: \"key\", schema type: STRING");
+                "Invalid value: null used for required key of map field: \"field\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(null, null),
-                "Invalid value: null used for required field: \"key\", schema type: STRING");
+                "Invalid value: null used for required key of map field: \"field\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap("key", true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"value\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for value of map field: \"field\"");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(true, "value"),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"key\"");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for key of map field: \"field\"");
 
-        // Null element schema
-        Schema nullElements = SchemaBuilder.type(Schema.Type.MAP);
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.emptyMap(),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", "value"),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", null),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(null, "value"),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(null, null),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", true),
-                "No schema defined for keys of field: \"field\"");
-        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(true, "value"),
-                "No schema defined for keys of field: \"field\"");
+        // Null key schema
+        Schema nullKeys = SchemaBuilder.type(Schema.Type.MAP);
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.emptyMap(),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap("key", "value"),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap("key", null),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap(null, "value"),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap(null, null),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap("key", true),
+                "No schema defined for key of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullKeys, Collections.singletonMap(true, "value"),
+                "No schema defined for key of map field: \"field\"");
+
+        // Null value schema
+        Schema nullValues = SchemaBuilder.mapWithNullValues(Schema.OPTIONAL_STRING_SCHEMA);
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.emptyMap(),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap("key", "value"),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap("key", null),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap(null, "value"),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap(null, null),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap("key", true),
+                "No schema defined for value of map field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullValues, Collections.singletonMap(true, "value"),
+                "No schema defined for value of map field: \"field\"");
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -371,31 +371,38 @@ public class ConnectSchemaTest {
         ConnectSchema.validateValue(fieldName, optionalStrings, Arrays.asList("hello", null));
         ConnectSchema.validateValue(fieldName, optionalStrings, Arrays.asList(null, "world"));
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonList(true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"entry\"");
 
         // Required element schema
         Schema requiredStrings = SchemaBuilder.array(Schema.STRING_SCHEMA);
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.emptyList());
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.singletonList("hello"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonList(null),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"entry\", schema type: STRING");
         ConnectSchema.validateValue(fieldName, requiredStrings, Arrays.asList("hello", "world"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Arrays.asList("hello", null),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"entry\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Arrays.asList(null, "world"),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"entry\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonList(true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"entry\"");
 
         // Null element schema
         Schema nullElements = SchemaBuilder.type(Schema.Type.ARRAY);
-        ConnectSchema.validateValue(fieldName, nullElements, Collections.emptyList());
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonList("hello")));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonList(null)));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Arrays.asList("hello", "world")));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Arrays.asList("hello", null)));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Arrays.asList(null, "world")));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonList(true)));
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.emptyList(),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList("hello"),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList(null),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList("hello", "world"),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList("hello", null),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Arrays.asList(null, "world"),
+                "No schema defined for elements of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonList(true),
+                "No schema defined for elements of field: \"field\"");
     }
 
     @Test
@@ -410,33 +417,40 @@ public class ConnectSchemaTest {
         ConnectSchema.validateValue(fieldName, optionalStrings, Collections.singletonMap(null, "value"));
         ConnectSchema.validateValue(fieldName, optionalStrings, Collections.singletonMap(null, null));
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonMap("key", true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"value\"");
         assertInvalidValueForSchema(fieldName, optionalStrings, Collections.singletonMap(true, "value"),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"key\"");
 
         // Required element schema
         Schema requiredStrings = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.emptyMap());
         ConnectSchema.validateValue(fieldName, requiredStrings, Collections.singletonMap("key", "value"));
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap("key", null),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"value\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(null, "value"),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"key\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(null, null),
-                "Invalid value: null used for required field: \"null\", schema type: STRING");
+                "Invalid value: null used for required field: \"key\", schema type: STRING");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap("key", true),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"value\"");
         assertInvalidValueForSchema(fieldName, requiredStrings, Collections.singletonMap(true, "value"),
-                "Invalid Java object for schema with type STRING: class java.lang.Boolean");
+                "Invalid Java object for schema with type STRING: class java.lang.Boolean for field: \"key\"");
 
         // Null element schema
         Schema nullElements = SchemaBuilder.type(Schema.Type.MAP);
-        ConnectSchema.validateValue(fieldName, nullElements, Collections.emptyMap());
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap("key", "value")));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap("key", null)));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap(null, "value")));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap(null, null)));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap("key", true)));
-        assertThrows(NullPointerException.class, () -> ConnectSchema.validateValue(fieldName, nullElements, Collections.singletonMap(true, "value")));
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.emptyMap(),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", "value"),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", null),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(null, "value"),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(null, null),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap("key", true),
+                "No schema defined for keys of field: \"field\"");
+        assertInvalidValueForSchema(fieldName, nullElements, Collections.singletonMap(true, "value"),
+                "No schema defined for keys of field: \"field\"");
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -305,39 +305,6 @@ public class StructTest {
     }
 
     @Test
-    public void testValidateFieldWithInvalidValueType() {
-        String fieldName = "field";
-        FakeSchema fakeSchema = new FakeSchema();
-
-        Exception e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
-            fakeSchema, new Object()));
-        assertEquals("Invalid Java object for schema \"fake\" with type null: class java.lang.Object for field: \"field\"",
-            e.getMessage());
-
-        e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
-            Schema.INT8_SCHEMA, new Object()));
-        assertEquals("Invalid Java object for schema with type INT8: class java.lang.Object for field: \"field\"",
-            e.getMessage());
-
-        e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(Schema.INT8_SCHEMA, new Object()));
-        assertEquals("Invalid Java object for schema with type INT8: class java.lang.Object", e.getMessage());
-    }
-
-    @Test
-    public void testValidateFieldWithInvalidValueMismatchTimestamp() {
-        String fieldName = "field";
-        long longValue = 1000L;
-
-        // Does not throw
-        ConnectSchema.validateValue(fieldName, Schema.INT64_SCHEMA, longValue);
-
-        Exception e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
-            Timestamp.SCHEMA, longValue));
-        assertEquals("Invalid Java object for schema \"org.apache.kafka.connect.data.Timestamp\" " +
-                "with type INT64: class java.lang.Long for field: \"field\"", e.getMessage());
-    }
-
-    @Test
     public void testPutNullField() {
         final String fieldName = "fieldName";
         Schema testSchema = SchemaBuilder.struct()


### PR DESCRIPTION
The SchemaBuilder interface allows for objects with null valueSchema and/or keySchema to be constructed. These currently cause the validateValue to throw an NPE on non-empty containers. This changes empty and non-empty containers to throw DataException instead.

The first commit rewrites some existing tests, and adds assertions for the prior behavior. Look at only changes in the later commits to see the actual behavior change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
