### PR TITLE
Minor: Add URL to log for Connect RestClient

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -190,15 +190,15 @@ public class RestClient {
                         "Unexpected status code when handling forwarded request: " + responseCode);
             }
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
-            log.error("IO error forwarding REST request: ", e);
+            log.error("IO error forwarding REST request to {} :", url, e);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "IO Error trying to forward REST request: " + e.getMessage(), e);
         } catch (ConnectRestException e) {
             // catching any explicitly thrown ConnectRestException-s to preserve its status code
             // and to avoid getting it overridden by the more generic catch (Throwable) clause down below
-            log.error("Error forwarding REST request", e);
+            log.error("Error forwarding REST request to {} :", url, e);
             throw e;
         } catch (Throwable t) {
-            log.error("Error forwarding REST request", t);
+            log.error("Error forwarding REST request to {} :", url, t);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "Error trying to forward REST request: " + t.getMessage(), t);
         }
     }


### PR DESCRIPTION
I was using Kafka Connect ([Confluent Image](https://hub.docker.com/r/confluentinc/cp-kafka-connect)) to run an Iceberg Sink connector on 2 different AWS environments (running on ECS) and same Kafka cluster.

One of the connectors was working fine, but the other was continuously getting error below:

> {"error_code":500,"message":"IO Error trying to forward REST request: java.net.SocketTimeoutException: Connect Timeout"}

After hours of debugging, I found that the Connect in second AWS environment was trying to reach out to the Connect in first AWS environment (apparently, that was the leader) and our firewall was dropping the request. By fixing the firewall, issue solved.
By having the URL in the error log message, we could easily find issue by looking at which IP it's trying to reach.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
