### PR TITLE
KAFKA-16879 SystemTime should use singleton mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -302,7 +302,7 @@ public class CommonClientConfigs {
             return Optional.empty();
         }
 
-        ClientTelemetryReporter telemetryReporter = new ClientTelemetryReporter(Time.SYSTEM);
+        ClientTelemetryReporter telemetryReporter = new ClientTelemetryReporter(SystemTime.getSystemTime());
         telemetryReporter.configure(config.originals(Collections.singletonMap(CommonClientConfigs.CLIENT_ID_CONFIG, clientId)));
         return Optional.of(telemetryReporter);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -248,6 +248,7 @@ import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
@@ -510,7 +511,7 @@ public class KafkaAdminClient extends AdminClient {
     ) {
         Metrics metrics = null;
         NetworkClient networkClient = null;
-        Time time = Time.SYSTEM;
+        Time time = SystemTime.getSystemTime();
         String clientId = generateClientId(config);
         ApiVersions apiVersions = new ApiVersions();
         LogContext logContext = createLogContext(clientId);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -90,6 +90,7 @@ import org.apache.kafka.common.telemetry.internals.ClientTelemetryUtils;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -264,7 +265,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             config,
             keyDeserializer,
             valueDeserializer,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             ApplicationEventHandler::new,
             CompletableEventReaper::new,
             FetchCollector::new,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
@@ -56,6 +56,7 @@ import org.apache.kafka.common.telemetry.internals.ClientTelemetryUtils;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
@@ -164,7 +165,7 @@ public class LegacyKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             log.debug("Initializing the Kafka consumer");
             this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
             this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
-            this.time = Time.SYSTEM;
+            this.time = SystemTime.getSystemTime();
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             this.clientTelemetryReporter = CommonClientConfigs.telemetryReporter(clientId, config);
             this.clientTelemetryReporter.ifPresent(reporters::add);
@@ -1116,7 +1117,7 @@ public class LegacyKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
     private Timer createTimerForRequest(final Duration timeout) {
         // this.time could be null if an exception occurs in constructor prior to setting the this.time field
-        final Time localTime = (time == null) ? Time.SYSTEM : time;
+        final Time localTime = (time == null) ? SystemTime.getSystemTime() : time;
         return localTime.timer(Math.min(timeout.toMillis(), requestTimeoutMs));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -73,6 +73,7 @@ import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -293,7 +294,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      */
     public KafkaProducer(Map<String, Object> configs, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         this(new ProducerConfig(ProducerConfig.appendSerializerToConfig(configs, keySerializer, valueSerializer)),
-                keySerializer, valueSerializer, null, null, null, Time.SYSTEM);
+                keySerializer, valueSerializer, null, null, null, SystemTime.getSystemTime());
     }
 
     /**
@@ -456,7 +457,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         config.getLong(ProducerConfig.METADATA_MAX_IDLE_CONFIG),
                         logContext,
                         clusterResourceListeners,
-                        Time.SYSTEM);
+                        SystemTime.getSystemTime());
                 this.metadata.bootstrap(addresses);
             }
             this.errors = this.metrics.sensor("errors");

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -31,7 +31,7 @@ import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -338,7 +338,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         TopicPartition topicPartition = new TopicPartition(record.topic(), partition);
         ProduceRequestResult result = new ProduceRequestResult(topicPartition);
         FutureRecordMetadata future = new FutureRecordMetadata(result, 0, RecordBatch.NO_TIMESTAMP,
-                0, 0, Time.SYSTEM);
+                0, 0, SystemTime.getSystemTime());
         long offset = nextOffset(topicPartition);
         long baseOffset = Math.max(0, offset - Integer.MAX_VALUE);
         int batchIndex = (int) Math.min(Integer.MAX_VALUE, offset);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,7 +152,7 @@ public final class ProducerBatch {
                                                                    timestamp,
                                                                    key == null ? -1 : key.length,
                                                                    value == null ? -1 : value.length,
-                                                                   Time.SYSTEM);
+                                                                   SystemTime.getSystemTime());
             // we have to keep every future returned to the users in case the batch needs to be
             // split to several new batches and resent.
             thunks.add(new Thunk(callback, future));
@@ -177,7 +177,7 @@ public final class ProducerBatch {
                                                                    timestamp,
                                                                    key == null ? -1 : key.remaining(),
                                                                    value == null ? -1 : value.remaining(),
-                                                                   Time.SYSTEM);
+                                                                   SystemTime.getSystemTime());
             // Chain the future to the original thunk.
             thunk.future.chain(future);
             this.thunks.add(thunk);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.internals.MetricsUtils;
 import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +109,7 @@ public class Metrics implements Closeable {
      * @param defaultConfig The default config to use for all metrics that don't override their config
      */
     public Metrics(MetricConfig defaultConfig) {
-        this(defaultConfig, new ArrayList<>(0), Time.SYSTEM);
+        this(defaultConfig, new ArrayList<>(0), SystemTime.getSystemTime());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.security.authenticator.AbstractLogin;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.Shell;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,7 @@ public class KerberosLogin extends AbstractLogin {
 
     private static final Random RNG = new Random();
 
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
     private Thread t;
     private boolean isKrbTicket;
     private boolean isUsingTicketCache;

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
@@ -28,6 +28,7 @@ import javax.security.auth.login.LoginException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.Login;
 import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,7 +154,7 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
             ExpiringCredentialRefreshConfig expiringCredentialRefreshConfig,
             AuthenticateCallbackHandler callbackHandler, Class<?> mandatoryClassToSynchronizeOnPriorToRefresh) {
         this(contextName, configuration, expiringCredentialRefreshConfig, callbackHandler,
-                mandatoryClassToSynchronizeOnPriorToRefresh, new LoginContextFactory(), Time.SYSTEM);
+                mandatoryClassToSynchronizeOnPriorToRefresh, new LoginContextFactory(), SystemTime.getSystemTime());
     }
 
     public ExpiringCredentialRefreshingLogin(String contextName, Configuration configuration,

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/Retry.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/Retry.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.security.oauthbearer.internals.secured;
 
 import java.util.concurrent.ExecutionException;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public class Retry<R> {
     private final long retryBackoffMaxMs;
 
     public Retry(long retryBackoffMs, long retryBackoffMaxMs) {
-        this(Time.SYSTEM, retryBackoffMs, retryBackoffMaxMs);
+        this(SystemTime.getSystemTime(), retryBackoffMs, retryBackoffMaxMs);
     }
 
     public Retry(Time time, long retryBackoffMs, long retryBackoffMaxMs) {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactory.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.jose4j.http.Get;
 import org.jose4j.jwk.HttpsJwks;
 
@@ -77,7 +77,7 @@ public class VerificationKeyResolverFactory {
                 httpsJwks.setSimpleHttpGet(get);
             }
 
-            RefreshingHttpsJwks refreshingHttpsJwks = new RefreshingHttpsJwks(Time.SYSTEM,
+            RefreshingHttpsJwks refreshingHttpsJwks = new RefreshingHttpsJwks(SystemTime.getSystemTime(),
                 httpsJwks,
                 refreshIntervalMs,
                 cu.validateLong(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS),

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.security.auth.SaslExtensions;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -113,7 +114,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandler implements AuthenticateCal
     private static final String LIST_CLAIM_PREFIX = OPTION_PREFIX + "ListClaim_";
     private static final String EXTENSION_PREFIX = OPTION_PREFIX + "Extension_";
     private static final String QUOTE = "\"";
-    private Time time = Time.SYSTEM;
+    private Time time = SystemTime.getSystemTime();
     private Map<String, String> moduleOptions = null;
     private boolean configured = false;
 

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandler.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerExtensionsValidatorCallback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -85,7 +86,7 @@ public class OAuthBearerUnsecuredValidatorCallbackHandler implements Authenticat
     private static final String SCOPE_CLAIM_NAME_OPTION = OPTION_PREFIX + "ScopeClaimName";
     private static final String REQUIRED_SCOPE_OPTION = OPTION_PREFIX + "RequiredScope";
     private static final String ALLOWABLE_CLOCK_SKEW_MILLIS_OPTION = OPTION_PREFIX + "AllowableClockSkewMs";
-    private Time time = Time.SYSTEM;
+    private Time time = SystemTime.getSystemTime();
     private Map<String, String> moduleOptions = null;
     private boolean configured = false;
 

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/KafkaMetricsCollector.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/KafkaMetricsCollector.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.SimpleRate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.telemetry.internals.LastValueTracker.InstantAndValue;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,7 +131,7 @@ public class KafkaMetricsCollector implements MetricsCollector {
     private final Set<String> excludeLabels;
 
     public KafkaMetricsCollector(MetricNamingStrategy<MetricName> metricNamingStrategy, Set<String> excludeLabels) {
-        this(metricNamingStrategy, Time.SYSTEM, excludeLabels);
+        this(metricNamingStrategy, SystemTime.getSystemTime(), excludeLabels);
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/common/utils/SystemScheduler.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SystemScheduler.java
@@ -32,7 +32,7 @@ public class SystemScheduler implements Scheduler {
 
     @Override
     public Time time() {
-        return Time.SYSTEM;
+        return SystemTime.getSystemTime();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/utils/SystemTime.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SystemTime.java
@@ -21,10 +21,18 @@ import org.apache.kafka.common.errors.TimeoutException;
 import java.util.function.Supplier;
 
 /**
- * A time implementation that uses the system clock and sleep call. Use `Time.SYSTEM` instead of creating an instance
- * of this class.
+ * A time implementation that uses the system clock and sleep call.
+ * Every kafka process has a single instance of class <code>SystemTime</code> that allows the process to interface
+ * with the system clock. The current SystemTime can be obtained from the #{@link SystemTime#getSystemTime()} method.
+ * An process cannot create its own instance of this class
  */
 public class SystemTime implements Time {
+
+    private final static SystemTime SYSTEM_TIME = new SystemTime();
+
+    public static SystemTime getSystemTime() {
+        return SYSTEM_TIME;
+    }
 
     @Override
     public long milliseconds() {
@@ -57,4 +65,6 @@ public class SystemTime implements Time {
         }
     }
 
+    private SystemTime() {
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Time.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Time.java
@@ -30,8 +30,6 @@ import java.util.function.Supplier;
  */
 public interface Time {
 
-    Time SYSTEM = new SystemTime();
-
     /**
      * Returns the current time in milliseconds.
      */

--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -38,7 +38,7 @@ package org.apache.kafka.common.utils;
  * A typical usage might look something like this:
  *
  * <pre>
- *     Time time = Time.SYSTEM;
+ *     Time time = SystemTime.getSystemTime;
  *     Timer timer = time.timer(500);
  *
  *     while (!conditionSatisfied() && timer.notExpired()) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 import java.time.Duration;
@@ -51,7 +52,7 @@ public class AdminClientUnitTestEnv implements AutoCloseable {
     private final KafkaAdminClient adminClient;
 
     public AdminClientUnitTestEnv(Cluster cluster, String... vals) {
-        this(Time.SYSTEM, cluster, vals);
+        this(SystemTime.getSystemTime(), cluster, vals);
     }
 
     public AdminClientUnitTestEnv(Time time, Cluster cluster, String... vals) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -223,6 +223,7 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.MockMetricsReporter;
@@ -777,7 +778,7 @@ public class KafkaAdminClientTest {
      */
     @Test
     public void testTimeoutWithoutMetadata() throws Exception {
-        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, mockBootstrapCluster(),
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(SystemTime.getSystemTime(), mockBootstrapCluster(),
                 newStrMap(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10"))) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareCreateTopicsResponse("myTopic", Errors.NONE));
@@ -794,7 +795,7 @@ public class KafkaAdminClientTest {
         // the server disconnects before sending the full response
 
         Cluster cluster = mockBootstrapCluster();
-        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, cluster)) {
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(SystemTime.getSystemTime(), cluster)) {
             Cluster discoveredCluster = mockCluster(3, 0);
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(request -> request instanceof MetadataRequest, null, true);
@@ -819,7 +820,7 @@ public class KafkaAdminClientTest {
 
         Cluster cluster = Cluster.bootstrap(singletonList(new InetSocketAddress("localhost", 8121)));
         Map<Node, Long> unreachableNodes = Collections.singletonMap(cluster.nodes().get(0), 200L);
-        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, cluster,
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(SystemTime.getSystemTime(), cluster,
                 AdminClientUnitTestEnv.clientConfigs(), unreachableNodes)) {
             Cluster discoveredCluster = mockCluster(3, 0);
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
@@ -842,7 +843,7 @@ public class KafkaAdminClientTest {
      */
     @Test
     public void testPropagatedMetadataFetchException() throws Exception {
-        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM,
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(SystemTime.getSystemTime(),
                 mockCluster(3, 0),
                 newStrMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:8121",
                 AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10"))) {
@@ -1634,7 +1635,7 @@ public class KafkaAdminClientTest {
     @Test
     public void testAdminClientApisAuthenticationFailure() {
         Cluster cluster = mockBootstrapCluster();
-        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, cluster,
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(SystemTime.getSystemTime(), cluster,
                 newStrMap(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "1000"))) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().createPendingAuthenticationError(cluster.nodes().get(0),
@@ -6961,7 +6962,7 @@ public class KafkaAdminClientTest {
     @Test
     public void testUnregisterBrokerTimeoutMaxRetry() {
         int nodeId = 1;
-        try (final AdminClientUnitTestEnv env = mockClientEnv(Time.SYSTEM, AdminClientConfig.RETRIES_CONFIG, "1")) {
+        try (final AdminClientUnitTestEnv env = mockClientEnv(SystemTime.getSystemTime(), AdminClientConfig.RETRIES_CONFIG, "1")) {
             env.kafkaClient().setNodeApiVersions(
                     NodeApiVersions.create(ApiKeys.UNREGISTER_BROKER.id, (short) 0, (short) 0));
             env.kafkaClient().prepareResponse(prepareUnregisterBrokerResponse(Errors.REQUEST_TIMED_OUT, 0));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3587,7 +3587,7 @@ public abstract class ConsumerCoordinatorTest {
     public void shouldLoseAllOwnedPartitionsBeforeRejoiningAfterDroppingOutOfTheGroup() {
         final List<TopicPartition> partitions = singletonList(t1p);
         try (ConsumerCoordinator coordinator = prepareCoordinatorForCloseTest(true, false, Optional.of("group-id"), true)) {
-            final SystemTime realTime = new SystemTime();
+            final SystemTime realTime = SystemTime.getSystemTime();
             coordinator.ensureActiveGroup();
 
             prepareOffsetCommitRequest(singletonMap(t1p, 100L), Errors.REBALANCE_IN_PROGRESS);
@@ -3620,7 +3620,7 @@ public abstract class ConsumerCoordinatorTest {
     public void shouldLoseAllOwnedPartitionsBeforeRejoiningAfterResettingGenerationId() {
         final List<TopicPartition> partitions = singletonList(t1p);
         try (ConsumerCoordinator coordinator = prepareCoordinatorForCloseTest(true, false, Optional.of("group-id"), true)) {
-            final SystemTime realTime = new SystemTime();
+            final SystemTime realTime = SystemTime.getSystemTime();
             coordinator.ensureActiveGroup();
 
             prepareOffsetCommitRequest(singletonMap(t1p, 100L), Errors.REBALANCE_IN_PROGRESS);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -32,7 +32,7 @@ import org.apache.kafka.clients.producer.internals.ProduceRequestResult;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.junit.jupiter.api.Test;
 
 public class RecordSendTest {
@@ -48,7 +48,7 @@ public class RecordSendTest {
     public void testTimeout() throws Exception {
         ProduceRequestResult request = new ProduceRequestResult(topicPartition);
         FutureRecordMetadata future = new FutureRecordMetadata(request, relOffset,
-                RecordBatch.NO_TIMESTAMP, 0, 0, Time.SYSTEM);
+                RecordBatch.NO_TIMESTAMP, 0, 0, SystemTime.getSystemTime());
         assertFalse(future.isDone(), "Request is not completed");
         try {
             future.get(5, TimeUnit.MILLISECONDS);
@@ -68,7 +68,7 @@ public class RecordSendTest {
     @Test
     public void testError() {
         FutureRecordMetadata future = new FutureRecordMetadata(asyncRequest(baseOffset, new CorruptRecordException(), 50L),
-                relOffset, RecordBatch.NO_TIMESTAMP, 0, 0, Time.SYSTEM);
+                relOffset, RecordBatch.NO_TIMESTAMP, 0, 0, SystemTime.getSystemTime());
         assertThrows(ExecutionException.class, future::get);
     }
 
@@ -78,7 +78,7 @@ public class RecordSendTest {
     @Test
     public void testBlocking() throws Exception {
         FutureRecordMetadata future = new FutureRecordMetadata(asyncRequest(baseOffset, null, 50L),
-                relOffset, RecordBatch.NO_TIMESTAMP, 0, 0, Time.SYSTEM);
+                relOffset, RecordBatch.NO_TIMESTAMP, 0, 0, SystemTime.getSystemTime());
         assertEquals(baseOffset + relOffset, future.get().offset());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +49,7 @@ public class ProducerMetadataTest {
     private final long refreshBackoffMaxMs = 1000;
     private final long metadataExpireMs = 1000;
     private final ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, refreshBackoffMaxMs, metadataExpireMs, METADATA_IDLE_MS,
-            new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
+            new LogContext(), new ClusterResourceListeners(), SystemTime.getSystemTime());
     private final AtomicReference<Exception> backgroundError = new AtomicReference<>();
 
     @AfterEach
@@ -59,7 +59,7 @@ public class ProducerMetadataTest {
 
     @Test
     public void testMetadata() throws Exception {
-        long time = Time.SYSTEM.milliseconds();
+        long time = SystemTime.getSystemTime().milliseconds();
         String topic = "my-topic";
         metadata.add(topic, time);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -50,7 +50,7 @@ import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -675,7 +675,7 @@ public class RecordAccumulatorTest {
 
     private void delayedInterrupt(final Thread thread, final long delayMs) {
         Thread t = new Thread(() -> {
-            Time.SYSTEM.sleep(delayMs);
+            SystemTime.getSystemTime().sleep(delayMs);
             thread.interrupt();
         });
         t.start();

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.metrics;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
@@ -164,7 +164,7 @@ public class JmxReporterTest {
         JmxReporter reporter = new JmxReporter();
         MetricsContext metricsContext = new KafkaMetricsContext("kafka.server");
         MetricConfig metricConfig = new MetricConfig();
-        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Collections.singletonList(reporter)), Time.SYSTEM, metricsContext);
+        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Collections.singletonList(reporter)), SystemTime.getSystemTime(), metricsContext);
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {
@@ -183,7 +183,7 @@ public class JmxReporterTest {
 
         // for backwards compatibility, ensure prefix does not get overridden by the default empty namespace in metricscontext
         MetricConfig metricConfig = new MetricConfig();
-        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Collections.singletonList(reporter)), Time.SYSTEM);
+        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Collections.singletonList(reporter)), SystemTime.getSystemTime());
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
@@ -80,45 +80,45 @@ public class SensorTest {
 
     @Test
     public void testShouldRecordForInfoLevelSensor() {
-        Sensor infoSensor = new Sensor(null, "infoSensor", null, INFO_CONFIG, new SystemTime(),
+        Sensor infoSensor = new Sensor(null, "infoSensor", null, INFO_CONFIG, SystemTime.getSystemTime(),
             0, Sensor.RecordingLevel.INFO);
         assertTrue(infoSensor.shouldRecord());
 
-        infoSensor = new Sensor(null, "infoSensor", null, DEBUG_CONFIG, new SystemTime(),
+        infoSensor = new Sensor(null, "infoSensor", null, DEBUG_CONFIG, SystemTime.getSystemTime(),
             0, Sensor.RecordingLevel.INFO);
         assertTrue(infoSensor.shouldRecord());
 
-        infoSensor = new Sensor(null, "infoSensor", null, TRACE_CONFIG, new SystemTime(),
+        infoSensor = new Sensor(null, "infoSensor", null, TRACE_CONFIG, SystemTime.getSystemTime(),
             0, Sensor.RecordingLevel.INFO);
         assertTrue(infoSensor.shouldRecord());
     }
 
     @Test
     public void testShouldRecordForDebugLevelSensor() {
-        Sensor debugSensor = new Sensor(null, "debugSensor", null, INFO_CONFIG, new SystemTime(),
+        Sensor debugSensor = new Sensor(null, "debugSensor", null, INFO_CONFIG, SystemTime.getSystemTime(),
             0, Sensor.RecordingLevel.DEBUG);
         assertFalse(debugSensor.shouldRecord());
 
-        debugSensor = new Sensor(null, "debugSensor", null, DEBUG_CONFIG, new SystemTime(),
+        debugSensor = new Sensor(null, "debugSensor", null, DEBUG_CONFIG, SystemTime.getSystemTime(),
              0, Sensor.RecordingLevel.DEBUG);
         assertTrue(debugSensor.shouldRecord());
 
-        debugSensor = new Sensor(null, "debugSensor", null, TRACE_CONFIG, new SystemTime(),
+        debugSensor = new Sensor(null, "debugSensor", null, TRACE_CONFIG, SystemTime.getSystemTime(),
              0, Sensor.RecordingLevel.DEBUG);
         assertTrue(debugSensor.shouldRecord());
     }
 
     @Test
     public void testShouldRecordForTraceLevelSensor() {
-        Sensor traceSensor = new Sensor(null, "traceSensor", null, INFO_CONFIG, new SystemTime(),
+        Sensor traceSensor = new Sensor(null, "traceSensor", null, INFO_CONFIG, SystemTime.getSystemTime(),
              0, Sensor.RecordingLevel.TRACE);
         assertFalse(traceSensor.shouldRecord());
 
-        traceSensor = new Sensor(null, "traceSensor", null, DEBUG_CONFIG, new SystemTime(),
+        traceSensor = new Sensor(null, "traceSensor", null, DEBUG_CONFIG, SystemTime.getSystemTime(),
              0, Sensor.RecordingLevel.TRACE);
         assertFalse(traceSensor.shouldRecord());
 
-        traceSensor = new Sensor(null, "traceSensor", null, TRACE_CONFIG, new SystemTime(),
+        traceSensor = new Sensor(null, "traceSensor", null, TRACE_CONFIG, SystemTime.getSystemTime(),
              0, Sensor.RecordingLevel.TRACE);
         assertTrue(traceSensor.shouldRecord());
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
@@ -32,7 +32,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.test.TestUtils;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
@@ -165,7 +165,7 @@ public class SaslChannelBuilderTest {
     private SaslChannelBuilder createGssapiChannelBuilder(Map<String, JaasContext> jaasContexts, GSSManager gssManager) {
         SaslChannelBuilder channelBuilder = new SaslChannelBuilder(Mode.SERVER, jaasContexts,
             SecurityProtocol.SASL_PLAINTEXT, new ListenerName("GSSAPI"), false, "GSSAPI",
-            true, null, null, null, Time.SYSTEM, new LogContext(), defaultApiVersionsSupplier()) {
+            true, null, null, null, SystemTime.getSystemTime(), new LogContext(), defaultApiVersionsSupplier()) {
 
             @Override
             protected GSSManager gssManager() {
@@ -205,7 +205,7 @@ public class SaslChannelBuilderTest {
         Map<String, JaasContext> jaasContexts = Collections.singletonMap(saslMechanism, jaasContext);
         return new SaslChannelBuilder(Mode.CLIENT, jaasContexts, securityProtocol, new ListenerName(saslMechanism),
                 false, saslMechanism, true, null,
-                null, null, Time.SYSTEM, new LogContext(), defaultApiVersionsSupplier());
+                null, null, SystemTime.getSystemTime(), new LogContext(), defaultApiVersionsSupplier());
     }
 
     public static final class TestGssapiLoginModule implements LoginModule {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
@@ -95,7 +96,7 @@ import static org.mockito.Mockito.when;
 public class SslTransportLayerTest {
 
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static final Time TIME = Time.SYSTEM;
+    private static final Time TIME = SystemTime.getSystemTime();
 
     private static class Args {
         private final String tlsProtocol;
@@ -765,7 +766,7 @@ public class SslTransportLayerTest {
         LogContext logContext = new LogContext();
         ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
         channelBuilder.configure(args.sslClientConfigs);
-        try (Selector selector = new Selector(NetworkReceive.UNLIMITED, Selector.NO_IDLE_TIMEOUT_MS, new Metrics(), Time.SYSTEM,
+        try (Selector selector = new Selector(NetworkReceive.UNLIMITED, Selector.NO_IDLE_TIMEOUT_MS, new Metrics(), SystemTime.getSystemTime(),
                 "MetricGroup", new HashMap<>(), false, true, channelBuilder, MemoryPool.NONE, logContext)) {
 
             String node = "0";

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.condition.JRE;
 
 public class SslTransportTls12Tls13Test {
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static final Time TIME = Time.SYSTEM;
+    private static final Time TIME = SystemTime.getSystemTime();
 
     private NioEchoServer server;
     private Selector selector;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslVersionsTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslVersionsTransportLayerTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class SslVersionsTransportLayerTest {
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static final Time TIME = Time.SYSTEM;
+    private static final Time TIME = SystemTime.getSystemTime();
 
     public static Stream<Arguments> parameters() {
         List<Arguments> parameters = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -427,7 +428,7 @@ public class FileRecordsTest {
 
         // Lazy down-conversion will not return any messages for a partial input batch
         TopicPartition tp = new TopicPartition("topic-1", 0);
-        LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, slice, RecordBatch.MAGIC_VALUE_V0, 0, Time.SYSTEM);
+        LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, slice, RecordBatch.MAGIC_VALUE_V0, 0, SystemTime.getSystemTime());
         Iterator<ConvertedRecords<?>> it = lazyRecords.iterator(16 * 1024L);
         assertFalse(it.hasNext(), "No messages should be returned");
     }
@@ -436,7 +437,7 @@ public class FileRecordsTest {
     public void testFormatConversionWithNoMessages() {
         TopicPartition tp = new TopicPartition("topic-1", 0);
         LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, MemoryRecords.EMPTY, RecordBatch.MAGIC_VALUE_V0,
-            0, Time.SYSTEM);
+            0, SystemTime.getSystemTime());
         assertEquals(0, lazyRecords.sizeInBytes());
         Iterator<ConvertedRecords<?>> it = lazyRecords.iterator(16 * 1024L);
         assertFalse(it.hasNext(), "No messages should be returned");
@@ -646,7 +647,7 @@ public class FileRecordsTest {
                 1L);
         for (long readSize : maximumReadSize) {
             TopicPartition tp = new TopicPartition("topic-1", 0);
-            LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, fileRecords, toMagic, firstOffset, Time.SYSTEM);
+            LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, fileRecords, toMagic, firstOffset, SystemTime.getSystemTime());
             Iterator<ConvertedRecords<?>> it = lazyRecords.iterator(readSize);
             while (it.hasNext())
                 convertedRecords.add(it.next().records());

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.network.TransferableChannel;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,7 +54,7 @@ public class LazyDownConversionRecordsTest {
      */
     @Test
     public void testConversionOfCommitMarker() throws IOException {
-        MemoryRecords recordsToConvert = MemoryRecords.withEndTransactionMarker(0, Time.SYSTEM.milliseconds(), RecordBatch.NO_PARTITION_LEADER_EPOCH,
+        MemoryRecords recordsToConvert = MemoryRecords.withEndTransactionMarker(0, SystemTime.getSystemTime().milliseconds(), RecordBatch.NO_PARTITION_LEADER_EPOCH,
                 1, (short) 1, new EndTransactionMarker(ControlRecordType.COMMIT, 0));
         MemoryRecords convertedRecords = convertRecords(recordsToConvert, (byte) 1, recordsToConvert.sizeInBytes());
         ByteBuffer buffer = convertedRecords.buffer();
@@ -148,7 +148,7 @@ public class LazyDownConversionRecordsTest {
             inputRecords.flush();
 
             LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(new TopicPartition("test", 1),
-                    inputRecords, toMagic, 0L, Time.SYSTEM);
+                    inputRecords, toMagic, 0L, SystemTime.getSystemTime());
             LazyDownConversionRecordsSend lazySend = lazyRecords.toSend();
             File outputFile = tempFile();
             ByteBuffer convertedRecordsBuffer;

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.CloseableIterator;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
@@ -94,7 +95,7 @@ public class MemoryRecordsBuilderTest {
         }
     }
 
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
 
     @Test
     public void testUnsupportedCompress() {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -94,6 +94,7 @@ import org.apache.kafka.common.security.token.delegation.internals.DelegationTok
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SecurityUtils;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
@@ -153,7 +154,7 @@ public class SaslAuthenticatorTest {
 
     private static final long CONNECTIONS_MAX_REAUTH_MS_VALUE = 100L;
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static Time time = Time.SYSTEM;
+    private static Time time = SystemTime.getSystemTime();
 
     private NioEchoServer server;
     private Selector selector;
@@ -166,7 +167,7 @@ public class SaslAuthenticatorTest {
     @BeforeEach
     public void setup() throws Exception {
         LoginManager.closeAll();
-        time = Time.SYSTEM;
+        time = SystemTime.getSystemTime();
         CertStores serverCertStores = new CertStores(true, "localhost");
         CertStores clientCertStores = new CertStores(false, "localhost");
         saslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
@@ -1767,10 +1768,10 @@ public class SaslAuthenticatorTest {
         server.verifyReauthenticationMetrics(0, 0);
         double successfulReauthentications = 0;
         int desiredNumReauthentications = 5;
-        long startMs = Time.SYSTEM.milliseconds();
+        long startMs = SystemTime.getSystemTime().milliseconds();
         long timeoutMs = startMs + 1000 * 15; // stop after 15 seconds
         while (successfulReauthentications < desiredNumReauthentications
-                && Time.SYSTEM.milliseconds() < timeoutMs) {
+                && SystemTime.getSystemTime().milliseconds() < timeoutMs) {
             checkClientConnection(node);
             successfulReauthentications = server.metricValue("successful-reauthentication-total");
         }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
@@ -24,6 +24,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ public class OAuthBearerValidationUtilsTest {
     private static final String QUOTE = "\"";
     private static final String HEADER_COMPACT_SERIALIZATION = Base64.getUrlEncoder().withoutPadding()
             .encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8)) + ".";
-    private static final Time TIME = Time.SYSTEM;
+    private static final Time TIME = SystemTime.getSystemTime();
 
     @Test
     public void validateClaimForExistenceAndType() throws OAuthBearerIllegalTokenException {

--- a/clients/src/test/java/org/apache/kafka/common/utils/SystemTimeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/SystemTimeTest.java
@@ -20,6 +20,6 @@ public class SystemTimeTest extends TimeTest {
 
     @Override
     protected Time createTime() {
-        return Time.SYSTEM;
+        return SystemTime.getSystemTime();
     }
 }

--- a/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
+++ b/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.kafka.common.utils.CopyOnWriteMap;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 public class Microbenchmarks {
@@ -75,7 +76,7 @@ public class Microbenchmarks {
         System.out.println(loc);
         System.out.println("binary search: " + (System.nanoTime() - start) / iters);
 
-        final Time time = Time.SYSTEM;
+        final Time time = SystemTime.getSystemTime();
         final AtomicBoolean done = new AtomicBoolean(false);
         final Object lock = new Object();
         Thread t1 = new Thread(() -> {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/CheckpointStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/CheckpointStore.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.protocol.types.SchemaException;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
@@ -189,7 +189,7 @@ public class CheckpointStore implements AutoCloseable {
                     null,
                     cpAdmin,
                     consumedCallback,
-                    Time.SYSTEM,
+                    SystemTime.getSystemTime(),
                     ignored -> {
                     },
                     topicPartition -> topicPartition.partition() == 0);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.Exit;
@@ -170,7 +171,7 @@ public class MirrorMaker {
     }
 
     public MirrorMaker(Map<String, String> props, List<String> clusters) {
-        this(props, clusters, Time.SYSTEM);
+        this(props, clusters, SystemTime.getSystemTime());
     }
 
     public MirrorMaker(Map<String, String> props) {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
@@ -93,7 +93,7 @@ public class OffsetSyncStore implements AutoCloseable {
                 null,
                 admin,
                 (error, record) -> this.handleRecord(record),
-                Time.SYSTEM,
+                SystemTime.getSystemTime(),
                 ignored -> { },
                 topicPartition -> topicPartition.partition() == 0
         );

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
@@ -1120,7 +1120,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         for (ProducerRecord<byte[], byte[]> record : records) {
             futures.add(producer.send(record));
         }
-        Timer timer = Time.SYSTEM.timer(RECORD_PRODUCE_DURATION_MS);
+        Timer timer = SystemTime.getSystemTime().timer(RECORD_PRODUCE_DURATION_MS);
         try {
             for (Future<RecordMetadata> future : futures) {
                 future.get(timer.remainingMs(), TimeUnit.MILLISECONDS);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.cli;
 
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
@@ -45,7 +46,7 @@ public abstract class AbstractConnectCli<T extends WorkerConfig> {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractConnectCli.class);
     private final String[] args;
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
 
     /**
      *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.connect.cli;
 
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
@@ -81,11 +81,11 @@ public class ConnectDistributed extends AbstractConnectCli<DistributedConfig> {
                         Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false")));
         offsetBackingStore.configure(config);
 
-        Worker worker = new Worker(workerId, Time.SYSTEM, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
+        Worker worker = new Worker(workerId, SystemTime.getSystemTime(), plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
         WorkerConfigTransformer configTransformer = worker.configTransformer();
 
         Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(Time.SYSTEM, internalValueConverter, sharedAdmin, clientIdBase);
+        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(SystemTime.getSystemTime(), internalValueConverter, sharedAdmin, clientIdBase);
         statusBackingStore.configure(config);
 
         ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(
@@ -97,7 +97,7 @@ public class ConnectDistributed extends AbstractConnectCli<DistributedConfig> {
 
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
-        return new DistributedHerder(config, Time.SYSTEM, worker,
+        return new DistributedHerder(config, SystemTime.getSystemTime(), worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
                 restServer.advertisedUrl().toString(), restClient, connectorClientConfigOverridePolicy,
                 Collections.emptyList(), sharedAdmin);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -166,7 +166,7 @@ public class ConnectStandalone extends AbstractConnectCli<StandaloneConfig> {
                 true, JsonConverter.class.getName(), Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false")));
         offsetBackingStore.configure(config);
 
-        Worker worker = new Worker(workerId, Time.SYSTEM, plugins, config, offsetBackingStore,
+        Worker worker = new Worker(workerId, SystemTime.getSystemTime(), plugins, config, offsetBackingStore,
                 connectorClientConfigOverridePolicy);
 
         return new StandaloneHerder(worker, config.kafkaClusterId(), connectorClientConfigOverridePolicy);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.utils.ThreadUtils;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
@@ -1788,7 +1789,7 @@ public class Worker {
                     connectorConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG));
 
             RetryWithToleranceOperator<T> retryWithToleranceOperator = new RetryWithToleranceOperator<>(connectorConfig.errorRetryTimeout(),
-                    connectorConfig.errorMaxDelayInMillis(), connectorConfig.errorToleranceType(), Time.SYSTEM, errorHandlingMetrics);
+                    connectorConfig.errorMaxDelayInMillis(), connectorConfig.errorToleranceType(), SystemTime.getSystemTime(), errorHandlingMetrics);
 
             TransformationChain<T, R> transformationChain = new TransformationChain<>(connectorConfig.<R>transformationStages(), retryWithToleranceOperator);
             log.info("Initializing: {}", transformationChain);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ErrorHandlingMetrics implements AutoCloseable {
 
-    private final Time time = new SystemTime();
+    private final Time time = SystemTime.getSystemTime();
 
     private final ConnectMetrics.MetricGroup metricGroup;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime.standalone;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
@@ -85,7 +86,7 @@ public class StandaloneHerder extends AbstractHerder {
                 new MemoryStatusBackingStore(),
                 new MemoryConfigBackingStore(worker.configTransformer()),
                 connectorClientConfigOverridePolicy,
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.util.Callback;
@@ -77,7 +78,7 @@ public class ConnectorOffsetBackingStore implements OffsetBackingStore {
         Objects.requireNonNull(connectorOffsetsTopic);
         Objects.requireNonNull(connectorStoreAdmin);
         return new ConnectorOffsetBackingStore(
-                Time.SYSTEM,
+                SystemTime.getSystemTime(),
                 loggingContext,
                 connectorOffsetsTopic,
                 workerStore,
@@ -103,7 +104,7 @@ public class ConnectorOffsetBackingStore implements OffsetBackingStore {
     ) {
         Objects.requireNonNull(loggingContext);
         Objects.requireNonNull(workerStore);
-        return new ConnectorOffsetBackingStore(Time.SYSTEM, loggingContext, workerOffsetsTopic, workerStore, null, null);
+        return new ConnectorOffsetBackingStore(SystemTime.getSystemTime(), loggingContext, workerOffsetsTopic, workerStore, null, null);
     }
 
     /**
@@ -126,7 +127,7 @@ public class ConnectorOffsetBackingStore implements OffsetBackingStore {
         Objects.requireNonNull(connectorOffsetsTopic);
         Objects.requireNonNull(connectorStoreAdmin);
         return new ConnectorOffsetBackingStore(
-                Time.SYSTEM,
+                SystemTime.getSystemTime(),
                 loggingContext,
                 connectorOffsetsTopic,
                 null,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
@@ -333,7 +334,7 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
     }
 
     public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer, Supplier<TopicAdmin> adminSupplier, String clientIdBase) {
-        this(converter, config, configTransformer, adminSupplier, clientIdBase, Time.SYSTEM);
+        this(converter, config, configTransformer, adminSupplier, clientIdBase, SystemTime.getSystemTime());
     }
 
     @SuppressWarnings("this-escape")

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
@@ -96,8 +96,8 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
                         producer,
                         topicAdmin,
                         consumedCallback,
-                        Time.SYSTEM,
-                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM),
+                        SystemTime.getSystemTime(),
+                        topicInitializer(topic, newTopicDescription(topic, config), config, SystemTime.getSystemTime()),
                         ignored -> true
                 );
             }
@@ -129,8 +129,8 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
                         null,
                         topicAdmin,
                         consumedCallback,
-                        Time.SYSTEM,
-                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM),
+                        SystemTime.getSystemTime(),
+                        topicInitializer(topic, newTopicDescription(topic, config), config, SystemTime.getSystemTime()),
                         ignored -> true
                 );
             }
@@ -211,7 +211,7 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         NewTopic topicDescription = newTopicDescription(topic, config);
 
-        this.offsetLog = createKafkaBasedLog(topic, producerProps, consumerProps, consumedCallback, topicDescription, topicAdminSupplier, config, Time.SYSTEM);
+        this.offsetLog = createKafkaBasedLog(topic, producerProps, consumerProps, consumedCallback, topicDescription, topicAdminSupplier, config, SystemTime.getSystemTime());
     }
 
     protected NewTopic newTopicDescription(final String topic, final WorkerConfig config) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.util;
 
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -53,7 +54,7 @@ public class RetryUtil {
      * @throws ConnectException If the task exhausted all the retries
      */
     public static <T> T retryUntilTimeout(Callable<T> callable, Supplier<String> description, Duration timeoutDuration, long retryBackoffMs) throws Exception {
-        return retryUntilTimeout(callable, description, timeoutDuration, retryBackoffMs, Time.SYSTEM);
+        return retryUntilTimeout(callable, description, timeoutDuration, retryBackoffMs, SystemTime.getSystemTime());
     }
 
     // visible for testing

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
@@ -414,7 +414,7 @@ public class BlockingConnectorTest {
          * it will block.
          */
         public static void waitForBlock() throws InterruptedException, TimeoutException {
-            Timer timer = Time.SYSTEM.timer(CONNECTOR_BLOCK_TIMEOUT_MS);
+            Timer timer = SystemTime.getSystemTime().timer(CONNECTOR_BLOCK_TIMEOUT_MS);
 
             CountDownLatch awaitBlockLatch;
             synchronized (Block.class) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 public class StartAndStopCounter {
@@ -31,11 +32,11 @@ public class StartAndStopCounter {
     private final Time clock;
 
     public StartAndStopCounter() {
-        this(Time.SYSTEM);
+        this(SystemTime.getSystemTime());
     }
 
     public StartAndStopCounter(Time clock) {
-        this.clock = clock != null ? clock : Time.SYSTEM;
+        this.clock = clock != null ? clock : SystemTime.getSystemTime();
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.provider.DirectoryConfigProvider;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
@@ -1198,7 +1198,7 @@ public class AbstractHerderTest {
 
     private AbstractHerder testHerder(ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy) {
         return mock(AbstractHerder.class, withSettings()
-                .useConstructor(worker, workerId, kafkaClusterId, statusStore, configStore, connectorClientConfigOverridePolicy, Time.SYSTEM)
+                .useConstructor(worker, workerId, kafkaClusterId, statusStore, configStore, connectorClientConfigOverridePolicy, SystemTime.getSystemTime())
                 .defaultAnswer(CALLS_REAL_METHODS));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -724,7 +724,7 @@ public class AbstractWorkerSourceTaskTest {
         when(statusBackingStore.getTopic(anyString(), anyString())).thenAnswer((Answer<TopicStatus>) invocation -> {
             String connector = invocation.getArgument(0, String.class);
             String topic = invocation.getArgument(1, String.class);
-            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), Time.SYSTEM.milliseconds());
+            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), SystemTime.getSystemTime().milliseconds());
         });
     }
 
@@ -812,7 +812,7 @@ public class AbstractWorkerSourceTaskTest {
         workerTask = new AbstractWorkerSourceTask(
                 taskId, sourceTask, statusListener, TargetState.STARTED, keyConverter, valueConverter, headerConverter, transformationChain,
                 sourceTaskContext, producer, admin, TopicCreationGroup.configuredGroups(sourceConfig), offsetReader, offsetWriter, offsetStore,
-                config, metrics, errorHandlingMetrics,  plugins.delegatingLoader(), Time.SYSTEM, retryWithToleranceOperator,
+                config, metrics, errorHandlingMetrics,  plugins.delegatingLoader(), SystemTime.getSystemTime(), retryWithToleranceOperator,
                 statusBackingStore, Runnable::run, errorReportersSupplier) {
             @Override
             protected void prepareToInitializeTask() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -86,7 +87,6 @@ import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -274,7 +274,7 @@ public class ErrorHandlingTaskTest {
     private <T> RetryWithToleranceOperator<T> operator() {
         return new RetryWithToleranceOperator<>(OPERATOR_RETRY_TIMEOUT_MILLIS,
                 OPERATOR_RETRY_MAX_DELAY_MILLIS, OPERATOR_TOLERANCE_TYPE,
-                SYSTEM, errorHandlingMetrics);
+                SystemTime.getSystemTime(), errorHandlingMetrics);
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -196,7 +197,7 @@ public class ExactlyOnceWorkerSourceTaskTest {
         config = new StandaloneConfig(workerProps);
         sourceConfig = new SourceConnectorConfig(plugins, sourceConnectorProps(), true);
         metrics = new MockConnectMetrics();
-        time = Time.SYSTEM;
+        time = SystemTime.getSystemTime();
         when(offsetStore.primaryOffsetsTopic()).thenReturn("offsets-topic");
         when(sourceTask.poll()).thenAnswer(invocation -> {
             // Capture the records we'll return before decrementing the poll latch,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -72,7 +72,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -1868,7 +1868,7 @@ public class WorkerSinkTaskTest {
         when(statusBackingStore.getTopic(anyString(), anyString())).thenAnswer((Answer<TopicStatus>) invocation -> {
             String connector = invocation.getArgument(0, String.class);
             String topic = invocation.getArgument(1, String.class);
-            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), Time.SYSTEM.milliseconds());
+            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), SystemTime.getSystemTime().milliseconds());
         });
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -680,7 +681,7 @@ public class WorkerSinkTaskThreadedTest {
         when(statusBackingStore.getTopic(anyString(), anyString())).thenAnswer((Answer<TopicStatus>) invocation -> {
             String connector = invocation.getArgument(0, String.class);
             String topic = invocation.getArgument(1, String.class);
-            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), Time.SYSTEM.milliseconds());
+            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), SystemTime.getSystemTime().milliseconds());
         });
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.integration.MonitorableSourceConnector;
@@ -263,7 +263,7 @@ public class WorkerSourceTaskTest {
                                   HeaderConverter headerConverter, RetryWithToleranceOperator<SourceRecord> retryWithToleranceOperator) {
         workerTask = new WorkerSourceTask(taskId, sourceTask, statusListener, initialState, keyConverter, valueConverter, errorHandlingMetrics, headerConverter,
                 transformationChain, producer, admin, TopicCreationGroup.configuredGroups(sourceConfig),
-                offsetReader, offsetWriter, offsetStore, config, clusterConfigState, metrics, plugins.delegatingLoader(), Time.SYSTEM,
+                offsetReader, offsetWriter, offsetStore, config, clusterConfigState, metrics, plugins.delegatingLoader(), SystemTime.getSystemTime(),
                 retryWithToleranceOperator, statusBackingStore, Runnable::run, Collections::emptyList);
     }
 
@@ -843,7 +843,7 @@ public class WorkerSourceTaskTest {
         when(statusBackingStore.getTopic(anyString(), anyString())).thenAnswer((Answer<TopicStatus>) invocation -> {
             String connector = invocation.getArgument(0, String.class);
             String topic = invocation.getArgument(1, String.class);
-            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), Time.SYSTEM.milliseconds());
+            return new TopicStatus(topic, new ConnectorTaskId(connector, 0), SystemTime.getSystemTime().milliseconds());
         });
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.TaskStatus.Listener;
@@ -83,7 +84,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore);
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore);
         workerTask.initialize(TASK_CONFIG);
         workerTask.run();
         workerTask.stop();
@@ -98,7 +99,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore) {
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore) {
 
             @Override
             public void initializeAndStart() {
@@ -125,7 +126,7 @@ public class WorkerTaskTest {
         final CountDownLatch stopped = new CountDownLatch(1);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore) {
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore) {
 
             @Override
             public void execute() {
@@ -162,7 +163,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore);
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore);
 
         List<ErrorReporter<Object>> errorReporters = new ArrayList<>();
         when(errorReportersSupplier.get()).thenReturn(errorReporters);
@@ -176,7 +177,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore);
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore);
         when(errorReportersSupplier.get()).thenThrow(new ConnectException("Failed to create error reporters"));
 
         assertThrows(ConnectException.class, workerTask::doStart);
@@ -187,7 +188,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore);
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore);
 
         workerTask.doClose();
 
@@ -200,7 +201,7 @@ public class WorkerTaskTest {
         ConnectorTaskId taskId = new ConnectorTaskId("foo", 0);
 
         WorkerTask<Object, SourceRecord> workerTask = new TestWorkerTask(taskId, statusListener, TargetState.STARTED, loader, metrics, errorHandlingMetrics,
-                retryWithToleranceOperator, transformationChain, errorReportersSupplier, Time.SYSTEM, statusBackingStore) {
+                retryWithToleranceOperator, transformationChain, errorReportersSupplier, SystemTime.getSystemTime(), statusBackingStore) {
             @Override
             protected void close() {
                 throw new ConnectException("Failure during close");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
@@ -1721,7 +1722,7 @@ public class WorkerTest {
         mockFileConfigProvider();
 
         Worker worker = new Worker("worker-1",
-                Time.SYSTEM,
+                SystemTime.getSystemTime(),
                 plugins,
                 config,
                 offsetBackingStore,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.internals.RequestFuture;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.ConnectorsAndTasks;
@@ -75,7 +76,7 @@ public class IncrementalCooperativeAssignorTest {
     @Before
     public void setup() {
         generationId = 1000;
-        time = Time.SYSTEM;
+        time = SystemTime.getSystemTime();
         rebalanceDelay = DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_DEFAULT;
         connectors = new HashMap<>();
         addNewConnector("connector1", 4);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.runtime.MockConnectMetrics;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
@@ -66,7 +66,7 @@ public class WorkerGroupMemberTest {
         doReturn("cluster-1").when(config).kafkaClusterId();
 
         LogContext logContext = new LogContext("[Worker clientId=client-1 + groupId= group-1]");
-        member = new WorkerGroupMember(config, "", configBackingStore, null, Time.SYSTEM, "client-1", logContext);
+        member = new WorkerGroupMember(config, "", configBackingStore, null, SystemTime.getSystemTime(), "client-1", logContext);
 
         verify(config, atLeastOnce()).kafkaClusterId();
         boolean foundMockReporter = false;
@@ -109,7 +109,7 @@ public class WorkerGroupMemberTest {
         doReturn("cluster-1").when(config).kafkaClusterId();
 
         LogContext logContext = new LogContext("[Worker clientId=client-1 + groupId= group-1]");
-        member = new WorkerGroupMember(config, "", configBackingStore, null, Time.SYSTEM, "client-1", logContext);
+        member = new WorkerGroupMember(config, "", configBackingStore, null, SystemTime.getSystemTime(), "client-1", logContext);
 
         verify(config, atLeastOnce()).kafkaClusterId();
         assertTrue(member.metrics().reporters().isEmpty());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -56,7 +56,6 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_RETRY_MAX_DELAY_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_RETRY_MAX_DELAY_DEFAULT;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_RETRY_TIMEOUT_CONFIG;
@@ -97,18 +96,18 @@ public class RetryWithToleranceOperatorTest {
         return genericOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, NONE, new ErrorHandlingMetrics(
                 new ConnectorTaskId("noop-connector", -1),
                 new ConnectMetrics("noop-worker", new TestableWorkerConfig(PROPERTIES),
-                        new SystemTime(), "test-cluster")));
+                        SystemTime.getSystemTime(), "test-cluster")));
     }
 
     public static <T> RetryWithToleranceOperator<T> allOperator() {
         return genericOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ALL, new ErrorHandlingMetrics(
                 new ConnectorTaskId("errors-all-tolerate-connector", -1),
                 new ConnectMetrics("errors-all-tolerate-worker", new TestableWorkerConfig(PROPERTIES),
-                        new SystemTime(), "test-cluster")));
+                        SystemTime.getSystemTime(), "test-cluster")));
     }
 
     private static <T> RetryWithToleranceOperator<T> genericOperator(int retryTimeout, ToleranceType toleranceType, ErrorHandlingMetrics metrics) {
-        return new RetryWithToleranceOperator<>(retryTimeout, ERRORS_RETRY_MAX_DELAY_DEFAULT, toleranceType, SYSTEM, metrics);
+        return new RetryWithToleranceOperator<>(retryTimeout, ERRORS_RETRY_MAX_DELAY_DEFAULT, toleranceType, SystemTime.getSystemTime(), metrics);
     }
 
     @Mock

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.runtime.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.InternalSinkRecord;
@@ -98,7 +98,7 @@ public class WorkerErrantRecordReporterTest {
                 5000,
                 ConnectorConfig.ERRORS_RETRY_MAX_DELAY_DEFAULT,
                 errorsTolerated ? ToleranceType.ALL : ToleranceType.NONE,
-                Time.SYSTEM,
+                SystemTime.getSystemTime(),
                 errorHandlingMetrics
         );
         retryWithToleranceOperator.reporters(Collections.singletonList(errorReporter));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.TopicStatus;
@@ -155,7 +156,7 @@ public class KafkaStatusBackingStoreFormatTest {
 
     @Test
     public void readTopicStatus() {
-        TopicStatus topicStatus = new TopicStatus(FOO_TOPIC, new ConnectorTaskId(FOO_CONNECTOR, 0), Time.SYSTEM.milliseconds());
+        TopicStatus topicStatus = new TopicStatus(FOO_TOPIC, new ConnectorTaskId(FOO_CONNECTOR, 0), SystemTime.getSystemTime().milliseconds());
         String key = TOPIC_STATUS_PREFIX + FOO_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
         byte[] value = store.serializeTopicStatus(topicStatus);
         ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, key, value);
@@ -167,7 +168,7 @@ public class KafkaStatusBackingStoreFormatTest {
 
     @Test
     public void deleteTopicStatus() {
-        TopicStatus topicStatus = new TopicStatus("foo", new ConnectorTaskId("bar", 0), Time.SYSTEM.milliseconds());
+        TopicStatus topicStatus = new TopicStatus("foo", new ConnectorTaskId("bar", 0), SystemTime.getSystemTime().milliseconds());
         store.topics.computeIfAbsent("bar", k -> new ConcurrentHashMap<>()).put("foo", topicStatus);
         assertTrue(store.topics.containsKey("bar"));
         assertTrue(store.topics.get("bar").containsKey("foo"));

--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -32,6 +32,7 @@ import kafka.server.QuotaFactory.QuotaManagers;
 import kafka.server.ReplicaManager;
 import kafka.server.metadata.ConfigRepository;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.server.ClientMetricsManager;
@@ -60,7 +61,7 @@ public class KafkaApisBuilder {
     private FetchManager fetchManager = null;
     private BrokerTopicStats brokerTopicStats = null;
     private String clusterId = "clusterId";
-    private Time time = Time.SYSTEM;
+    private Time time = SystemTime.getSystemTime();
     private DelegationTokenManager tokenManager = null;
     private ApiVersionManager apiVersionManager = null;
     private Optional<ClientMetricsManager> clientMetricsManager = Optional.empty();

--- a/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
@@ -20,6 +20,7 @@ package kafka.server.builders;
 import kafka.log.LogManager;
 import kafka.server.BrokerTopicStats;
 import kafka.server.metadata.ConfigRepository;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.config.ServerLogConfigs;
@@ -53,7 +54,7 @@ public class LogManagerBuilder {
     private Scheduler scheduler = null;
     private BrokerTopicStats brokerTopicStats = null;
     private LogDirFailureChannel logDirFailureChannel = null;
-    private Time time = Time.SYSTEM;
+    private Time time = SystemTime.getSystemTime();
     private boolean keepPartitionMetadataFile = true;
     private boolean remoteStorageSystemEnable = false;
     private long initialTaskDelayMs = ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_DEFAULT;

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -34,6 +34,7 @@ import kafka.server.ReplicaManager;
 import kafka.log.remote.RemoteLogManager;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.DirectoryEventHandler;
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel;
@@ -48,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ReplicaManagerBuilder {
     private KafkaConfig config = null;
     private Metrics metrics = null;
-    private Time time = Time.SYSTEM;
+    private Time time =  SystemTime.getSystemTime();
     private Scheduler scheduler = null;
     private LogManager logManager = null;
     private QuotaManagers quotaManagers = null;

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -22,7 +22,7 @@ import joptsimple.OptionParser
 import kafka.server.{KafkaConfig, KafkaRaftServer, KafkaServer, Server}
 import kafka.utils.Implicits._
 import kafka.utils.{Exit, Logging}
-import org.apache.kafka.common.utils.{Java, LoggingSignalHandler, OperatingSystem, Time, Utils}
+import org.apache.kafka.common.utils.{Java, LoggingSignalHandler, OperatingSystem, SystemTime, Utils}
 import org.apache.kafka.server.util.CommandLineUtils
 
 object Kafka extends Logging {
@@ -72,14 +72,14 @@ object Kafka extends Logging {
     if (config.requiresZookeeper) {
       new KafkaServer(
         config,
-        Time.SYSTEM,
+        SystemTime.getSystemTime,
         threadNamePrefix = None,
         enableForwarding = enableApiForwarding(config)
       )
     } else {
       new KafkaRaftServer(
         config,
-        Time.SYSTEM,
+        SystemTime.getSystemTime,
       )
     }
   }

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import joptsimple.OptionSpec
 import kafka.utils.Implicits._
 import kafka.utils.Logging
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{KafkaThread, LogContext, SystemTime, Time, Utils}
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ClientResponse, ClientUtils, CommonClientConfigs, Metadata, NetworkClient, NodeApiVersions}
 import org.apache.kafka.clients.consumer.internals.{ConsumerNetworkClient, RequestFuture}
 import org.apache.kafka.common.config.ConfigDef.ValidString._
@@ -36,8 +36,6 @@ import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.Selector
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.utils.LogContext
-import org.apache.kafka.common.utils.{KafkaThread, Time}
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ApiVersionsRequest, ApiVersionsResponse, MetadataRequest, MetadataResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -270,7 +268,7 @@ object BrokerApiVersionsCommand {
     def create(config: AdminConfig): AdminClient = {
       val clientId = "admin-" + AdminClientIdSequence.getAndIncrement()
       val logContext = new LogContext(s"[LegacyAdminClient clientId=$clientId] ")
-      val time = Time.SYSTEM
+      val time = SystemTime.getSystemTime
       val metrics = new Metrics(time)
       val metadata = new Metadata(CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MS,
         CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MAX_MS,

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter, ClientQuotaFilterComponent}
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
-import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
+import org.apache.kafka.common.utils.{Sanitizer, SystemTime, Time, Utils}
 import org.apache.kafka.server.config.{ConfigType, QuotaConfigs, ZkConfigs, ZooKeeperInternals}
 import org.apache.kafka.security.{PasswordEncoder, PasswordEncoderConfigs}
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
@@ -115,7 +115,7 @@ object ConfigCommand extends Logging {
     val zkClientConfig = ZkSecurityMigrator.createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile)
       .getOrElse(new ZKClientConfig())
     val zkClient = KafkaZkClient(zkConnectString, JaasUtils.isZkSaslEnabled || KafkaConfig.zkTlsClientAuthEnabled(zkClientConfig), 30000, 30000,
-      Int.MaxValue, Time.SYSTEM, zkClientConfig = zkClientConfig, name = "ConfigCommand", enableEntityConfigControllerCheck = false)
+      Int.MaxValue, SystemTime.getSystemTime, zkClientConfig = zkClientConfig, name = "ConfigCommand", enableEntityConfigControllerCheck = false)
     val adminZkClient = new AdminZkClient(zkClient)
     try {
       if (opts.options.has(opts.alterOpt))

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter, ClientQuotaFilterComponent}
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
-import org.apache.kafka.common.utils.{Sanitizer, SystemTime, Time, Utils}
+import org.apache.kafka.common.utils.{Sanitizer, SystemTime, Utils}
 import org.apache.kafka.server.config.{ConfigType, QuotaConfigs, ZkConfigs, ZooKeeperInternals}
 import org.apache.kafka.security.{PasswordEncoder, PasswordEncoderConfigs}
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -23,7 +23,7 @@ import kafka.utils.{Exit, Logging, ToolsUtils}
 import kafka.utils.Implicits._
 import kafka.zk.{ControllerZNode, KafkaZkClient, ZkData, ZkSecurityMigratorUtils}
 import org.apache.kafka.common.security.JaasUtils
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.server.config.ZkConfigs
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
 import org.apache.zookeeper.AsyncCallback.{ChildrenCallback, StatCallback}
@@ -107,7 +107,7 @@ object ZkSecurityMigrator extends Logging {
     val zkSessionTimeout = opts.options.valueOf(opts.zkSessionTimeoutOpt).intValue
     val zkConnectionTimeout = opts.options.valueOf(opts.zkConnectionTimeoutOpt).intValue
     val zkClient = KafkaZkClient(zkUrl, zkAcl, zkSessionTimeout, zkConnectionTimeout,
-      Int.MaxValue, Time.SYSTEM, zkClientConfig = zkClientConfig, name = "ZkSecurityMigrator", enableEntityConfigControllerCheck = false)
+      Int.MaxValue, SystemTime.getSystemTime, zkClientConfig = zkClientConfig, name = "ZkSecurityMigrator", enableEntityConfigControllerCheck = false)
     val enablePathCheck = opts.options.has(opts.enablePathCheckOpt)
     val migrator = new ZkSecurityMigrator(zkClient)
     migrator.run(enablePathCheck)

--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -19,11 +19,10 @@ package kafka.common
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-
 import kafka.utils.Logging
 import kafka.zk.{KafkaZkClient, StateChangeHandlers}
 import kafka.zookeeper.{StateChangeHandler, ZNodeChildChangeHandler}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime, Time}
 import org.apache.kafka.server.util.ShutdownableThread
 
 import scala.collection.Seq
@@ -55,7 +54,7 @@ class ZkNodeChangeNotificationListener(private val zkClient: KafkaZkClient,
                                        private val seqNodePrefix: String,
                                        private val notificationHandler: NotificationHandler,
                                        private val changeExpirationMs: Long = 15 * 60 * 1000,
-                                       private val time: Time = Time.SYSTEM) extends Logging {
+                                       private val time: Time = SystemTime.getSystemTime) extends Logging {
   private var lastExecutedChange = -1L
   private val queue = new LinkedBlockingQueue[ChangeNotification]
   private val thread = new ChangeEventProcessThread(s"$seqNodeRoot-event-process-thread")

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -41,7 +41,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.{OffsetCommitRequest, OffsetFetchResponse}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.apache.kafka.common.{MessageFormatter, TopicIdPartition, TopicPartition}
 import org.apache.kafka.coordinator.group.OffsetConfig
 import org.apache.kafka.coordinator.group.generated.{GroupMetadataValue, OffsetCommitKey, OffsetCommitValue, GroupMetadataKey => GroupMetadataKeyData}
@@ -1276,7 +1276,7 @@ object GroupMetadataManager {
           val value = consumerRecord.value
           val formattedValue =
             if (value == null) "NULL"
-            else GroupMetadataManager.readGroupMessageValue(groupId, ByteBuffer.wrap(value), Time.SYSTEM).toString
+            else GroupMetadataManager.readGroupMessageValue(groupId, ByteBuffer.wrap(value), SystemTime.getSystemTime).toString
           output.write(groupId.getBytes(StandardCharsets.UTF_8))
           output.write("::".getBytes(StandardCharsets.UTF_8))
           output.write(formattedValue.getBytes(StandardCharsets.UTF_8))

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -21,7 +21,7 @@ import kafka.utils.Logging
 import org.apache.kafka.common.errors.{KafkaStorageException, OffsetOutOfRangeException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.MemoryRecords
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.log.{AbortedTxn, FetchDataInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata, LogSegment, LogSegments, OffsetPosition}
@@ -948,7 +948,7 @@ object LocalLog extends Logging {
 
   private[log] def createNewCleanedSegment(dir: File, logConfig: LogConfig, baseOffset: Long): LogSegment = {
     LogSegment.deleteIfExists(dir, baseOffset, CleanedFileSuffix)
-    LogSegment.open(dir, baseOffset, logConfig, Time.SYSTEM, false, logConfig.initFileSize, logConfig.preallocate, CleanedFileSuffix)
+    LogSegment.open(dir, baseOffset, logConfig, SystemTime.getSystemTime, false, logConfig.initFileSize, logConfig.preallocate, CleanedFileSuffix)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.errors.{CorruptRecordException, KafkaStorageExcep
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter.BatchRetention
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.{BufferSupplier, Time}
+import org.apache.kafka.common.utils.{BufferSupplier, SystemTime, Time}
 import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.ShutdownableThread
@@ -100,7 +100,7 @@ class LogCleaner(initialConfig: CleanerConfig,
                  val logDirs: Seq[File],
                  val logs: Pool[TopicPartition, UnifiedLog],
                  val logDirFailureChannel: LogDirFailureChannel,
-                 time: Time = Time.SYSTEM) extends Logging with BrokerReconfigurable {
+                 time: Time = SystemTime.getSystemTime) extends Logging with BrokerReconfigurable {
   // Visible for test.
   private[log] val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
@@ -1162,7 +1162,7 @@ private class PreCleanStats {
 /**
  * A simple struct for collecting stats about log cleaning
  */
-private class CleanerStats(time: Time = Time.SYSTEM) {
+private class CleanerStats(time: Time = SystemTime.getSystemTime) {
   val startTime = time.milliseconds
   var mapCompleteTime: Long = -1L
   var endTime: Long = -1L

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -26,7 +26,7 @@ import kafka.utils.CoreUtils._
 import kafka.utils.{Logging, Pool}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime, Time}
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
@@ -110,7 +110,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
         uncleanablePartitions.get(dir.getAbsolutePath) match {
           case Some(partitions) =>
             val lastClean = allCleanerCheckpoints
-            val now = Time.SYSTEM.milliseconds
+            val now = SystemTime.getSystemTime.milliseconds
             partitions.iterator.map { tp =>
               Option(logs.get(tp)).map {
                 log =>
@@ -134,8 +134,8 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   metricsGroup.newGauge(MaxDirtyPercentMetricName, () => (100 * dirtiestLogCleanableRatio).toInt)
 
   /* a gauge for tracking the time since the last log cleaner run, in milli seconds */
-  @volatile private var timeOfLastRun: Long = Time.SYSTEM.milliseconds
-  metricsGroup.newGauge(TimeSinceLastRunMsMetricName, () => Time.SYSTEM.milliseconds - timeOfLastRun)
+  @volatile private var timeOfLastRun: Long = SystemTime.getSystemTime.milliseconds
+  metricsGroup.newGauge(TimeSinceLastRunMsMetricName, () => SystemTime.getSystemTime.milliseconds - timeOfLastRun)
 
   /**
    * @return the position processed for all logs.

--- a/core/src/main/scala/kafka/migration/MigrationPropagator.scala
+++ b/core/src/main/scala/kafka/migration/MigrationPropagator.scala
@@ -23,7 +23,7 @@ import kafka.server.KafkaConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.requests.AbstractControlRequest
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.image.{ClusterImage, MetadataDelta, MetadataImage, TopicsImage}
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.metadata.migration.LegacyPropagator
@@ -61,7 +61,7 @@ class MigrationPropagator(
   val channelManager = new ControllerChannelManager(
     () => _image.highestOffsetAndEpoch().epoch(),
     config,
-    Time.SYSTEM,
+    SystemTime.getSystemTime,
     new Metrics(),
     stateChangeLogger
   )

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.message.EnvelopeResponseData
 import org.apache.kafka.common.network.{ClientInformation, Send}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime, Time}
 import org.apache.kafka.network.Session
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
@@ -209,12 +209,12 @@ object RequestChannel extends Logging {
     trace(s"Processor $processor received request: ${requestDesc(true)}")
 
     def requestThreadTimeNanos: Long = {
-      if (apiLocalCompleteTimeNanos == -1L) apiLocalCompleteTimeNanos = Time.SYSTEM.nanoseconds
+      if (apiLocalCompleteTimeNanos == -1L) apiLocalCompleteTimeNanos = SystemTime.getSystemTime.nanoseconds
       math.max(apiLocalCompleteTimeNanos - requestDequeueTimeNanos, 0L)
     }
 
     def updateRequestMetrics(networkThreadTimeNanos: Long, response: Response): Unit = {
-      val endTimeNanos = Time.SYSTEM.nanoseconds
+      val endTimeNanos = SystemTime.getSystemTime.nanoseconds
 
       /**
        * Converts nanos to millis with micros precision as additional decimal places in the request log have low

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -43,11 +43,11 @@ import org.apache.kafka.common.network.{ChannelBuilder, ChannelBuilders, ClientI
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{ApiVersionsRequest, RequestContext, RequestHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.{KafkaThread, LogContext, Time, Utils}
+import org.apache.kafka.common.utils.{KafkaThread, LogContext, SystemTime, Time, Utils}
 import org.apache.kafka.common.{Endpoint, KafkaException, MetricName, Reconfigurable}
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.security.CredentialProvider
-import org.apache.kafka.server.config.{ServerConfigs, QuotaConfigs}
+import org.apache.kafka.server.config.{QuotaConfigs, ServerConfigs}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.FutureUtils
 import org.slf4j.event.Level
@@ -1332,7 +1332,7 @@ private[kafka] class Processor(
   private def dequeueResponse(): RequestChannel.Response = {
     val response = responseQueue.poll()
     if (response != null)
-      response.request.responseDequeueTimeNanos = Time.SYSTEM.nanoseconds
+      response.request.responseDequeueTimeNanos = SystemTime.getSystemTime.nanoseconds
     response
   }
 

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.errors.{ApiException, InvalidRequestException, Un
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.resource._
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.utils.{SecurityUtils, Time}
+import org.apache.kafka.common.utils.{SecurityUtils, SystemTime}
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.authorizer.AclDeleteResult.AclBindingDeleteResult
 import org.apache.kafka.server.authorizer._
@@ -205,7 +205,7 @@ class AclAuthorizer extends Authorizer with Logging {
     val zkMaxInFlightRequests = configs.get(AclAuthorizer.ZkMaxInFlightRequests).map(_.toString.trim.toInt).getOrElse(kafkaConfig.zkMaxInFlightRequests)
 
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(kafkaConfig, configs)
-    val time = Time.SYSTEM
+    val time = SystemTime.getSystemTime
     // createChrootIfNecessary=true is necessary in case we are running in a KRaft cluster
     // because such a cluster will not create any chroot path in ZooKeeper (it doesn't connect to ZooKeeper)
     zkClient = KafkaZkClient(zkUrl, kafkaConfig.zkEnableSecureAcls, zkSessionTimeOutMs, zkConnectionTimeoutMs,

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.security.CredentialProvider
@@ -115,7 +115,7 @@ trait KafkaBroker extends Logging {
   metricsGroup.newGauge("ClusterId", () => clusterId)
   metricsGroup.newGauge("yammer-metrics-count", () =>  KafkaYammerMetrics.defaultRegistry.allMetrics.size)
 
-  private val linuxIoMetricsCollector = new LinuxIoMetricsCollector("/proc", Time.SYSTEM, logger.underlying)
+  private val linuxIoMetricsCollector = new LinuxIoMetricsCollector("/proc", SystemTime.getSystemTime, logger.underlying)
 
   if (linuxIoMetricsCollector.usable()) {
     metricsGroup.newGauge("linux-disk-read-bytes", () => linuxIoMetricsCollector.readBytes())

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.errors.{TimeoutException, WakeupException}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
@@ -74,7 +74,7 @@ object MirrorMaker extends Logging {
   private var abortOnSendFailure: Boolean = true
   @volatile private var exitingOnSendFailure: Boolean = false
   private var lastSuccessfulCommitTime = -1L
-  private val time = Time.SYSTEM
+  private val time = SystemTime.getSystemTime
 
   // If a message send failed after retries are exhausted. The offset of the messages will also be removed from
   // the unacked offset list to avoid offset commit being stuck on that offset. In this case, the offset of that

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -32,10 +32,10 @@ import org.apache.kafka.common.metrics.stats.{Meter, Percentile, Percentiles}
 import org.apache.kafka.common.protocol.{ObjectSerializationCache, Writable}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.apache.kafka.common.{TopicPartition, Uuid, protocol}
 import org.apache.kafka.raft.errors.NotLeaderException
-import org.apache.kafka.raft.{Batch, BatchReader, LeaderAndEpoch, RaftClient, QuorumConfig}
+import org.apache.kafka.raft.{Batch, BatchReader, LeaderAndEpoch, QuorumConfig, RaftClient}
 import org.apache.kafka.security.CredentialProvider
 import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion}
 import org.apache.kafka.server.common.serialization.RecordSerde
@@ -61,7 +61,7 @@ class TestRaftServer(
   private val partition = new TopicPartition("__raft_performance_test", 0)
   // The topic ID must be constant. This value was chosen as to not conflict with the topic ID used for __cluster_metadata.
   private val topicId = new Uuid(0L, 2L)
-  private val time = Time.SYSTEM
+  private val time = SystemTime.getSystemTime
   private val metrics = new Metrics(time)
   private val shutdownLatch = new CountDownLatch(1)
   private val threadNamePrefix = "test-raft"

--- a/core/src/main/scala/kafka/utils/DelayedItem.scala
+++ b/core/src/main/scala/kafka/utils/DelayedItem.scala
@@ -18,14 +18,13 @@
 package kafka.utils
 
 import java.util.concurrent._
-
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime}
 
 import scala.math._
 
 class DelayedItem(val delayMs: Long) extends Delayed with Logging {
 
-  private val dueMs = Time.SYSTEM.milliseconds + delayMs
+  private val dueMs = SystemTime.getSystemTime.milliseconds + delayMs
 
   def this(delay: Long, unit: TimeUnit) = this(unit.toMillis(delay))
 
@@ -33,7 +32,7 @@ class DelayedItem(val delayMs: Long) extends Delayed with Logging {
    * The remaining delay time
    */
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(dueMs - Time.SYSTEM.milliseconds, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(dueMs - SystemTime.getSystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.token.delegation.TokenInformation
-import org.apache.kafka.common.utils.{SecurityUtils, SystemTime, Time}
+import org.apache.kafka.common.utils.{SecurityUtils, SystemTime}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.token.delegation.TokenInformation
-import org.apache.kafka.common.utils.{SecurityUtils, Time}
+import org.apache.kafka.common.utils.{SecurityUtils, SystemTime, Time}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
@@ -158,7 +158,7 @@ object BrokerIdZNode {
       PortKey -> port,
       EndpointsKey -> advertisedEndpoints.map(_.connectionString).toBuffer.asJava,
       JmxPortKey -> jmxPort,
-      TimestampKey -> Time.SYSTEM.milliseconds().toString
+      TimestampKey -> SystemTime.getSystemTime.milliseconds().toString
     )
     rack.foreach(rack => if (version >= 3) jsonMap += (RackKey -> rack))
 

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -29,8 +29,8 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.controller.Controller;
 import org.apache.kafka.metadata.bootstrap.BootstrapDirectory;
@@ -242,7 +242,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                     SharedServer sharedServer = new SharedServer(
                         createNodeConfig(node),
                         node.initialMetaPropertiesEnsemble(),
-                        Time.SYSTEM,
+                        SystemTime.getSystemTime(),
                         new Metrics(),
                         connectFutureManager.future,
                         Collections.emptyList(),
@@ -275,7 +275,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                         id -> new SharedServer(
                             createNodeConfig(node),
                             node.initialMetaPropertiesEnsemble(),
-                            Time.SYSTEM,
+                            SystemTime.getSystemTime(),
                             new Metrics(),
                             connectFutureManager.future,
                             Collections.emptyList(),

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -40,7 +40,7 @@ import org.apache.kafka.common.config.{ConfigResource, LogLevelConfig, SslConfig
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.requests.{DeleteRecordsRequest, MetadataResponse}
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.common.{ConsumerGroupState, ElectionType, TopicCollection, TopicPartition, TopicPartitionInfo, TopicPartitionReplica, Uuid}
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
@@ -1075,11 +1075,11 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, s"localhost:${TestUtils.IncorrectBrokerPort}")
     config.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "0")
     client = Admin.create(config)
-    val startTimeMs = Time.SYSTEM.milliseconds()
+    val startTimeMs = SystemTime.getSystemTime.milliseconds()
     val future = client.createTopics(Seq("mytopic", "mytopic2").map(new NewTopic(_, 1, 1.toShort)).asJava,
       new CreateTopicsOptions().timeoutMs(2)).all()
     assertFutureExceptionTypeEquals(future, classOf[TimeoutException])
-    val endTimeMs = Time.SYSTEM.milliseconds()
+    val endTimeMs = SystemTime.getSystemTime.milliseconds()
     assertTrue(endTimeMs > startTimeMs, "Expected the timeout to take at least one millisecond.")
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.authenticator.LoginManager
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.config.ConfigType
 import org.apache.zookeeper.client.ZKClientConfig
 
@@ -203,7 +203,7 @@ trait SaslSetup {
     val zkClientConfig = new ZKClientConfig()
     Using(KafkaZkClient(
       zkConnect, JaasUtils.isZkSaslEnabled || KafkaConfig.zkTlsClientAuthEnabled(zkClientConfig), 30000, 30000,
-      Int.MaxValue, Time.SYSTEM, name = "SaslSetup", zkClientConfig = zkClientConfig, enableEntityConfigControllerCheck = false)) { zkClient =>
+      Int.MaxValue, SystemTime.getSystemTime, name = "SaslSetup", zkClientConfig = zkClientConfig, enableEntityConfigControllerCheck = false)) { zkClient =>
       val adminZkClient = new AdminZkClient(zkClient)
 
       val entityType = ConfigType.USER

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.metadata.FeatureLevelRecord
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.{Exit, Time}
+import org.apache.kafka.common.utils.{Exit, SystemTime, Time}
 import org.apache.kafka.common.{DirectoryId, Uuid}
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata
 import org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.VerificationFlag.{REQUIRE_AT_LEAST_ONE_VALID, REQUIRE_METADATA_LOG_DIR}
@@ -54,7 +54,7 @@ import scala.compat.java8.OptionConverters._
 trait QuorumImplementation {
   def createBroker(
     config: KafkaConfig,
-    time: Time = Time.SYSTEM,
+    time: Time = SystemTime.getSystemTime,
     startup: Boolean = true,
     threadNamePrefix: Option[String] = None,
   ): KafkaBroker
@@ -297,7 +297,7 @@ abstract class QuorumTestHarness extends Logging {
 
   def createBroker(
     config: KafkaConfig,
-    time: Time = Time.SYSTEM,
+    time: Time = SystemTime.getSystemTime,
     startup: Boolean = true,
     threadNamePrefix: Option[String] = None
   ): KafkaBroker = {
@@ -377,7 +377,7 @@ abstract class QuorumTestHarness extends Logging {
     val sharedServer = new SharedServer(
       config,
       metaPropertiesEnsemble,
-      Time.SYSTEM,
+      SystemTime.getSystemTime,
       new Metrics(),
       controllerQuorumVotersFuture,
       Collections.emptyList(),
@@ -430,7 +430,7 @@ abstract class QuorumTestHarness extends Logging {
         zkSessionTimeout,
         zkConnectionTimeout,
         zkMaxInFlightRequests,
-        Time.SYSTEM,
+        SystemTime.getSystemTime,
         name = "ZooKeeperTestHarness",
         new ZKClientConfig,
         enableEntityConfigControllerCheck = false)

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationFailoverTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationFailoverTest.scala
@@ -19,7 +19,7 @@ package kafka.zk
 import kafka.utils.{Logging, TestUtils}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.metadata.{FeatureLevelRecord, TopicRecord}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.controller.QuorumFeatures
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics
 import org.apache.kafka.image.loader.LogDeltaManifest
@@ -90,8 +90,8 @@ class ZkMigrationFailoverTest extends Logging {
       .setFaultHandler(faultHandler)
       .setQuorumFeatures(new QuorumFeatures(nodeId, QuorumFeatures.defaultFeatureMap(true), util.Arrays.asList(3000, 3001, 3002)))
       .setConfigSchema(KafkaConfigSchema.EMPTY)
-      .setControllerMetrics(new QuorumControllerMetrics(Optional.empty(), Time.SYSTEM, true))
-      .setTime(Time.SYSTEM)
+      .setControllerMetrics(new QuorumControllerMetrics(Optional.empty(), SystemTime.getSystemTime, true))
+      .setTime(SystemTime.getSystemTime)
       .setPropagator(new LegacyPropagator() {
         override def startup(): Unit = ???
 
@@ -133,7 +133,7 @@ class ZkMigrationFailoverTest extends Logging {
         30000,
         60000,
         1,
-        Time.SYSTEM,
+        SystemTime.getSystemTime,
         name = "ZkMigrationFailoverTest",
         new ZKClientConfig)
     } catch {

--- a/core/src/test/scala/other/kafka/TestLinearWriteSpeed.scala
+++ b/core/src/test/scala/other/kafka/TestLinearWriteSpeed.scala
@@ -29,7 +29,7 @@ import kafka.utils._
 import org.apache.kafka.common.compress.{Compression, GzipCompression, Lz4Compression, ZstdCompression}
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.server.util.{KafkaScheduler, Scheduler}
 import org.apache.kafka.server.util.CommandLineUtils
@@ -234,7 +234,7 @@ object TestLinearWriteSpeed {
       recoveryPoint = 0L,
       scheduler = scheduler,
       brokerTopicStats = new BrokerTopicStats,
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       maxTransactionTimeoutMs = 5 * 60 * 1000,
       producerStateManagerConfig = new ProducerStateManagerConfig(TransactionLogConfigs.PRODUCER_ID_EXPIRATION_MS_DEFAULT, false),
       producerIdExpirationCheckIntervalMs = TransactionLogConfigs.PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_DEFAULT,

--- a/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
+++ b/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
@@ -23,7 +23,7 @@ import java.util.Random
 import java.util.concurrent._
 import joptsimple._
 import kafka.server.{DelayedOperation, DelayedOperationPurgatory}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.util.{CommandLineUtils, ShutdownableThread}
 
 import scala.math._
@@ -275,7 +275,7 @@ object TestPurgatoryPerformance {
 
     private class Scheduled(val operation: FakeOperation) extends Delayed {
       def getDelay(unit: TimeUnit): Long = {
-        unit.convert(max(operation.completesAt - Time.SYSTEM.milliseconds, 0), TimeUnit.MILLISECONDS)
+        unit.convert(max(operation.completesAt - SystemTime.getSystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
       }
 
       def compareTo(d: Delayed): Int = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2913,7 +2913,7 @@ class PartitionTest extends AbstractPartitionTest {
     val topicPartition = new TopicPartition("test", 1)
     val partition = new Partition(
       topicPartition, 1000, MetadataVersion.latestTesting, 0, () => defaultBrokerEpoch(0),
-      new SystemTime(), mock(classOf[AlterPartitionListener]), mock(classOf[DelayedOperations]),
+      SystemTime.getSystemTime, mock(classOf[AlterPartitionListener]), mock(classOf[DelayedOperations]),
       mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterPartitionManager]))
 
     val replicas = Seq(0, 1, 2, 3)

--- a/core/src/test/scala/unit/kafka/common/ZkNodeChangeNotificationListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/common/ZkNodeChangeNotificationListenerTest.scala
@@ -64,7 +64,7 @@ class ZkNodeChangeNotificationListenerTest extends QuorumTestHarness {
     /*
      * There is no easy way to test purging. Even if we mock kafka time with MockTime, the purging compares kafka time
      * with the time stored in ZooKeeper stat and the embedded ZooKeeper server does not provide a way to mock time.
-     * So to test purging we would have to use Time.SYSTEM.sleep(changeExpirationMs + 1) issue a write and check
+     * So to test purging we would have to use SystemTime.getSystemTime.sleep(changeExpirationMs + 1) issue a write and check
      * Assert.assertEquals(1, KafkaZkClient.getChildren(seqNodeRoot).size). However even that the assertion
      * can fail as the second node can be deleted depending on how threads get scheduled.
      */

--- a/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
@@ -23,7 +23,7 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException
 import org.apache.kafka.common.record.{ControlRecordType, EndTransactionMarker, FileRecords, MemoryRecords, RecordBatch, SimpleRecord}
 import org.apache.kafka.common.requests.TransactionResult
-import org.apache.kafka.common.utils.{MockTime, Time}
+import org.apache.kafka.common.utils.{MockTime, SystemTime}
 import org.apache.kafka.coordinator.group.runtime.CoordinatorLoader.UnknownRecordTypeException
 import org.apache.kafka.coordinator.group.runtime.{CoordinatorPlayback, Deserializer}
 import org.apache.kafka.storage.internals.log.{FetchDataInfo, FetchIsolation, LogOffsetMetadata}
@@ -59,7 +59,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -79,7 +79,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -100,7 +100,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -203,7 +203,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -246,7 +246,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -286,7 +286,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -327,7 +327,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -414,7 +414,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -489,7 +489,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -515,7 +515,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000
@@ -591,7 +591,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
     Using(new CoordinatorLoaderImpl[(String, String)](
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       replicaManager = replicaManager,
       deserializer = serde,
       loadBufferSize = 1000

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{OffsetFetchResponse, RequestContext, RequestHeader}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.apache.kafka.common.utils.{BufferSupplier, Time}
+import org.apache.kafka.common.utils.{BufferSupplier, SystemTime}
 import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.test.TestUtils.assertFutureThrows
@@ -65,7 +65,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testJoinConsumerGroup(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.CONSUMER_GROUP_HEARTBEAT, ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion)
     val request = new ConsumerGroupHeartbeatRequestData()
@@ -82,7 +82,7 @@ class GroupCoordinatorAdapterTest {
   @ApiKeyVersionsSource(apiKey = ApiKeys.JOIN_GROUP)
   def testJoinGroup(version: Short): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.JOIN_GROUP, version)
     val request = new JoinGroupRequestData()
@@ -170,7 +170,7 @@ class GroupCoordinatorAdapterTest {
   @ApiKeyVersionsSource(apiKey = ApiKeys.SYNC_GROUP)
   def testSyncGroup(version: Short): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.SYNC_GROUP, version)
     val data = new SyncGroupRequestData()
@@ -237,7 +237,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testHeartbeat(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.HEARTBEAT, ApiKeys.HEARTBEAT.latestVersion)
     val data = new HeartbeatRequestData()
@@ -268,7 +268,7 @@ class GroupCoordinatorAdapterTest {
 
   def testLeaveGroup(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.LEAVE_GROUP, ApiKeys.LEAVE_GROUP.latestVersion)
     val data = new LeaveGroupRequestData()
@@ -340,7 +340,7 @@ class GroupCoordinatorAdapterTest {
     expectedTypesFilter: Set[String]
   ): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.LIST_GROUPS, ApiKeys.LIST_GROUPS.latestVersion)
     val data = new ListGroupsRequestData()
@@ -379,7 +379,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testDescribeGroup(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val groupId1 = "group-1"
     val groupId2 = "group-2"
@@ -436,7 +436,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testDeleteGroups(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val ctx = makeContext(ApiKeys.DELETE_GROUPS, ApiKeys.DELETE_GROUPS.latestVersion)
     val groupIds = List("group-1", "group-2", "group-3")
@@ -475,7 +475,7 @@ class GroupCoordinatorAdapterTest {
     val bar1 = new TopicPartition("bar", 1)
 
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     when(groupCoordinator.handleFetchOffsets(
       "group",
@@ -557,7 +557,7 @@ class GroupCoordinatorAdapterTest {
     val bar1 = new TopicPartition("bar", 1)
 
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     when(groupCoordinator.handleFetchOffsets(
       "group",
@@ -786,7 +786,7 @@ class GroupCoordinatorAdapterTest {
 
   def testDeleteOffsets(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val foo0 = new TopicPartition("foo", 0)
     val foo1 = new TopicPartition("foo", 1)
@@ -859,7 +859,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testDeleteOffsetsWithGroupLevelError(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
 
     val foo0 = new TopicPartition("foo", 0)
     val foo1 = new TopicPartition("foo", 1)
@@ -892,7 +892,7 @@ class GroupCoordinatorAdapterTest {
   @Test
   def testConsumerGroupDescribe(): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator, SystemTime.getSystemTime)
     val context = makeContext(ApiKeys.CONSUMER_GROUP_DESCRIBE, ApiKeys.CONSUMER_GROUP_DESCRIBE.latestVersion)
     val groupIds = List("group-id-1", "group-id-2").asJava
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{JoinGroupRequest, OffsetFetchResponse}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
@@ -290,7 +290,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     }
     override def runWithCallback(member: GroupMember, responseCallback: CommitOffsetCallback): Unit = {
       val tip = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
-      val offsets = immutable.Map(tip -> OffsetAndMetadata(1, "", Time.SYSTEM.milliseconds()))
+      val offsets = immutable.Map(tip -> OffsetAndMetadata(1, "", SystemTime.getSystemTime.milliseconds()))
       groupCoordinator.handleCommitOffsets(member.groupId, member.memberId,
         member.groupInstanceId, member.generationId, offsets, responseCallback)
       replicaManager.tryCompleteActions()
@@ -303,7 +303,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
 
   class CommitTxnOffsetsOperation(lock: Option[Lock] = None) extends CommitOffsetsOperation {
     override def runWithCallback(member: GroupMember, responseCallback: CommitOffsetCallback): Unit = {
-      val offsets = immutable.Map(new TopicIdPartition(Uuid.randomUuid(), 0, "topic") -> OffsetAndMetadata(1, "", Time.SYSTEM.milliseconds()))
+      val offsets = immutable.Map(new TopicIdPartition(Uuid.randomUuid(), 0, "topic") -> OffsetAndMetadata(1, "", SystemTime.getSystemTime.milliseconds()))
       val producerId = 1000L
       val producerEpoch : Short = 2
       // When transaction offsets are appended to the log, transactions may be scheduled for

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.utils.{MockTime, Time}
+import org.apache.kafka.common.utils.{MockTime, SystemTime}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test}
 
@@ -44,7 +44,7 @@ class GroupMetadataTest {
 
   @BeforeEach
   def setUp(): Unit = {
-    group = new GroupMetadata("groupId", Empty, Time.SYSTEM)
+    group = new GroupMetadata("groupId", Empty, SystemTime.getSystemTime)
   }
 
   @Test
@@ -858,7 +858,7 @@ class GroupMetadataTest {
     assertTrue(group.is(targetState))
   }
 
-  private def offsetAndMetadata(offset: Long, timestamp: Long = Time.SYSTEM.milliseconds()): OffsetAndMetadata = {
+  private def offsetAndMetadata(offset: Long, timestamp: Long = SystemTime.getSystemTime.milliseconds()): OffsetAndMetadata = {
     OffsetAndMetadata(offset, "", timestamp)
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.errors.CoordinatorLoadInProgressException
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.AllocateProducerIdsResponse
-import org.apache.kafka.common.utils.{MockTime, Time}
+import org.apache.kafka.common.utils.{MockTime, SystemTime, Time}
 import org.apache.kafka.server.NodeToControllerChannelManager
 import org.apache.kafka.server.common.ProducerIdsBlock
 import org.junit.jupiter.api.Assertions._
@@ -52,7 +52,7 @@ class ProducerIdManagerTest {
     val idLen: Int,
     val errorQueue: ConcurrentLinkedQueue[Errors] = new ConcurrentLinkedQueue[Errors](),
     val isErroneousBlock: Boolean = false,
-    val time: Time = Time.SYSTEM
+    val time: Time = SystemTime.getSystemTime
   ) extends RPCProducerIdManager(brokerId, time, () => 1, brokerToController) {
 
     private val brokerToControllerRequestExecutor = Executors.newSingleThreadExecutor()

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.scram.ScramCredential
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime, Time}
 import org.apache.kafka.common.{KafkaException, Uuid}
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -110,7 +110,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
   protected def trustStoreFile: Option[File] = None
   protected def serverSaslProperties: Option[Properties] = None
   protected def clientSaslProperties: Option[Properties] = None
-  protected def brokerTime(brokerId: Int): Time = Time.SYSTEM
+  protected def brokerTime(brokerId: Int): Time = SystemTime.getSystemTime
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {

--- a/core/src/test/scala/unit/kafka/log/LogConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConcurrencyTest.scala
@@ -23,7 +23,7 @@ import kafka.server.BrokerTopicStats
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.record.SimpleRecord
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.server.util.KafkaScheduler
 import org.apache.kafka.storage.internals.log.{FetchIsolation, LogConfig, LogDirFailureChannel, ProducerStateManagerConfig}
@@ -150,7 +150,7 @@ class LogConcurrencyTest {
       recoveryPoint = 0L,
       scheduler = scheduler,
       brokerTopicStats = brokerTopicStats,
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       maxTransactionTimeoutMs = 5 * 60 * 1000,
       producerStateManagerConfig = new ProducerStateManagerConfig(TransactionLogConfigs.PRODUCER_ID_EXPIRATION_MS_DEFAULT, false),
       producerIdExpirationCheckIntervalMs = TransactionLogConfigs.PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_DEFAULT,

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.message.LeaderAndIsrRequestData
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrTopicState
 import org.apache.kafka.common.requests.{AbstractControlRequest, LeaderAndIsrRequest}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.common.{DirectoryId, KafkaException, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.image.{TopicImage, TopicsImage}
@@ -1370,7 +1370,7 @@ class LogManagerTest {
       producerStateManagerConfig = new ProducerStateManagerConfig(TransactionLogConfigs.PRODUCER_ID_EXPIRATION_MS_DEFAULT, false),
       producerIdExpirationCheckIntervalMs = TransactionLogConfigs.PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_DEFAULT,
       scheduler = scheduler,
-      time = Time.SYSTEM,
+      time = SystemTime.getSystemTime,
       brokerTopicStats = new BrokerTopicStats,
       logDirFailureChannel = new LogDirFailureChannel(1),
       keepPartitionMetadataFile = true,

--- a/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
@@ -19,7 +19,7 @@ package kafka.log
 import java.io.File
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.apache.kafka.storage.internals.log.{LogSegment, LogSegments}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
@@ -38,7 +38,7 @@ class LogSegmentsTest {
   /* create a segment with the given base offset */
   private def createSegment(offset: Long,
                     indexIntervalBytes: Int = 10,
-                    time: Time = Time.SYSTEM): LogSegment = {
+                    time: Time = SystemTime.getSystemTime): LogSegment = {
     LogTestUtils.createSegment(offset, logDir, indexIntervalBytes, time)
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
@@ -26,7 +26,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.record.{ControlRecordType, EndTransactionMarker, FileRecords, MemoryRecords, RecordBatch, SimpleRecord}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
 
 import java.nio.file.Files
@@ -47,7 +47,7 @@ object LogTestUtils {
   def createSegment(offset: Long,
                     logDir: File,
                     indexIntervalBytes: Int = 10,
-                    time: Time = Time.SYSTEM): LogSegment = {
+                    time: Time = SystemTime.getSystemTime): LogSegment = {
     val ms = FileRecords.open(LogFileUtils.logFile(logDir, offset))
     val idx = LazyIndex.forOffset(LogFileUtils.offsetIndexFile(logDir, offset), offset, 1000)
     val timeIdx = LazyIndex.forTime(LogFileUtils.timeIndexFile(logDir, offset), offset, 1500)

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -23,7 +23,7 @@ import kafka.utils.TestUtils.meterCount
 import org.apache.kafka.common.compress.{Compression, GzipCompression, Lz4Compression}
 import org.apache.kafka.common.errors.{InvalidTimestampException, UnsupportedCompressionTypeException, UnsupportedForMessageFormatException}
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.{PrimitiveRef, Time}
+import org.apache.kafka.common.utils.{PrimitiveRef, SystemTime}
 import org.apache.kafka.common.{InvalidRecordException, TopicPartition}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.storage.internals.log.LogValidator.ValidationResult
@@ -38,7 +38,7 @@ import scala.jdk.CollectionConverters._
 
 class LogValidatorTest {
 
-  val time = Time.SYSTEM
+  val time = SystemTime.getSystemTime
   val topicPartition = new TopicPartition("topic", 0)
   val metricsKeySet = KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala
   val metricsRecorder = UnifiedLog.newValidatorMetricsRecorder(new BrokerTopicStats().allTopicsStats)

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse}
-import org.apache.kafka.common.utils.{BufferSupplier, Time, Utils}
+import org.apache.kafka.common.utils.{BufferSupplier, SystemTime, Time, Utils}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
@@ -4256,8 +4256,8 @@ class UnifiedLogTest {
     val log = createLog(logDir, LogTestUtils.createLogConfig())
 
     val segments: java.util.List[LogSegment] = new java.util.ArrayList[LogSegment]()
-    val seg1 = LogTestUtils.createSegment(1, logDir, 10, Time.SYSTEM)
-    val seg2 = LogTestUtils.createSegment(2, logDir, 10, Time.SYSTEM)
+    val seg1 = LogTestUtils.createSegment(1, logDir, 10, SystemTime.getSystemTime)
+    val seg2 = LogTestUtils.createSegment(2, logDir, 10, SystemTime.getSystemTime)
     segments.add(seg1)
     segments.add(seg2)
     assertEquals(Seq(Long.MaxValue, Long.MaxValue), log.getFirstBatchTimestampForSegments(segments).asScala.toSeq)

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -31,7 +31,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.metrics.JmxReporter
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
@@ -110,7 +110,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
   def testLinuxIoMetrics(quorum: String): Unit = {
     // Check if linux-disk-{read,write}-bytes metrics either do or do not exist depending on whether we are or are not
     // able to collect those metrics on the platform where this test is running.
-    val usable = new LinuxIoMetricsCollector("/proc", Time.SYSTEM, logger.underlying).usable()
+    val usable = new LinuxIoMetricsCollector("/proc", SystemTime.getSystemTime, logger.underlying).usable()
     val expectedCount = if (usable) 1 else 0
     val metrics = KafkaYammerMetrics.defaultRegistry.allMetrics
     Set("linux-disk-read-bytes", "linux-disk-write-bytes").foreach(name =>

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -30,9 +30,9 @@ import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.metrics.internals.MetricsUtils
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Metrics}
 import org.apache.kafka.common.network._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SystemTime, Time}
 import org.apache.kafka.network.SocketServerConfigs
-import org.apache.kafka.server.config.{ReplicationConfigs, QuotaConfigs}
+import org.apache.kafka.server.config.{QuotaConfigs, ReplicationConfigs}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.MockTime
 import org.junit.jupiter.api.Assertions._
@@ -78,7 +78,7 @@ class ConnectionQuotasTest {
   }
 
   private def setupMockTime(): Unit = {
-    // clean up metrics initialized with Time.SYSTEM
+    // clean up metrics initialized with SystemTime.getSystemTime
     metrics.close()
     time = new MockTime()
     metrics = new Metrics(time)
@@ -95,7 +95,7 @@ class ConnectionQuotasTest {
     }
     // use system time, because ConnectionQuota causes the current thread to wait with timeout, which waits based on
     // system time; so using mock time will likely result in test flakiness due to a mixed use of mock and system time
-    time = Time.SYSTEM
+    time = SystemTime.getSystemTime
     metrics = new Metrics(new MetricConfig(), Collections.emptyList(), time)
     executor = Executors.newFixedThreadPool(listeners.size)
   }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -94,7 +94,7 @@ class SocketServerTest {
 
   @BeforeEach
   def setUp(): Unit = {
-    server = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+    server = new SocketServer(config, metrics, SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     server.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
     // Run the tests with TRACE logging to exercise request logging path
     logLevelToRestore = kafkaLogger.getLevel
@@ -867,7 +867,7 @@ class SocketServerTest {
     newProps.setProperty(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG, "0")
     newProps.setProperty(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, "%s:%s".format("127.0.0.1", "5"))
     val server = new SocketServer(KafkaConfig.fromProps(newProps), new Metrics(),
-      Time.SYSTEM, credentialProvider, apiVersionManager)
+      SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       server.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
       // make the maximum allowable number of connections
@@ -906,7 +906,7 @@ class SocketServerTest {
     overrideProps.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$overrideNum")
     val serverMetrics = new Metrics()
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), serverMetrics,
-      Time.SYSTEM, credentialProvider, apiVersionManager)
+      SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       overrideServer.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
       // make the maximum allowable number of connections
@@ -932,7 +932,7 @@ class SocketServerTest {
     val serverMetrics = new Metrics()
 
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics,
-      Time.SYSTEM, credentialProvider, apiVersionManager) {
+      SystemTime.getSystemTime, credentialProvider, apiVersionManager) {
 
       // same as SocketServer.createAcceptor,
       // except the Acceptor overriding a method to inject the exception
@@ -1041,7 +1041,7 @@ class SocketServerTest {
   def testSslSocketServer(): Unit = {
     val serverMetrics = new Metrics
     val overrideServer = new SocketServer(KafkaConfig.fromProps(sslServerProps), serverMetrics,
-      Time.SYSTEM, credentialProvider, apiVersionManager)
+      SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       overrideServer.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
       val sslContext = SSLContext.getInstance(TestSslUtils.DEFAULT_TLS_PROTOCOL_FOR_TESTS)
@@ -1251,7 +1251,7 @@ class SocketServerTest {
     val serverMetrics = new Metrics
     var conn: Socket = null
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics,
-      Time.SYSTEM, credentialProvider, apiVersionManager)
+      SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       overrideServer.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
       conn = connect(overrideServer)
@@ -1996,7 +1996,7 @@ class SocketServerTest {
   @Test
   def testAuthorizerFailureCausesEnableRequestProcessingFailure(): Unit = {
     shutdownServerAndMetrics(server)
-    val newServer = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+    val newServer = new SocketServer(config, metrics, SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       val failedFuture = new CompletableFuture[Void]()
       failedFuture.completeExceptionally(new RuntimeException("authorizer startup failed"))
@@ -2011,7 +2011,7 @@ class SocketServerTest {
   @Test
   def testFailedAcceptorStartupCausesEnableRequestProcessingFailure(): Unit = {
     shutdownServerAndMetrics(server)
-    val newServer = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+    val newServer = new SocketServer(config, metrics, SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       newServer.dataPlaneAcceptors.values().forEach(a => a.shouldRun.set(false))
       assertThrows(classOf[ExecutionException], () => {
@@ -2025,7 +2025,7 @@ class SocketServerTest {
   @Test
   def testAcceptorStartOpensPortIfNeeded(): Unit = {
     shutdownServerAndMetrics(server)
-    val newServer = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+    val newServer = new SocketServer(config, metrics, SystemTime.getSystemTime, credentialProvider, apiVersionManager)
     try {
       newServer.dataPlaneAcceptors.values().forEach(a => {
         a.serverChannel.close()
@@ -2205,7 +2205,7 @@ class SocketServerTest {
   class TestableSocketServer(
     config : KafkaConfig = KafkaConfig.fromProps(props),
     connectionQueueSize: Int = 20,
-    time: Time = Time.SYSTEM
+    time: Time = SystemTime.getSystemTime
   ) extends SocketServer(
     config, new Metrics, time, credentialProvider, apiVersionManager,
   ) {

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -28,10 +28,10 @@ import kafka.tools.TestRaftServer.ByteArraySerde
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
-import org.apache.kafka.server.config.{KRaftConfigs, ServerConfigs, ReplicationConfigs, ServerLogConfigs, ZkConfigs}
+import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerConfigs, ServerLogConfigs, ZkConfigs}
 import org.apache.kafka.server.ProcessRole
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
@@ -114,8 +114,8 @@ class RaftManagerTest {
       new ByteArraySerde,
       topicPartition,
       topicId,
-      Time.SYSTEM,
-      new Metrics(Time.SYSTEM),
+      SystemTime.getSystemTime,
+      new Metrics(SystemTime.getSystemTime),
       Option.empty,
       CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumVoters)),
       QuorumConfig.parseBootstrapServers(config.quorumBootstrapServers),

--- a/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
@@ -18,7 +18,6 @@
 package kafka.security.auth
 
 import java.nio.charset.StandardCharsets
-
 import kafka.admin.ZkSecurityMigrator
 import kafka.server.QuorumTestHarness
 import kafka.utils.{Logging, TestUtils}
@@ -35,7 +34,7 @@ import kafka.cluster.{Broker, EndPoint}
 import kafka.controller.ReplicaAssignment
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.zookeeper.client.ZKClientConfig
 
@@ -140,7 +139,7 @@ class ZkAuthorizationTest extends QuorumTestHarness with Logging {
     (securityProtocol), securityProtocol)), rack = rack), MetadataVersion.latestTesting, jmxPort = port + 10)
 
   private def newKafkaZkClient(connectionString: String, isSecure: Boolean) =
-    KafkaZkClient(connectionString, isSecure, 6000, 6000, Int.MaxValue, Time.SYSTEM, "ZkAuthorizationTest",
+    KafkaZkClient(connectionString, isSecure, 6000, 6000, Int.MaxValue, SystemTime.getSystemTime, "ZkAuthorizationTest",
       new ZKClientConfig)
 
   /**

--- a/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerInterfaceDefaultTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerInterfaceDefaultTest.scala
@@ -24,7 +24,7 @@ import kafka.server.QuorumTestHarness
 import kafka.zookeeper.ZooKeeperClient
 import org.apache.kafka.common.Endpoint
 import org.apache.kafka.common.acl._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.authorizer._
 import org.apache.zookeeper.client.ZKClientConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -49,7 +49,7 @@ class AuthorizerInterfaceDefaultTest extends QuorumTestHarness with BaseAuthoriz
     interfaceDefaultAuthorizer.authorizer.configure(config.originals)
 
     zooKeeperClient = new ZooKeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, zkMaxInFlightRequests,
-      Time.SYSTEM, "kafka.test", "AuthorizerInterfaceDefaultTest", new ZKClientConfig,
+      SystemTime.getSystemTime, "kafka.test", "AuthorizerInterfaceDefaultTest", new ZKClientConfig,
       "AuthorizerInterfaceDefaultTest")
   }
 

--- a/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.resource.ResourcePattern.WILDCARD_RESOURCE
 import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.apache.kafka.common.utils.{Time, SecurityUtils => JSecurityUtils}
+import org.apache.kafka.common.utils.{SystemTime, SecurityUtils => JSecurityUtils}
 import org.apache.kafka.controller.MockAclMutator
 import org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.AuthorizerTestServerInfo
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
@@ -100,7 +100,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
 
     if (!TestInfoUtils.isKRaft(testInfo)) {
       zooKeeperClient = new ZooKeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, zkMaxInFlightRequests,
-        Time.SYSTEM, "kafka.test", "AclAuthorizerTest", new ZKClientConfig, "AclAuthorizerTest")
+        SystemTime.getSystemTime, "kafka.test", "AclAuthorizerTest", new ZKClientConfig, "AclAuthorizerTest")
       // Increase maxUpdateRetries to avoid transient failures
       authorizer1.asInstanceOf[AclAuthorizer].maxUpdateRetries = Int.MaxValue
       authorizer2.asInstanceOf[AclAuthorizer].maxUpdateRetries = Int.MaxValue

--- a/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
@@ -18,7 +18,6 @@
 package kafka.server
 
 import java.util.Collections
-
 import kafka.api.LeaderAndIsr
 import kafka.cluster.Broker
 import kafka.controller.{ControllerChannelManager, ControllerContext, StateChangeLogger}
@@ -34,7 +33,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -135,7 +134,7 @@ class BrokerEpochIntegrationTest extends QuorumTestHarness {
     val controllerChannelManager = new ControllerChannelManager(
       () => controllerContext.epoch,
       controllerConfig,
-      Time.SYSTEM,
+      SystemTime.getSystemTime,
       metrics,
       new StateChangeLogger(controllerId, inControllerContext = true, None)
     )

--- a/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.common.{Node, Uuid}
 import org.apache.kafka.server.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.common.MetadataVersion
@@ -67,7 +67,7 @@ class BrokerRegistrationRequestTest {
         override def getControllerInfo(): ControllerInformation =
           ControllerInformation(node, listenerName, securityProtocol, saslMechanism, isZkController)
       },
-      Time.SYSTEM,
+      SystemTime.getSystemTime,
       new Metrics(),
       clusterInstance.anyControllerSocketServer().config,
       "heartbeat",

--- a/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.common.message.ControllerRegistrationResponseData
 import org.apache.kafka.common.metadata.{FeatureLevelRecord, RegisterControllerRecord}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.ControllerRegistrationResponse
-import org.apache.kafka.common.utils.{ExponentialBackoff, Time}
+import org.apache.kafka.common.utils.{ExponentialBackoff, SystemTime}
 import org.apache.kafka.image.loader.{LogDeltaManifest, SnapshotManifest}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.{ListenerInfo, RecordTestUtils, VersionRange}
@@ -72,7 +72,7 @@ class ControllerRegistrationManagerTest {
   ): ControllerRegistrationManager = {
     new ControllerRegistrationManager(context.config.nodeId,
       context.clusterId,
-      Time.SYSTEM,
+      SystemTime.getSystemTime,
       "controller-registration-manager-test-",
       createSupportedFeatures(MetadataVersion.IBP_3_7_IV0),
       false,

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
 class LeaderElectionTest extends QuorumTestHarness {
@@ -142,7 +142,7 @@ class LeaderElectionTest extends QuorumTestHarness {
     val controllerChannelManager = new ControllerChannelManager(
       () => controllerContext.epoch,
       controllerConfig,
-      Time.SYSTEM,
+      SystemTime.getSystemTime,
       metrics,
       new StateChangeLogger(controllerId, inControllerContext = true, None)
     )

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -23,7 +23,7 @@ import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartit
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.storage.internals.log.{LogSegment, LogStartOffsetIncrementReason}
 import org.junit.jupiter.api.Assertions._
@@ -221,7 +221,7 @@ class LogOffsetTest extends BaseRequestTest {
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)
     log.flush(false)
 
-    val now = Time.SYSTEM.milliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
+    val now = SystemTime.getSystemTime.milliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
 
     val offsets = log.legacyFetchOffsetsBefore(now, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)

--- a/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
+++ b/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
@@ -20,7 +20,7 @@ package kafka.server
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET
 import org.apache.kafka.common.requests.FetchResponse
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.storage.internals.log.LogAppendInfo
@@ -107,7 +107,7 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
       lastEpoch,
       maxTimestamp,
       shallowOffsetOfMaxTimestamp,
-      Time.SYSTEM.milliseconds(),
+      SystemTime.getSystemTime.milliseconds(),
       state.logStartOffset,
       RecordValidationStats.EMPTY,
       CompressionType.NONE,

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -168,7 +168,7 @@ class ReplicaFetcherThreadTest {
       t1p1 -> newOffsetForLeaderPartitionResult(t1p1, leaderEpoch, 1)).asJava
 
     //Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, SystemTime.getSystemTime)
 
     val thread = createReplicaFetcherThread(
       "bob",
@@ -317,7 +317,7 @@ class ReplicaFetcherThreadTest {
       t1p1 -> newOffsetForLeaderPartitionResult(t1p1, leaderEpoch, 1)).asJava
 
     //Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -383,7 +383,7 @@ class ReplicaFetcherThreadTest {
       t2p1 -> newOffsetForLeaderPartitionResult(t2p1, leaderEpoch, 172)).asJava
 
     //Create the thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -443,7 +443,7 @@ class ReplicaFetcherThreadTest {
       t2p1 -> newOffsetForLeaderPartitionResult(t2p1, leaderEpochAtLeader, 202)).asJava
 
     //Create the thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -506,7 +506,7 @@ class ReplicaFetcherThreadTest {
       t1p1 -> newOffsetForLeaderPartitionResult(t1p1, 4, 143)).asJava
 
     // Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -584,7 +584,7 @@ class ReplicaFetcherThreadTest {
     stub(partition, replicaManager, log)
 
     // Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(Collections.emptyMap(), brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(Collections.emptyMap(), brokerEndPoint, SystemTime.getSystemTime)
     val logContext = new LogContext(s"[ReplicaFetcher replicaId=${config.brokerId}, leaderId=${brokerEndPoint.id}, fetcherId=0] ")
     val fetchSessionHandler = new FetchSessionHandler(logContext, brokerEndPoint.id)
     val leader = new RemoteLeaderEndPoint(logContext.logPrefix, mockNetwork, fetchSessionHandler, config,
@@ -694,7 +694,7 @@ class ReplicaFetcherThreadTest {
     val mockNetwork = new MockBlockingSender(
       Collections.emptyMap(),
       brokerEndPoint,
-      new SystemTime()
+      SystemTime.getSystemTime
     )
 
     val leader = new RemoteLeaderEndPoint(
@@ -787,7 +787,7 @@ class ReplicaFetcherThreadTest {
     val mockNetwork = new MockBlockingSender(
       Collections.emptyMap(),
       brokerEndPoint,
-      new SystemTime()
+      SystemTime.getSystemTime
     )
 
     val leader = new RemoteLeaderEndPoint(
@@ -883,7 +883,7 @@ class ReplicaFetcherThreadTest {
       t1p1 -> newOffsetForLeaderPartitionResult(t1p1, UNDEFINED_EPOCH, 143)).asJava
 
     // Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsets, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -947,7 +947,7 @@ class ReplicaFetcherThreadTest {
       t1p0 -> newOffsetForLeaderPartitionResult(t1p0, UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET)).asJava
 
     //Create the thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -1008,7 +1008,7 @@ class ReplicaFetcherThreadTest {
     ).asJava
 
     //Create the thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -1070,7 +1070,7 @@ class ReplicaFetcherThreadTest {
     ).asJava
 
     //Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,
@@ -1130,7 +1130,7 @@ class ReplicaFetcherThreadTest {
     ).asJava
 
     //Create the fetcher thread
-    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, new SystemTime())
+    val mockNetwork = new MockBlockingSender(offsetsReply, brokerEndPoint, SystemTime.getSystemTime)
     val thread = createReplicaFetcherThread(
       "bob",
       0,

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -17,7 +17,7 @@
 package kafka.server
 
 import kafka.utils.TestUtils
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Utils}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, PropertiesUtils}
 import org.apache.kafka.server.config.ServerConfigs
 import org.apache.zookeeper.KeeperException.NodeExistsException
@@ -187,6 +187,6 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
   }
 
   private def createServer(config: KafkaConfig, threadNamePrefix: Option[String]): KafkaServer = {
-    TestUtils.createServer(config, Time.SYSTEM, threadNamePrefix)
+    TestUtils.createServer(config, SystemTime.getSystemTime, threadNamePrefix)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -22,7 +22,7 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import ExecutionContext.Implicits._
 import kafka.utils.TestUtils
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -231,6 +231,6 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
   }
 
   def createServer(config: KafkaConfig, threadNamePrefix: Option[String]): KafkaServer = {
-    TestUtils.createServer(config, Time.SYSTEM, threadNamePrefix)
+    TestUtils.createServer(config, SystemTime.getSystemTime, threadNamePrefix)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.LeaderAndIsrRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.config.{KRaftConfigs, ServerLogConfigs, ZkConfigs}
 import org.junit.jupiter.api.{BeforeEach, TestInfo, Timeout}
@@ -284,7 +284,7 @@ class ServerShutdownTest extends KafkaServerTestHarness {
       controllerChannelManager = new ControllerChannelManager(
         () => controllerContext.epoch,
         controllerConfig,
-        Time.SYSTEM,
+        SystemTime.getSystemTime,
         metrics,
         new StateChangeLogger(controllerId, inControllerContext = true, None))
       controllerChannelManager.startup(controllerContext.liveOrShuttingDownBrokers)

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -246,7 +246,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
     val node = from.metadataCache.getAliveBrokerNode(to.config.brokerId,
       from.config.interBrokerListenerName).get
     val endPoint = new BrokerEndPoint(node.id(), node.host(), node.port())
-    new BrokerBlockingSender(endPoint, from.config, new Metrics(), new SystemTime(), 42, "TestFetcher", new LogContext())
+    new BrokerBlockingSender(endPoint, from.config, new Metrics(), SystemTime.getSystemTime, 42, "TestFetcher", new LogContext())
   }
 
   private def waitForEpochChangeTo(topic: String, partition: Int, epoch: Int): Unit = {

--- a/core/src/test/scala/unit/kafka/server/epoch/util/MockBlockingSender.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/util/MockBlockingSender.scala
@@ -46,7 +46,7 @@ class MockBlockingSender(offsets: java.util.Map[TopicPartition, EpochEndOffset],
                          time: Time)
   extends BlockingSend {
 
-  private val client = new MockClient(new SystemTime)
+  private val client = new MockClient(SystemTime.getSystemTime)
   var fetchCount = 0
   var epochFetchCount = 0
   var listOffsetsCount = 0

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -51,7 +51,7 @@ import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.Utils.formatAddress
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{SystemTime, Time, Utils}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.metadata.properties.MetaProperties
@@ -171,7 +171,7 @@ object TestUtils extends Logging {
    *
    * @param config The configuration of the server
    */
-  def createServer(config: KafkaConfig, time: Time = Time.SYSTEM): KafkaServer = {
+  def createServer(config: KafkaConfig, time: Time = SystemTime.getSystemTime): KafkaServer = {
     createServer(config, time, None)
   }
 

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
@@ -18,7 +18,7 @@ package kafka.zk.migration
 
 import kafka.server.{KafkaConfig, QuorumTestHarness}
 import kafka.zk.ZkMigrationClient
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.security.{PasswordEncoder, PasswordEncoderConfigs}
 import org.apache.kafka.server.config.ZkConfigs
@@ -62,6 +62,6 @@ class ZkMigrationTestHarness extends QuorumTestHarness {
 
   private def initialMigrationState: ZkMigrationLeadershipState = {
     val (epoch, stat) = zkClient.getControllerEpoch.get
-    new ZkMigrationLeadershipState(3000, InitialControllerEpoch, 100, InitialKRaftEpoch, Time.SYSTEM.milliseconds(), -1, epoch, stat.getVersion)
+    new ZkMigrationLeadershipState(3000, InitialControllerEpoch, 100, InitialKRaftEpoch, SystemTime.getSystemTime.milliseconds(), -1, epoch, stat.getVersion)
   }
 }

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -26,7 +26,7 @@ import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.server.QuorumTestHarness
 import org.apache.kafka.common.security.JaasUtils
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.server.config.ZkConfigs
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.zookeeper.KeeperException.{Code, NoNodeException}
@@ -41,7 +41,7 @@ import scala.jdk.CollectionConverters._
 
 class ZooKeeperClientTest extends QuorumTestHarness {
   private val mockPath = "/foo"
-  private val time = Time.SYSTEM
+  private val time = SystemTime.getSystemTime
 
   private var zooKeeperClient: ZooKeeperClient = _
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -57,6 +57,7 @@ import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.assignor.MemberAssignment;
@@ -262,7 +263,7 @@ public class GroupMetadataManager {
             if (logContext == null) logContext = new LogContext();
             if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
             if (metadataImage == null) metadataImage = MetadataImage.EMPTY;
-            if (time == null) time = Time.SYSTEM;
+            if (time == null) time = SystemTime.getSystemTime();
 
             if (timer == null)
                 throw new IllegalArgumentException("Timer must be set.");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
@@ -129,7 +130,7 @@ public class OffsetMetadataManager {
             if (logContext == null) logContext = new LogContext();
             if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
             if (metadataImage == null) metadataImage = MetadataImage.EMPTY;
-            if (time == null) time = Time.SYSTEM;
+            if (time == null) time = SystemTime.getSystemTime();
 
             if (groupMetadataManager == null) {
                 throw new IllegalArgumentException("GroupMetadataManager cannot be null");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorRuntimeMetrics;
@@ -108,7 +109,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private PartitionWriter partitionWriter;
         private CoordinatorLoader<U> loader;
         private CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private Timer timer;
         private Duration defaultWriteTimeout;
         private CoordinatorRuntimeMetrics runtimeMetrics;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
@@ -95,8 +96,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -127,8 +128,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -159,7 +160,7 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             new MockCoordinatorTimer<>(new MockTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
@@ -189,8 +190,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             mock(CoordinatorMetrics.class),
             mock(CoordinatorMetricsShard.class)
@@ -246,8 +247,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             mock(CoordinatorMetrics.class),
             mock(CoordinatorMetricsShard.class)
@@ -316,8 +317,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -361,7 +362,7 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             new MockCoordinatorTimer<>(new MockTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
@@ -406,8 +407,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -450,8 +451,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -478,8 +479,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -505,8 +506,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -533,8 +534,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -560,8 +561,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -588,8 +589,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -615,8 +616,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -643,8 +644,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -670,8 +671,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -698,8 +699,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -725,8 +726,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -753,8 +754,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -780,8 +781,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -806,8 +807,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -835,8 +836,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -862,8 +863,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -890,8 +891,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -1003,8 +1004,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -1032,8 +1033,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            Time.SYSTEM,
-            new MockCoordinatorTimer<>(Time.SYSTEM),
+            SystemTime.getSystemTime(),
+            new MockCoordinatorTimer<>(SystemTime.getSystemTime()),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.coordinator.group.OffsetAndMetadata;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
@@ -90,7 +90,7 @@ public class ClassicGroupTest {
 
     @BeforeEach
     public void initialize() {
-        group = new ClassicGroup(logContext, "groupId", EMPTY, Time.SYSTEM, metrics);
+        group = new ClassicGroup(logContext, "groupId", EMPTY, SystemTime.getSystemTime(), metrics);
     }
 
     @Test
@@ -1195,7 +1195,7 @@ public class ClassicGroupTest {
 
     @Test
     public void testIsSubscribedToTopic() {
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, mock(GroupCoordinatorMetricsShard.class));
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, SystemTime.getSystemTime(), mock(GroupCoordinatorMetricsShard.class));
 
         // 1. group has no protocol type => not subscribed
         assertFalse(group.isSubscribedToTopic("topic"));
@@ -1262,7 +1262,7 @@ public class ClassicGroupTest {
         // Confirm metrics is not updated when a new GenericGroup is created but only when the group transitions
         // its state.
         GroupCoordinatorMetricsShard metrics = mock(GroupCoordinatorMetricsShard.class);
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, metrics);
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, SystemTime.getSystemTime(), metrics);
         verify(metrics, times(0)).onClassicGroupStateTransition(any(), any());
 
         group.transitionTo(PREPARING_REBALANCE);
@@ -1280,7 +1280,7 @@ public class ClassicGroupTest {
 
     @Test
     public void testIsInStates() {
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, mock(GroupCoordinatorMetricsShard.class));
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, SystemTime.getSystemTime(), mock(GroupCoordinatorMetricsShard.class));
         assertTrue(group.isInStates(Collections.singleton("empty"), 0));
 
         group.transitionTo(PREPARING_REBALANCE);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
@@ -106,10 +106,10 @@ public class GroupCoordinatorMetricsShardTest {
         coordinatorMetrics.activateMetricsShard(shard);
 
         LogContext logContext = new LogContext();
-        ClassicGroup group0 = new ClassicGroup(logContext, "groupId0", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group1 = new ClassicGroup(logContext, "groupId1", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group2 = new ClassicGroup(logContext, "groupId2", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group3 = new ClassicGroup(logContext, "groupId3", EMPTY, Time.SYSTEM, shard);
+        ClassicGroup group0 = new ClassicGroup(logContext, "groupId0", EMPTY, SystemTime.getSystemTime(), shard);
+        ClassicGroup group1 = new ClassicGroup(logContext, "groupId1", EMPTY, SystemTime.getSystemTime(), shard);
+        ClassicGroup group2 = new ClassicGroup(logContext, "groupId2", EMPTY, SystemTime.getSystemTime(), shard);
+        ClassicGroup group3 = new ClassicGroup(logContext, "groupId3", EMPTY, SystemTime.getSystemTime(), shard);
 
         IntStream.range(0, 4).forEach(__ -> shard.incrementNumClassicGroups(EMPTY));
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
@@ -2695,7 +2696,7 @@ public class CoordinatorRuntimeTest {
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
-                .withTime(Time.SYSTEM)
+                .withTime(SystemTime.getSystemTime())
                 .withTimer(timer)
                 .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader(
@@ -2752,7 +2753,7 @@ public class CoordinatorRuntimeTest {
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
-                .withTime(Time.SYSTEM)
+                .withTime(SystemTime.getSystemTime())
                 .withTimer(timer)
                 .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.runtime;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics;
 import org.junit.jupiter.api.Test;
@@ -161,7 +162,7 @@ public class MultiThreadedEventProcessorTest {
             new LogContext(),
             "event-processor-",
             2,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             mock(GroupCoordinatorRuntimeMetrics.class)
         );
         eventProcessor.close();
@@ -173,7 +174,7 @@ public class MultiThreadedEventProcessorTest {
             new LogContext(),
             "event-processor-",
             2,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
@@ -210,7 +211,7 @@ public class MultiThreadedEventProcessorTest {
             new LogContext(),
             "event-processor-",
             2,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
@@ -295,7 +296,7 @@ public class MultiThreadedEventProcessorTest {
             new LogContext(),
             "event-processor-",
             2,
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             mock(GroupCoordinatorRuntimeMetrics.class)
         );
 
@@ -311,7 +312,7 @@ public class MultiThreadedEventProcessorTest {
             new LogContext(),
             "event-processor-",
             1, // Use a single thread to block event in the processor.
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -21,6 +21,7 @@ import kafka.cluster.BrokerEndPoint;
 import kafka.cluster.DelayedOperations;
 import kafka.cluster.AlterPartitionListener;
 import kafka.cluster.Partition;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.server.util.MockTime;
 import org.apache.kafka.storage.internals.log.LogAppendInfo;
 import kafka.log.LogManager;
@@ -64,7 +65,6 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.UpdateMetadataRequest;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -151,7 +151,7 @@ public class ReplicaFetcherThreadBenchmark {
             setScheduler(scheduler).
             setBrokerTopicStats(brokerTopicStats).
             setLogDirFailureChannel(logDirFailureChannel).
-            setTime(Time.SYSTEM).
+            setTime(SystemTime.getSystemTime()).
             setKeepPartitionMetadataFile(true).
             build();
 
@@ -177,7 +177,7 @@ public class ReplicaFetcherThreadBenchmark {
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterPartitionManager isrChannelManager = Mockito.mock(AlterPartitionManager.class);
             Partition partition = new Partition(tp, 100, MetadataVersion.latestTesting(),
-                    0, () -> -1, Time.SYSTEM, alterPartitionListener, new DelayedOperationsMock(tp),
+                    0, () -> -1, SystemTime.getSystemTime(), alterPartitionListener, new DelayedOperationsMock(tp),
                     Mockito.mock(MetadataCache.class), logManager, isrChannelManager, topicId);
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId, Option.empty());
@@ -303,7 +303,7 @@ public class ReplicaFetcherThreadBenchmark {
                                     new BrokerEndPoint(3, "host", 3000),
                                     config,
                                     new Metrics(),
-                                    Time.SYSTEM,
+                                    SystemTime.getSystemTime(),
                                     3,
                                     String.format("broker-%d-fetcher-%d", 3, 3),
                                     new LogContext(String.format("[ReplicaFetcher replicaId=%d, leaderId=%d, fetcherId=%d", config.brokerId(), 3, 3))

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -53,7 +53,7 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -198,7 +198,7 @@ public class KRaftMetadataRequestBenchmark {
                 setFetchManager(fetchManager).
                 setBrokerTopicStats(brokerTopicStats).
                 setClusterId("clusterId").
-                setTime(Time.SYSTEM).
+                setTime(SystemTime.getSystemTime()).
                 setTokenManager(null).
                 setApiVersionManager(new SimpleApiVersionManager(
                         ApiMessageType.ListenerType.BROKER,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -57,7 +57,7 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.UpdateMetadataRequest;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.server.common.FinalizedFeatures;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -198,7 +198,7 @@ public class MetadataRequestBenchmark {
             setFetchManager(fetchManager).
             setBrokerTopicStats(brokerTopicStats).
             setClusterId("clusterId").
-            setTime(Time.SYSTEM).
+            setTime(SystemTime.getSystemTime()).
             setTokenManager(null).
             setApiVersionManager(new SimpleApiVersionManager(
                     ApiMessageType.ListenerType.ZK_BROKER,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.storage.internals.log.CleanerConfig;
@@ -112,7 +112,7 @@ public class PartitionMakeFollowerBenchmark {
             setScheduler(scheduler).
             setBrokerTopicStats(brokerTopicStats).
             setLogDirFailureChannel(logDirFailureChannel).
-            setTime(Time.SYSTEM).setKeepPartitionMetadataFile(true).
+            setTime(SystemTime.getSystemTime()).setKeepPartitionMetadataFile(true).
             build();
 
         TopicPartition tp = new TopicPartition("topic", 0);
@@ -122,7 +122,7 @@ public class PartitionMakeFollowerBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(tp, 100,
-            MetadataVersion.latestTesting(), 0, () -> -1, Time.SYSTEM,
+            MetadataVersion.latestTesting(), 0, () -> -1, SystemTime.getSystemTime(),
             alterPartitionListener, delayedOperations,
             Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId);
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId, Option.empty());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -31,7 +31,7 @@ import kafka.server.metadata.MockConfigRepository;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.storage.internals.log.CleanerConfig;
 import org.apache.kafka.storage.internals.log.LogConfig;
@@ -102,7 +102,7 @@ public class UpdateFollowerFetchStateBenchmark {
             setScheduler(scheduler).
             setBrokerTopicStats(brokerTopicStats).
             setLogDirFailureChannel(logDirFailureChannel).
-            setTime(Time.SYSTEM).
+            setTime(SystemTime.getSystemTime()).
             setKeepPartitionMetadataFile(true).
             build();
         OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
@@ -125,7 +125,7 @@ public class UpdateFollowerFetchStateBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(topicPartition, 100,
-                MetadataVersion.latestTesting(), 0, () -> -1, Time.SYSTEM,
+                MetadataVersion.latestTesting(), 0, () -> -1, SystemTime.getSystemTime(),
                 alterPartitionListener, delayedOperations,
                 Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId, Option.empty());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.PrimitiveRef;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.LogValidator;
@@ -53,7 +53,7 @@ public class CompressedRecordBatchValidationBenchmark extends BaseRecordBatchBen
     public void measureValidateMessagesAndAssignOffsetsCompressed(Blackhole bh) {
         MemoryRecords records = MemoryRecords.readableRecords(singleBatchBuffer.duplicate());
         new LogValidator(records, new TopicPartition("a", 0),
-            Time.SYSTEM, compressionType, compression(), false,  messageVersion,
+            SystemTime.getSystemTime(), compressionType, compression(), false,  messageVersion,
             TimestampType.CREATE_TIME, Long.MAX_VALUE, Long.MAX_VALUE, 0, AppendOrigin.CLIENT,
             MetadataVersion.latestTesting()
         ).validateMessagesAndAssignOffsetsCompressed(PrimitiveRef.ofLong(startingOffset),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/UncompressedRecordBatchValidationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/UncompressedRecordBatchValidationBenchmark.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.PrimitiveRef;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.LogValidator;
@@ -49,7 +49,7 @@ public class UncompressedRecordBatchValidationBenchmark extends BaseRecordBatchB
     public void measureAssignOffsetsNonCompressed(Blackhole bh) {
         MemoryRecords records = MemoryRecords.readableRecords(singleBatchBuffer.duplicate());
         new LogValidator(records, new TopicPartition("a", 0),
-            Time.SYSTEM, CompressionType.NONE, Compression.NONE, false,
+            SystemTime.getSystemTime(), CompressionType.NONE, Compression.NONE, false,
             messageVersion, TimestampType.CREATE_TIME, Long.MAX_VALUE, Long.MAX_VALUE, 0, AppendOrigin.CLIENT,
             MetadataVersion.latestTesting()
         ).assignOffsetsNonCompressed(PrimitiveRef.ofLong(startingOffset), validatorMetricsRecorder);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -111,7 +112,7 @@ public class PartitionCreationBench {
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
                 (short) 1, false));
         this.metrics = new Metrics();
-        this.time = Time.SYSTEM;
+        this.time = SystemTime.getSystemTime();
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(false);
         final List<File> files =
@@ -138,12 +139,12 @@ public class PartitionCreationBench {
             setScheduler(scheduler).
             setBrokerTopicStats(brokerTopicStats).
             setLogDirFailureChannel(failureChannel).
-            setTime(Time.SYSTEM).
+            setTime(SystemTime.getSystemTime()).
             setKeepPartitionMetadataFile(true).
             build();
         scheduler.startup();
         this.quotaManagers = QuotaFactory.instantiate(this.brokerProperties, this.metrics, this.time, "");
-        this.zkClient = new KafkaZkClient(null, false, Time.SYSTEM, false) {
+        this.zkClient = new KafkaZkClient(null, false, SystemTime.getSystemTime(), false) {
             @Override
             public Properties getEntityConfigs(String rootEntityType, String sanitizedEntityName) {
                 return new Properties();

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.BrokerRegistrationFencingChange;
@@ -86,7 +87,7 @@ public class ClusterControlManager {
     static class Builder {
         private LogContext logContext = null;
         private String clusterId = null;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private SnapshotRegistry snapshotRegistry = null;
         private long sessionTimeoutNs = DEFAULT_SESSION_TIMEOUT_NS;
         private ReplicaPlacer replicaPlacer = null;

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.metadata.DelegationTokenData;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -59,7 +60,7 @@ import static org.apache.kafka.common.protocol.Errors.UNSUPPORTED_VERSION;
  * Manages DelegationTokens.
  */
 public class DelegationTokenControlManager {
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
 
     static class Builder {
         private LogContext logContext = null;

--- a/metadata/src/main/java/org/apache/kafka/controller/OffsetControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/OffsetControlManager.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.metadata.AbortTransactionRecord;
 import org.apache.kafka.common.metadata.BeginTransactionRecord;
 import org.apache.kafka.common.metadata.EndTransactionRecord;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
 import org.apache.kafka.raft.Batch;
@@ -48,7 +49,7 @@ class OffsetControlManager {
         private LogContext logContext = null;
         private SnapshotRegistry snapshotRegistry = null;
         private QuorumControllerMetrics metrics = null;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
 
         Builder setLogContext(LogContext logContext) {
             this.logContext = logContext;

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -90,6 +90,7 @@ import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.controller.errors.ControllerExceptions;
@@ -197,7 +198,7 @@ public final class QuorumController implements Controller {
         private final String clusterId;
         private FaultHandler nonFatalFaultHandler = null;
         private FaultHandler fatalFaultHandler = null;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private String threadNamePrefix = null;
         private LogContext logContext = null;
         private KafkaConfigSchema configSchema = KafkaConfigSchema.EMPTY;

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image.loader;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -70,7 +71,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
     public static class Builder {
         private int nodeId = -1;
         private String threadNamePrefix = "";
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private LogContext logContext = null;
         private FaultHandler faultHandler = (m, e) -> new FaultHandlerException(m, e);
         private MetadataLoaderMetrics metrics = null;
@@ -213,7 +214,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
             faultHandler,
             this::maybePublishMetadata);
         this.eventQueue = new KafkaEventQueue(
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             logContext,
             threadNamePrefix + "metadata-loader-",
             new ShutdownEvent());

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image.publisher;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.image.MetadataImage;
@@ -45,7 +46,7 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
     private final static int DEFAULT_BATCH_SIZE = 1024;
 
     public static class Builder {
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private int nodeId = 0;
         private RaftClient<ApiMessageAndVersion> raftClient = null;
         private int batchSize = DEFAULT_BATCH_SIZE;

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image.publisher;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -40,7 +41,7 @@ public class SnapshotGenerator implements MetadataPublisher {
     public static class Builder {
         private final Emitter emitter;
         private int nodeId = 0;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private FaultHandler faultHandler = (m, e) -> null;
         private long maxBytesSinceLastSnapshot = 100 * 1024L * 1024L;
         private long maxTimeSinceLastSnapshotNs = TimeUnit.DAYS.toNanos(1);

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -18,6 +18,7 @@ package org.apache.kafka.metadata.migration;
 
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.controller.QuorumFeatures;
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
@@ -138,7 +139,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         this.log = log;
         this.migrationState = MigrationDriverState.UNINITIALIZED;
         this.migrationLeadershipState = ZkMigrationLeadershipState.EMPTY;
-        this.eventQueue = new KafkaEventQueue(Time.SYSTEM, logContext, "controller-" + nodeId + "-migration-driver-");
+        this.eventQueue = new KafkaEventQueue(SystemTime.getSystemTime(), logContext, "controller-" + nodeId + "-migration-driver-");
         this.pollTimeSupplier = new PollTimeSupplier();
         this.image = MetadataImage.EMPTY;
         this.firstPublish = false;

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/BatchFileWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/BatchFileWriter.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.record.ControlRecordUtils;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.metadata.MetadataRecordSerde;
@@ -89,7 +90,7 @@ public class BatchFileWriter implements AutoCloseable {
     }
 
     public static BatchFileWriter open(Path snapshotPath) throws IOException {
-        Time time = Time.SYSTEM;
+        Time time = SystemTime.getSystemTime();
         BatchAccumulator<ApiMessageAndVersion> batchAccumulator = new BatchAccumulator<>(
             0,
             0,

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.record.FileLogInputStream.FileChannelRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.metadata.MetadataRecordSerde;
 import org.apache.kafka.queue.EventQueue;
 import org.apache.kafka.queue.KafkaEventQueue;
@@ -65,7 +65,7 @@ public final class SnapshotFileReader implements AutoCloseable {
     public SnapshotFileReader(String snapshotPath, RaftClient.Listener<ApiMessageAndVersion> listener) {
         this.snapshotPath = snapshotPath;
         this.listener = listener;
-        this.queue = new KafkaEventQueue(Time.SYSTEM,
+        this.queue = new KafkaEventQueue(SystemTime.getSystemTime(),
             new LogContext("[snapshotReaderQueue] "), "snapshotReaderQueue_", new ShutdownEvent());
         this.caughtUpFuture = new CompletableFuture<>();
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsIntegrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsIntegrationTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
 import org.apache.kafka.metalog.LocalLogManagerTestEnv;
@@ -56,7 +56,7 @@ public class QuorumControllerMetricsIntegrationTest {
         final AtomicBoolean closed = new AtomicBoolean(false);
 
         MockControllerMetrics() {
-            super(Optional.empty(), Time.SYSTEM, true);
+            super(Optional.empty(), SystemTime.getSystemTime(), true);
         }
 
         @Override

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.controller.QuorumFeatures;
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
@@ -95,7 +96,7 @@ public class KRaftMigrationDriverTest {
         final AtomicBoolean closed = new AtomicBoolean(false);
 
         MockControllerMetrics() {
-            super(Optional.empty(), Time.SYSTEM, false);
+            super(Optional.empty(), SystemTime.getSystemTime(), false);
         }
 
         @Override

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.metadata.MetadataRecordSerde;
 import org.apache.kafka.queue.EventQueue;
 import org.apache.kafka.queue.KafkaEventQueue;
@@ -518,7 +518,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
         this.nodeId = nodeId;
         this.shared = shared;
         this.maxReadOffset = shared.initialMaxReadOffset();
-        this.eventQueue = new KafkaEventQueue(Time.SYSTEM, logContext,
+        this.eventQueue = new KafkaEventQueue(SystemTime.getSystemTime(), logContext,
                 threadNamePrefix, new ShutdownEvent());
         shared.registerLogManager(this);
     }

--- a/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.internals.BatchAccumulator.CompletedBatch;
@@ -143,7 +144,7 @@ final public class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
     final public static class Builder {
         private long lastContainedLogTimestamp = 0;
         private Compression compression = Compression.NONE;
-        private Time time = Time.SYSTEM;
+        private Time time = SystemTime.getSystemTime();
         private int maxBatchSize = 1024;
         private MemoryPool memoryPool = MemoryPool.NONE;
         private short kraftVersion = 1;

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
@@ -17,8 +17,8 @@
 package org.apache.kafka.server.util.timer;
 
 import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.ExecutorService;
@@ -42,7 +42,7 @@ public class SystemTimer implements Timer {
     private final ReentrantReadWriteLock.WriteLock writeLock = readWriteLock.writeLock();
 
     public SystemTimer(String executorName) {
-        this(executorName, 1, 20, Time.SYSTEM.hiResClockMs());
+        this(executorName, 1, 20, SystemTime.getSystemTime().hiResClockMs());
     }
 
     public SystemTimer(
@@ -67,7 +67,7 @@ public class SystemTimer implements Timer {
     public void add(TimerTask timerTask) {
         readLock.lock();
         try {
-            addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + Time.SYSTEM.hiResClockMs()));
+            addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + SystemTime.getSystemTime().hiResClockMs()));
         } finally {
             readLock.unlock();
         }

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/TimerTaskList.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/TimerTaskList.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.server.util.timer;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 import java.util.concurrent.Delayed;
@@ -37,7 +38,7 @@ class TimerTaskList implements Delayed {
     TimerTaskList(
         AtomicInteger taskCounter
     ) {
-        this(taskCounter, Time.SYSTEM);
+        this(taskCounter, SystemTime.getSystemTime());
     }
 
     TimerTaskList(

--- a/server-common/src/test/java/org/apache/kafka/server/util/FutureUtilsTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/FutureUtilsTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.kafka.server.util;
 
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,8 +50,8 @@ public class FutureUtilsTest {
             "[FutureUtilsTest] ",
             "the future to be completed",
             future,
-            Deadline.fromDelay(Time.SYSTEM, 30, TimeUnit.SECONDS),
-            Time.SYSTEM));
+            Deadline.fromDelay(SystemTime.getSystemTime(), 30, TimeUnit.SECONDS),
+            SystemTime.getSystemTime()));
         executorService.shutdownNow();
         executorService.awaitTermination(1, TimeUnit.MINUTES);
     }
@@ -68,9 +68,9 @@ public class FutureUtilsTest {
                 "the future to be completed",
                 future,
                 immediateTimeout ?
-                    Deadline.fromDelay(Time.SYSTEM, 0, TimeUnit.SECONDS) :
-                    Deadline.fromDelay(Time.SYSTEM, 1, TimeUnit.MILLISECONDS),
-                Time.SYSTEM);
+                    Deadline.fromDelay(SystemTime.getSystemTime(), 0, TimeUnit.SECONDS) :
+                    Deadline.fromDelay(SystemTime.getSystemTime(), 1, TimeUnit.MILLISECONDS),
+                    SystemTime.getSystemTime());
         });
         executorService.shutdownNow();
         executorService.awaitTermination(1, TimeUnit.MINUTES);
@@ -89,8 +89,8 @@ public class FutureUtilsTest {
                     "[FutureUtilsTest] ",
                     "the future to be completed",
                     future,
-                    Deadline.fromDelay(Time.SYSTEM, 30, TimeUnit.SECONDS),
-                    Time.SYSTEM);
+                    Deadline.fromDelay(SystemTime.getSystemTime(), 30, TimeUnit.SECONDS),
+                    SystemTime.getSystemTime());
             }).getMessage());
         executorService.shutdown();
         executorService.awaitTermination(1, TimeUnit.MINUTES);

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.server.util.timer;
 
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +71,7 @@ public class TimerTest {
 
     @BeforeEach
     public void setup() {
-        timer = new SystemTimer("test", 1, 3, Time.SYSTEM.hiResClockMs());
+        timer = new SystemTimer("test", 1, 3, SystemTime.getSystemTime().hiResClockMs());
     }
 
     @AfterEach

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.internals.FatalExitError;
 import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
@@ -75,7 +76,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
     // if the field is read but not updated in a spin loop like in #initializeResources() method.
     private final AtomicBoolean closing = new AtomicBoolean(false);
     private final AtomicBoolean initialized = new AtomicBoolean(false);
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
     private final boolean startConsumerThread;
 
     private Thread initializationThread;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -21,7 +21,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundException;
@@ -250,7 +250,7 @@ public class RemoteIndexCache implements Closeable {
     }
 
     private void init() throws IOException {
-        long start = Time.SYSTEM.hiResClockMs();
+        long start = SystemTime.getSystemTime().hiResClockMs();
 
         try {
             Files.createDirectory(cacheDir.toPath());
@@ -332,7 +332,7 @@ public class RemoteIndexCache implements Closeable {
                 }
             }
         }
-        log.info("RemoteIndexCache starts up in {} ms.", Time.SYSTEM.hiResClockMs() - start);
+        log.info("RemoteIndexCache starts up in {} ms.", SystemTime.getSystemTime().hiResClockMs() - start);
     }
 
     private <T> T loadIndexFile(File file, RemoteLogSegmentMetadata remoteLogSegmentMetadata,

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTaskTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTaskTest.java
@@ -92,7 +92,7 @@ public class ConsumerTaskTest {
             .collect(Collectors.toMap(Function.identity(), e -> 0L));
         consumer = spy(new MockConsumer<>(OffsetResetStrategy.EARLIEST));
         consumer.updateBeginningOffsets(offsets);
-        consumerTask = new ConsumerTask(handler, partitioner, consumer, 10L, 300_000L, new SystemTime());
+        consumerTask = new ConsumerTask(handler, partitioner, consumer, 10L, 300_000L, SystemTime.getSystemTime());
         thread = new Thread(consumerTask);
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
@@ -19,6 +19,7 @@ package org.apache.kafka.tiered.storage.utils;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.FileLogInputStream;
 import org.apache.kafka.common.record.FileRecords;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
@@ -44,7 +45,7 @@ public final class BrokerLocalStorage {
     private final Integer storageWaitTimeoutSec;
 
     private final int storagePollPeriodSec = 1;
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
 
     public BrokerLocalStorage(Integer brokerId,
                               Set<String> storageDirnames,

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
@@ -855,7 +856,7 @@ public class KafkaStreams implements AutoCloseable {
     public KafkaStreams(final Topology topology,
                         final Properties props,
                         final KafkaClientSupplier clientSupplier) {
-        this(topology, new StreamsConfig(props), clientSupplier, Time.SYSTEM);
+        this(topology, new StreamsConfig(props), clientSupplier, SystemTime.getSystemTime());
     }
 
     /**
@@ -955,7 +956,7 @@ public class KafkaStreams implements AutoCloseable {
     protected KafkaStreams(final TopologyMetadata topologyMetadata,
                            final StreamsConfig applicationConfigs,
                            final KafkaClientSupplier clientSupplier) throws StreamsException {
-        this(topologyMetadata, applicationConfigs, clientSupplier, Time.SYSTEM);
+        this(topologyMetadata, applicationConfigs, clientSupplier, SystemTime.getSystemTime());
     }
 
     @SuppressWarnings("this-escape")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractKStreamTimeWindowAggregateProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractKStreamTimeWindowAggregateProcessor.java
@@ -23,6 +23,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.d
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -44,7 +45,7 @@ import org.slf4j.Logger;
 
 public abstract class AbstractKStreamTimeWindowAggregateProcessor<KIn, VIn, VAgg> extends ContextualProcessor<KIn, VIn, Windowed<KIn>, Change<VAgg>> {
 
-    private final Time time = Time.SYSTEM;
+    private final Time time = SystemTime.getSystemTime();
     private final String storeName;
     private final EmitStrategy emitStrategy;
     private final boolean sendOldValues;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -101,7 +102,7 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
         private long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
         private InternalProcessorContext<Windowed<KIn>, Change<VAgg>> internalProcessorContext;
 
-        private final Time time = Time.SYSTEM;
+        private final Time time = SystemTime.getSystemTime();
         protected final KStreamImplJoin.TimeTracker timeTracker = new KStreamImplJoin.TimeTracker();
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
@@ -21,7 +21,7 @@ import static org.apache.kafka.streams.internals.ApiUtils.validateMillisecondDur
 
 import java.time.Duration;
 import java.util.Map;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
@@ -125,7 +125,7 @@ public class OuterStreamJoinStoreFactory<K, V1, V2> extends AbstractConfigurable
                         supplier,
                         timestampedKeyAndJoinSideSerde,
                         leftOrRightValueSerde,
-                        Time.SYSTEM
+                        SystemTime.getSystemTime()
                 );
 
         if (loggingEnabled) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.state.internals.InMemoryKeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemorySessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemoryWindowBytesStoreSupplier;
@@ -460,7 +460,7 @@ public final class Stores {
                                                                                 final Serde<K> keySerde,
                                                                                 final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new KeyValueStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new KeyValueStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 
     /**
@@ -482,7 +482,7 @@ public final class Stores {
                                                                                                       final Serde<K> keySerde,
                                                                                                       final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new TimestampedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new TimestampedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 
     /**
@@ -500,7 +500,7 @@ public final class Stores {
                                                                                                   final Serde<K> keySerde,
                                                                                                   final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new VersionedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new VersionedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 
     /**
@@ -521,7 +521,7 @@ public final class Stores {
                                                                             final Serde<K> keySerde,
                                                                             final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new WindowStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new WindowStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 
     /**
@@ -543,7 +543,7 @@ public final class Stores {
                                                                                                   final Serde<K> keySerde,
                                                                                                   final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new TimestampedWindowStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new TimestampedWindowStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 
     /**
@@ -561,6 +561,6 @@ public final class Stores {
                                                                               final Serde<K> keySerde,
                                                                               final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new SessionStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new SessionStoreBuilder<>(supplier, keySerde, valueSerde, SystemTime.getSystemTime());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.ProcessorStateException;
@@ -121,7 +122,7 @@ public class MeteredKeyValueStore<K, V>
                          final Serde<V> valueSerde) {
         super(inner);
         this.metricsScope = metricsScope;
-        this.time = time != null ? time : Time.SYSTEM;
+        this.time = time != null ? time : SystemTime.getSystemTime();
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -119,14 +119,14 @@ public class IQv2IntegrationTest {
                     new ProducerRecord<>(
                         INPUT_TOPIC_NAME,
                         i % partitions,
-                        Time.SYSTEM.milliseconds(),
+                        SystemTime.getSystemTime().milliseconds(),
                         i,
                         i,
                         null
                     )
                 );
                 futures.add(send);
-                Time.SYSTEM.sleep(1L);
+                SystemTime.getSystemTime().sleep(1L);
             }
             producer.flush();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -425,7 +426,7 @@ public class IQv2StoreIntegrationTest {
                     )
                 );
                 futures.add(send);
-                Time.SYSTEM.sleep(1L);
+                SystemTime.getSystemTime().sleep(1L);
             }
             producer.flush();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -324,7 +324,7 @@ public class PositionRestartIntegrationTest {
                     )
                 );
                 futures.add(send);
-                Time.SYSTEM.sleep(1L);
+                SystemTime.getSystemTime().sleep(1L);
             }
             producer.flush();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -148,7 +148,7 @@ public class KTableSuppressProcessorMetricsTest {
         streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         final MockInternalNewProcessorContext<String, Change<Long>> context =
             new MockInternalNewProcessorContext<>(streamsConfig, TASK_ID, TestUtils.tempDirectory());
-        final Time time = new SystemTime();
+        final Time time = SystemTime.getSystemTime();
         context.setCurrentNode(new ProcessorNode("testNode"));
         context.setSystemTimeMs(time.milliseconds());
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -71,7 +71,7 @@ public class GlobalProcessorContextImplTest {
             stateManager,
             null,
             null,
-            Time.SYSTEM);
+            SystemTime.getSystemTime());
 
         final ProcessorNode<Object, Object, Object, Object> processorNode = new ProcessorNode<>("testNode");
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.jupiter.api.Test;
 
@@ -213,7 +213,7 @@ class ReadOnlyTaskTest {
                     parameters[i] = Collections.emptySet();
                     break;
                 case "org.apache.kafka.common.utils.Time":
-                    parameters[i] = Time.SYSTEM;
+                    parameters[i] = SystemTime.getSystemTime();
                     break;
                 default:
                     parameters[i] = parameterTypes[i].getConstructor().newInstance();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.AlwaysContinueProductionExceptionHandler;
@@ -153,7 +154,7 @@ public class RecordCollectorTest {
             null,
             processId,
             logContext,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
         mockProducer = clientSupplier.producers.get(0);
         final SinkNode<?, ?> sinkNode = new SinkNode<>(
@@ -1369,7 +1370,7 @@ public class RecordCollectorTest {
                 taskId,
                 processId,
                 logContext,
-                Time.SYSTEM
+                SystemTime.getSystemTime()
             ),
             productionExceptionHandler,
             streamsMetrics,
@@ -1402,7 +1403,7 @@ public class RecordCollectorTest {
                 null,
                 null,
                 logContext,
-                Time.SYSTEM
+                SystemTime.getSystemTime()
             ),
             productionExceptionHandler,
             streamsMetrics,
@@ -1438,7 +1439,7 @@ public class RecordCollectorTest {
                 taskId,
                 processId,
                 logContext,
-                Time.SYSTEM
+                SystemTime.getSystemTime()
             ),
             productionExceptionHandler,
             streamsMetrics,
@@ -1552,7 +1553,7 @@ public class RecordCollectorTest {
             null,
             null,
             logContext,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -1574,7 +1575,7 @@ public class RecordCollectorTest {
             null,
             null,
             logContext,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
@@ -203,7 +204,7 @@ public class StreamsProducerTest {
             );
         eosBetaStreamsProducer.initTransaction();
         eosBetaMockProducer = eosBetaMockClientSupplier.producers.get(0);
-        when(mockTime.nanoseconds()).thenReturn(Time.SYSTEM.nanoseconds());
+        when(mockTime.nanoseconds()).thenReturn(SystemTime.getSystemTime().nanoseconds());
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
@@ -219,7 +219,7 @@ public class KeyValueStoreTestDriver<K, V> {
                 null,
                 null,
                 logContext,
-                Time.SYSTEM),
+                SystemTime.getSystemTime()),
             new DefaultProductionExceptionHandler(),
             new MockStreamsMetrics(new Metrics()),
             topology

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -1350,7 +1350,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -1386,7 +1386,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -1425,7 +1425,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -1466,7 +1466,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -1584,7 +1584,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
             TestUtils.tempDirectory(),
             new StreamsConfig(streamsConfig)
         );
-        final Time time = new SystemTime();
+        final Time time = SystemTime.getSystemTime();
         context.setSystemTimeMs(time.milliseconds());
         bytesStore.init((StateStoreContext) context, bytesStore);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -551,7 +551,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -589,7 +589,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -629,7 +629,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -671,7 +671,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 new StreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-                Time.SYSTEM
+                SystemTime.getSystemTime()
         );
         bytesStore = getBytesStore();
         bytesStore.init((StateStoreContext) context, bytesStore);
@@ -789,7 +789,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             TestUtils.tempDirectory(),
             new StreamsConfig(streamsConfig)
         );
-        final Time time = new SystemTime();
+        final Time time = SystemTime.getSystemTime();
         context.setSystemTimeMs(time.milliseconds());
         bytesStore.init((StateStoreContext) context, bytesStore);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -801,7 +801,7 @@ public abstract class AbstractSessionBytesStoreTest {
             new StreamsConfig(streamsConfig),
             recordCollector
         );
-        final Time time = new SystemTime();
+        final Time time = SystemTime.getSystemTime();
         context.setTime(1L);
         context.setSystemTimeMs(time.milliseconds());
         sessionStore.init((StateStoreContext) context, sessionStore);
@@ -940,7 +940,7 @@ public abstract class AbstractSessionBytesStoreTest {
 
     @Test
     public void shouldNotFetchExpiredSessions() {
-        final long systemTime = Time.SYSTEM.milliseconds();
+        final long systemTime = SystemTime.getSystemTime().milliseconds();
         sessionStore.put(new Windowed<>("p", new SessionWindow(systemTime - 3 * RETENTION_PERIOD, systemTime - 2 * RETENTION_PERIOD)), 1L);
         sessionStore.put(new Windowed<>("q", new SessionWindow(systemTime - 2 * RETENTION_PERIOD, systemTime - RETENTION_PERIOD)), 4L);
         sessionStore.put(new Windowed<>("r", new SessionWindow(systemTime - RETENTION_PERIOD, systemTime - RETENTION_PERIOD / 2)), 3L);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -993,7 +993,7 @@ public abstract class AbstractWindowBytesStoreTest {
             new StreamsConfig(streamsConfig),
             recordCollector
         );
-        final Time time = new SystemTime();
+        final Time time = SystemTime.getSystemTime();
         context.setSystemTimeMs(time.milliseconds());
         context.setTime(1L);
         windowStore.init((StateStoreContext) context, windowStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -99,7 +99,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
             streamsConfig,
             () -> collector,
             new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -102,7 +102,7 @@ public class ListValueStoreTest {
                 : Stores.inMemoryKeyValueStore("in-memory list store"),
             keySerde,
             valueSerde,
-            Time.SYSTEM)
+            SystemTime.getSystemTime())
             .build();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -30,7 +30,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -404,7 +404,7 @@ public class MeteredSessionStoreTest {
 
     @Test
     public void shouldReturnNoSessionsWhenFetchedKeyHasExpired() {
-        final long systemTime = Time.SYSTEM.milliseconds();
+        final long systemTime = SystemTime.getSystemTime().milliseconds();
         when(innerStore.findSessions(KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
                 .thenReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
         init();
@@ -416,7 +416,7 @@ public class MeteredSessionStoreTest {
 
     @Test
     public void shouldReturnNoSessionsInBackwardOrderWhenFetchedKeyHasExpired() {
-        final long systemTime = Time.SYSTEM.milliseconds();
+        final long systemTime = SystemTime.getSystemTime().milliseconds();
         when(innerStore.backwardFindSessions(KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
                 .thenReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
         init();
@@ -428,7 +428,7 @@ public class MeteredSessionStoreTest {
 
     @Test
     public void shouldNotFindExpiredSessionRangeFromStore() {
-        final long systemTime = Time.SYSTEM.milliseconds();
+        final long systemTime = SystemTime.getSystemTime().milliseconds();
         when(innerStore.findSessions(KEY_BYTES, KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
                 .thenReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
         init();
@@ -440,7 +440,7 @@ public class MeteredSessionStoreTest {
 
     @Test
     public void shouldNotFindExpiredSessionRangeInBackwardOrderFromStore() {
-        final long systemTime = Time.SYSTEM.milliseconds();
+        final long systemTime = SystemTime.getSystemTime().milliseconds();
         when(innerStore.backwardFindSessions(KEY_BYTES, KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
                 .thenReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
         init();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -87,7 +87,7 @@ public class MeteredTimestampedWindowStoreTest {
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             MockRecordCollector::new,
             new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
-            Time.SYSTEM,
+            SystemTime.getSystemTime(),
             taskId
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -31,7 +31,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -123,7 +123,7 @@ public class MeteredWindowStoreTest {
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             MockRecordCollector::new,
             new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
         tags = mkMap(
             mkEntry(THREAD_ID_TAG_KEY, threadId),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
@@ -436,7 +436,7 @@ public class StreamThreadStateStoreProviderTest {
                 new TaskId(0, 0),
                 UUID.randomUUID(),
                 logContext,
-                Time.SYSTEM
+                SystemTime.getSystemTime()
             ),
             streamsConfig.defaultProductionExceptionHandler(),
             new MockStreamsMetrics(metrics),

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -93,7 +94,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             null,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -112,7 +113,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             config,
             null,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -125,7 +126,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             null,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -145,7 +146,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             config,
             () -> collector,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -161,7 +162,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             config,
             null,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -181,7 +182,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             () -> collector,
             null,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 
@@ -198,7 +199,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             () -> collector,
             cache,
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
     }
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
@@ -242,7 +242,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
             new Metrics(metricConfig),
             threadId,
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG),
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
         TaskMetrics.droppedRecordsSensor(threadId, taskId.toString(), metrics);
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.Topology;
@@ -258,7 +258,7 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
             new Metrics(metricConfig),
             threadId,
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG),
-            Time.SYSTEM
+            SystemTime.getSystemTime()
         );
         TaskMetrics.droppedRecordsSensor(threadId, taskId.toString(), metrics);
     }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -871,14 +871,14 @@ public abstract class TopologyTestDriverTest {
                 Stores.inMemoryKeyValueStore("store"),
                 Serdes.ByteArray(),
                 Serdes.ByteArray(),
-                new SystemTime()),
+                SystemTime.getSystemTime()),
             "processor");
         topology.addGlobalStore(
             new KeyValueStoreBuilder<>(
                 Stores.inMemoryKeyValueStore("globalStore"),
                 Serdes.ByteArray(),
                 Serdes.ByteArray(),
-                new SystemTime()).withLoggingDisabled(),
+                SystemTime.getSystemTime()).withLoggingDisabled(),
             "sourceProcessorName",
             Serdes.ByteArray().deserializer(),
             Serdes.ByteArray().deserializer(),
@@ -1263,13 +1263,13 @@ public abstract class TopologyTestDriverTest {
                 Stores.inMemoryKeyValueStore("store"),
                 Serdes.ByteArray(),
                 Serdes.ByteArray(),
-                new SystemTime()));
+                SystemTime.getSystemTime()));
         topology.addGlobalStore(
             new KeyValueStoreBuilder<>(
                 Stores.inMemoryKeyValueStore("globalStore"),
                 Serdes.ByteArray(),
                 Serdes.ByteArray(),
-                new SystemTime()).withLoggingDisabled(),
+                SystemTime.getSystemTime()).withLoggingDisabled(),
             "sourceProcessorName",
             Serdes.ByteArray().deserializer(),
             Serdes.ByteArray().deserializer(),

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -49,7 +49,7 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -229,7 +229,7 @@ public class ClientCompatibilityTest {
 
     ClientCompatibilityTest(TestConfig testConfig) {
         this.testConfig = testConfig;
-        long curTime = Time.SYSTEM.milliseconds();
+        long curTime = SystemTime.getSystemTime().milliseconds();
 
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.putLong(curTime);
@@ -243,7 +243,7 @@ public class ClientCompatibilityTest {
     }
 
     void run() throws Throwable {
-        long prodTimeMs = Time.SYSTEM.milliseconds();
+        long prodTimeMs = SystemTime.getSystemTime().milliseconds();
         testAdminClient();
         testProduce();
         testConsume(prodTimeMs);
@@ -442,7 +442,7 @@ public class ClientCompatibilityTest {
 
                 private byte[] fetchNext() {
                     while (true) {
-                        long curTime = Time.SYSTEM.milliseconds();
+                        long curTime = SystemTime.getSystemTime().milliseconds();
                         if (curTime - prodTimeMs > TIMEOUT_MS)
                             throw new RuntimeException("Timed out after " + TIMEOUT_MS + " ms.");
                         if (recordIter == null) {

--- a/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
@@ -95,7 +95,7 @@ public class PushHttpMetricsReporter implements MetricsReporter {
                             "producer/consumer/streams/connect instance");
 
     public PushHttpMetricsReporter() {
-        time = new SystemTime();
+        time = SystemTime.getSystemTime();
         executor = Executors.newSingleThreadScheduledExecutor();
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandDefaultOptions;
@@ -205,7 +206,7 @@ public class ReplicaVerificationTool {
 
                 fetcherThreads.forEach(Thread::start);
                 System.out.printf("%s: verification process is started%n",
-                    DATE_FORMAT.format(new Date(Time.SYSTEM.milliseconds())));
+                    DATE_FORMAT.format(new Date(SystemTime.getSystemTime().milliseconds())));
             }
         } catch (Throwable e) {
             System.err.println(e.getMessage());
@@ -391,7 +392,7 @@ public class ReplicaVerificationTool {
             this.recordsCache = new HashMap<>();
             this.fetcherBarrier = new AtomicReference<>(new CountDownLatch(expectedNumFetchers));
             this.verificationBarrier = new AtomicReference<>(new CountDownLatch(1));
-            this.lastReportTime = Time.SYSTEM.milliseconds();
+            this.lastReportTime = SystemTime.getSystemTime().milliseconds();
             this.maxLag = -1L;
             this.offsetWithMaxLag = -1L;
 
@@ -484,7 +485,7 @@ public class ReplicaVerificationTool {
                                         MessageInfo messageInfoFromFirstReplica = messageInfoFromFirstReplicaOpt.get();
 
                                         if (messageInfoFromFirstReplica.offset != batch.lastOffset()) {
-                                            println.accept(DATE_FORMAT.format(new Date(Time.SYSTEM.milliseconds())) +
+                                            println.accept(DATE_FORMAT.format(new Date(SystemTime.getSystemTime().milliseconds())) +
                                                 ": partition " + topicPartition +
                                                 ": replica " + messageInfoFromFirstReplica.replicaId +
                                                 "'s offset " + messageInfoFromFirstReplica.offset +
@@ -494,7 +495,7 @@ public class ReplicaVerificationTool {
                                         }
 
                                         if (messageInfoFromFirstReplica.checksum != batch.checksum())
-                                            println.accept(DATE_FORMAT.format(new Date(Time.SYSTEM.milliseconds())) +
+                                            println.accept(DATE_FORMAT.format(new Date(SystemTime.getSystemTime().milliseconds())) +
                                                 ": partition " + topicPartition +
                                                 " has unmatched checksum at offset " + batch.lastOffset() +
                                                 "; replica " + messageInfoFromFirstReplica.replicaId +
@@ -529,7 +530,7 @@ public class ReplicaVerificationTool {
                 fetchResponsePerReplica.clear();
             }
 
-            long currentTimeMs = Time.SYSTEM.milliseconds();
+            long currentTimeMs = SystemTime.getSystemTime().milliseconds();
             if (currentTimeMs - lastReportTime > reportInterval) {
                 println.accept(DATE_FORMAT.format(new Date(currentTimeMs)) +
                     ": max lag is " + maxLag + " for partition " +
@@ -573,7 +574,7 @@ public class ReplicaVerificationTool {
             this.minBytes = minBytes;
             this.doVerification = doVerification;
             this.fetchEndpoint = new ReplicaFetcherBlockingSend(sourceBroker, new ConsumerConfig(consumerConfig), new Metrics(),
-                Time.SYSTEM, fetcherId, "broker-" + FetchRequest.DEBUGGING_CONSUMER_ID + "-fetcher-" + fetcherId);
+                SystemTime.getSystemTime(), fetcherId, "broker-" + FetchRequest.DEBUGGING_CONSUMER_ID + "-fetcher-" + fetcherId);
             this.topicNames = topicIds.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
         }

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.TransactionalIdNotFoundException;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -1025,7 +1026,7 @@ public abstract class TransactionsCommand {
     }
 
     public static void main(String[] args) throws Exception {
-        execute(args, TransactionsCommand::buildAdminClient, System.out, Time.SYSTEM);
+        execute(args, TransactionsCommand::buildAdminClient, System.out, SystemTime.getSystemTime());
     }
 
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,7 +144,7 @@ public class ConsoleConsumer {
     }
 
     public static class ConsumerWrapper {
-        final Time time = Time.SYSTEM;
+        final Time time = SystemTime.getSystemTime();
         final long timeoutMs;
         final Consumer<byte[], byte[]> consumer;
 

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.AdminCommandFailedException;
@@ -166,13 +167,13 @@ public class ReassignPartitionsCommand {
                 opts.options.valueOf(opts.interBrokerThrottleOpt),
                 opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt),
                 opts.options.valueOf(opts.timeoutOpt),
-                Time.SYSTEM);
+                SystemTime.getSystemTime());
         } else if (opts.options.has(opts.cancelOpt)) {
             cancelAssignment(adminClient,
                 Utils.readFileAsString(opts.options.valueOf(opts.reassignmentJsonFileOpt)),
                 opts.options.has(opts.preserveThrottlesOpt),
                 opts.options.valueOf(opts.timeoutOpt),
-                Time.SYSTEM);
+                SystemTime.getSystemTime());
         } else if (opts.options.has(opts.listOpt)) {
             listReassignments(adminClient);
         } else {

--- a/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
+++ b/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
@@ -34,7 +34,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.tools.reassign.ReassignPartitionsCommand;
 import org.apache.log4j.PropertyConfigurator;
@@ -167,7 +167,7 @@ public class ReplicationQuotasTestRig {
         void startBrokers(List<Integer> brokerIds) {
             System.out.println("Starting Brokers");
             servers = brokerIds.stream().map(i -> createBrokerConfig(i, zkConnect()))
-                .map(c -> TestUtils.createServer(KafkaConfig.fromProps(c), Time.SYSTEM))
+                .map(c -> TestUtils.createServer(KafkaConfig.fromProps(c), SystemTime.getSystemTime()))
                 .collect(Collectors.toList());
 
             TestUtils.waitUntilBrokerMetadataIsPropagated(seq(servers), DEFAULT_MAX_WAIT_MS);
@@ -224,7 +224,7 @@ public class ReplicationQuotasTestRig {
 
             ReassignPartitionsCommand.executeAssignment(adminClient, false,
                 ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Collections.emptyMap()),
-                config.throttle, -1L, 10000L, Time.SYSTEM);
+                config.throttle, -1L, 10000L, SystemTime.getSystemTime());
 
             //Await completion
             waitForReassignmentToComplete();

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -47,7 +47,7 @@ import org.apache.kafka.common.TopicPartitionReplica;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.server.config.QuotaConfigs;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.tools.TerseException;
@@ -714,7 +714,7 @@ public class ReassignPartitionsCommandTest {
                                       Long replicaAlterLogDirsThrottle) throws RuntimeException {
         try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             executeAssignment(admin, additional, reassignmentJson,
-                    interBrokerThrottle, replicaAlterLogDirsThrottle, 10000L, Time.SYSTEM);
+                    interBrokerThrottle, replicaAlterLogDirsThrottle, 10000L, SystemTime.getSystemTime());
         } catch (ExecutionException | InterruptedException | JsonProcessingException | TerseException e) {
             throw new RuntimeException(e);
         }
@@ -725,7 +725,7 @@ public class ReassignPartitionsCommandTest {
             Boolean preserveThrottles
     ) {
         try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            return cancelAssignment(admin, jsonString, preserveThrottles, 10000L, Time.SYSTEM);
+            return cancelAssignment(admin, jsonString, preserveThrottles, 10000L, SystemTime.getSystemTime());
         } catch (ExecutionException | InterruptedException | JsonProcessingException | TerseException e) {
             throw new RuntimeException(e);
         }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.AdminCommandFailedException;
 import org.apache.kafka.server.common.AdminOperationException;
@@ -606,7 +607,7 @@ public class ReassignPartitionsUnitTest {
                     "{\"version\":1,\"partitions\":" +
                         "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1],\"log_dirs\":[\"any\",\"any\"]}," +
                         "{\"topic\":\"quux\",\"partition\":0,\"replicas\":[2,3,4],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
-                        "]}", -1L, -1L, 10000L, Time.SYSTEM), "Expected reassignment with non-existent topic to fail").getCause().getMessage());
+                        "]}", -1L, -1L, 10000L, SystemTime.getSystemTime()), "Expected reassignment with non-existent topic to fail").getCause().getMessage());
         }
     }
 
@@ -619,7 +620,7 @@ public class ReassignPartitionsUnitTest {
                     "{\"version\":1,\"partitions\":" +
                         "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1],\"log_dirs\":[\"any\",\"any\"]}," +
                         "{\"topic\":\"foo\",\"partition\":1,\"replicas\":[2,3,4],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
-                        "]}", -1L, -1L, 10000L, Time.SYSTEM), "Expected reassignment with non-existent broker id to fail").getMessage());
+                        "]}", -1L, -1L, 10000L, SystemTime.getSystemTime()), "Expected reassignment with non-existent broker id to fail").getMessage());
         }
     }
 
@@ -762,7 +763,7 @@ public class ReassignPartitionsUnitTest {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(4).build()) {
             addTopics(adminClient);
             assertStartsWith("Unexpected character",
-                assertThrows(AdminOperationException.class, () -> executeAssignment(adminClient, false, "{invalid_json", -1L, -1L, 10000L, Time.SYSTEM)).getMessage());
+                assertThrows(AdminOperationException.class, () -> executeAssignment(adminClient, false, "{invalid_json", -1L, -1L, 10000L, SystemTime.getSystemTime())).getMessage());
         }
     }
 }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -176,7 +176,7 @@ public final class WorkerUtils {
      */
     private static Collection<String> createTopics(Logger log, Admin adminClient,
                                                    Collection<NewTopic> topics) throws Throwable {
-        long startMs = Time.SYSTEM.milliseconds();
+        long startMs = SystemTime.getSystemTime().milliseconds();
         int tries = 0;
         List<String> existingTopics = new ArrayList<>();
 
@@ -223,7 +223,7 @@ public final class WorkerUtils {
             if (topicsToCreate.isEmpty()) {
                 break;
             }
-            if (Time.SYSTEM.milliseconds() > startMs + CREATE_TOPICS_CALL_TIMEOUT) {
+            if (SystemTime.getSystemTime().milliseconds() > startMs + CREATE_TOPICS_CALL_TIMEOUT) {
                 String str = "Unable to create topic(s): " +
                              String.join(", ", topicsToCreate) + "after " + tries + " attempt(s)";
                 log.warn(str);

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConfigurableProducerWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConfigurableProducerWorker.java
@@ -29,8 +29,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.Platform;
 import org.apache.kafka.trogdor.common.WorkerUtils;
@@ -134,7 +134,7 @@ public class ConfigurableProducerWorker implements TaskWorker {
 
         @Override
         public void onCompletion(RecordMetadata metadata, Exception exception) {
-            long now = Time.SYSTEM.milliseconds();
+            long now = SystemTime.getSystemTime().milliseconds();
             long durationMs = now - startMs;
             sendRecords.recordDuration(durationMs);
             if (exception != null) {
@@ -177,7 +177,7 @@ public class ConfigurableProducerWorker implements TaskWorker {
 
         @Override
         public Void call() throws Exception {
-            long startTimeMs = Time.SYSTEM.milliseconds();
+            long startTimeMs = SystemTime.getSystemTime().milliseconds();
             try {
                 try {
                     long sentMessages = 0;
@@ -202,7 +202,7 @@ public class ConfigurableProducerWorker implements TaskWorker {
             } finally {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData = new StatusUpdater(histogram).update();
-                long curTimeMs = Time.SYSTEM.milliseconds();
+                long curTimeMs = SystemTime.getSystemTime().milliseconds();
                 log.info("Sent {} total record(s) in {} ms.  status: {}",
                     histogram.summarize().numSamples(), curTimeMs - startTimeMs, statusData);
             }
@@ -217,7 +217,7 @@ public class ConfigurableProducerWorker implements TaskWorker {
             } else {
                 record = new ProducerRecord<>(activeTopic, keys.next(), values.next());
             }
-            sendFuture = producer.send(record, new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
+            sendFuture = producer.send(record, new SendRecordsCallback(this, SystemTime.getSystemTime().milliseconds()));
             spec.flushGenerator().ifPresent(flushGenerator -> flushGenerator.increment(producer));
             spec.throughputGenerator().throttle();
         }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.ThreadUtils;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.trogdor.common.JsonUtil;
@@ -61,7 +62,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ConnectionStressWorker implements TaskWorker {
     private static final Logger log = LoggerFactory.getLogger(ConnectionStressWorker.class);
-    private static final Time TIME = Time.SYSTEM;
+    private static final Time TIME = SystemTime.getSystemTime();
 
     private static final int THROTTLE_PERIOD_MS = 100;
 
@@ -251,7 +252,7 @@ public class ConnectionStressWorker implements TaskWorker {
         @Override
         public void run() {
             try {
-                long lastTimeMs = Time.SYSTEM.milliseconds();
+                long lastTimeMs = SystemTime.getSystemTime().milliseconds();
                 JsonNode node;
                 synchronized (ConnectionStressWorker.this) {
                     node = JsonUtil.JSON_SERDE.valueToTree(

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConstantThroughputGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConstantThroughputGenerator.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.trogdor.workload;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 /**
  * This throughput generator configures constant throughput.
@@ -74,7 +74,7 @@ public class ConstantThroughputGenerator implements ThroughputGenerator {
         messageTracker = 0;
 
         // Calculate the next window start time.
-        long now = Time.SYSTEM.milliseconds();
+        long now = SystemTime.getSystemTime().milliseconds();
         if (nextWindowStarts > 0) {
             while (nextWindowStarts <= now) {
                 nextWindowStarts += windowSizeMs;
@@ -92,7 +92,7 @@ public class ConstantThroughputGenerator implements ThroughputGenerator {
         }
 
         // Calculate the next window if we've moved beyond the current one.
-        if (Time.SYSTEM.milliseconds() >= nextWindowStarts) {
+        if (SystemTime.getSystemTime().milliseconds() >= nextWindowStarts) {
             calculateNextWindow();
         }
 
@@ -103,8 +103,8 @@ public class ConstantThroughputGenerator implements ThroughputGenerator {
         if (messageTracker >= messagesPerWindow) {
 
             // Wait the difference in time between now and when the next window starts.
-            while (nextWindowStarts > Time.SYSTEM.milliseconds()) {
-                wait(nextWindowStarts - Time.SYSTEM.milliseconds());
+            while (nextWindowStarts > SystemTime.getSystemTime().milliseconds()) {
+                wait(nextWindowStarts - SystemTime.getSystemTime().milliseconds());
             }
         }
     }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -28,8 +28,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.Platform;
@@ -238,7 +238,7 @@ public class ConsumeBenchWorker implements TaskWorker {
         public Void call() throws Exception {
             long messagesConsumed = 0;
             long bytesConsumed = 0;
-            long startTimeMs = Time.SYSTEM.milliseconds();
+            long startTimeMs = SystemTime.getSystemTime().milliseconds();
             long startBatchMs = startTimeMs;
             long maxMessages = spec.maxMessages();
             try {
@@ -247,7 +247,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                     if (records.isEmpty()) {
                         continue;
                     }
-                    long endBatchMs = Time.SYSTEM.milliseconds();
+                    long endBatchMs = SystemTime.getSystemTime().milliseconds();
                     long elapsedBatchMs = endBatchMs - startBatchMs;
 
                     // Do the record batch processing immediately to avoid latency skew.
@@ -270,7 +270,7 @@ public class ConsumeBenchWorker implements TaskWorker {
 
                         throttle.increment();
                     }
-                    startBatchMs = Time.SYSTEM.milliseconds();
+                    startBatchMs = SystemTime.getSystemTime().milliseconds();
                 }
             } catch (Exception e) {
                 WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
@@ -278,7 +278,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData =
                     new ConsumeStatusUpdater(latencyHistogram, messageSizeHistogram, consumer, spec.recordProcessor()).update();
-                long curTimeMs = Time.SYSTEM.milliseconds();
+                long curTimeMs = SystemTime.getSystemTime().milliseconds();
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
             }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianThroughputGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianThroughputGenerator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 import java.util.Random;
 
 /*
@@ -107,7 +107,7 @@ public class GaussianThroughputGenerator implements ThroughputGenerator {
         messageTracker = 0;
 
         // Calculate the next window start time.
-        long now = Time.SYSTEM.milliseconds();
+        long now = SystemTime.getSystemTime().milliseconds();
         if (nextWindowStarts > 0) {
             while (nextWindowStarts < now) {
                 nextWindowStarts += windowSizeMs;
@@ -130,7 +130,7 @@ public class GaussianThroughputGenerator implements ThroughputGenerator {
     @Override
     public synchronized void throttle() throws InterruptedException {
         // Calculate the next window if we've moved beyond the current one.
-        if (Time.SYSTEM.milliseconds() >= nextWindowStarts) {
+        if (SystemTime.getSystemTime().milliseconds() >= nextWindowStarts) {
             calculateNextWindow(false);
         }
 
@@ -141,8 +141,8 @@ public class GaussianThroughputGenerator implements ThroughputGenerator {
         if (messageTracker >= throttleMessages) {
 
             // Wait the difference in time between now and when the next window starts.
-            while (nextWindowStarts > Time.SYSTEM.milliseconds()) {
-                wait(nextWindowStarts - Time.SYSTEM.milliseconds());
+            while (nextWindowStarts > SystemTime.getSystemTime().milliseconds()) {
+                wait(nextWindowStarts - SystemTime.getSystemTime().milliseconds());
             }
         }
     }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianTimestampConstantPayloadGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianTimestampConstantPayloadGenerator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -117,7 +117,7 @@ public class GaussianTimestampConstantPayloadGenerator implements PayloadGenerat
 
         // Do the timestamp generation as the very last task.
         buffer.clear();
-        buffer.putLong(Time.SYSTEM.milliseconds());
+        buffer.putLong(SystemTime.getSystemTime().milliseconds());
         buffer.rewind();
         System.arraycopy(buffer.array(), 0, result, 0, Long.BYTES);
         return result;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianTimestampRandomPayloadGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/GaussianTimestampRandomPayloadGenerator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -119,7 +119,7 @@ public class GaussianTimestampRandomPayloadGenerator implements PayloadGenerator
 
         // Do the timestamp generation as the very last task.
         buffer.clear();
-        buffer.putLong(Time.SYSTEM.milliseconds());
+        buffer.putLong(SystemTime.getSystemTime().milliseconds());
         buffer.rewind();
         System.arraycopy(buffer.array(), 0, result, 0, Long.BYTES);
         return result;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -29,8 +29,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.Platform;
 import org.apache.kafka.trogdor.common.WorkerUtils;
@@ -139,7 +139,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
         @Override
         public void onCompletion(RecordMetadata metadata, Exception exception) {
-            long now = Time.SYSTEM.milliseconds();
+            long now = SystemTime.getSystemTime().milliseconds();
             long durationMs = now - startMs;
             sendRecords.recordDuration(durationMs);
             if (exception != null) {
@@ -223,7 +223,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
         @Override
         public Void call() throws Exception {
-            long startTimeMs = Time.SYSTEM.milliseconds();
+            long startTimeMs = SystemTime.getSystemTime().milliseconds();
             try {
                 try {
                     if (enableTransactions)
@@ -260,7 +260,7 @@ public class ProduceBenchWorker implements TaskWorker {
             } finally {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData = new StatusUpdater(histogram, transactionsCommitted).update();
-                long curTimeMs = Time.SYSTEM.milliseconds();
+                long curTimeMs = SystemTime.getSystemTime().milliseconds();
                 log.info("Sent {} total record(s) in {} ms.  status: {}",
                     histogram.summarize().numSamples(), curTimeMs - startTimeMs, statusData);
             }
@@ -306,7 +306,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     partition.topic(), partition.partition(), keys.next(), values.next());
             }
             sendFuture = producer.send(record,
-                new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
+                new SendRecordsCallback(this, SystemTime.getSystemTime().milliseconds()));
             throttle.increment();
         }
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -35,8 +35,8 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.ThreadUtils;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.Platform;
@@ -348,7 +348,7 @@ public class RoundTripWorker implements TaskWorker {
             long pollInvoked = 0;
             log.debug("{}: Starting RoundTripWorker#ConsumerRunnable.", id);
             try {
-                long lastLogTimeMs = Time.SYSTEM.milliseconds();
+                long lastLogTimeMs = SystemTime.getSystemTime().milliseconds();
                 while (true) {
                     try {
                         pollInvoked++;
@@ -376,7 +376,7 @@ public class RoundTripWorker implements TaskWorker {
                                 }
                             }
                         }
-                        long curTimeMs = Time.SYSTEM.milliseconds();
+                        long curTimeMs = SystemTime.getSystemTime().milliseconds();
                         if (curTimeMs > lastLogTimeMs + LOG_INTERVAL_MS) {
                             toReceiveTracker.log();
                             lastLogTimeMs = curTimeMs;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
 
 public class SustainedConnectionWorker implements TaskWorker {
     private static final Logger log = LoggerFactory.getLogger(SustainedConnectionWorker.class);
-    private static final SystemTime SYSTEM_TIME = new SystemTime();
+    private static final SystemTime SYSTEM_TIME = SystemTime.getSystemTime();
 
     // This is the metadata for the test itself.
     private final String id;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.trogdor.workload;
 
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 public class Throttle {
@@ -59,7 +60,7 @@ public class Throttle {
     }
 
     protected Time time() {
-        return Time.SYSTEM;
+        return SystemTime.getSystemTime();
     }
 
     protected synchronized void delay(long amount) throws InterruptedException {

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimeIntervalTransactionsGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimeIntervalTransactionsGenerator.java
@@ -18,6 +18,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 /**
@@ -34,7 +35,7 @@ public class TimeIntervalTransactionsGenerator implements TransactionGenerator {
 
     @JsonCreator
     public TimeIntervalTransactionsGenerator(@JsonProperty("transactionIntervalMs") int intervalMs) {
-        this(intervalMs, Time.SYSTEM);
+        this(intervalMs, SystemTime.getSystemTime());
     }
 
     TimeIntervalTransactionsGenerator(@JsonProperty("transactionIntervalMs") int intervalMs,

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampConstantPayloadGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampConstantPayloadGenerator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import java.nio.ByteOrder;
 import java.nio.ByteBuffer;
@@ -70,7 +70,7 @@ public class TimestampConstantPayloadGenerator implements PayloadGenerator {
 
         // Do the timestamp generation as the very last task.
         buffer.clear();
-        buffer.putLong(Time.SYSTEM.milliseconds());
+        buffer.putLong(SystemTime.getSystemTime().milliseconds());
         buffer.rewind();
         System.arraycopy(buffer.array(), 0, result, 0, Long.BYTES);
         return result;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampRandomPayloadGenerator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampRandomPayloadGenerator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.SystemTime;
 
 import java.nio.ByteOrder;
 import java.util.Random;
@@ -94,7 +94,7 @@ public class TimestampRandomPayloadGenerator implements PayloadGenerator {
 
         // Do the timestamp generation as the very last task.
         buffer.clear();
-        buffer.putLong(Time.SYSTEM.milliseconds());
+        buffer.putLong(SystemTime.getSystemTime().milliseconds());
         buffer.rewind();
         System.arraycopy(buffer.array(), 0, result, 0, Long.BYTES);
         return result;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampRecordProcessor.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TimestampRecordProcessor.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.trogdor.common.JsonUtil;
-import org.apache.kafka.common.utils.Time;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +92,7 @@ public class TimestampRecordProcessor implements RecordProcessor {
     @Override
     public synchronized void processRecords(ConsumerRecords<byte[], byte[]> consumerRecords) {
         // Save the current time to prevent skew by processing time.
-        long curTime = Time.SYSTEM.milliseconds();
+        long curTime = SystemTime.getSystemTime().milliseconds();
         for (ConsumerRecord<byte[], byte[]> record : consumerRecords) {
             try {
                 buffer.clear();


### PR DESCRIPTION
Currently, the SystemTime class, which provides system time-related functionalities such as getting the current timestamp 、sleep、and await can be instantiated multiple times.

Howerver,  system time is unique，In an application, the time obtained in different places should be consistent,  But now the time obtained by using the Java System class to interact with the underlying layer is the same。

So I suggest changing it to a singleton mode， reflect the uniqueness of system time in design

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
