### PR TITLE
KAFKA-16918: TestUtils#assertFutureThrows should use future.get with timeout

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -558,20 +558,10 @@ public class TestUtils {
      * @return The caught exception cause
      */
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
-        try {
-            future.get(5, TimeUnit.SECONDS);
-            ExecutionException exception = assertThrows(ExecutionException.class, future::get);
-            assertInstanceOf(exceptionCauseClass, exception.getCause(),
-                    "Unexpected exception cause " + exception.getCause());
-            return exceptionCauseClass.cast(exception.getCause());
-        } catch (TimeoutException e) {
-            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
-        } catch (ExecutionException e) {
-            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
-        } catch (InterruptedException e) {
-            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
-        }
-        return null;
+        ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+        assertInstanceOf(exceptionCauseClass, exception.getCause(),
+                "Unexpected exception cause " + exception.getCause());
+        return exceptionCauseClass.cast(exception.getCause());
     }
 
     public static <T extends Throwable> void assertFutureThrows(

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -558,14 +558,13 @@ public class TestUtils {
      */
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
         try {
-            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
+            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS);
             fail("Future should throw expected exception " + exceptionCauseClass.getSimpleName() + " but succeed.");
         } catch (TimeoutException | InterruptedException | ExecutionException e) {
-            assertInstanceOf(exceptionCauseClass, e.getCause(),
-                    "Unexpected exception cause " + e.getCause());
+            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
             return exceptionCauseClass.cast(e.getCause());
         }
-        return null;
+        throw new RuntimeException("Future should throw expected exception but unexpected error happened.");
     }
 
     public static <T extends Throwable> void assertFutureThrows(
@@ -580,7 +579,7 @@ public class TestUtils {
     public static void assertFutureError(Future<?> future, Class<? extends Throwable> exceptionClass)
         throws InterruptedException {
         try {
-            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
+            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS);
             fail("Expected a " + exceptionClass.getSimpleName() + " exception, but got success.");
         } catch (ExecutionException ee) {
             assertInstanceOf(exceptionClass, ee.getCause(), "Expected a" + exceptionClass.getSimpleName() + "but got" + ee.getCause());

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -576,15 +576,12 @@ public class TestUtils {
     public static void assertFutureError(Future<?> future, Class<? extends Throwable> exceptionClass)
         throws InterruptedException {
         try {
-            future.get(5, TimeUnit.SECONDS);
+            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
             fail("Expected a " + exceptionClass.getSimpleName() + " exception, but got success.");
         } catch (ExecutionException ee) {
-            Throwable cause = ee.getCause();
-            assertEquals(exceptionClass, cause.getClass(),
-                "Expected a " + exceptionClass.getSimpleName() + " exception, but got " +
-                    cause.getClass().getSimpleName());
+            assertInstanceOf(exceptionClass, ee.getCause(), "Expected a" + exceptionClass.getSimpleName() + "but got" + ee.getCause());
         } catch (TimeoutException e) {
-            assertInstanceOf(exceptionClass, e.getCause(), "Expected a" + exceptionClass.getSimpleName() + "but got" + e.getCause());
+            fail("Future did not throw expected exception " + exceptionClass.getSimpleName() + " in time.");
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +78,6 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -558,12 +556,16 @@ public class TestUtils {
      * @param <T> Exception cause type parameter
      * @return The caught exception cause
      */
-    @Timeout(DEFAULT_MAX_WAIT_MS)
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
-        ExecutionException exception = assertThrows(ExecutionException.class, future::get);
-        assertInstanceOf(exceptionCauseClass, exception.getCause(),
-                "Unexpected exception cause " + exception.getCause());
-        return exceptionCauseClass.cast(exception.getCause());
+        try {
+            future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
+            fail("Future should throw expected exception " + exceptionCauseClass.getSimpleName() + " but succeed.");
+        } catch (TimeoutException | InterruptedException | ExecutionException e) {
+            assertInstanceOf(exceptionCauseClass, e.getCause(),
+                    "Unexpected exception cause " + e.getCause());
+            return exceptionCauseClass.cast(e.getCause());
+        }
+        return null;
     }
 
     public static <T extends Throwable> void assertFutureThrows(

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -557,6 +558,7 @@ public class TestUtils {
      * @param <T> Exception cause type parameter
      * @return The caught exception cause
      */
+    @Timeout(DEFAULT_MAX_WAIT_MS)
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
         ExecutionException exception = assertThrows(ExecutionException.class, future::get);
         assertInstanceOf(exceptionCauseClass, exception.getCause(),

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -556,10 +557,16 @@ public class TestUtils {
      * @return The caught exception cause
      */
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
-        ExecutionException exception = assertThrows(ExecutionException.class, future::get);
-        assertInstanceOf(exceptionCauseClass, exception.getCause(),
-            "Unexpected exception cause " + exception.getCause());
-        return exceptionCauseClass.cast(exception.getCause());
+        try {
+            future.get(5, TimeUnit.SECONDS);
+            ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+            assertInstanceOf(exceptionCauseClass, exception.getCause(),
+                    "Unexpected exception cause " + exception.getCause());
+            return exceptionCauseClass.cast(exception.getCause());
+
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     public static <T extends Throwable> void assertFutureThrows(

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -563,7 +563,6 @@ public class TestUtils {
             assertInstanceOf(exceptionCauseClass, exception.getCause(),
                     "Unexpected exception cause " + exception.getCause());
             return exceptionCauseClass.cast(exception.getCause());
-
         } catch (Exception ignored) {
             return null;
         }

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -560,18 +560,16 @@ public class TestUtils {
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
         try {
             future.get(5, TimeUnit.SECONDS);
-            fail("expected to throw ExecutionException...");
-        } catch (TimeoutException e) {
-            fail("timeout waiting");
-            return null;
-        } catch (ExecutionException e) {
             ExecutionException exception = assertThrows(ExecutionException.class, future::get);
             assertInstanceOf(exceptionCauseClass, exception.getCause(),
                     "Unexpected exception cause " + exception.getCause());
             return exceptionCauseClass.cast(exception.getCause());
+        } catch (TimeoutException e) {
+            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
+        } catch (ExecutionException e) {
+            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
         } catch (InterruptedException e) {
-            fail("Unexpected exception cause" + e.getCause());
-            return null;
+            assertInstanceOf(exceptionCauseClass, e.getCause(), "Expected a" + exceptionCauseClass.getSimpleName() + "but got" + e.getCause());
         }
         return null;
     }
@@ -596,7 +594,7 @@ public class TestUtils {
                 "Expected a " + exceptionClass.getSimpleName() + " exception, but got " +
                     cause.getClass().getSimpleName());
         } catch (TimeoutException e) {
-            fail("timeout waiting");
+            assertInstanceOf(exceptionClass, e.getCause(), "Expected a" + exceptionClass.getSimpleName() + "but got" + e.getCause());
         }
     }
 


### PR DESCRIPTION
Based on [KAFKA-16918](https://issues.apache.org/jira/browse/KAFKA-16918), this pr add `future.get()` with timeout in `assertFutureThrows`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
