### PR TITLE
MINOR: Use project path instead of name for spotlessApplyModules in Gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -799,7 +799,7 @@ subprojects {
     skipConfigurations = [ "zinc" ]
   }
 
-  if (project.name in spotlessApplyModules) {
+  if (project.path in spotlessApplyModules) {
     apply plugin: 'com.diffplug.spotless'
     spotless {
       java {


### PR DESCRIPTION
For nested subprojects like `:connect:runtime`, the `project.name` field will only return the name of the leaf project, e.g., `runtime`, which can be ambiguous and confusing when reading and modifying the build script. The `project.path` field includes the fully-qualified name (e.g., `:connect:runtime`), which is unambiguous and hopefully easier to read.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
