### PR TITLE
KAFKA-16916: Fixing error in completing future

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2326,7 +2326,7 @@ public class KafkaAdminClient extends AdminClient {
         clusterResult.nodes().whenComplete(
             (nodes, exception) -> {
                 if (exception != null) {
-                    completeAllExceptionally(topicFutures.values(), exception.getCause());
+                    completeAllExceptionally(topicFutures.values(), exception);
                     return;
                 }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -111,9 +110,6 @@ public class ClientAuthenticationFailureTest {
     }
 
     @Test
-    // The test runs forever on trunk after c01279b9. (KAFKA-16916)
-    // We disable the test temporarily until we fix it to unblock the CI.
-    @Disabled
     public void testAdminClientWithInvalidCredentials() {
         Map<String, Object> props = new HashMap<>(saslClientConfigs);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + server.port());


### PR DESCRIPTION
Fix to complete Future which was stuck due the `exception.getCause()` throws an error.

The fix in the https://github.com/apache/kafka/pull/16217 unblocked blocking thread but `exception` in `catch` block from blocking `get` call was wrapped in `ExecutionException` which is not the case when moved to async workflow hence `getCause` is not needed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
