### PR TITLE
KAFKA-16924: add slf4jlog4j dependey in tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2167,7 +2167,6 @@ project(':tools') {
   }
 
   dependencies {
-    compileOnly libs.slf4jlog4j
     implementation project(':clients')
     implementation project(':storage')
     implementation project(':server-common')
@@ -2178,6 +2177,7 @@ project(':tools') {
     implementation libs.jacksonDataformatCsv
     implementation libs.jacksonJDK8Datatypes
     implementation libs.slf4jApi
+    implementation libs.slf4jlog4j
     implementation libs.joptSimple
 
     implementation libs.jose4j                    // for SASL/OAUTHBEARER JWT validation
@@ -2204,7 +2204,6 @@ project(':tools') {
       exclude group: 'junit', module: 'junit'
     }
     testImplementation libs.log4j
-    testRuntimeOnly libs.slf4jlog4j
   }
 
   javadoc {


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/12148 , we removed log4jAppender dependency, and add testImplementation dependency for `slf4jlog4j` lib. However, we need this runtime dependency in tools module to output logs. ([ref](https://stackoverflow.com/a/21787813)) Adding this dependency back.

Note: The `slf4jlog4j` lib was added in `log4j-appender` dependency. Since it's removed, we need to explicitly declare it.

Current output will be like this:

```
> ./gradlew clean jar
> bin/kafka-server-start.sh config/kraft/controller.properties
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

After this PR, it'll be normal:
```
> ./gradlew clean jar
> bin/kafka-server-start.sh config/kraft/controller.properties 
[2024-06-10 08:38:50,734] INFO Registered kafka:type=kafka.Log4jController MBean (kafka.utils.Log4jControllerRegistration$)
[2024-06-10 08:38:50,832] INFO Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation (org.apache.zookeeper.common.X509Util)
...
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
