### PR TITLE
KAFKA-16892: fix TopicsDelta generated from snapshot #localChanges return empty deletes

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
@@ -69,8 +69,16 @@ public final class TopicsDelta {
     }
 
     public void replay(TopicRecord record) {
-        TopicDelta delta = new TopicDelta(
-            new TopicImage(record.name(), record.topicId(), Collections.emptyMap()));
+        TopicDelta delta = changedTopics.get(record.topicId());
+        if (delta != null) {
+            return;
+        }
+        TopicImage topicImage = image.getTopic(record.topicId());
+        if (topicImage == null) {
+            delta = new TopicDelta(new TopicImage(record.name(), record.topicId(), Collections.emptyMap()));
+        } else {
+            delta = new TopicDelta(topicImage);
+        }
         changedTopics.put(record.topicId(), delta);
         createdTopicIds.add(record.topicId());
     }

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -372,6 +372,12 @@ public class TopicsImageTest {
         TopicsImage image = new TopicsImage(newTopicsByIdMap(topics), newTopicsByNameMap(topics));
 
         List<ApiMessageAndVersion> topicRecords = new ArrayList<>();
+        topicRecords.add(
+            new ApiMessageAndVersion(
+                new TopicRecord().setTopicId(zooId).setName("zoo"),
+                TOPIC_RECORD.highestSupportedVersion()
+            )
+        );
         // zoo-0 - follower to leader
         topicRecords.add(
             new ApiMessageAndVersion(


### PR DESCRIPTION
Fix https://issues.apache.org/jira/browse/KAFKA-16892

*Generate TopicDelta from TopicImage when exec TopicsDelta#replay(TopicRecord)*


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
