### PR TITLE
KAFKA-16912 Migrate ConsumerNetworkThreadTest.testPollResultTimer() to NetworkClientDelegateTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,7 +63,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerTestBuilder.DEFAULT_HEARTBEAT_INTERVAL_MS;
-import static org.apache.kafka.clients.consumer.internals.ConsumerTestBuilder.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.apache.kafka.clients.consumer.internals.ConsumerTestBuilder.createDefaultGroupInformation;
 import static org.apache.kafka.clients.consumer.internals.events.CompletableEvent.calculateDeadlineMs;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -245,28 +245,6 @@ public class ConsumerNetworkThreadTest {
     }
 
     @Test
-    void testPollResultTimer() {
-        NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
-                new FindCoordinatorRequest.Builder(
-                        new FindCoordinatorRequestData()
-                                .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
-                                .setKey("foobar")),
-                Optional.empty());
-        req.setTimer(time, DEFAULT_REQUEST_TIMEOUT_MS);
-
-        // purposely setting a non-MAX time to ensure it is returning Long.MAX_VALUE upon success
-        NetworkClientDelegate.PollResult success = new NetworkClientDelegate.PollResult(
-                10,
-                Collections.singletonList(req));
-        assertEquals(10, networkClient.addAll(success));
-
-        NetworkClientDelegate.PollResult failure = new NetworkClientDelegate.PollResult(
-                10,
-                new ArrayList<>());
-        assertEquals(10, networkClient.addAll(failure));
-    }
-
-    @Test
     void testMaximumTimeToWait() {
         // Initial value before runOnce has been called
         assertEquals(ConsumerNetworkThread.MAX_POLL_TIMEOUT_MS, consumerNetworkThread.maximumTimeToWait());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
 public class NetworkClientDelegateTest {
     private static final int REQUEST_TIMEOUT_MS = 5000;
     private static final String GROUP_ID = "group";
+    private static final long DEFAULT_REQUEST_TIMEOUT_MS = 500;
     private MockTime time;
     private MockClient client;
 
@@ -60,6 +62,30 @@ public class NetworkClientDelegateTest {
     public void setup() {
         this.time = new MockTime(0);
         this.client = new MockClient(time, Collections.singletonList(mockNode()));
+    }
+
+    @Test
+    void testPollResultTimer() throws Exception{
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate()) {
+            NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
+                    new FindCoordinatorRequest.Builder(
+                            new FindCoordinatorRequestData()
+                                    .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
+                                    .setKey("foobar")),
+                    Optional.empty());
+            req.setTimer(time, DEFAULT_REQUEST_TIMEOUT_MS);
+
+            // purposely setting a non-MAX time to ensure it is returning Long.MAX_VALUE upon success
+            NetworkClientDelegate.PollResult success = new NetworkClientDelegate.PollResult(
+                    10,
+                    Collections.singletonList(req));
+            assertEquals(10, ncd.addAll(success));
+
+            NetworkClientDelegate.PollResult failure = new NetworkClientDelegate.PollResult(
+                    10,
+                    new ArrayList<>());
+            assertEquals(10, ncd.addAll(failure));
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -65,7 +65,7 @@ public class NetworkClientDelegateTest {
     }
 
     @Test
-    void testPollResultTimer() throws Exception{
+    void testPollResultTimer() throws Exception {
         try (NetworkClientDelegate ncd = newNetworkClientDelegate()) {
             NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                     new FindCoordinatorRequest.Builder(


### PR DESCRIPTION
Moved testPollResultTimer() to NetworkClientDelegateTest from ConsumerNetworkThreadTest. The test had nothing really to do with the ConsumerNetworkThread, it was only testing NetworkClientDelegate