### PR TITLE
KAFKA-16881: InitialState type leaks into the Connect REST API OpenAPI spec

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequest.java
@@ -47,7 +47,7 @@ public class CreateConnectorRequest {
         return config;
     }
 
-    @JsonProperty
+    @JsonProperty("initial_state")
     public InitialState initialState() {
         return initialState;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-16881

I add `@JsonProperty` value to match the `initial_state` to solve the problem

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
