### PR TITLE
KAFKA-16888 Fix failed StorageToolTest.testFormatSucceedsIfAllDirectoriesAreAvailable and StorageToolTest.testFormatEmptyDirectory

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -182,7 +182,7 @@ Found problem:
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false))
-      assertTrue(stream.toString().startsWith("Formatting %s".format(tempDir)))
+      assertTrue(stream.toString().split("\\r?\\n").drop(1)(0).startsWith("Formatting %s".format(tempDir)))
 
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false)) catch {
@@ -194,7 +194,7 @@ Found problem:
       val stream2 = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = true))
-      assertEquals("All of the log directories are already formatted.%n".format(), stream2.toString())
+      assertEquals("All of the log directories are already formatted.".format(), stream2.toString().split("\\r?\\n").drop(1)(0))
     } finally Utils.delete(tempDir)
   }
 
@@ -213,7 +213,7 @@ Found problem:
     val availableDirs = Seq(TestUtils.tempDir(), TestUtils.tempDir(), TestUtils.tempDir()).map(dir => dir.toString)
     val stream = new ByteArrayOutputStream()
     assertEquals(0, runFormatCommand(stream, availableDirs))
-    val actual = stream.toString().split("\\r?\\n")
+    val actual = stream.toString().split("\\r?\\n").drop(1)
     val expect = availableDirs.map("Formatting %s".format(_))
     assertEquals(availableDirs.size, actual.size)
     expect.foreach(dir => {

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -182,7 +182,7 @@ Found problem:
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false))
-      assertTrue(stream.toString().split("\\r?\\n").drop(1)(0).startsWith("Formatting %s".format(tempDir)))
+      assertTrue(stream.toString().split("\\r?\\n").exists(_.startsWith("Formatting %s".format(tempDir))))
 
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false)) catch {
@@ -194,7 +194,7 @@ Found problem:
       val stream2 = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = true))
-      assertEquals("All of the log directories are already formatted.".format(), stream2.toString().split("\\r?\\n").drop(1)(0))
+      assertEquals(1, stream2.toString().split("\\r?\\n").count(_.startsWith("All of the log directories are already formatted")))
     } finally Utils.delete(tempDir)
   }
 
@@ -213,9 +213,8 @@ Found problem:
     val availableDirs = Seq(TestUtils.tempDir(), TestUtils.tempDir(), TestUtils.tempDir()).map(dir => dir.toString)
     val stream = new ByteArrayOutputStream()
     assertEquals(0, runFormatCommand(stream, availableDirs))
-    val actual = stream.toString().split("\\r?\\n").drop(1)
+    val actual = stream.toString().split("\\r?\\n")
     val expect = availableDirs.map("Formatting %s".format(_))
-    assertEquals(availableDirs.size, actual.size)
     expect.foreach(dir => {
       assertEquals(1, actual.count(_.startsWith(dir)))
     })


### PR DESCRIPTION
a quick fix for https://issues.apache.org/jira/browse/KAFKA-16888

https://github.com/apache/kafka/commit/459da4795a511f6933e940fcf105a824bd9e589c#diff-4bacfdbf0e63a4d5f3deb1a0d39037a18510ac24ee5ec276fe70bc818ba4d209L505 put extra information as follows to the beginning of the output which break some tests in StorageToolTest that rely on the original output.  
```
metaPropertiesEnsemble=MetaPropertiesEnsemble(metadataLogDir=Optional.empty, dirs={/tmp/kafka-10468059960007009962: EMPTY, /tmp/kafka-11677474438939329103: EMPTY, /tmp/kafka-17616780619664597434: EMPTY})
```

This pr modified the test `testFormatSucceedsIfAllDirectoriesAreAvailable`, `testFormatEmptyDirectory` to get rid of those extra infos to avoid test failed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
