### PR TITLE
KAFKA-16902: Consider socket timeout in blocking Sender waits

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -873,9 +873,10 @@ public class NetworkClient implements KafkaClient {
             this.selector.close(nodeId);
             log.info(
                 "Disconnecting from node {} due to socket connection setup timeout. " +
-                "The timeout value is {} ms.",
+                "The timeout value is {} ms. {} ms since last attempt",
                 nodeId,
-                connectionStates.connectionSetupTimeoutMs(nodeId));
+                connectionStates.connectionSetupTimeoutMs(nodeId),
+                now - connectionStates.lastConnectAttemptMs(nodeId));
             processTimeoutDisconnection(responses, nodeId, now);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -565,7 +565,8 @@ public class Sender implements Runnable {
     }
 
     private boolean awaitNodeReady(Node node, FindCoordinatorRequest.CoordinatorType coordinatorType) throws IOException {
-        if (NetworkClientUtils.awaitReady(client, node, time, requestTimeoutMs)) {
+        long waitTimeout = Math.min(requestTimeoutMs, client.connectionDelay(node, time.milliseconds()));
+        if (NetworkClientUtils.awaitReady(client, node, time, waitTimeout)) {
             if (coordinatorType == FindCoordinatorRequest.CoordinatorType.TRANSACTION) {
                 // Indicate to the transaction manager that the coordinator is ready, allowing it to check ApiVersions
                 // This allows us to bump transactional epochs even if the coordinator is temporarily unavailable at

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -718,14 +718,15 @@ public class SenderTest {
         Node node = metadata.fetch().nodes().get(0);
         client.delayReady(node, REQUEST_TIMEOUT + 20);
         prepareFindCoordinatorResponse(Errors.NONE, "testNodeNotReady");
-        sender.runOnce();
-        sender.runOnce();
+        for (int i = 0; i < 5; i++) {
+            sender.runOnce();
+        }
         assertNotNull(transactionManager.coordinator(CoordinatorType.TRANSACTION), "Coordinator not found");
 
         client.throttle(node, REQUEST_TIMEOUT + 20);
         prepareFindCoordinatorResponse(Errors.NONE, "Coordinator not found");
         prepareInitProducerResponse(Errors.NONE, producerIdAndEpoch.producerId, producerIdAndEpoch.epoch);
-        waitForProducerId(transactionManager, producerIdAndEpoch);
+        waitForProducerId(transactionManager, producerIdAndEpoch, 10000L);
     }
 
     @Test
@@ -3826,8 +3827,14 @@ public class SenderTest {
     }
 
     private void waitForProducerId(TransactionManager transactionManager, ProducerIdAndEpoch producerIdAndEpoch) {
-        for (int i = 0; i < 5 && !transactionManager.hasProducerId(); i++)
+        waitForProducerId(transactionManager, producerIdAndEpoch, 0L);
+    }
+
+    private void waitForProducerId(TransactionManager transactionManager, ProducerIdAndEpoch producerIdAndEpoch, long iterationSleepTime) {
+        for (int i = 0; i < 5 && !transactionManager.hasProducerId(); i++) {
             sender.runOnce();
+            time.sleep(iterationSleepTime);
+        }
 
         assertTrue(transactionManager.hasProducerId());
         assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());


### PR DESCRIPTION
Use the lesser of request.timeout.ms and
socket.connection.setup.timeout.ms when Sender is performing blocking
waits for node readiness.

This ensures faster processing of connection setup failures by allowing
the NetworkClient to perform a full poll() execution within the
expected timeout.

When a connection to a broker times out on
socket.connection.setup.timeout.ms, log the amount of time spent
attempting to connect to the broker in addition to the configured
timeout. This helps to discover situations where the timeout is not
being correctly respected and clients are waiting longer than
configured.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
