### PR TITLE
MINOR: Fix broken ReassignPartitionsCommandTest test

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1363,14 +1363,6 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       }
       validateAdvertisedListenersNonEmptyForBroker()
     }
-    if (processRoles.contains(ProcessRole.BrokerRole)
-      && originals.containsKey(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG)
-      && logDirs.size > 1) {
-        require(interBrokerProtocolVersion.isDirectoryAssignmentSupported,
-          s"Multiple log directories (aka JBOD) are not supported with the configured " +
-            s"${interBrokerProtocolVersion} ${ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG}. " +
-            s"Need ${MetadataVersion.IBP_3_7_IV2} or higher")
-    }
 
     val listenerNames = listeners.map(_.listenerName).toSet
     if (processRoles.isEmpty || processRoles.contains(ProcessRole.BrokerRole)) {


### PR DESCRIPTION
KAFKA-16606 (#15834) introduced a change that broke ReassignPartitionsCommandTest.testReassignmentCompletionDuringPartialUpgrade.

The point was to validate that the MetadataVersion supports JBOD in KRaft when multiple log directories are configured. We do that by checking the version used in
kafka-features.sh upgrade --metadata, and the version discovered via a FeatureRecord for metadata.version in the cluster metadata.

There's no point in checking inter.broker.protocol.version in KafkaConfig, since in KRaft, that configuration is deprecated and ignored — always assuming the value of MINIMUM_KRAFT_VERSION.

The broken that was broken sets inter.broker.protocol.version in KRaft mode and configures 3 directories. So alternatively, we could change the test to not configure this property. Since the property isn't forbidden in KRaft mode, just ignored, and operators may forget to remove it, it seems better to remote the fail condition in KafkaConfig.

