### PR TITLE
KAFKA-16661: Added a lower `log.initial.task.delay.ms` value

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -347,6 +347,7 @@ object TestUtils extends Logging {
     props.put(ServerConfigs.CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_CONFIG, "100")
     props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, "2097152")
     props.put(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+    props.put(ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_CONFIG, "100")
     if (!props.containsKey(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG))
       props.put(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, "5")
     if (!props.containsKey(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG))
@@ -1181,7 +1182,7 @@ object TestUtils extends Logging {
                        transactionVerificationEnabled: Boolean = false,
                        log: Option[UnifiedLog] = None,
                        remoteStorageSystemEnable: Boolean = false,
-                       initialTaskDelayMs: Long = ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_DEFAULT_INTEGRATION_TEST): LogManager = {
+                       initialTaskDelayMs: Long = ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_DEFAULT): LogManager = {
     val logManager = new LogManager(logDirs = logDirs.map(_.getAbsoluteFile),
                    initialOfflineDirs = Array.empty[File],
                    configRepository = configRepository,

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1181,7 +1181,7 @@ object TestUtils extends Logging {
                        transactionVerificationEnabled: Boolean = false,
                        log: Option[UnifiedLog] = None,
                        remoteStorageSystemEnable: Boolean = false,
-                       initialTaskDelayMs: Long = ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_DEFAULT): LogManager = {
+                       initialTaskDelayMs: Long = ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_DEFAULT_INTEGRATION_TEST): LogManager = {
     val logManager = new LogManager(logDirs = logDirs.map(_.getAbsoluteFile),
                    initialOfflineDirs = Array.empty[File],
                    configRepository = configRepository,

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -188,7 +188,6 @@ public class ServerLogConfigs {
 
     public static final String LOG_INITIAL_TASK_DELAY_MS_CONFIG = LOG_PREFIX + "initial.task.delay.ms";
     public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT = 30 * 1000L;
-    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT_INTEGRATION_TEST = 500L;
     public static final String LOG_INITIAL_TASK_DELAY_MS_DOC = "The initial task delay in millisecond when initializing " +
             "tasks in LogManager. This should be used for testing only.";
 

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -187,7 +187,8 @@ public class ServerLogConfigs {
             "does not apply to any message format conversion that might be required for replication to followers.";
 
     public static final String LOG_INITIAL_TASK_DELAY_MS_CONFIG = LOG_PREFIX + "initial.task.delay.ms";
-    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT = 500L;
+    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT = 30 * 1000L;
+    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT_INTEGRATION_TEST = 500L;
     public static final String LOG_INITIAL_TASK_DELAY_MS_DOC = "The initial task delay in millisecond when initializing " +
             "tasks in LogManager. This should be used for testing only.";
 

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -187,7 +187,7 @@ public class ServerLogConfigs {
             "does not apply to any message format conversion that might be required for replication to followers.";
 
     public static final String LOG_INITIAL_TASK_DELAY_MS_CONFIG = LOG_PREFIX + "initial.task.delay.ms";
-    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT = 30 * 1000L;
+    public static final long LOG_INITIAL_TASK_DELAY_MS_DEFAULT = 500L;
     public static final String LOG_INITIAL_TASK_DELAY_MS_DOC = "The initial task delay in millisecond when initializing " +
             "tasks in LogManager. This should be used for testing only.";
 


### PR DESCRIPTION
related to [KAFKA-16661](https://issues.apache.org/jira/browse/KAFKA-16661),

configured lower `log.initial.task.delay.ms` value to integration test framework to 500ms

Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)