### PR TITLE
KAFKA-16893: ConnectorUtils can group elements in round-robin fashion

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/util/ConnectorUtils.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/util/ConnectorUtils.java
@@ -59,4 +59,35 @@ public class ConnectorUtils {
 
         return result;
     }
+
+    /**
+     * Groups elements into a specified number of groups in a round-robin fashion.
+     *
+     * @param <T> The type of elements in the input list.
+     * @param elements The list of elements to be grouped.
+     * @param numGroups The number of groups to divide the elements into.
+     * @return A list of lists, where each inner list represents a group.
+     */
+    public static <T> List<List<T>> groupElementsRoundRobin(List<T> elements, int numGroups) {
+        if (elements == null) {
+            throw new IllegalArgumentException("Elements must not be null.");
+        }
+
+        if (numGroups <= 0) {
+            throw new IllegalArgumentException("Number of groups must be positive.");
+        }
+
+        List<List<T>> result = new ArrayList<>(numGroups);
+        for (int i = 0; i < numGroups; i++) {
+            result.add(new ArrayList<>());
+        }
+
+        int groupNumber = 0;
+        for (T element : elements) {
+            result.get(groupNumber).add(element);
+            groupNumber = (groupNumber + 1) % numGroups;
+        }
+
+        return result;
+    }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/util/ConnectorUtilsTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/util/ConnectorUtilsTest.java
@@ -63,6 +63,42 @@ public class ConnectorUtilsTest {
     @Test
     public void testGroupPartitionsInvalidCount() {
         assertThrows(IllegalArgumentException.class,
-            () -> ConnectorUtils.groupPartitions(FIVE_ELEMENTS, 0));
+                () -> ConnectorUtils.groupPartitions(FIVE_ELEMENTS, 0));
+    }
+
+    @Test
+    public void testGroupElementsRoundRobin() {
+        List<List<Integer>> grouped = ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 1);
+        assertEquals(Collections.singletonList(FIVE_ELEMENTS), grouped);
+
+        grouped = ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 2);
+        assertEquals(Arrays.asList(Arrays.asList(1, 3, 5), Arrays.asList(2, 4)), grouped);
+
+        grouped = ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 3);
+        assertEquals(Arrays.asList(Arrays.asList(1, 4), Arrays.asList(2, 5), Collections.singletonList(3)), grouped);
+
+        grouped = ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 5);
+        assertEquals(Arrays.asList(Collections.singletonList(1),
+                Collections.singletonList(2),
+                Collections.singletonList(3),
+                Collections.singletonList(4),
+                Collections.singletonList(5)), grouped);
+
+        grouped = ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 7);
+        assertEquals(Arrays.asList(Collections.singletonList(1),
+                Collections.singletonList(2),
+                Collections.singletonList(3),
+                Collections.singletonList(4),
+                Collections.singletonList(5),
+                Collections.emptyList(),
+                Collections.emptyList()), grouped);
+    }
+
+    @Test
+    public void testGroupElementsRoundRobinInvalidArgument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectorUtils.groupElementsRoundRobin(FIVE_ELEMENTS, 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectorUtils.groupElementsRoundRobin(null, 1));
     }
 }


### PR DESCRIPTION
Current ConnectorUtils can only assign continuous elements in groups. But in some scenario, continuous elements need to be distributed in different groups.
This PR adds round-robin assignment strategy.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
