### PR TITLE
MINOR: Using rocksdb's prefixScan in fk joins for better performances

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
@@ -35,11 +35,14 @@ public class CombinedKeySchemaTest {
             () -> "pkTopic", Serdes.Integer()
         );
         final Integer primary = -999;
-        final Bytes result = cks.toBytes("foreignKey", primary);
+        final String foreignKey = "foreignKey";
+        final Bytes result = cks.toBytes(foreignKey, primary);
 
         final CombinedKey<String, Integer> deserializedKey = cks.fromBytes(result);
-        assertEquals("foreignKey", deserializedKey.foreignKey());
+        assertEquals(foreignKey, deserializedKey.foreignKey());
         assertEquals(primary, deserializedKey.primaryKey());
+
+        assertEquals(primary, cks.deserializePrimaryKeyFromBytes(result));
     }
 
     @Test


### PR DESCRIPTION
Use `prefixScan` for scanning subscribed keys to a foreign key instead of `range`. The native store's `prefixScan` already exclude the last key corresponding to the bytes increment (needed for scanning) while `range` included it. It allows removing the `Arrays.equals`, improving performances. I also removed the full combined key to be deserialized as we only need the PK (the suffix).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
