### PR TITLE
KAFKA-15045: (KIP-924 pt. 21) UUID to ProcessId migration

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -200,7 +200,7 @@
               files="StreamThread.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(InternalTopologyBuilder|KafkaStreams|KStreamImpl|KTableImpl).java"/>
+              files="(InternalTopologyBuilder|KafkaStreams|KStreamImpl|KTableImpl|StreamsPartitionAssignor).java"/>
 
     <suppress checks="CyclomaticComplexity"
               files="(KafkaStreams|StreamsPartitionAssignor|StreamThread|TaskManager|PartitionGroup|SubscriptionWrapperSerde|AssignorConfiguration).java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.assignment;
 import java.util.UUID;
 
 /** A simple wrapper around UUID that abstracts a Process ID */
-public class ProcessId {
+public class ProcessId implements Comparable<ProcessId> {
 
     private final UUID id;
 
@@ -55,5 +55,10 @@ public class ProcessId {
             return false;
         final ProcessId other = (ProcessId) obj;
         return this.id.equals(other.id());
+    }
+
+    @Override
+    public int compareTo(final ProcessId o) {
+        return this.id.compareTo(o.id);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
@@ -37,7 +37,7 @@ public class ProcessId implements Comparable<ProcessId> {
 
     @Override
     public String toString() {
-        return "ProcessId{id=" + id + "}";
+        return id.toString();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -51,6 +51,7 @@ import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.processor.StandbyUpdateListener;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -444,7 +445,7 @@ public class StreamThread extends Thread implements ProcessingThread {
         final TaskManager taskManager = new TaskManager(
             time,
             changelogReader,
-            processId,
+            new ProcessId(processId),
             logPrefix,
             activeTaskCreator,
             standbyTaskCreator,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -920,12 +920,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
 
         for (final Map.Entry<ProcessId, ClientMetadata> entry : clientMetadataMap.entrySet()) {
-            final ProcessId uuid = entry.getKey();
+            final ProcessId processId = entry.getKey();
             final ClientState state = entry.getValue().state;
             state.initializePrevTasks(taskForPartition, taskManager.topologyMetadata().hasNamedTopologies());
 
-            state.computeTaskLags(uuid, allTaskEndOffsetSums);
-            clientStates.put(uuid, state);
+            state.computeTaskLags(processId, allTaskEndOffsetSums);
+            clientStates.put(processId, state);
         }
 
         return fetchEndOffsetsSuccessful;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.StateDirectory.TaskDirectory;
 import org.apache.kafka.streams.processor.internals.Task.State;
 import org.apache.kafka.streams.processor.internals.tasks.DefaultTaskManager;
@@ -62,7 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -84,7 +84,7 @@ public class TaskManager {
     private final Logger log;
     private final Time time;
     private final TasksRegistry tasks;
-    private final UUID processId;
+    private final ProcessId processId;
     private final String logPrefix;
     private final Admin adminClient;
     private final StateDirectory stateDirectory;
@@ -109,7 +109,7 @@ public class TaskManager {
     private final DefaultTaskManager schedulingTaskManager;
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
-                final UUID processId,
+                final ProcessId processId,
                 final String logPrefix,
                 final ActiveTaskCreator activeTaskCreator,
                 final StandbyTaskCreator standbyTaskCreator,
@@ -153,7 +153,7 @@ public class TaskManager {
         return activeTaskCreator.totalProducerBlockedTime();
     }
 
-    public UUID processId() {
+    public ProcessId processId() {
         return processId;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.KafkaStreamsAssignment;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -63,7 +63,7 @@ public class ClientState {
     private final ClientStateTask previousActiveTasks = new ClientStateTask(null, new TreeMap<>());
     private final ClientStateTask previousStandbyTasks = new ClientStateTask(null, null);
     private final ClientStateTask revokingActiveTasks = new ClientStateTask(null, new TreeMap<>());
-    private final UUID processId;
+    private final ProcessId processId;
 
     private Optional<Instant> followupRebalanceDeadline = Optional.empty();
     private int capacity;
@@ -72,7 +72,7 @@ public class ClientState {
         this(null, 0);
     }
 
-    public ClientState(final UUID processId, final Map<String, String> clientTags) {
+    public ClientState(final ProcessId processId, final Map<String, String> clientTags) {
         this(processId, 0, clientTags);
     }
 
@@ -80,11 +80,11 @@ public class ClientState {
         this(null, capacity);
     }
 
-    ClientState(final UUID processId, final int capacity) {
+    ClientState(final ProcessId processId, final int capacity) {
         this(processId, capacity, Collections.emptyMap());
     }
 
-    ClientState(final UUID processId, final int capacity, final Map<String, String> clientTags) {
+    ClientState(final ProcessId processId, final int capacity, final Map<String, String> clientTags) {
         previousStandbyTasks.setTaskIds(new TreeSet<>());
         previousActiveTasks.setTaskIds(new TreeSet<>());
         taskOffsetSums = new TreeMap<>();
@@ -109,7 +109,7 @@ public class ClientState {
                        final Map<TaskId, Long> taskLagTotals,
                        final Map<String, String> clientTags,
                        final int capacity,
-                       final UUID processId) {
+                       final ProcessId processId) {
         this.previousStandbyTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousStandbyTasks)));
         this.previousActiveTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousActiveTasks)));
         taskOffsetSums = emptyMap();
@@ -135,7 +135,7 @@ public class ClientState {
         return capacity;
     }
 
-    UUID processId() {
+    ProcessId processId() {
         return processId;
     }
 
@@ -378,7 +378,7 @@ public class ClientState {
     /**
      * Compute the lag for each stateful task, including tasks this client did not previously have.
      */
-    public void computeTaskLags(final UUID uuid, final Map<TaskId, Long> allTaskEndOffsetSums) {
+    public void computeTaskLags(final ProcessId uuid, final Map<TaskId, Long> allTaskEndOffsetSums) {
         if (!taskLagTotals.isEmpty()) {
             throw new IllegalStateException("Already computed task lags for this client.");
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultApplicationState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultApplicationState.java
@@ -21,7 +21,6 @@ import static java.util.Collections.unmodifiableMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import org.apache.kafka.streams.processor.assignment.TaskInfo;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.ClientMetadata;
 import org.apache.kafka.streams.processor.TaskId;
@@ -35,13 +34,13 @@ public class DefaultApplicationState implements ApplicationState {
 
     private final AssignmentConfigs assignmentConfigs;
     private final Map<TaskId, TaskInfo> tasks;
-    private final Map<UUID, ClientMetadata> clientStates;
+    private final Map<ProcessId, ClientMetadata> clientStates;
 
     private final Map<Boolean, Map<ProcessId, KafkaStreamsState>> cachedKafkaStreamStates;
 
     public DefaultApplicationState(final AssignmentConfigs assignmentConfigs,
                                    final Map<TaskId, TaskInfo> tasks,
-                                   final Map<UUID, ClientMetadata> clientStates) {
+                                   final Map<ProcessId, ClientMetadata> clientStates) {
         this.assignmentConfigs = assignmentConfigs;
         this.tasks = unmodifiableMap(tasks);
         this.clientStates = clientStates;
@@ -55,10 +54,10 @@ public class DefaultApplicationState implements ApplicationState {
         }
 
         final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates = new HashMap<>();
-        for (final Map.Entry<UUID, StreamsPartitionAssignor.ClientMetadata> clientEntry : clientStates.entrySet()) {
+        for (final Map.Entry<ProcessId, StreamsPartitionAssignor.ClientMetadata> clientEntry : clientStates.entrySet()) {
             final ClientMetadata metadata = clientEntry.getValue();
             final ClientState clientState = metadata.state();
-            final ProcessId processId = new ProcessId(clientEntry.getKey());
+            final ProcessId processId = clientEntry.getKey();
             final Map<TaskId, Long> taskLagTotals = computeTaskLags ? clientState.taskLagTotals() : null;
             final KafkaStreamsState kafkaStreamsState = new DefaultKafkaStreamsState(
                 processId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStandbyTaskAssignor.java
@@ -18,12 +18,12 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.computeTasksToRemainingStandbys;
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.createLeastLoadedPrioritySetConstrainedByAssignedTask;
@@ -38,7 +38,7 @@ class DefaultStandbyTaskAssignor implements StandbyTaskAssignor {
     private static final Logger log = LoggerFactory.getLogger(DefaultStandbyTaskAssignor.class);
 
     @Override
-    public boolean assign(final Map<UUID, ClientState> clients,
+    public boolean assign(final Map<ProcessId, ClientState> clients,
                           final Set<TaskId> allTaskIds,
                           final Set<TaskId> statefulTaskIds,
                           final AssignmentConfigs configs) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignor.java
@@ -20,8 +20,8 @@ import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 
 /**
  * A special task assignor implementation to be used as a fallback in case the
@@ -39,7 +39,7 @@ public class FallbackPriorTaskAssignor implements TaskAssignor {
     }
 
     @Override
-    public boolean assign(final Map<UUID, ClientState> clients,
+    public boolean assign(final Map<ProcessId, ClientState> clients,
                           final Set<TaskId> allTaskIds,
                           final Set<TaskId> statefulTaskIds,
                           final RackAwareTaskAssignor rackAwareTaskAssignor,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignmentUtils.java
@@ -17,11 +17,11 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.slf4j.Logger;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 
 import static java.util.stream.Collectors.toMap;
@@ -29,20 +29,20 @@ import static java.util.stream.Collectors.toMap;
 final class StandbyTaskAssignmentUtils {
     private StandbyTaskAssignmentUtils() {}
 
-    static ConstrainedPrioritySet createLeastLoadedPrioritySetConstrainedByAssignedTask(final Map<UUID, ClientState> clients) {
+    static ConstrainedPrioritySet createLeastLoadedPrioritySetConstrainedByAssignedTask(final Map<ProcessId, ClientState> clients) {
         return new ConstrainedPrioritySet((client, t) -> !clients.get(client).hasAssignedTask(t),
                                           client -> clients.get(client).assignedTaskLoad());
     }
 
     static void pollClientAndMaybeAssignAndUpdateRemainingStandbyTasks(final int numStandbyReplicas,
-                                                                       final Map<UUID, ClientState> clients,
+                                                                       final Map<ProcessId, ClientState> clients,
                                                                        final Map<TaskId, Integer> tasksToRemainingStandbys,
                                                                        final ConstrainedPrioritySet standbyTaskClientsByTaskLoad,
                                                                        final TaskId activeTaskId,
                                                                        final Logger log) {
         int numRemainingStandbys = tasksToRemainingStandbys.get(activeTaskId);
         while (numRemainingStandbys > 0) {
-            final UUID client = standbyTaskClientsByTaskLoad.poll(activeTaskId);
+            final ProcessId client = standbyTaskClientsByTaskLoad.poll(activeTaskId);
             if (client == null) {
                 break;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignor.java
@@ -18,9 +18,9 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 
 interface StandbyTaskAssignor extends TaskAssignor {
     default boolean isAllowedTaskMovement(final ClientState source, final ClientState destination) {
@@ -38,11 +38,11 @@ interface StandbyTaskAssignor extends TaskAssignor {
     default boolean isAllowedTaskMovement(final ClientState source,
                                           final ClientState destination,
                                           final TaskId sourceTask,
-                                          final Map<UUID, ClientState> clientStateMap) {
+                                          final Map<ProcessId, ClientState> clientStateMap) {
         return true;
     }
 
-    default boolean assign(final Map<UUID, ClientState> clients,
+    default boolean assign(final Map<ProcessId, ClientState> clients,
                            final Set<TaskId> allTaskIds,
                            final Set<TaskId> statefulTaskIds,
                            final RackAwareTaskAssignor rackAwareTaskAssignor,
@@ -50,7 +50,7 @@ interface StandbyTaskAssignor extends TaskAssignor {
         return assign(clients, allTaskIds, statefulTaskIds, configs);
     }
 
-    boolean assign(final Map<UUID, ClientState> clients,
+    boolean assign(final Map<ProcessId, ClientState> clients,
                    final Set<TaskId> allTaskIds,
                    final Set<TaskId> statefulTaskIds,
                    final AssignmentConfigs configs);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -21,8 +21,8 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 
 class StandbyTaskAssignorFactory {
     private StandbyTaskAssignorFactory() {}
@@ -33,7 +33,7 @@ class StandbyTaskAssignorFactory {
             return new ClientTagAwareStandbyTaskAssignor();
         } else if (rackAwareTaskAssignor != null && rackAwareTaskAssignor.validClientRack()) {
             // racksForProcess should be populated if rackAwareTaskAssignor isn't null
-            final Map<UUID, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
+            final Map<ProcessId, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
             return new ClientTagAwareStandbyTaskAssignor(
                 (processId, clientState) -> mkMap(mkEntry("rack", racksForProcess.get(processId))),
                 assignmentConfigs -> Collections.singletonList("rack")

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.ClientT
 import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.PartitionToOffsetSum;
 import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.TaskOffsetSum;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.Task;
 
 import org.slf4j.Logger;
@@ -84,7 +85,7 @@ public class SubscriptionInfo {
 
     public SubscriptionInfo(final int version,
                             final int latestSupportedVersion,
-                            final UUID processId,
+                            final ProcessId processId,
                             final String userEndPoint,
                             final Map<TaskId, Long> taskOffsetSums,
                             final byte uniqueField,
@@ -93,8 +94,8 @@ public class SubscriptionInfo {
         validateVersions(version, latestSupportedVersion);
         final SubscriptionInfoData data = new SubscriptionInfoData();
         data.setVersion(version);
-        data.setProcessId(new Uuid(processId.getMostSignificantBits(),
-                processId.getLeastSignificantBits()));
+        data.setProcessId(new Uuid(processId.id().getMostSignificantBits(),
+                processId.id().getLeastSignificantBits()));
 
         if (version >= 2) {
             data.setUserEndPoint(userEndPoint == null
@@ -228,8 +229,8 @@ public class SubscriptionInfo {
         return data.latestSupportedVersion();
     }
 
-    public UUID processId() {
-        return new UUID(data.processId().getMostSignificantBits(), data.processId().getLeastSignificantBits());
+    public ProcessId processId() {
+        return new ProcessId(new UUID(data.processId().getMostSignificantBits(), data.processId().getLeastSignificantBits()));
     }
 
     public Set<TaskId> prevTasks() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignor.java
@@ -20,14 +20,14 @@ import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 
 public interface TaskAssignor {
     /**
      * @return whether the generated assignment requires a followup probing rebalance to satisfy all conditions
      */
-    boolean assign(final Map<UUID, ClientState> clients,
+    boolean assign(final Map<ProcessId, ClientState> clients,
                    final Set<TaskId> allTaskIds,
                    final Set<TaskId> statefulTaskIds,
                    final RackAwareTaskAssignor rackAwareTaskAssignor,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
@@ -50,7 +51,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -63,8 +63,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -147,7 +147,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
 
     private void createMockTaskManager() {
         when(taskManager.topologyMetadata()).thenReturn(topologyMetadata);
-        when(taskManager.processId()).thenReturn(UUID_1);
+        when(taskManager.processId()).thenReturn(PID_1);
         topologyMetadata.buildAndRewriteTopology();
     }
 
@@ -186,12 +186,12 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         subscriptions.put(firstConsumer,
                           new Subscription(
                               singletonList("source1"),
-                              getInfo(UUID_1, allTasks).encode()
+                              getInfo(PID_1, allTasks).encode()
                           ));
         subscriptions.put(newConsumer,
                           new Subscription(
                               singletonList("source1"),
-                              getInfo(UUID_2, EMPTY_TASKS).encode()
+                              getInfo(PID_2, EMPTY_TASKS).encode()
                           ));
 
         final Map<String, Assignment> assignments = partitionAssignor
@@ -240,12 +240,12 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         subscriptions.put(firstConsumer,
                           new Subscription(
                               singletonList("source1"),
-                              getInfo(UUID_1, allTasks).encode()
+                              getInfo(PID_1, allTasks).encode()
                           ));
         subscriptions.put(newConsumer,
                           new Subscription(
                               singletonList("source1"),
-                              getInfo(UUID_2, EMPTY_TASKS).encode()
+                              getInfo(PID_2, EMPTY_TASKS).encode()
                           ));
 
         final Map<String, Assignment> assignments = partitionAssignor
@@ -297,7 +297,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         return changelogEndOffsets;
     }
 
-    private static SubscriptionInfo getInfo(final UUID processId,
+    private static SubscriptionInfo getInfo(final ProcessId processId,
                                             final Set<TaskId> prevTasks) {
         return new SubscriptionInfo(
             LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks), (byte) 0, 0, Collections.emptyMap());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
@@ -45,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -56,15 +56,15 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CHANGELOG_END_OFFSETS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_4;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_5;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_6;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_7;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_8;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_9;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_4;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_5;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_6;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_7;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_8;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_9;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -162,7 +162,7 @@ public class RackAwarenessStreamsPartitionAssignorTest {
     private void createMockTaskManager() {
         taskManager = mock(TaskManager.class);
         when(taskManager.topologyMetadata()).thenReturn(topologyMetadata);
-        when(taskManager.processId()).thenReturn(UUID_1);
+        when(taskManager.processId()).thenReturn(PID_1);
         topologyMetadata.buildAndRewriteTopology();
     }
 
@@ -201,11 +201,11 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         }
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
-        subscriptions.put(consumer1, getSubscription(UUID_1, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer1, clientTags1);
-        subscriptions.put(consumer2, getSubscription(UUID_2, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer2, getSubscription(PID_2, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer2, clientTags1);
-        subscriptions.put(consumer3, getSubscription(UUID_3, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer3, getSubscription(PID_3, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer3, clientTags2);
 
         Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor
@@ -216,8 +216,8 @@ public class RackAwarenessStreamsPartitionAssignorTest {
 
         // kill the first consumer and rebalance, should still achieve ideal distribution
         subscriptions.clear();
-        subscriptions.put(consumer2, getSubscription(UUID_2, AssignmentInfo.decode(assignments.get(consumer2).userData()).activeTasks(), clientTags1));
-        subscriptions.put(consumer3, getSubscription(UUID_3, AssignmentInfo.decode(assignments.get(consumer3).userData()).activeTasks(), clientTags2));
+        subscriptions.put(consumer2, getSubscription(PID_2, AssignmentInfo.decode(assignments.get(consumer2).userData()).activeTasks(), clientTags1));
+        subscriptions.put(consumer3, getSubscription(PID_3, AssignmentInfo.decode(assignments.get(consumer3).userData()).activeTasks(), clientTags2));
 
         assignments = partitionAssignor.assign(metadata, new ConsumerPartitionAssignor.GroupSubscription(subscriptions))
             .groupAssignment();
@@ -252,17 +252,17 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         final String consumer6 = "consumer6";
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
-        subscriptions.put(consumer1, getSubscription(UUID_1, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer1, clientTags1);
-        subscriptions.put(consumer2, getSubscription(UUID_2, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer2, getSubscription(PID_2, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer2, clientTags1);
-        subscriptions.put(consumer3, getSubscription(UUID_3, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer3, getSubscription(PID_3, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer3, clientTags1);
-        subscriptions.put(consumer4, getSubscription(UUID_4, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer4, getSubscription(PID_4, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer4, clientTags2);
-        subscriptions.put(consumer5, getSubscription(UUID_5, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer5, getSubscription(PID_5, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer5, clientTags2);
-        subscriptions.put(consumer6, getSubscription(UUID_6, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer6, getSubscription(PID_6, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer6, clientTags2);
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor
@@ -311,23 +311,23 @@ public class RackAwarenessStreamsPartitionAssignorTest {
             mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
-        subscriptions.put(consumer1, getSubscription(UUID_1, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer1, clientTags1);
-        subscriptions.put(consumer2, getSubscription(UUID_2, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer2, getSubscription(PID_2, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer2, clientTags2);
-        subscriptions.put(consumer3, getSubscription(UUID_3, EMPTY_TASKS, clientTags3));
+        subscriptions.put(consumer3, getSubscription(PID_3, EMPTY_TASKS, clientTags3));
         hostTags.put(consumer3, clientTags3);
-        subscriptions.put(consumer4, getSubscription(UUID_4, EMPTY_TASKS, clientTags4));
+        subscriptions.put(consumer4, getSubscription(PID_4, EMPTY_TASKS, clientTags4));
         hostTags.put(consumer4, clientTags4);
-        subscriptions.put(consumer5, getSubscription(UUID_5, EMPTY_TASKS, clientTags5));
+        subscriptions.put(consumer5, getSubscription(PID_5, EMPTY_TASKS, clientTags5));
         hostTags.put(consumer5, clientTags5);
-        subscriptions.put(consumer6, getSubscription(UUID_6, EMPTY_TASKS, clientTags6));
+        subscriptions.put(consumer6, getSubscription(PID_6, EMPTY_TASKS, clientTags6));
         hostTags.put(consumer6, clientTags6);
-        subscriptions.put(consumer7, getSubscription(UUID_7, EMPTY_TASKS, clientTags7));
+        subscriptions.put(consumer7, getSubscription(PID_7, EMPTY_TASKS, clientTags7));
         hostTags.put(consumer7, clientTags7);
-        subscriptions.put(consumer8, getSubscription(UUID_8, EMPTY_TASKS, clientTags8));
+        subscriptions.put(consumer8, getSubscription(PID_8, EMPTY_TASKS, clientTags8));
         hostTags.put(consumer8, clientTags8);
-        subscriptions.put(consumer9, getSubscription(UUID_9, EMPTY_TASKS, clientTags9));
+        subscriptions.put(consumer9, getSubscription(PID_9, EMPTY_TASKS, clientTags9));
         hostTags.put(consumer9, clientTags9);
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor
@@ -367,17 +367,17 @@ public class RackAwarenessStreamsPartitionAssignorTest {
             mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
-        subscriptions.put(consumer1, getSubscription(UUID_1, EMPTY_TASKS, clientTags1));
+        subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));
         hostTags.put(consumer1, clientTags1);
-        subscriptions.put(consumer2, getSubscription(UUID_2, EMPTY_TASKS, clientTags2));
+        subscriptions.put(consumer2, getSubscription(PID_2, EMPTY_TASKS, clientTags2));
         hostTags.put(consumer2, clientTags2);
-        subscriptions.put(consumer3, getSubscription(UUID_3, EMPTY_TASKS, clientTags3));
+        subscriptions.put(consumer3, getSubscription(PID_3, EMPTY_TASKS, clientTags3));
         hostTags.put(consumer3, clientTags3);
-        subscriptions.put(consumer4, getSubscription(UUID_4, EMPTY_TASKS, clientTags4));
+        subscriptions.put(consumer4, getSubscription(PID_4, EMPTY_TASKS, clientTags4));
         hostTags.put(consumer4, clientTags4);
-        subscriptions.put(consumer5, getSubscription(UUID_5, EMPTY_TASKS, clientTags5));
+        subscriptions.put(consumer5, getSubscription(PID_5, EMPTY_TASKS, clientTags5));
         hostTags.put(consumer5, clientTags5);
-        subscriptions.put(consumer6, getSubscription(UUID_6, EMPTY_TASKS, clientTags6));
+        subscriptions.put(consumer6, getSubscription(PID_6, EMPTY_TASKS, clientTags6));
         hostTags.put(consumer6, clientTags6);
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor
@@ -534,7 +534,7 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         return changelogEndOffsets;
     }
 
-    private static ConsumerPartitionAssignor.Subscription getSubscription(final UUID processId,
+    private static ConsumerPartitionAssignor.Subscription getSubscription(final ProcessId processId,
                                                                           final Collection<TaskId> prevActiveTasks,
                                                                           final Map<String, String> clientTags) {
         return new ConsumerPartitionAssignor.Subscription(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
@@ -63,7 +63,7 @@ import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getInfo;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -239,7 +239,7 @@ public class StreamsAssignmentScaleTest {
                     getConsumerName(i, client),
                     new Subscription(
                         topic,
-                        getInfo(uuidForInt(client), EMPTY_TASKS, EMPTY_TASKS).encode(),
+                        getInfo(processIdForInt(client), EMPTY_TASKS, EMPTY_TASKS).encode(),
                         Collections.emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(String.format("rack-%d", client % 31))
@@ -270,7 +270,7 @@ public class StreamsAssignmentScaleTest {
                     consumer,
                     new Subscription(
                         topic,
-                        getInfo(uuidForInt(client), new HashSet<>(info.activeTasks()), info.standbyTasks().keySet()).encode(),
+                        getInfo(processIdForInt(client), new HashSet<>(info.activeTasks()), info.standbyTasks().keySet()).encode(),
                         assignment.partitions())
                 );
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -108,7 +109,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.time.Duration.ofMillis;
@@ -153,8 +153,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getInfo;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
@@ -221,7 +221,7 @@ public class StreamsPartitionAssignorTest {
         new PartitionInfo("topic3", 3, NODE_0, REPLICA_0, REPLICA_0)
     );
 
-    private final SubscriptionInfo defaultSubscriptionInfo = getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS);
+    private final SubscriptionInfo defaultSubscriptionInfo = getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS);
 
     private final Cluster metadata = new Cluster(
         "cluster",
@@ -311,7 +311,7 @@ public class StreamsPartitionAssignorTest {
         taskManager = mock(TaskManager.class);
         lenient().when(taskManager.topologyMetadata()).thenReturn(topologyMetadata);
         lenient().when(taskManager.getTaskOffsetSums()).thenReturn(getTaskOffsetSums(activeTasks, standbyTasks));
-        lenient().when(taskManager.processId()).thenReturn(UUID_1);
+        lenient().when(taskManager.processId()).thenReturn(PID_1);
         builder.setApplicationId(APPLICATION_ID);
         topologyMetadata.buildAndRewriteTopology();
     }
@@ -408,7 +408,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
         state.initializePrevTasks(emptyMap(), false);
-        state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
+        state.computeTaskLags(PID_1, getTaskEndOffsetSums(allTasks));
 
         assertEquivalentAssignment(
             previousAssignment,
@@ -439,7 +439,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
         state.initializePrevTasks(emptyMap(), false);
-        state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
+        state.computeTaskLags(PID_1, getTaskEndOffsetSums(allTasks));
 
         // We should be able to add a new task without sacrificing stickiness
         final TaskId newTask = TASK_2_0;
@@ -476,7 +476,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
         state.initializePrevTasks(emptyMap(), false);
-        state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
+        state.computeTaskLags(PID_1, getTaskEndOffsetSums(allTasks));
 
         // Consumer 3 leaves the group
         consumers.remove(CONSUMER_3);
@@ -520,7 +520,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_4, getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS));
 
         state.initializePrevTasks(emptyMap(), false);
-        state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
+        state.computeTaskLags(PID_1, getTaskEndOffsetSums(allTasks));
 
         final Map<String, List<TaskId>> assignment = assignTasksToThreads(
             allTasks,
@@ -597,7 +597,7 @@ public class StreamsPartitionAssignorTest {
         Collections.sort(subscription.topics());
         assertEquals(asList("topic1", "topic2"), subscription.topics());
 
-        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks, uniqueField);
+        final SubscriptionInfo info = getInfo(PID_1, prevTasks, standbyTasks, uniqueField);
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
     }
 
@@ -623,7 +623,7 @@ public class StreamsPartitionAssignorTest {
         Collections.sort(subscription.topics());
         assertEquals(asList("topic1", "topic2"), subscription.topics());
 
-        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks, uniqueField);
+        final SubscriptionInfo info = getInfo(PID_1, prevTasks, standbyTasks, uniqueField);
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
     }
 
@@ -666,7 +666,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks10, standbyTasks10).encode(),
+                              getInfo(PID_1, prevTasks10, standbyTasks10).encode(),
                               Collections.emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_3)
@@ -674,7 +674,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer11",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks11, standbyTasks11).encode(),
+                              getInfo(PID_1, prevTasks11, standbyTasks11).encode(),
                               Collections.emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_3)
@@ -682,7 +682,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer20",
                           new Subscription(
                               topics,
-                              getInfo(UUID_2, prevTasks20, standbyTasks20).encode(),
+                              getInfo(PID_2, prevTasks20, standbyTasks20).encode(),
                               Collections.emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0)
@@ -813,7 +813,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, mkSet(TASK_0_0, TASK_0_2), emptySet()).encode(),
+                              getInfo(PID_1, mkSet(TASK_0_0, TASK_0_2), emptySet()).encode(),
                               asList(t1p0, t1p2),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2)
@@ -821,7 +821,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer11",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, mkSet(TASK_0_1, TASK_0_3), emptySet()).encode(),
+                              getInfo(PID_1, mkSet(TASK_0_1, TASK_0_3), emptySet()).encode(),
                               asList(t1p1, t1p3),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2)
@@ -829,7 +829,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer20",
                           new Subscription(
                               topics,
-                              getInfo(UUID_2, emptySet(), emptySet()).encode(),
+                              getInfo(PID_2, emptySet(), emptySet()).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2)
@@ -867,7 +867,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks10, standbyTasks10).encode(),
+                              getInfo(PID_1, prevTasks10, standbyTasks10).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_3)
@@ -924,21 +924,21 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks10, EMPTY_TASKS).encode(),
+                              getInfo(PID_1, prevTasks10, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_4)));
         subscriptions.put("consumer11",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks11, EMPTY_TASKS).encode(),
+                              getInfo(PID_1, prevTasks11, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_4)));
         subscriptions.put("consumer20",
                           new Subscription(
                               topics,
-                              getInfo(UUID_2, prevTasks20, EMPTY_TASKS).encode(),
+                              getInfo(PID_2, prevTasks20, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_1)));
@@ -1014,7 +1014,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer20",
                           new Subscription(
                               topics,
-                              getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                              getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2)));
@@ -1081,14 +1081,14 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
             new Subscription(
                 topics,
-                getInfo(UUID_1, mkSet(TASK_0_0), emptySet()).encode(),
+                getInfo(PID_1, mkSet(TASK_0_0), emptySet()).encode(),
                 emptyList(),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_0)));
         subscriptions.put("consumer20",
             new Subscription(
                 topics,
-                getInfo(UUID_2, mkSet(TASK_0_2), emptySet()).encode(),
+                getInfo(PID_2, mkSet(TASK_0_2), emptySet()).encode(),
                 emptyList(),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_2)));
@@ -1117,14 +1117,14 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
             new Subscription(
                 topics,
-                getInfo(UUID_1, mkSet(TASK_0_0), emptySet()).encode(),
+                getInfo(PID_1, mkSet(TASK_0_0), emptySet()).encode(),
                 emptyList(),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_1)));
         subscriptions.put("consumer20",
             new Subscription(
                 topics,
-                getInfo(UUID_2, mkSet(TASK_0_2), emptySet()).encode(),
+                getInfo(PID_2, mkSet(TASK_0_2), emptySet()).encode(),
                 emptyList(),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_3)));
@@ -1175,21 +1175,21 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks00, EMPTY_TASKS, USER_END_POINT).encode(),
+                              getInfo(PID_1, prevTasks00, EMPTY_TASKS, USER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0)));
         subscriptions.put("consumer11",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, prevTasks01, standbyTasks02, USER_END_POINT).encode(),
+                              getInfo(PID_1, prevTasks01, standbyTasks02, USER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0)));
         subscriptions.put("consumer20",
                           new Subscription(
                               topics,
-                              getInfo(UUID_2, prevTasks02, standbyTasks00, OTHER_END_POINT).encode(),
+                              getInfo(PID_2, prevTasks02, standbyTasks00, OTHER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_4)));
@@ -1278,7 +1278,7 @@ public class StreamsPartitionAssignorTest {
             subscriptions.put(consumerId,
                     new Subscription(
                             topics,
-                            getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                            getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                             emptyList(),
                             DEFAULT_GENERATION,
                             Optional.of(RACK_2)));
@@ -1287,7 +1287,7 @@ public class StreamsPartitionAssignorTest {
             subscriptions.put(consumerId,
                     new Subscription(
                             topics,
-                            getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                            getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                             emptyList(),
                             DEFAULT_GENERATION,
                             Optional.of(RACK_4)));
@@ -1336,14 +1336,14 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                 new Subscription(
                         topics,
-                        getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_4)));
         subscriptions.put("consumer20",
                 new Subscription(
                         topics,
-                        getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_4)));
@@ -1387,28 +1387,28 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                 new Subscription(
                         topics,
-                        getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_0)));
         subscriptions.put("consumer11",
                 new Subscription(
                         topics,
-                        getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_0)));
         subscriptions.put("consumer20",
                 new Subscription(
                         topics,
-                        getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_2)));
         subscriptions.put("consumer21",
                 new Subscription(
                         topics,
-                        getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                        getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                         emptyList(),
                         DEFAULT_GENERATION,
                         Optional.of(RACK_2)));
@@ -1735,7 +1735,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer1",
                           new Subscription(
                               topics,
-                              getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                              getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2)
@@ -1887,7 +1887,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put(CONSUMER_1,
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfo(UUID_1, allTasks, EMPTY_TASKS).encode(),
+                              getInfo(PID_1, allTasks, EMPTY_TASKS).encode(),
                               allPartitions,
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0))
@@ -1895,7 +1895,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put(CONSUMER_2,
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfo(UUID_1, EMPTY_TASKS, allTasks).encode(),
+                              getInfo(PID_1, EMPTY_TASKS, allTasks).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0))
@@ -1943,7 +1943,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer1",
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                              getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_3))
@@ -1951,7 +1951,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer2",
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS, OTHER_END_POINT).encode(),
+                              getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS, OTHER_END_POINT).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_1))
@@ -2021,7 +2021,8 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer1",
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfoForOlderVersion(smallestVersion, UUID_1, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                              getInfoForOlderVersion(smallestVersion,
+                                  PID_1, EMPTY_TASKS, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_2))
@@ -2029,7 +2030,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer2",
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfoForOlderVersion(otherVersion, UUID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                              getInfoForOlderVersion(otherVersion, PID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_1)
@@ -2101,7 +2102,7 @@ public class StreamsPartitionAssignorTest {
             CONSUMER_1,
             new Subscription(
                 Collections.singletonList("topic1"),
-                getInfo(UUID_1, allTasks, EMPTY_TASKS).encode(),
+                getInfo(PID_1, allTasks, EMPTY_TASKS).encode(),
                 asList(t1p0, t1p1, t1p2),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_1)
@@ -2111,7 +2112,7 @@ public class StreamsPartitionAssignorTest {
             CONSUMER_2,
             new Subscription(
                 Collections.singletonList("topic1"),
-                getInfo(UUID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
                 emptyList(),
                 DEFAULT_GENERATION,
                 Optional.of(RACK_2)
@@ -2608,7 +2609,7 @@ public class StreamsPartitionAssignorTest {
         final Set<String> topics = mkSet("input");
         final Subscription subscription = new Subscription(new ArrayList<>(topics),
                                                            partitionAssignor.subscriptionUserData(topics));
-        final SubscriptionInfo info = getInfo(UUID_1, EMPTY_TASKS, EMPTY_TASKS, uniqueField, clientTags);
+        final SubscriptionInfo info = getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, uniqueField, clientTags);
 
         assertEquals(singletonList("input"), subscription.topics());
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
@@ -2638,9 +2639,9 @@ public class StreamsPartitionAssignorTest {
             )
         );
 
-        final UUID clientUuid1 = UUID.randomUUID();
-        final UUID clientUuid2 = UUID.randomUUID();
-        final Map<UUID, StreamsPartitionAssignor.ClientMetadata> clients = mkMap(
+        final ProcessId clientUuid1 = new ProcessId(UUID.randomUUID());
+        final ProcessId clientUuid2 = new ProcessId(UUID.randomUUID());
+        final Map<ProcessId, StreamsPartitionAssignor.ClientMetadata> clients = mkMap(
             mkEntry(clientUuid1, new StreamsPartitionAssignor.ClientMetadata(clientUuid1, "endpoint1:80", mkMap(), Optional.empty())),
             mkEntry(clientUuid2, new StreamsPartitionAssignor.ClientMetadata(clientUuid1, "endpoint2:80", mkMap(), Optional.empty()))
         );
@@ -2656,12 +2657,12 @@ public class StreamsPartitionAssignorTest {
         // ****
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment noError = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                KafkaStreamsAssignment.of(clientUuid1, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
                 )),
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet())
+                KafkaStreamsAssignment.of(clientUuid2, mkSet())
             )
         );
         org.apache.kafka.streams.processor.assignment.TaskAssignor.AssignmentError error = TaskAssignmentUtils.validateTaskAssignment(applicationState, noError);
@@ -2670,7 +2671,7 @@ public class StreamsPartitionAssignorTest {
         // ****
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment missingProcessId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                KafkaStreamsAssignment.of(clientUuid1, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
@@ -2683,12 +2684,12 @@ public class StreamsPartitionAssignorTest {
         // ****
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment unknownProcessId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                KafkaStreamsAssignment.of(clientUuid1, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
                 )),
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet()),
+                KafkaStreamsAssignment.of(clientUuid2, mkSet()),
                 KafkaStreamsAssignment.of(new ProcessId(UUID.randomUUID()), mkSet())
             )
         );
@@ -2698,12 +2699,12 @@ public class StreamsPartitionAssignorTest {
         // ****
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment unknownTaskId = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                KafkaStreamsAssignment.of(clientUuid1, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
                 )),
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet(
+                KafkaStreamsAssignment.of(clientUuid2, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(13, 13), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
@@ -2716,12 +2717,12 @@ public class StreamsPartitionAssignorTest {
         // ****
         final org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment activeTaskDuplicated = new org.apache.kafka.streams.processor.assignment.TaskAssignor.TaskAssignment(
             mkSet(
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid1), mkSet(
+                KafkaStreamsAssignment.of(clientUuid1, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
                 )),
-                KafkaStreamsAssignment.of(new ProcessId(clientUuid2), mkSet(
+                KafkaStreamsAssignment.of(clientUuid2, mkSet(
                     new KafkaStreamsAssignment.AssignedTask(
                         new TaskId(1, 1), KafkaStreamsAssignment.AssignedTask.Type.ACTIVE
                     )
@@ -2767,7 +2768,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer1",
                           new Subscription(
                               Collections.singletonList("topic1"),
-                              getInfoForOlderVersion(oldVersion, UUID_1, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                              getInfoForOlderVersion(oldVersion, PID_1, EMPTY_TASKS, EMPTY_TASKS).encode(),
                               emptyList(),
                               DEFAULT_GENERATION,
                               Optional.of(RACK_0))
@@ -2894,7 +2895,7 @@ public class StreamsPartitionAssignorTest {
 
 
     private static SubscriptionInfo getInfoForOlderVersion(final int version,
-                                                           final UUID processId,
+                                                           final ProcessId processId,
                                                            final Set<TaskId> prevTasks,
                                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.UUID;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.DeletedRecords;
@@ -46,6 +47,7 @@ import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.StateDirectory.TaskDirectory;
 import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTask;
 import org.apache.kafka.streams.processor.internals.Task.State;
@@ -84,7 +86,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -239,7 +240,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = new TaskManager(
             time,
             changeLogReader,
-            UUID.randomUUID(),
+            new ProcessId(UUID.randomUUID()),
             "taskManagerTest",
             activeTaskCreator,
             standbyTaskCreator,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -46,12 +46,12 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasActiveTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasStandbyTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -552,15 +552,15 @@ public class ClientStateTest {
 
     @Test
     public void shouldSetProcessId() {
-        assertEquals(UUID_1, new ClientState(UUID_1, 1).processId());
-        assertEquals(UUID_2, new ClientState(UUID_2, mkMap()).processId());
-        assertEquals(UUID_3, new ClientState(UUID_3, 1, mkMap()).processId());
+        assertEquals(PID_1, new ClientState(PID_1, 1).processId());
+        assertEquals(PID_2, new ClientState(PID_2, mkMap()).processId());
+        assertEquals(PID_3, new ClientState(PID_3, 1, mkMap()).processId());
         assertNull(new ClientState().processId());
     }
 
     @Test
     public void shouldCopyState() {
-        final ClientState clientState = new ClientState(mkSet(new TaskId(0, 0)), mkSet(new TaskId(0, 1)), Collections.emptyMap(), EMPTY_CLIENT_TAGS, 1, uuidForInt(1));
+        final ClientState clientState = new ClientState(mkSet(new TaskId(0, 0)), mkSet(new TaskId(0, 1)), Collections.emptyMap(), EMPTY_CLIENT_TAGS, 1, processIdForInt(1));
         final ClientState clientStateCopy = new ClientState(clientState);
 
         assertEquals(clientStateCopy.processId(), clientState.processId());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.assignment.ClientTagAwareStandbyTaskAssignor.TagEntry;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,13 +37,21 @@ import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_4;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_5;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_6;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_7;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_8;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_9;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.computeTasksToRemainingStandbys;
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.createLeastLoadedPrioritySetConstrainedByAssignedTask;
 import static org.junit.Assert.assertEquals;
@@ -66,16 +74,6 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     private static final String CLUSTER_2 = "cluster2";
     private static final String CLUSTER_3 = "cluster3";
 
-    private static final UUID UUID_1 = uuidForInt(1);
-    private static final UUID UUID_2 = uuidForInt(2);
-    private static final UUID UUID_3 = uuidForInt(3);
-    private static final UUID UUID_4 = uuidForInt(4);
-    private static final UUID UUID_5 = uuidForInt(5);
-    private static final UUID UUID_6 = uuidForInt(6);
-    private static final UUID UUID_7 = uuidForInt(7);
-    private static final UUID UUID_8 = uuidForInt(8);
-    private static final UUID UUID_9 = uuidForInt(9);
-
     private StandbyTaskAssignor standbyTaskAssignor;
 
     @Before
@@ -91,18 +89,18 @@ public class ClientTagAwareStandbyTaskAssignorTest {
             TASK_1_2
         );
 
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -121,24 +119,24 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     public void shouldRemoveClientToRemainingStandbysAndNotPopulatePendingStandbyTasksToClientIdWhenAllStandbyTasksWereAssigned() {
         final int numStandbyReplicas = 2;
         final Set<String> rackAwareAssignmentTags = mkSet(ZONE_TAG, CLUSTER_TAG);
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
-        final Map<TaskId, UUID> taskToClientId = mkMap(mkEntry(TASK_0_0, UUID_1),
-                                                       mkEntry(TASK_0_1, UUID_2),
-                                                       mkEntry(TASK_0_2, UUID_3));
+        final Map<TaskId, ProcessId> taskToClientId = mkMap(mkEntry(TASK_0_0, PID_1),
+                                                       mkEntry(TASK_0_1, PID_2),
+                                                       mkEntry(TASK_0_2, PID_3));
 
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
-        final Map<TagEntry, Set<UUID>> tagEntryToClients = new HashMap<>();
+        final Map<TagEntry, Set<ProcessId>> tagEntryToClients = new HashMap<>();
 
         new ClientTagAwareStandbyTaskAssignor().fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
 
-        final Map<TaskId, UUID> pendingStandbyTasksToClientId = new HashMap<>();
+        final Map<TaskId, ProcessId> pendingStandbyTasksToClientId = new HashMap<>();
         final Map<TaskId, Integer> tasksToRemainingStandbys = computeTasksToRemainingStandbys(numStandbyReplicas, allActiveTasks);
 
         for (final TaskId activeTaskId : allActiveTasks) {
@@ -163,25 +161,25 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldUpdateClientToRemainingStandbysAndPendingStandbyTasksToClientIdWhenNotAllStandbyTasksWereAssigned() {
         final Set<String> rackAwareAssignmentTags = mkSet(ZONE_TAG, CLUSTER_TAG);
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
         final int numStandbyReplicas = 3;
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
-        final Map<TaskId, UUID> taskToClientId = mkMap(mkEntry(TASK_0_0, UUID_1),
-                                                       mkEntry(TASK_0_1, UUID_2),
-                                                       mkEntry(TASK_0_2, UUID_3));
+        final Map<TaskId, ProcessId> taskToClientId = mkMap(mkEntry(TASK_0_0, PID_1),
+                                                       mkEntry(TASK_0_1, PID_2),
+                                                       mkEntry(TASK_0_2, PID_3));
 
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
-        final Map<TagEntry, Set<UUID>> tagEntryToClients = new HashMap<>();
+        final Map<TagEntry, Set<ProcessId>> tagEntryToClients = new HashMap<>();
 
         new ClientTagAwareStandbyTaskAssignor().fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
 
-        final Map<TaskId, UUID> pendingStandbyTasksToClientId = new HashMap<>();
+        final Map<TaskId, ProcessId> pendingStandbyTasksToClientId = new HashMap<>();
         final Map<TaskId, Integer> tasksToRemainingStandbys = computeTasksToRemainingStandbys(numStandbyReplicas, allActiveTasks);
 
         for (final TaskId activeTaskId : allActiveTasks) {
@@ -216,29 +214,29 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldPermitTaskMovementWhenClientTagsMatch() {
-        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
 
         assertTrue(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
 
     @Test
     public void shouldDeclineTaskMovementWhenClientTagsDoNotMatch() {
-        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
 
         assertFalse(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
 
     @Test
     public void shouldPermitSingleTaskMoveWhenClientTagMatch() {
-        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
-        final Map<UUID, ClientState> clientStateMap = mkMap(
-            mkEntry(UUID_1, source),
-            mkEntry(UUID_2, destination),
-            mkEntry(UUID_3, clientState)
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final Map<ProcessId, ClientState> clientStateMap = mkMap(
+            mkEntry(PID_1, source),
+            mkEntry(PID_2, destination),
+            mkEntry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -249,13 +247,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldPermitSingleTaskMoveWhenDifferentClientTagCountNotChange() {
-        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
-        final Map<UUID, ClientState> clientStateMap = mkMap(
-            mkEntry(UUID_1, source),
-            mkEntry(UUID_2, destination),
-            mkEntry(UUID_3, clientState)
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final Map<ProcessId, ClientState> clientStateMap = mkMap(
+            mkEntry(PID_1, source),
+            mkEntry(PID_2, destination),
+            mkEntry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -266,13 +264,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDeclineSingleTaskMoveWhenReduceClientTagCount() {
-        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
-        final Map<UUID, ClientState> clientStateMap = mkMap(
-            mkEntry(UUID_1, source),
-            mkEntry(UUID_2, destination),
-            mkEntry(UUID_3, clientState)
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final Map<ProcessId, ClientState> clientStateMap = mkMap(
+            mkEntry(PID_1, source),
+            mkEntry(PID_2, destination),
+            mkEntry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -284,18 +282,18 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameZone() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -305,8 +303,8 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
         assertTrue(clientStates.values().stream().allMatch(ClientState::reachedCapacity));
 
-        Stream.of(UUID_1, UUID_4, UUID_7).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0));
-        Stream.of(UUID_2, UUID_3, UUID_5, UUID_6, UUID_8, UUID_9).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 2));
+        Stream.of(PID_1, PID_4, PID_7).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0));
+        Stream.of(PID_2, PID_3, PID_5, PID_6, PID_8, PID_9).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 2));
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 12);
 
         assertTrue(
@@ -314,7 +312,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_9, UUID_5), mkSet(UUID_6, UUID_8)
+                    mkSet(PID_9, PID_5), mkSet(PID_6, PID_8)
                 )
             )
         );
@@ -323,7 +321,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_9, UUID_5), mkSet(UUID_6, UUID_8)
+                    mkSet(PID_9, PID_5), mkSet(PID_6, PID_8)
                 )
             )
         );
@@ -333,7 +331,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_2, UUID_9), mkSet(UUID_3, UUID_8)
+                    mkSet(PID_2, PID_9), mkSet(PID_3, PID_8)
                 )
             )
         );
@@ -342,7 +340,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_2, UUID_9), mkSet(UUID_3, UUID_8)
+                    mkSet(PID_2, PID_9), mkSet(PID_3, PID_8)
                 )
             )
         );
@@ -352,7 +350,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_5, UUID_3), mkSet(UUID_2, UUID_6)
+                    mkSet(PID_5, PID_3), mkSet(PID_2, PID_6)
                 )
             )
         );
@@ -361,7 +359,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_5, UUID_3), mkSet(UUID_2, UUID_6)
+                    mkSet(PID_5, PID_3), mkSet(PID_2, PID_6)
                 )
             )
         );
@@ -369,16 +367,16 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDistributeStandbyTasksUsingFunctionAndSupplierTags() {
-        final Map<UUID, String> racksForProcess = mkMap(
-            mkEntry(UUID_1, "rack1"),
-            mkEntry(UUID_2, "rack2"),
-            mkEntry(UUID_3, "rack3"),
-            mkEntry(UUID_4, "rack1"),
-            mkEntry(UUID_5, "rack2"),
-            mkEntry(UUID_6, "rack3"),
-            mkEntry(UUID_7, "rack1"),
-            mkEntry(UUID_8, "rack2"),
-            mkEntry(UUID_9, "rack3")
+        final Map<ProcessId, String> racksForProcess = mkMap(
+            mkEntry(PID_1, "rack1"),
+            mkEntry(PID_2, "rack2"),
+            mkEntry(PID_3, "rack3"),
+            mkEntry(PID_4, "rack1"),
+            mkEntry(PID_5, "rack2"),
+            mkEntry(PID_6, "rack3"),
+            mkEntry(PID_7, "rack1"),
+            mkEntry(PID_8, "rack2"),
+            mkEntry(PID_9, "rack3")
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = mock(RackAwareTaskAssignor.class);
         when(rackAwareTaskAssignor.validClientRack()).thenReturn(true);
@@ -387,32 +385,32 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         standbyTaskAssignor = StandbyTaskAssignorFactory.create(assignmentConfigs, rackAwareTaskAssignor);
         verify(rackAwareTaskAssignor, times(1)).racksForProcess();
 
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(), TASK_0_2, TASK_1_2)),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(), TASK_0_0, TASK_1_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(), TASK_0_1, TASK_1_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(), TASK_0_2, TASK_1_2)),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap())),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap())),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap())),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap())),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap())),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap())),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap())),
-            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap())),
-            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap()))
+            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap())),
+            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap())),
+            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap()))
         );
 
-        final Map<UUID, ClientState> clientStatesWithTags = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)), TASK_0_2, TASK_1_2)),
+        final Map<ProcessId, ClientState> clientStatesWithTags = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)), TASK_0_2, TASK_1_2)),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)))),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3))))
+            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -426,9 +424,9 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         Stream.of(clientStates, clientStatesWithTags).forEach(
             cs -> {
                 assertTrue(cs.values().stream().allMatch(ClientState::reachedCapacity));
-                Stream.of(UUID_1, UUID_2, UUID_3)
+                Stream.of(PID_1, PID_2, PID_3)
                     .forEach(client -> assertStandbyTaskCountForClientEqualsTo(cs, client, 0));
-                Stream.of(UUID_4, UUID_5, UUID_6, UUID_7, UUID_8, UUID_9)
+                Stream.of(PID_4, PID_5, PID_6, PID_7, PID_8, PID_9)
                     .forEach(client -> assertStandbyTaskCountForClientEqualsTo(cs, client, 2));
                 assertTotalNumberOfStandbyTasksEqualsTo(cs, 12);
 
@@ -436,14 +434,14 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                     containsStandbyTasks(
                         TASK_0_0,
                         cs,
-                        mkSet(UUID_2, UUID_3, UUID_5, UUID_6, UUID_8, UUID_9)
+                        mkSet(PID_2, PID_3, PID_5, PID_6, PID_8, PID_9)
                     )
                 );
                 assertTrue(
                     containsStandbyTasks(
                         TASK_1_0,
                         cs,
-                        mkSet(UUID_2, UUID_3, UUID_5, UUID_6, UUID_8, UUID_9)
+                        mkSet(PID_2, PID_3, PID_5, PID_6, PID_8, PID_9)
                     )
                 );
 
@@ -451,14 +449,14 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                     containsStandbyTasks(
                         TASK_0_1,
                         cs,
-                        mkSet(UUID_1, UUID_3, UUID_4, UUID_6, UUID_7, UUID_9)
+                        mkSet(PID_1, PID_3, PID_4, PID_6, PID_7, PID_9)
                     )
                 );
                 assertTrue(
                     containsStandbyTasks(
                         TASK_1_1,
                         cs,
-                        mkSet(UUID_1, UUID_3, UUID_4, UUID_6, UUID_7, UUID_9)
+                        mkSet(PID_1, PID_3, PID_4, PID_6, PID_7, PID_9)
                     )
                 );
 
@@ -466,14 +464,14 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                     containsStandbyTasks(
                         TASK_0_2,
                         cs,
-                        mkSet(UUID_1, UUID_2, UUID_4, UUID_5, UUID_7, UUID_8)
+                        mkSet(PID_1, PID_2, PID_4, PID_5, PID_7, PID_8)
                     )
                 );
                 assertTrue(
                     containsStandbyTasks(
                         TASK_1_2,
                         cs,
-                        mkSet(UUID_1, UUID_2, UUID_4, UUID_5, UUID_7, UUID_8)
+                        mkSet(PID_1, PID_2, PID_4, PID_5, PID_7, PID_8)
                     )
                 );
             }
@@ -482,18 +480,18 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameCluster() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -503,8 +501,8 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
         assertTrue(clientStates.values().stream().allMatch(ClientState::reachedCapacity));
 
-        Stream.of(UUID_1, UUID_2, UUID_3).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0));
-        Stream.of(UUID_4, UUID_5, UUID_6, UUID_7, UUID_8, UUID_9).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 2));
+        Stream.of(PID_1, PID_2, PID_3).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0));
+        Stream.of(PID_4, PID_5, PID_6, PID_7, PID_8, PID_9).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 2));
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 12);
 
         assertTrue(
@@ -512,7 +510,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_9, UUID_5), mkSet(UUID_6, UUID_8)
+                    mkSet(PID_9, PID_5), mkSet(PID_6, PID_8)
                 )
             )
         );
@@ -521,7 +519,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_9, UUID_5), mkSet(UUID_6, UUID_8)
+                    mkSet(PID_9, PID_5), mkSet(PID_6, PID_8)
                 )
             )
         );
@@ -531,7 +529,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_4, UUID_9), mkSet(UUID_6, UUID_7)
+                    mkSet(PID_4, PID_9), mkSet(PID_6, PID_7)
                 )
             )
         );
@@ -540,7 +538,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_4, UUID_9), mkSet(UUID_6, UUID_7)
+                    mkSet(PID_4, PID_9), mkSet(PID_6, PID_7)
                 )
             )
         );
@@ -550,7 +548,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_5, UUID_7), mkSet(UUID_4, UUID_8)
+                    mkSet(PID_5, PID_7), mkSet(PID_4, PID_8)
                 )
             )
         );
@@ -559,7 +557,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_5, UUID_7), mkSet(UUID_4, UUID_8)
+                    mkSet(PID_5, PID_7), mkSet(PID_4, PID_8)
                 )
             )
         );
@@ -567,14 +565,14 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDoThePartialRackAwareness() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_3)))),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_3)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_3)), TASK_1_0))
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_3)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -594,9 +592,9 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         // can be satisfied by placing the 2nd standby client on a different `zone` tag compared to active and corresponding standby tasks.
         // The `zone` on either `cluster` tags are valid candidates for the partial rack awareness, as our goal is to distribute clients on the different `zone` tags.
 
-        Stream.of(UUID_2, UUID_5).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 1));
+        Stream.of(PID_2, PID_5).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 1));
         // There's no strong guarantee where 2nd standby task will end up.
-        Stream.of(UUID_1, UUID_3, UUID_4, UUID_6).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0, 1));
+        Stream.of(PID_1, PID_3, PID_4, PID_6).forEach(client -> assertStandbyTaskCountForClientEqualsTo(clientStates, client, 0, 1));
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 4);
 
         assertTrue(
@@ -605,12 +603,12 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 clientStates,
                 asList(
                     // Since it's located on a different `cluster` and `zone` tag dimensions,
-                    // `UUID_5` is the "ideal" distribution for the 1st standby task assignment.
-                    // For the 2nd standby, either `UUID_3` or `UUID_6` are valid destinations as
+                    // `PID_5` is the "ideal" distribution for the 1st standby task assignment.
+                    // For the 2nd standby, either `PID_3` or `PID_6` are valid destinations as
                     // we need to distribute the clients on different `zone`
                     // tags without considering the `cluster` tag value.
-                    mkSet(UUID_5, UUID_3),
-                    mkSet(UUID_5, UUID_6)
+                    mkSet(PID_5, PID_3),
+                    mkSet(PID_5, PID_6)
                 )
             )
         );
@@ -620,11 +618,11 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 clientStates,
                 asList(
                     // The same comment as above applies here too.
-                    // `UUID_2` is the ideal distribution on different `cluster`
-                    // and `zone` tag dimensions. In contrast, `UUID_4` and `UUID_1`
+                    // `PID_2` is the ideal distribution on different `cluster`
+                    // and `zone` tag dimensions. In contrast, `PID_4` and `PID_1`
                     // satisfy only the partial rack awareness as they are located on a different `zone` tag dimension.
-                    mkSet(UUID_2, UUID_4),
-                    mkSet(UUID_2, UUID_1)
+                    mkSet(PID_2, PID_4),
+                    mkSet(PID_2, PID_1)
                 )
             )
         );
@@ -632,13 +630,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDistributeClientsOnDifferentZoneTagsEvenWhenClientsReachedCapacity() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
-            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
-            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
+            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
+            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -654,7 +652,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_2), mkSet(UUID_5), mkSet(UUID_3), mkSet(UUID_6)
+                    mkSet(PID_2), mkSet(PID_5), mkSet(PID_3), mkSet(PID_6)
                 )
             )
         );
@@ -663,7 +661,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_0,
                 clientStates,
                 asList(
-                    mkSet(UUID_2), mkSet(UUID_5), mkSet(UUID_3), mkSet(UUID_6)
+                    mkSet(PID_2), mkSet(PID_5), mkSet(PID_3), mkSet(PID_6)
                 )
             )
         );
@@ -673,7 +671,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_1), mkSet(UUID_4), mkSet(UUID_3), mkSet(UUID_6)
+                    mkSet(PID_1), mkSet(PID_4), mkSet(PID_3), mkSet(PID_6)
                 )
             )
         );
@@ -682,7 +680,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_1,
                 clientStates,
                 asList(
-                    mkSet(UUID_1), mkSet(UUID_4), mkSet(UUID_3), mkSet(UUID_6)
+                    mkSet(PID_1), mkSet(PID_4), mkSet(PID_3), mkSet(PID_6)
                 )
             )
         );
@@ -692,7 +690,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_1), mkSet(UUID_4), mkSet(UUID_2), mkSet(UUID_5)
+                    mkSet(PID_1), mkSet(PID_4), mkSet(PID_2), mkSet(PID_5)
                 )
             )
         );
@@ -701,7 +699,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_1_2,
                 clientStates,
                 asList(
-                    mkSet(UUID_1), mkSet(UUID_4), mkSet(UUID_2), mkSet(UUID_5)
+                    mkSet(PID_1), mkSet(PID_4), mkSet(PID_2), mkSet(PID_5)
                 )
             )
         );
@@ -709,11 +707,11 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldIgnoreTagsThatAreNotPresentInRackAwareness() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
 
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1))))
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -722,14 +720,14 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         standbyTaskAssignor.assign(clientStates, allActiveTasks, allActiveTasks, assignmentConfigs);
 
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 1);
-        assertEquals(1, clientStates.get(UUID_3).standbyTaskCount());
+        assertEquals(1, clientStates.get(PID_3).standbyTaskCount());
     }
 
     @Test
     public void shouldHandleOverlappingTagValuesBetweenDifferentTagKeys() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, CLUSTER_1), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, CLUSTER_1), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -743,7 +741,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                 TASK_0_0,
                 clientStates,
                 singletonList(
-                    mkSet(UUID_2)
+                    mkSet(PID_2)
                 )
             )
         );
@@ -751,11 +749,11 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDistributeStandbyTasksOnLeastLoadedClientsWhenClientsAreNotOnDifferentTagDimensions() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_2)),
-            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_1_0))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_1)),
+            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_2)),
+            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -764,16 +762,16 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         standbyTaskAssignor.assign(clientStates, allActiveTasks, allActiveTasks, assignmentConfigs);
 
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 4);
-        assertEquals(1, clientStates.get(UUID_1).standbyTaskCount());
-        assertEquals(1, clientStates.get(UUID_2).standbyTaskCount());
-        assertEquals(1, clientStates.get(UUID_3).standbyTaskCount());
-        assertEquals(1, clientStates.get(UUID_4).standbyTaskCount());
+        assertEquals(1, clientStates.get(PID_1).standbyTaskCount());
+        assertEquals(1, clientStates.get(PID_2).standbyTaskCount());
+        assertEquals(1, clientStates.get(PID_3).standbyTaskCount());
+        assertEquals(1, clientStates.get(PID_4).standbyTaskCount());
     }
 
     @Test
     public void shouldNotAssignStandbyTasksIfThereAreNoEnoughClients() {
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0))
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -782,16 +780,16 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         standbyTaskAssignor.assign(clientStates, allActiveTasks, allActiveTasks, assignmentConfigs);
 
         assertTotalNumberOfStandbyTasksEqualsTo(clientStates, 0);
-        assertEquals(0, clientStates.get(UUID_1).standbyTaskCount());
+        assertEquals(0, clientStates.get(PID_1).standbyTaskCount());
     }
 
-    private static void assertTotalNumberOfStandbyTasksEqualsTo(final Map<UUID, ClientState> clientStates, final int expectedTotalNumberOfStandbyTasks) {
+    private static void assertTotalNumberOfStandbyTasksEqualsTo(final Map<ProcessId, ClientState> clientStates, final int expectedTotalNumberOfStandbyTasks) {
         final int actualTotalNumberOfStandbyTasks = clientStates.values().stream().map(ClientState::standbyTaskCount).reduce(0, Integer::sum);
         assertEquals(expectedTotalNumberOfStandbyTasks, actualTotalNumberOfStandbyTasks);
     }
 
-    private static void assertStandbyTaskCountForClientEqualsTo(final Map<UUID, ClientState> clientStates,
-                                                                final UUID client,
+    private static void assertStandbyTaskCountForClientEqualsTo(final Map<ProcessId, ClientState> clientStates,
+                                                                final ProcessId client,
                                                                 final int... expectedStandbyTaskCounts) {
         final int standbyTaskCount = clientStates.get(client).standbyTaskCount();
         final String msg = String.format("Client [%s] doesn't have expected number of standby tasks. " +
@@ -802,9 +800,9 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     }
 
     private static boolean standbyClientsHonorRackAwareness(final TaskId activeTaskId,
-                                                            final Map<UUID, ClientState> clientStates,
-                                                            final List<Set<UUID>> validClientIdsBasedOnRackAwareAssignmentTags) {
-        final Set<UUID> standbyTaskClientIds = findAllStandbyTaskClients(clientStates, activeTaskId);
+                                                            final Map<ProcessId, ClientState> clientStates,
+                                                            final List<Set<ProcessId>> validClientIdsBasedOnRackAwareAssignmentTags) {
+        final Set<ProcessId> standbyTaskClientIds = findAllStandbyTaskClients(clientStates, activeTaskId);
 
         return validClientIdsBasedOnRackAwareAssignmentTags.stream()
                                                            .filter(it -> it.equals(standbyTaskClientIds))
@@ -812,13 +810,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     }
 
     private static boolean containsStandbyTasks(final TaskId activeTaskId,
-                                                final Map<UUID, ClientState> clientStates,
-                                                final Set<UUID> validClientIdsBasedOnRackAwareAssignmentTags) {
-        final Set<UUID> standbyTaskClientIds = findAllStandbyTaskClients(clientStates, activeTaskId);
+                                                final Map<ProcessId, ClientState> clientStates,
+                                                final Set<ProcessId> validClientIdsBasedOnRackAwareAssignmentTags) {
+        final Set<ProcessId> standbyTaskClientIds = findAllStandbyTaskClients(clientStates, activeTaskId);
         return validClientIdsBasedOnRackAwareAssignmentTags.containsAll(standbyTaskClientIds);
     }
 
-    private static Set<UUID> findAllStandbyTaskClients(final Map<UUID, ClientState> clientStates, final TaskId task) {
+    private static Set<ProcessId> findAllStandbyTaskClients(final Map<ProcessId, ClientState> clientStates, final TaskId task) {
         return clientStates.keySet()
                            .stream()
                            .filter(clientId -> clientStates.get(clientId).standbyTasks().contains(task))
@@ -834,7 +832,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                                      asList(rackAwareAssignmentTags));
     }
 
-    private static ClientState createClientStateWithCapacity(final UUID processId,
+    private static ClientState createClientStateWithCapacity(final ProcessId processId,
                                                              final int capacity,
                                                              final Map<String, String> clientTags,
                                                              final TaskId... tasks) {
@@ -845,7 +843,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         return clientState;
     }
 
-    private static Set<TaskId> findAllActiveTasks(final Map<UUID, ClientState> clientStates) {
+    private static Set<TaskId> findAllActiveTasks(final Map<ProcessId, ClientState> clientStates) {
         return clientStates.entrySet()
                            .stream()
                            .flatMap(clientStateEntry -> clientStateEntry.getValue().activeTasks().stream())

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ConstrainedPrioritySetTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ConstrainedPrioritySetTest.java
@@ -18,16 +18,16 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.junit.Test;
 
-import java.util.UUID;
 import java.util.function.BiFunction;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,22 +35,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ConstrainedPrioritySetTest {
     private static final TaskId DUMMY_TASK = new TaskId(0, 0);
 
-    private final BiFunction<UUID, TaskId, Boolean> alwaysTrue = (client, task) -> true;
-    private final BiFunction<UUID, TaskId, Boolean> alwaysFalse = (client, task) -> false;
+    private final BiFunction<ProcessId, TaskId, Boolean> alwaysTrue = (client, task) -> true;
+    private final BiFunction<ProcessId, TaskId, Boolean> alwaysFalse = (client, task) -> false;
 
     @Test
     public void shouldReturnOnlyClient() {
         final ConstrainedPrioritySet queue = new ConstrainedPrioritySet(alwaysTrue, client -> 1.0);
-        queue.offerAll(singleton(UUID_1));
+        queue.offerAll(singleton(PID_1));
 
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_1));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_1));
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
 
     @Test
     public void shouldReturnNull() {
         final ConstrainedPrioritySet queue = new ConstrainedPrioritySet(alwaysFalse, client -> 1.0);
-        queue.offerAll(singleton(UUID_1));
+        queue.offerAll(singleton(PID_1));
 
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
@@ -59,14 +59,14 @@ public class ConstrainedPrioritySetTest {
     public void shouldReturnLeastLoadedClient() {
         final ConstrainedPrioritySet queue = new ConstrainedPrioritySet(
             alwaysTrue,
-            client -> (client == UUID_1) ? 3.0 : (client == UUID_2) ? 2.0 : 1.0
+            client -> (client == PID_1) ? 3.0 : (client == PID_2) ? 2.0 : 1.0
         );
 
-        queue.offerAll(asList(UUID_1, UUID_2, UUID_3));
+        queue.offerAll(asList(PID_1, PID_2, PID_3));
 
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_3));
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_2));
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_1));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_3));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_2));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_1));
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
 
@@ -74,23 +74,23 @@ public class ConstrainedPrioritySetTest {
     public void shouldNotRetainDuplicates() {
         final ConstrainedPrioritySet queue = new ConstrainedPrioritySet(alwaysTrue, client -> 1.0);
 
-        queue.offerAll(singleton(UUID_1));
-        queue.offer(UUID_1);
+        queue.offerAll(singleton(PID_1));
+        queue.offer(PID_1);
 
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_1));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_1));
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
 
     @Test
     public void shouldOnlyReturnValidClients() {
         final ConstrainedPrioritySet queue = new ConstrainedPrioritySet(
-            (client, task) -> client.equals(UUID_1),
+            (client, task) -> client.equals(PID_1),
             client -> 1.0
         );
 
-        queue.offerAll(asList(UUID_1, UUID_2));
+        queue.offerAll(asList(PID_1, PID_2));
 
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_1));
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_1));
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
 
@@ -101,11 +101,11 @@ public class ConstrainedPrioritySetTest {
             client -> 1.0
         );
 
-        queue.offerAll(asList(UUID_1, UUID_2));
+        queue.offerAll(asList(PID_1, PID_2));
 
-        assertThat(queue.poll(DUMMY_TASK, client -> client.equals(UUID_1)), equalTo(UUID_1));
-        assertThat(queue.poll(DUMMY_TASK, client -> client.equals(UUID_1)), nullValue());
-        assertThat(queue.poll(DUMMY_TASK), equalTo(UUID_2));
+        assertThat(queue.poll(DUMMY_TASK, client -> client.equals(PID_1)), equalTo(PID_1));
+        assertThat(queue.poll(DUMMY_TASK, client -> client.equals(PID_1)), nullValue());
+        assertThat(queue.poll(DUMMY_TASK), equalTo(PID_2));
         assertThat(queue.poll(DUMMY_TASK), nullValue());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignorTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -25,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
@@ -33,8 +33,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -42,12 +42,12 @@ import static org.hamcrest.Matchers.is;
 
 public class FallbackPriorTaskAssignorTest {
 
-    private final Map<UUID, ClientState> clients = new TreeMap<>();
+    private final Map<ProcessId, ClientState> clients = new TreeMap<>();
 
     @Test
     public void shouldViolateBalanceToPreserveActiveTaskStickiness() {
-        final ClientState c1 = createClientWithPreviousActiveTasks(UUID_1, 1, TASK_0_0, TASK_0_1, TASK_0_2);
-        final ClientState c2 = createClient(UUID_2, 1);
+        final ClientState c1 = createClientWithPreviousActiveTasks(PID_1, 1, TASK_0_0, TASK_0_1, TASK_0_2);
+        final ClientState c2 = createClient(PID_2, 1);
 
         final List<TaskId> taskIds = asList(TASK_0_0, TASK_0_1, TASK_0_2);
         Collections.shuffle(taskIds);
@@ -64,11 +64,11 @@ public class FallbackPriorTaskAssignorTest {
         assertThat(c2.activeTasks(), empty());
     }
 
-    private ClientState createClient(final UUID processId, final int capacity) {
+    private ClientState createClient(final ProcessId processId, final int capacity) {
         return createClientWithPreviousActiveTasks(processId, capacity);
     }
 
-    private ClientState createClientWithPreviousActiveTasks(final UUID processId, final int capacity, final TaskId... taskIds) {
+    private ClientState createClientWithPreviousActiveTasks(final ProcessId processId, final int capacity, final TaskId... taskIds) {
         final ClientState clientState = new ClientState(capacity);
         clientState.addPreviousActiveTasks(mkSet(taskIds));
         clients.put(processId, clientState);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.hamcrest.Matchers;
@@ -38,7 +39,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -65,9 +65,9 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.analyzeTaskAssignmentBalance;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedActiveAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedStatefulAssignment;
@@ -156,14 +156,20 @@ public class HighAvailabilityTaskAssignorTest {
     @Test
     public void shouldBeStickyForActiveAndStandbyTasksWhileWarmingUp() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
-        final ClientState clientState1 = new ClientState(allTaskIds, emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), allTaskIds, allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L)), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1, UUID_3);
+        final ClientState clientState1 = new ClientState(allTaskIds, emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), allTaskIds, allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L)), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
 
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         );
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -205,14 +211,20 @@ public class HighAvailabilityTaskAssignorTest {
     @Test
     public void shouldSkipWarmupsWhenAcceptableLagIsMax() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
-        final ClientState clientState1 = new ClientState(allTaskIds, emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1, UUID_3);
+        final ClientState clientState1 = new ClientState(allTaskIds, emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
 
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         );
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -252,10 +264,16 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsWhereNumberOfClientsIntegralDivisorOfNumberOfTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_3);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -298,10 +316,16 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsWhereNumberOfThreadsIntegralDivisorOfNumberOfTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3, UUID_3);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -345,9 +369,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsWhereNumberOfClientsNotIntegralDivisorOfNumberOfTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -387,10 +415,16 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverUnevenlyDistributedStreamThreads() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 2, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3, UUID_3);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 2,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -436,10 +470,16 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsWithMoreClientsThanTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1, UUID_3);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -477,10 +517,16 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsAndStreamThreadsWithEqualStreamThreadsPerClientAsTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9, UUID_3);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 9,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -526,10 +572,16 @@ public class HighAvailabilityTaskAssignorTest {
         final Map<TaskId, Long> lagsForCaughtUpClient = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L));
         final Map<TaskId, Long> lagsForNotCaughtUpClient =
             allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
-        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5, UUID_1);
-        final ClientState notCaughtUpClientState1 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5, UUID_2);
-        final ClientState notCaughtUpClientState2 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5, UUID_3);
-        final Map<UUID, ClientState> clientStates =
+        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+            PID_1
+        );
+        final ClientState notCaughtUpClientState1 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+            PID_2
+        );
+        final ClientState notCaughtUpClientState2 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates =
             getClientStatesMap(caughtUpClientState, notCaughtUpClientState1, notCaughtUpClientState2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -568,9 +620,9 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldEvenlyAssignActiveStatefulTasksIfClientsAreWarmedUpToBalanceTaskOverClients() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
 
-        // If RackAwareTaskAssignor is enabled, TASK_1_1 is assigned UUID_2
+        // If RackAwareTaskAssignor is enabled, TASK_1_1 is assigned ProcessId_2
         final TaskId warmupTaskId1 = enableRackAwareTaskAssignor ? TASK_1_1 : TASK_0_1;
-        // If RackAwareTaskAssignor is enabled, TASK_0_1 is assigned UUID_3
+        // If RackAwareTaskAssignor is enabled, TASK_0_1 is assigned ProcessId_3
         final TaskId warmupTaskId2 = enableRackAwareTaskAssignor ? TASK_0_1 : TASK_1_0;
         final Set<TaskId> warmedUpTaskIds1 = mkSet(warmupTaskId1);
         final Set<TaskId> warmedUpTaskIds2 = mkSet(warmupTaskId2);
@@ -582,10 +634,16 @@ public class HighAvailabilityTaskAssignorTest {
             allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
         lagsForWarmedUpClient2.put(warmupTaskId2, 0L);
 
-        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5, UUID_1);
-        final ClientState warmedUpClientState1 = new ClientState(emptySet(), warmedUpTaskIds1, lagsForWarmedUpClient1, EMPTY_CLIENT_TAGS, 5, UUID_2);
-        final ClientState warmedUpClientState2 = new ClientState(emptySet(), warmedUpTaskIds2, lagsForWarmedUpClient2, EMPTY_CLIENT_TAGS, 5, UUID_3);
-        final Map<UUID, ClientState> clientStates =
+        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+            PID_1
+        );
+        final ClientState warmedUpClientState1 = new ClientState(emptySet(), warmedUpTaskIds1, lagsForWarmedUpClient1, EMPTY_CLIENT_TAGS, 5,
+            PID_2
+        );
+        final ClientState warmedUpClientState2 = new ClientState(emptySet(), warmedUpTaskIds2, lagsForWarmedUpClient2, EMPTY_CLIENT_TAGS, 5,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates =
             getClientStatesMap(caughtUpClientState, warmedUpClientState1, warmedUpClientState2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -625,9 +683,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverStreamThreadsButBestEffortOverClients() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 6, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3, UUID_2);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 6,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, EMPTY_CLIENT_TAGS, 3,
+            PID_2
+        );
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -667,8 +729,10 @@ public class HighAvailabilityTaskAssignorTest {
     @Test
     public void shouldComputeNewAssignmentIfThereAreUnassignedActiveTasks() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
-        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final Map<UUID, ClientState> clientStates = singletonMap(UUID_1, client1);
+        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final Map<ProcessId, ClientState> clientStates = singletonMap(PID_1, client1);
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -698,9 +762,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfThereAreUnassignedStandbyTasks() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0);
-        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState client2 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final Map<UUID, ClientState> clientStates = mkMap(mkEntry(UUID_1, client1), mkEntry(UUID_2, client2));
+        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState client2 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final Map<ProcessId, ClientState> clientStates = mkMap(mkEntry(PID_1, client1), mkEntry(PID_2, client2));
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -714,7 +782,7 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                          rackAwareTaskAssignor,
                                                                                          configs);
 
-        assertThat(clientStates.get(UUID_2).standbyTasks(), not(empty()));
+        assertThat(clientStates.get(PID_2).standbyTasks(), not(empty()));
         assertThat(probingRebalanceNeeded, is(false));
         assertValidAssignment(1, allTasks, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
@@ -728,11 +796,15 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfActiveTasksWasNotOnCaughtUpClient() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0);
-        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState client2 = new ClientState(singleton(TASK_0_1), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, client1),
-            mkEntry(UUID_2, client2)
+        final ClientState client1 = new ClientState(singleton(TASK_0_0), emptySet(), singletonMap(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState client2 = new ClientState(singleton(TASK_0_1), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+            mkEntry(PID_1, client1),
+            mkEntry(PID_2, client2)
         );
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
@@ -744,8 +816,8 @@ public class HighAvailabilityTaskAssignorTest {
         final boolean probingRebalanceNeeded =
             new HighAvailabilityTaskAssignor().assign(clientStates, allTasks, statefulTasks, rackAwareTaskAssignor, configs);
 
-        assertThat(clientStates.get(UUID_1).activeTasks(), is(singleton(TASK_0_1)));
-        assertThat(clientStates.get(UUID_2).activeTasks(), is(singleton(TASK_0_0)));
+        assertThat(clientStates.get(PID_1).activeTasks(), is(singleton(TASK_0_1)));
+        assertThat(clientStates.get(PID_2).activeTasks(), is(singleton(TASK_0_0)));
         // we'll warm up task 0_0 on client1 because it's first in sorted order,
         // although this isn't an optimal convergence
         assertThat(probingRebalanceNeeded, is(true));
@@ -761,13 +833,19 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignToMostCaughtUpIfActiveTasksWasNotOnCaughtUpClient() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0);
-        final ClientState client1 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, Long.MAX_VALUE), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState client2 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 1000L), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState client3 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1, UUID_3);
-        final Map<UUID, ClientState> clientStates = mkMap(
-                mkEntry(UUID_1, client1),
-                mkEntry(UUID_2, client2),
-                mkEntry(UUID_3, client3)
+        final ClientState client1 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, Long.MAX_VALUE), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState client2 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 1000L), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState client3 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
+        final Map<ProcessId, ClientState> clientStates = mkMap(
+                mkEntry(PID_1, client1),
+                mkEntry(PID_2, client2),
+                mkEntry(PID_3, client3)
         );
 
         final AssignmentConfigs configs = getConfigWithStandbys();
@@ -779,13 +857,13 @@ public class HighAvailabilityTaskAssignorTest {
         final boolean probingRebalanceNeeded =
                 new HighAvailabilityTaskAssignor().assign(clientStates, allTasks, statefulTasks, rackAwareTaskAssignor, configs);
 
-        assertThat(clientStates.get(UUID_1).activeTasks(), is(emptySet()));
-        assertThat(clientStates.get(UUID_2).activeTasks(), is(emptySet()));
-        assertThat(clientStates.get(UUID_3).activeTasks(), is(singleton(TASK_0_0)));
+        assertThat(clientStates.get(PID_1).activeTasks(), is(emptySet()));
+        assertThat(clientStates.get(PID_2).activeTasks(), is(emptySet()));
+        assertThat(clientStates.get(PID_3).activeTasks(), is(singleton(TASK_0_0)));
 
-        assertThat(clientStates.get(UUID_1).standbyTasks(), is(singleton(TASK_0_0))); // warm up
-        assertThat(clientStates.get(UUID_2).standbyTasks(), is(singleton(TASK_0_0))); // standby
-        assertThat(clientStates.get(UUID_3).standbyTasks(), is(emptySet()));
+        assertThat(clientStates.get(PID_1).standbyTasks(), is(singleton(TASK_0_0))); // warm up
+        assertThat(clientStates.get(PID_2).standbyTasks(), is(singleton(TASK_0_0))); // standby
+        assertThat(clientStates.get(PID_3).standbyTasks(), is(emptySet()));
 
         assertThat(probingRebalanceNeeded, is(true));
         assertValidAssignment(1, 1, allTasks, emptySet(), clientStates, new StringBuilder());
@@ -801,8 +879,12 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1);
 
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0), statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_1), statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0), statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_1), statefulTasks,
+            PID_2
+        );
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -810,7 +892,7 @@ public class HighAvailabilityTaskAssignorTest {
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
         final boolean probingRebalanceNeeded =
             new HighAvailabilityTaskAssignor().assign(clientStates, allTasks, statefulTasks, rackAwareTaskAssignor, configs);
 
@@ -829,10 +911,14 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = EMPTY_TASKS;
 
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -856,10 +942,14 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignWarmupReplicasEvenIfNoStandbyReplicasConfigured() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1), statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1), statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -885,10 +975,14 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldNotAssignMoreThanMaxWarmupReplicas() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3), statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3), statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             /*acceptableRecoveryLag*/ 100L,
@@ -927,10 +1021,14 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldNotAssignWarmupAndStandbyToTheSameClient() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3), statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3), statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             /*acceptableRecoveryLag*/ 100L,
@@ -968,9 +1066,11 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldNotAssignAnyStandbysWithInsufficientCapacity() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1), statefulTasks, UUID_1);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(mkSet(TASK_0_0, TASK_0_1), statefulTasks,
+            PID_1
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1);
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -992,9 +1092,11 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveTasksToNotCaughtUpClientIfNoneExist() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_1);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_1
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1);
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1015,11 +1117,17 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldNotAssignMoreThanMaxWarmupReplicasWithStandbys() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(statefulTasks, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
-        final ClientState client3 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_3);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(statefulTasks, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
+        final ClientState client3 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_3
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1049,10 +1157,14 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
         final Set<TaskId> statelessTasks = mkSet(TASK_1_0, TASK_1_1, TASK_1_2);
 
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(statefulTasks, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(statefulTasks, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = getConfigWithStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1094,7 +1206,7 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), allTaskLags, EMPTY_CLIENT_TAGS, 50);
         final ClientState client3 = new ClientState(emptySet(), emptySet(), allTaskLags, EMPTY_CLIENT_TAGS, 1);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1121,10 +1233,14 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statefulTasks = new HashSet<>(allTasks);
         final Set<TaskId> caughtUpTasks1 = enableRackAwareTaskAssignor ? mkSet(TASK_0_0, TASK_0_3) : mkSet(TASK_0_0, TASK_0_2);
         final Set<TaskId> caughtUpTasks2 = enableRackAwareTaskAssignor ? mkSet(TASK_0_1, TASK_0_2) : mkSet(TASK_0_1, TASK_0_3);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(caughtUpTasks1, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(caughtUpTasks2, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(caughtUpTasks1, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(caughtUpTasks2, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1146,10 +1262,14 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldReturnFalseIfNoWarmupTasksAreAssigned() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
         final Set<TaskId> statefulTasks = EMPTY_TASKS;
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1169,8 +1289,12 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldReturnTrueIfWarmupTasksAreAssigned() {
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = mkSet(TASK_0_0, TASK_0_1);
-        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(allTasks, statefulTasks, UUID_1);
-        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks, UUID_2);
+        final ClientState client1 = getMockClientWithPreviousCaughtUpTasks(allTasks, statefulTasks,
+            PID_1
+        );
+        final ClientState client2 = getMockClientWithPreviousCaughtUpTasks(EMPTY_TASKS, statefulTasks,
+            PID_2
+        );
 
         final AssignmentConfigs configs = getConfigWithoutStandbys();
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
@@ -1178,7 +1302,7 @@ public class HighAvailabilityTaskAssignorTest {
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
         final boolean probingRebalanceNeeded =
             new HighAvailabilityTaskAssignor().assign(clientStates, allTasks, statefulTasks, rackAwareTaskAssignor, configs);
         assertThat(probingRebalanceNeeded, is(true));
@@ -1198,7 +1322,7 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 7);
         final ClientState client3 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 7);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -1248,7 +1372,7 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 2);
         final ClientState client3 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 2);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -1298,7 +1422,7 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 2);
         final ClientState client3 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 3);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -1348,7 +1472,7 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 3);
         final ClientState client3 = new ClientState(emptySet(), emptySet(), taskLags, EMPTY_CLIENT_TAGS, 3);
 
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final AssignmentConfigs configs = new AssignmentConfigs(
             0L,
@@ -1414,7 +1538,7 @@ public class HighAvailabilityTaskAssignorTest {
         final List<Set<TaskId>> statefulAndStatelessTasks = getRandomSubset(taskIds, 2);
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final Set<TaskId> statelessTasks = statefulAndStatelessTasks.get(1);
-        final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
+        final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(clientSize,
             tpSize, partitionSize, maxCapacity, false, statefulTasks);
 
 
@@ -1456,7 +1580,7 @@ public class HighAvailabilityTaskAssignorTest {
         final Cluster cluster = getRandomCluster(nodeSize, tpSize, partitionSize);
         final Map<TaskId, Set<TopicPartition>> taskChangelogTopicPartitionMap = getTaskTopicPartitionMap(tpSize, partitionSize, true);
         final Map<Subtopology, Set<TaskId>> subtopologySetMap = getTasksForTopicGroup(tpSize, partitionSize);
-        final Map<UUID, Map<String, Optional<String>>> processRackMap = getRandomProcessRacks(clientSize, nodeSize);
+        final Map<ProcessId, Map<String, Optional<String>>> processRackMap = getRandomProcessRacks(clientSize, nodeSize);
         final InternalTopicManager mockInternalTopicManager = mockInternalTopicManagerForRandomChangelog(nodeSize, tpSize, partitionSize);
 
         AssignmentConfigs configs = new AssignmentConfigs(
@@ -1485,7 +1609,7 @@ public class HighAvailabilityTaskAssignorTest {
         final List<Set<TaskId>> statefulAndStatelessTasks = getRandomSubset(taskIds, 2);
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final Set<TaskId> statelessTasks = statefulAndStatelessTasks.get(1);
-        final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
+        final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(clientSize,
             tpSize, partitionSize, maxCapacity, false, statefulTasks);
 
         new HighAvailabilityTaskAssignor().assign(
@@ -1507,7 +1631,7 @@ public class HighAvailabilityTaskAssignorTest {
             return;
         }
 
-        final SortedMap<UUID, ClientState> clientStateMapCopy = copyClientStateMap(clientStateMap);
+        final SortedMap<ProcessId, ClientState> clientStateMapCopy = copyClientStateMap(clientStateMap);
         configs = new AssignmentConfigs(
             0L,
             1,
@@ -1538,7 +1662,7 @@ public class HighAvailabilityTaskAssignorTest {
             configs
         );
 
-        for (final Map.Entry<UUID, ClientState> entry : clientStateMap.entrySet()) {
+        for (final Map.Entry<ProcessId, ClientState> entry : clientStateMap.entrySet()) {
             assertThat(entry.getValue().statefulActiveTasks(), Matchers.equalTo(clientStateMapCopy.get(entry.getKey()).statefulActiveTasks()));
             assertThat(entry.getValue().standbyTasks(), Matchers.equalTo(clientStateMapCopy.get(entry.getKey()).standbyTasks()));
         }
@@ -1558,7 +1682,7 @@ public class HighAvailabilityTaskAssignorTest {
 
     private static ClientState getMockClientWithPreviousCaughtUpTasks(final Set<TaskId> statefulActiveTasks,
                                                                       final Set<TaskId> statefulTasks,
-                                                                      final UUID processId) {
+                                                                      final ProcessId processId) {
         if (!statefulTasks.containsAll(statefulActiveTasks)) {
             throw new IllegalArgumentException("Need to initialize stateful tasks set before creating mock clients");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
@@ -22,6 +22,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.StreamsAss
 
 import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,14 +41,14 @@ public class LegacySubscriptionInfoSerde {
 
     private final int usedVersion;
     private final int latestSupportedVersion;
-    private final UUID processId;
+    private final ProcessId processId;
     private final Set<TaskId> prevTasks;
     private final Set<TaskId> standbyTasks;
     private final String userEndPoint;
 
     public LegacySubscriptionInfoSerde(final int version,
                                        final int latestSupportedVersion,
-                                       final UUID processId,
+                                       final ProcessId processId,
                                        final Set<TaskId> prevTasks,
                                        final Set<TaskId> standbyTasks,
                                        final String userEndPoint) {
@@ -78,7 +79,7 @@ public class LegacySubscriptionInfoSerde {
         return latestSupportedVersion;
     }
 
-    public UUID processId() {
+    public ProcessId processId() {
         return processId;
     }
 
@@ -112,7 +113,7 @@ public class LegacySubscriptionInfoSerde {
 
             buf.putInt(usedVersion); // used version
             buf.putInt(LATEST_SUPPORTED_VERSION); // supported version
-            encodeClientUUID(buf, processId());
+            encodeClientUUID(buf, processId().id());
             encodeTasks(buf, prevTasks, usedVersion);
             encodeTasks(buf, standbyTasks, usedVersion);
             encodeUserEndPoint(buf, endPointBytes);
@@ -132,7 +133,7 @@ public class LegacySubscriptionInfoSerde {
             );
 
             buf.putInt(2); // version
-            encodeClientUUID(buf, processId());
+            encodeClientUUID(buf, processId().id());
             encodeTasks(buf, prevTasks, usedVersion);
             encodeTasks(buf, standbyTasks, usedVersion);
             encodeUserEndPoint(buf, endPointBytes);
@@ -149,7 +150,7 @@ public class LegacySubscriptionInfoSerde {
             );
 
             buf1.putInt(1); // version
-            encodeClientUUID(buf1, processId());
+            encodeClientUUID(buf1, processId().id());
             encodeTasks(buf1, prevTasks, usedVersion);
             encodeTasks(buf1, standbyTasks, usedVersion);
             buf1.rewind();
@@ -201,19 +202,19 @@ public class LegacySubscriptionInfoSerde {
         final int usedVersion = data.getInt();
         if (usedVersion > 2 && usedVersion < 7) {
             final int latestSupportedVersion = data.getInt();
-            final UUID processId = decodeProcessId(data);
+            final ProcessId processId = decodeProcessId(data);
             final Set<TaskId> prevTasks = decodeTasks(data, usedVersion);
             final Set<TaskId> standbyTasks = decodeTasks(data, usedVersion);
             final String userEndPoint = decodeUserEndpoint(data);
             return new LegacySubscriptionInfoSerde(usedVersion, latestSupportedVersion, processId, prevTasks, standbyTasks, userEndPoint);
         } else if (usedVersion == 2) {
-            final UUID processId = decodeProcessId(data);
+            final ProcessId processId = decodeProcessId(data);
             final Set<TaskId> prevTasks = decodeTasks(data, usedVersion);
             final Set<TaskId> standbyTasks = decodeTasks(data, usedVersion);
             final String userEndPoint = decodeUserEndpoint(data);
             return new LegacySubscriptionInfoSerde(2, UNKNOWN, processId, prevTasks, standbyTasks, userEndPoint);
         } else if (usedVersion == 1) {
-            final UUID processId = decodeProcessId(data);
+            final ProcessId processId = decodeProcessId(data);
             final Set<TaskId> prevTasks = decodeTasks(data, usedVersion);
             final Set<TaskId> standbyTasks = decodeTasks(data, usedVersion);
             return new LegacySubscriptionInfoSerde(1, UNKNOWN, processId, prevTasks, standbyTasks, null);
@@ -240,8 +241,8 @@ public class LegacySubscriptionInfoSerde {
         return prevTasks;
     }
 
-    private static UUID decodeProcessId(final ByteBuffer data) {
-        return new UUID(data.getLong(), data.getLong());
+    private static ProcessId decodeProcessId(final ByteBuffer data) {
+        return new ProcessId(new UUID(data.getLong(), data.getLong()));
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructorTest.java
@@ -36,9 +36,9 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.UUID;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,11 +62,11 @@ public class RackAwareGraphConstructorTest {
         TP_SIZE, PARTITION_SIZE, false);
     private final SortedSet<TaskId> taskIds = (SortedSet<TaskId>) taskTopicPartitionMap.keySet();
     private final List<TaskId> taskIdList = new ArrayList<>(taskIds);
-    private final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(CLIENT_SIZE,
+    private final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(CLIENT_SIZE,
         TP_SIZE, PARTITION_SIZE, 1, false, taskIds);
-    private final List<UUID> clientList = new ArrayList<>(clientStateMap.keySet());
-    private final Map<TaskId, UUID> taskClientMap = new HashMap<>();
-    private final Map<UUID, Integer> originalAssignedTaskNumber = new HashMap<>();
+    private final List<ProcessId> clientList = new ArrayList<>(clientStateMap.keySet());
+    private final Map<TaskId, ProcessId> taskClientMap = new HashMap<>();
+    private final Map<ProcessId, Integer> originalAssignedTaskNumber = new HashMap<>();
     private final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = getTasksForTopicGroup(TP_SIZE,
         PARTITION_SIZE);
     private RackAwareGraphConstructor<ClientState> constructor;
@@ -96,7 +96,7 @@ public class RackAwareGraphConstructorTest {
             clientList, taskIdList, clientStateMap, taskClientMap, originalAssignedTaskNumber, ClientState::hasAssignedTask, this::getCost, 10, 1, false, false);
     }
 
-    private int getCost(final TaskId taskId, final UUID processId, final boolean inCurrentAssignment, final int trafficCost, final int nonOverlapCost, final boolean isStandby) {
+    private int getCost(final TaskId taskId, final ProcessId processId, final boolean inCurrentAssignment, final int trafficCost, final int nonOverlapCost, final boolean isStandby) {
         return 1;
     }
 
@@ -156,7 +156,7 @@ public class RackAwareGraphConstructorTest {
         final int sinkId = clientList.size() + taskIdList.size();
         int totalFlow = 0;
         for (int i = 0; i < clientList.size(); i++) {
-            final UUID clientId = clientList.get(i);
+            final ProcessId clientId = clientList.get(i);
             final int originalAssignedCount = originalAssignedTaskNumber.get(clientId);
 
             final int clientNodeId = i + taskIdList.size();
@@ -222,7 +222,7 @@ public class RackAwareGraphConstructorTest {
         for (final Set<TaskId> tasks : tasksForTopicGroup.values()) {
             final int taskCount = tasks.size();
             for (int j = 0; j < clientList.size(); j++) {
-                final UUID clientId = clientList.get(j);
+                final ProcessId clientId = clientList.get(j);
                 final int originalAssignedCount = originalAssignedTaskNumber.get(clientId);
                 final int expectedCapacity = (int) Math.ceil(originalAssignedCount * 1.0 / taskIdList.size() * taskCount);
                 final int clientNodeId = topicGroupIndex * clientList.size() + taskIdList.size() + j;
@@ -244,7 +244,7 @@ public class RackAwareGraphConstructorTest {
         final int sinkId = clientList.size() + tasksForTopicGroup.size() * clientList.size() + taskIdList.size();
         int totalFlow = 0;
         for (int i = 0; i < clientList.size(); i++) {
-            final UUID clientId = clientList.get(i);
+            final ProcessId clientId = clientList.get(i);
             final int originalAssignedCount = originalAssignedTaskNumber.get(clientId);
 
             final int clientNodeId =
@@ -282,7 +282,7 @@ public class RackAwareGraphConstructorTest {
         }
     }
 
-    private void randomAssignTasksToClient(final List<TaskId> taskIdList, final SortedMap<UUID, ClientState> clientStateMap) {
+    private void randomAssignTasksToClient(final List<TaskId> taskIdList, final SortedMap<ProcessId, ClientState> clientStateMap) {
         int totalAssigned = 0;
         for (final ClientState clientState : clientStateMap.values()) {
             clientState.assignActive(taskIdList.get(totalAssigned++));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -44,13 +44,13 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_NAME;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_4;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_5;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_6;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_7;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_4;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_5;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_6;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_7;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertValidAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientTaskCount;
@@ -98,7 +98,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
@@ -109,6 +108,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockInternalTopicManager;
@@ -283,18 +283,18 @@ public class RackAwareTaskAssignorTest {
             getRackAwareEnabledConfig(),
             time
         );
-        final Map<UUID, String> racksForProcess = assignor.racksForProcess();
-        assertEquals(mkMap(mkEntry(UUID_1, RACK_1)), racksForProcess);
+        final Map<ProcessId, String> racksForProcess = assignor.racksForProcess();
+        assertEquals(mkMap(mkEntry(PID_1, RACK_1)), racksForProcess);
     }
 
     @Test
     public void shouldReturnInvalidClientRackWhenRackDiffersInSameProcess() {
-        final Map<UUID, Map<String, Optional<String>>> processRacks = new HashMap<>();
+        final Map<ProcessId, Map<String, Optional<String>>> processRacks = new HashMap<>();
 
         // Different consumers in same process have different rack ID. This shouldn't happen.
         // If happens, there's a bug somewhere
-        processRacks.computeIfAbsent(UUID_1, k -> new HashMap<>()).put("consumer1", Optional.of("rack1"));
-        processRacks.computeIfAbsent(UUID_1, k -> new HashMap<>()).put("consumer2", Optional.of("rack2"));
+        processRacks.computeIfAbsent(PID_1, k -> new HashMap<>()).put("consumer1", Optional.of("rack1"));
+        processRacks.computeIfAbsent(PID_1, k -> new HashMap<>()).put("consumer2", Optional.of("rack2"));
 
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForTopic0(),
@@ -491,8 +491,8 @@ public class RackAwareTaskAssignorTest {
 
         clientState1.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet();
 
@@ -531,15 +531,15 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActive(TASK_1_0);
         clientState3.assignActive(TASK_0_0);
 
-        // task_0_0 has same rack as UUID_1
-        // task_0_1 has same rack as UUID_2 and UUID_3
-        // task_1_0 has same rack as UUID_1 and UUID_3
-        // task_1_1 has same rack as UUID_2
-        // Optimal assignment is UUID_1: {0_0, 1_0}, UUID_2: {1_1}, UUID_3: {0_1} which result in no cross rack traffic
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        // task_0_0 has same rack as ProcessId_1
+        // task_0_1 has same rack as ProcessId_2 and ProcessId_3
+        // task_1_0 has same rack as ProcessId_1 and ProcessId_3
+        // task_1_1 has same rack as ProcessId_2
+        // Optimal assignment is ProcessId_1: {0_0, 1_0}, ProcessId_2: {1_1}, ProcessId_3: {0_1} which result in no cross rack traffic
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
 
@@ -576,16 +576,16 @@ public class RackAwareTaskAssignorTest {
         );
 
         final SortedSet<TaskId> taskIds = (SortedSet<TaskId>) taskTopicPartitionMap.keySet();
-        final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize, tpSize, partitionSize, 1, taskIds);
+        final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(clientSize, tpSize, partitionSize, 1, taskIds);
 
-        final Map<UUID, Integer> clientTaskCount = clientTaskCount(clientStateMap, ClientState::activeTaskCount);
+        final Map<ProcessId, Integer> clientTaskCount = clientTaskCount(clientStateMap, ClientState::activeTaskCount);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
         final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertThat(cost, lessThanOrEqualTo(originalCost));
 
-        for (final Entry<UUID, ClientState> entry : clientStateMap.entrySet()) {
+        for (final Entry<ProcessId, ClientState> entry : clientStateMap.entrySet()) {
             assertEquals((int) clientTaskCount.get(entry.getKey()), entry.getValue().activeTasks().size());
         }
 
@@ -613,10 +613,10 @@ public class RackAwareTaskAssignorTest {
         );
 
         final SortedSet<TaskId> taskIds = (SortedSet<TaskId>) taskTopicPartitionMap.keySet();
-        final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize, tpSize, partitionSize, 1, taskIds);
+        final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(clientSize, tpSize, partitionSize, 1, taskIds);
 
-        final Map<TaskId, UUID> taskClientMap = new HashMap<>();
-        for (final Entry<UUID, ClientState> entry : clientStateMap.entrySet()) {
+        final Map<TaskId, ProcessId> taskClientMap = new HashMap<>();
+        for (final Entry<ProcessId, ClientState> entry : clientStateMap.entrySet()) {
             entry.getValue().activeTasks().forEach(t -> taskClientMap.put(t, entry.getKey()));
         }
         assertEquals(taskIds.size(), taskClientMap.size());
@@ -632,7 +632,7 @@ public class RackAwareTaskAssignorTest {
             assertEquals(0, cost);
 
             // Make sure assignment doesn't change
-            for (final Entry<TaskId, UUID> entry : taskClientMap.entrySet()) {
+            for (final Entry<TaskId, ProcessId> entry : taskClientMap.entrySet()) {
                 final ClientState clientState = clientStateMap.get(entry.getValue());
                 assertTrue(clientState.hasAssignedTask(entry.getKey()));
             }
@@ -666,14 +666,14 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActive(TASK_1_0);
         clientState3.assignActive(TASK_0_0);
 
-        // task_0_0 has same rack as UUID_1 and UUID_2
-        // task_1_0 has same rack as UUID_1 and UUID_3
-        // Optimal assignment is UUID_1: {}, UUID_2: {0_0}, UUID_3: {1_0} which result in no cross rack traffic
-        // and keeps UUID_1 empty since it was originally empty
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        // task_0_0 has same rack as ProcessId_1 and ProcessId_2
+        // task_1_0 has same rack as ProcessId_1 and ProcessId_3
+        // Optimal assignment is ProcessId_1: {}, ProcessId_2: {0_0}, ProcessId_3: {1_0} which result in no cross rack traffic
+        // and keeps ProcessId_1 empty since it was originally empty
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_1_0);
 
@@ -686,7 +686,7 @@ public class RackAwareTaskAssignorTest {
         final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expected, cost);
 
-        // UUID_1 remains empty
+        // ProcessId_1 remains empty
         assertEquals(mkSet(), clientState1.activeTasks());
         assertEquals(mkSet(TASK_0_0), clientState2.activeTasks());
         assertEquals(mkSet(TASK_1_0), clientState3.activeTasks());
@@ -716,14 +716,14 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActiveTasks(mkSet(TASK_0_1, TASK_1_0));
         clientState3.assignActive(TASK_0_0);
 
-        // task_0_0 has same rack as UUID_1 and UUID_2
-        // task_0_1 has same rack as UUID_2 and UUID_3
-        // task_1_0 has same rack as UUID_1 and UUID_3
-        // Optimal assignment is UUID_1: {}, UUID_2: {0_0, 0_1}, UUID_3: {1_0} which result in no cross rack traffic
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        // task_0_0 has same rack as ProcessId_1 and ProcessId_2
+        // task_0_1 has same rack as ProcessId_2 and ProcessId_3
+        // task_1_0 has same rack as ProcessId_1 and ProcessId_3
+        // Optimal assignment is ProcessId_1: {}, ProcessId_2: {0_0, 0_1}, ProcessId_3: {1_0} which result in no cross rack traffic
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0);
 
@@ -765,13 +765,13 @@ public class RackAwareTaskAssignorTest {
         clientState1.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
 
-        // task_0_0 has same rack as UUID_2
-        // task_0_1 has same rack as UUID_2
-        // task_1_1 has same rack as UUID_2
-        // UUID_5 is not in same rack as any task
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_2, clientState1),
-            mkEntry(UUID_5, clientState2)
+        // task_0_0 has same rack as ProcessId_2
+        // task_0_1 has same rack as ProcessId_2
+        // task_1_1 has same rack as ProcessId_2
+        // ProcessId_5 is not in same rack as any task
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_2, clientState1),
+            mkEntry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
 
@@ -784,8 +784,8 @@ public class RackAwareTaskAssignorTest {
         assertEquals(expectedCost, cost);
 
         if (stateful || assignmentStrategy.equals(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_MIN_TRAFFIC)) {
-            // Even though assigning all tasks to UUID_2 will result in min cost, but it's not balanced
-            // assignment. That's why TASK_0_1 is still assigned to UUID_5
+            // Even though assigning all tasks to ProcessId_2 will result in min cost, but it's not balanced
+            // assignment. That's why TASK_0_1 is still assigned to ProcessId_5
             assertEquals(mkSet(TASK_0_0, TASK_1_1), clientState1.activeTasks());
             assertEquals(mkSet(TASK_0_1), clientState2.activeTasks());
         } else {
@@ -813,9 +813,9 @@ public class RackAwareTaskAssignorTest {
         clientState1.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_2, clientState1),
-            mkEntry(UUID_5, clientState2)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_2, clientState1),
+            mkEntry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         final Exception exception = assertThrows(IllegalStateException.class,
@@ -843,9 +843,9 @@ public class RackAwareTaskAssignorTest {
         clientState1.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
         clientState2.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_2, clientState1),
-            mkEntry(UUID_5, clientState2)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_2, clientState1),
+            mkEntry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
@@ -875,9 +875,9 @@ public class RackAwareTaskAssignorTest {
         clientState1.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_2, clientState1),
-            mkEntry(UUID_5, clientState2)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_2, clientState1),
+            mkEntry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
@@ -900,18 +900,24 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_3);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
 
         clientState1.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
         clientState2.assignActive(TASK_1_0);
         clientState3.assignActive(TASK_0_0);
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3)
         ));
 
         final long originalCost = assignor.standByTasksCost(new TreeSet<>(), clientStateMap, 10, 1);
@@ -936,20 +942,32 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_3);
-        final ClientState clientState4 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_4);
-        final ClientState clientState5 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_6);
-        final ClientState clientState6 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_7);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
+        final ClientState clientState4 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_4
+        );
+        final ClientState clientState5 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_6
+        );
+        final ClientState clientState6 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_7
+        );
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3),
-            mkEntry(UUID_4, clientState4),
-            mkEntry(UUID_6, clientState5),
-            mkEntry(UUID_7, clientState6)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3),
+            mkEntry(PID_4, clientState4),
+            mkEntry(PID_6, clientState5),
+            mkEntry(PID_7, clientState6)
         ));
 
         clientState1.assignActive(TASK_0_0);
@@ -967,7 +985,7 @@ public class RackAwareTaskAssignorTest {
         clientState6.assignStandbyTasks(mkSet(TASK_0_2, TASK_1_1)); // Cost 10
 
         final SortedSet<TaskId> taskIds = new TreeSet<>(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2));
-        final Map<UUID, Integer> standbyTaskCount = clientTaskCount(clientStateMap, ClientState::standbyTaskCount);
+        final Map<ProcessId, Integer> standbyTaskCount = clientTaskCount(clientStateMap, ClientState::standbyTaskCount);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
         verifyStandbySatisfyRackReplica(taskIds, assignor.racksForProcess(), clientStateMap, replicaCount, false, null);
@@ -999,20 +1017,32 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_1);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_2);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_3);
-        final ClientState clientState4 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_4);
-        final ClientState clientState5 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_6);
-        final ClientState clientState6 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1, UUID_7);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_1
+        );
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_2
+        );
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_3
+        );
+        final ClientState clientState4 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_4
+        );
+        final ClientState clientState5 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_6
+        );
+        final ClientState clientState6 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1,
+            PID_7
+        );
 
-        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(UUID_1, clientState1),
-            mkEntry(UUID_2, clientState2),
-            mkEntry(UUID_3, clientState3),
-            mkEntry(UUID_4, clientState4),
-            mkEntry(UUID_6, clientState5),
-            mkEntry(UUID_7, clientState6)
+        final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(PID_1, clientState1),
+            mkEntry(PID_2, clientState2),
+            mkEntry(PID_3, clientState3),
+            mkEntry(PID_4, clientState4),
+            mkEntry(PID_6, clientState5),
+            mkEntry(PID_7, clientState6)
         ));
 
         clientState1.assignActive(TASK_0_0);
@@ -1030,7 +1060,7 @@ public class RackAwareTaskAssignorTest {
         clientState6.assignStandbyTasks(mkSet(TASK_0_2, TASK_1_1)); // Cost 10
 
         final SortedSet<TaskId> taskIds = new TreeSet<>(mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2));
-        final Map<UUID, Integer> standbyTaskCount = clientTaskCount(clientStateMap, ClientState::standbyTaskCount);
+        final Map<ProcessId, Integer> standbyTaskCount = clientTaskCount(clientStateMap, ClientState::standbyTaskCount);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
         verifyStandbySatisfyRackReplica(taskIds, assignor.racksForProcess(), clientStateMap, replicaCount, false, null);
@@ -1071,7 +1101,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         final SortedSet<TaskId> taskIds = (SortedSet<TaskId>) taskTopicPartitionMap.keySet();
-        final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
+        final SortedMap<ProcessId, ClientState> clientStateMap = getRandomClientState(clientSize,
             tpSize, partionSize, maxCapacity, taskIds);
 
         final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(
@@ -1079,7 +1109,7 @@ public class RackAwareTaskAssignorTest {
         assertInstanceOf(ClientTagAwareStandbyTaskAssignor.class, standbyTaskAssignor);
         // Get a standby assignment
         standbyTaskAssignor.assign(clientStateMap, taskIds, taskIds, assignorConfiguration);
-        final Map<UUID, Integer> standbyTaskCount = clientTaskCount(clientStateMap,
+        final Map<ProcessId, Integer> standbyTaskCount = clientTaskCount(clientStateMap,
             ClientState::standbyTaskCount);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
@@ -1131,20 +1161,20 @@ public class RackAwareTaskAssignorTest {
         );
     }
 
-    private Map<UUID, Map<String, Optional<String>>> getProcessRacksForProcess0() {
+    private Map<ProcessId, Map<String, Optional<String>>> getProcessRacksForProcess0() {
         return getProcessRacksForProcess0(false);
     }
 
-    private Map<UUID, Map<String, Optional<String>>> getProcessRacksForProcess0(final boolean missingRack) {
-        final Map<UUID, Map<String, Optional<String>>> processRacks = new HashMap<>();
+    private Map<ProcessId, Map<String, Optional<String>>> getProcessRacksForProcess0(final boolean missingRack) {
+        final Map<ProcessId, Map<String, Optional<String>>> processRacks = new HashMap<>();
         final Optional<String> rack = missingRack ? Optional.empty() : Optional.of("rack1");
-        processRacks.put(UUID_1, Collections.singletonMap("consumer1", rack));
+        processRacks.put(PID_1, Collections.singletonMap("consumer1", rack));
         return processRacks;
     }
 
-    private Map<UUID, Map<String, Optional<String>>> getProcessWithNoConsumerRacks() {
+    private Map<ProcessId, Map<String, Optional<String>>> getProcessWithNoConsumerRacks() {
         return mkMap(
-            mkEntry(UUID_1, mkMap())
+            mkEntry(PID_1, mkMap())
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignmentUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignmentUtilsTest.java
@@ -17,13 +17,13 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -49,7 +49,7 @@ public class StandbyTaskAssignmentUtilsTest {
 
     private static final Set<TaskId> ACTIVE_TASKS = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
 
-    private Map<UUID, ClientState> clients;
+    private Map<ProcessId, ClientState> clients;
     private ConstrainedPrioritySet clientsByTaskLoad;
 
     @Before

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -44,7 +44,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_0;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.MIN_NAMED_TOPOLOGY_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.MIN_VERSION_OFFSET_SUM_SUBSCRIPTION;
@@ -94,7 +94,7 @@ public class SubscriptionInfoTest {
         assertThrows(IllegalArgumentException.class, () -> new SubscriptionInfo(
             0,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1,
             "localhost:80",
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -108,7 +108,7 @@ public class SubscriptionInfoTest {
         assertThrows(IllegalArgumentException.class, () -> new SubscriptionInfo(
             LATEST_SUPPORTED_VERSION + 1,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1,
             "localhost:80",
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -122,7 +122,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo info = new SubscriptionInfo(
             1,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1,
             IGNORED_USER_ENDPOINT,
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -132,7 +132,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
         assertEquals(1, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertNull(decoded.userEndPoint());
@@ -143,7 +143,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo info = new SubscriptionInfo(
             1,
             1234,
-            UUID_1,
+            PID_1,
             "ignoreme",
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -155,7 +155,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
         assertEquals(1, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertNull(decoded.userEndPoint());
@@ -166,7 +166,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
             1,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1.id(),
             ACTIVE_TASKS,
             STANDBY_TASKS,
             "localhost:80"
@@ -176,7 +176,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo decoded = SubscriptionInfo.decode(buffer);
         assertEquals(1, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertNull(decoded.userEndPoint());
@@ -187,7 +187,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo info = new SubscriptionInfo(
             2,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1,
             "localhost:80",
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -197,7 +197,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
         assertEquals(2, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertEquals("localhost:80", decoded.userEndPoint());
@@ -208,7 +208,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo info = new SubscriptionInfo(
             2,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1,
             "localhost:80",
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
@@ -220,7 +220,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
         assertEquals(2, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertEquals("localhost:80", decoded.userEndPoint());
@@ -231,7 +231,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
             2,
             LATEST_SUPPORTED_VERSION,
-            UUID_1,
+            PID_1.id(),
             ACTIVE_TASKS,
             STANDBY_TASKS,
             "localhost:80"
@@ -241,7 +241,7 @@ public class SubscriptionInfoTest {
         final SubscriptionInfo decoded = SubscriptionInfo.decode(buffer);
         assertEquals(2, decoded.version());
         assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
-        assertEquals(UUID_1, decoded.processId());
+        assertEquals(PID_1, decoded.processId());
         assertEquals(ACTIVE_TASKS, decoded.prevTasks());
         assertEquals(STANDBY_TASKS, decoded.standbyTasks());
         assertEquals("localhost:80", decoded.userEndPoint());
@@ -253,7 +253,7 @@ public class SubscriptionInfoTest {
             final SubscriptionInfo info = new SubscriptionInfo(
                 version,
                 LATEST_SUPPORTED_VERSION,
-                UUID_1,
+                PID_1,
                 "localhost:80",
                 TASK_OFFSET_SUMS,
                 IGNORED_UNIQUE_FIELD,
@@ -263,7 +263,7 @@ public class SubscriptionInfoTest {
             final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
             assertEquals(version, decoded.version());
             assertEquals(LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
-            assertEquals(UUID_1, decoded.processId());
+            assertEquals(PID_1, decoded.processId());
             assertEquals(ACTIVE_TASKS, decoded.prevTasks());
             assertEquals(STANDBY_TASKS, decoded.standbyTasks());
             assertEquals("localhost:80", decoded.userEndPoint());
@@ -276,7 +276,7 @@ public class SubscriptionInfoTest {
             final SubscriptionInfo info = new SubscriptionInfo(
                 version,
                 LATEST_SUPPORTED_VERSION,
-                UUID_1,
+                PID_1,
                 "localhost:80",
                 TASK_OFFSET_SUMS,
                 IGNORED_UNIQUE_FIELD,
@@ -288,7 +288,7 @@ public class SubscriptionInfoTest {
             final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
             assertEquals(version, decoded.version());
             assertEquals(LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
-            assertEquals(UUID_1, decoded.processId());
+            assertEquals(PID_1, decoded.processId());
             assertEquals(ACTIVE_TASKS, decoded.prevTasks());
             assertEquals(STANDBY_TASKS, decoded.standbyTasks());
             assertEquals("localhost:80", decoded.userEndPoint());
@@ -301,7 +301,7 @@ public class SubscriptionInfoTest {
             final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
                 version,
                 LATEST_SUPPORTED_VERSION,
-                UUID_1,
+                PID_1.id(),
                 ACTIVE_TASKS,
                 STANDBY_TASKS,
                 "localhost:80"
@@ -312,7 +312,7 @@ public class SubscriptionInfoTest {
             final String message = "for version: " + version;
             assertEquals(message, version, decoded.version());
             assertEquals(message, LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
-            assertEquals(message, UUID_1, decoded.processId());
+            assertEquals(message, PID_1, decoded.processId());
             assertEquals(message, ACTIVE_TASKS, decoded.prevTasks());
             assertEquals(message, STANDBY_TASKS, decoded.standbyTasks());
             assertEquals(message, "localhost:80", decoded.userEndPoint());
@@ -322,7 +322,8 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldEncodeAndDecodeVersion5() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertEquals(info, SubscriptionInfo.decode(info.encode()));
     }
 
@@ -339,23 +340,27 @@ public class SubscriptionInfoTest {
         final int latestSupportedVersion = LATEST_SUPPORTED_VERSION - 1;
 
         final SubscriptionInfo info =
-            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(usedVersion, latestSupportedVersion,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         final SubscriptionInfo expectedInfo =
-            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(usedVersion, latestSupportedVersion,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion7() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldConvertTaskOffsetSumMapToTaskSets() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info.prevTasks(), is(ACTIVE_TASKS));
         assertThat(info.standbyTasks(), is(STANDBY_TASKS));
     }
@@ -364,7 +369,7 @@ public class SubscriptionInfoTest {
     public void shouldReturnTaskOffsetSumsMapForDecodedSubscription() {
         final SubscriptionInfo info = SubscriptionInfo.decode(
             new SubscriptionInfo(MIN_VERSION_OFFSET_SUM_SUBSCRIPTION,
-                                 LATEST_SUPPORTED_VERSION, UUID_1,
+                                 LATEST_SUPPORTED_VERSION, PID_1,
                                  "localhost:80",
                                  TASK_OFFSET_SUMS,
                                  IGNORED_UNIQUE_FIELD,
@@ -387,7 +392,7 @@ public class SubscriptionInfoTest {
             new LegacySubscriptionInfoSerde(
                 SubscriptionInfo.MIN_VERSION_OFFSET_SUM_SUBSCRIPTION - 1,
                 LATEST_SUPPORTED_VERSION,
-                UUID_1,
+                PID_1.id(),
                 ACTIVE_TASKS,
                 STANDBY_TASKS,
                 "localhost:80")
@@ -399,14 +404,16 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldEncodeAndDecodeVersion8() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(8, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(8, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldNotErrorAccessingFutureVars() {
         final SubscriptionInfo info =
-                new SubscriptionInfo(8, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+                new SubscriptionInfo(8, LATEST_SUPPORTED_VERSION,
+                    PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         try {
             info.errorCode();
         } catch (final Exception e) {
@@ -417,21 +424,24 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldEncodeAndDecodeVersion9() {
         final SubscriptionInfo info =
-                new SubscriptionInfo(9, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+                new SubscriptionInfo(9, LATEST_SUPPORTED_VERSION,
+                    PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion10() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion10WithNamedTopologies() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", NAMED_TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", NAMED_TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
@@ -439,21 +449,24 @@ public class SubscriptionInfoTest {
     public void shouldThrowIfAttemptingToUseNamedTopologiesWithOlderVersion() {
         assertThrows(
             TaskAssignmentException.class,
-            () -> new SubscriptionInfo(MIN_NAMED_TOPOLOGY_VERSION - 1, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", NAMED_TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS)
+            () -> new SubscriptionInfo(MIN_NAMED_TOPOLOGY_VERSION - 1, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", NAMED_TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS)
         );
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion11() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
+            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldReturnEncodeDecodeEmptyClientTagsOnVersion11() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
+            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, EMPTY_CLIENT_TAGS);
         assertThat(info.clientTags(), is(anEmptyMap()));
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
@@ -461,7 +474,8 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldReturnEmptyMapOfClientTagsOnOlderVersions() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
+            new SubscriptionInfo(10, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
 
         assertThat(info.clientTags(), is(anEmptyMap()));
     }
@@ -469,7 +483,8 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldReturnMapOfClientTagsOnVersion11() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
+            new SubscriptionInfo(11, LATEST_SUPPORTED_VERSION,
+                PID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD, IGNORED_ERROR_CODE, CLIENT_TAGS);
 
         assertThat(info.clientTags(), is(CLIENT_TAGS));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -166,7 +166,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
             1,
             LATEST_SUPPORTED_VERSION,
-            PID_1.id(),
+            PID_1,
             ACTIVE_TASKS,
             STANDBY_TASKS,
             "localhost:80"
@@ -231,7 +231,7 @@ public class SubscriptionInfoTest {
         final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
             2,
             LATEST_SUPPORTED_VERSION,
-            PID_1.id(),
+            PID_1,
             ACTIVE_TASKS,
             STANDBY_TASKS,
             "localhost:80"
@@ -301,7 +301,7 @@ public class SubscriptionInfoTest {
             final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
                 version,
                 LATEST_SUPPORTED_VERSION,
-                PID_1.id(),
+                PID_1,
                 ACTIVE_TASKS,
                 STANDBY_TASKS,
                 "localhost:80"
@@ -392,7 +392,7 @@ public class SubscriptionInfoTest {
             new LegacySubscriptionInfoSerde(
                 SubscriptionInfo.MIN_VERSION_OFFSET_SUM_SUBSCRIPTION - 1,
                 LATEST_SUPPORTED_VERSION,
-                PID_1.id(),
+                PID_1,
                 ACTIVE_TASKS,
                 STANDBY_TASKS,
                 "localhost:80")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignmentUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignmentUtilsTest.java
@@ -25,7 +25,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_4;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_5;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -257,7 +257,7 @@ public class TaskAssignmentUtilsTest {
                                                                         final Set<TaskId> previousActiveTasks,
                                                                         final Set<TaskId> previousStandbyTasks,
                                                                         final Map<String, String> clientTags) {
-        final ProcessId processId = new ProcessId(uuidForInt(id));
+        final ProcessId processId = processIdForInt(id);
         return mkEntry(processId, new DefaultKafkaStreamsState(
             processId,
             numProcessingThreads,
@@ -272,7 +272,7 @@ public class TaskAssignmentUtilsTest {
     }
 
     public static ProcessId processId(final int id) {
-        return new ProcessId(uuidForInt(id));
+        return processIdForInt(id);
     }
 
     public static Map.Entry<ProcessId, KafkaStreamsAssignment> mkAssignment(final AssignedTask.Type taskType,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.junit.Test;
 
 import java.util.Comparator;
@@ -27,7 +28,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
@@ -44,9 +44,9 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasProperty;
 import static org.apache.kafka.streams.processor.internals.assignment.TaskMovement.assignActiveTaskMovements;
@@ -59,11 +59,11 @@ public class TaskMovementTest {
         final int maxWarmupReplicas = Integer.MAX_VALUE;
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = new HashMap<>();
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = new HashMap<>();
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = new HashMap<>();
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = new HashMap<>();
         for (final TaskId task : allTasks) {
-            tasksToCaughtUpClients.put(task, mkSortedSet(UUID_1, UUID_2, UUID_3));
-            tasksToClientByLag.put(task, mkOrderedSet(UUID_1, UUID_2, UUID_3));
+            tasksToCaughtUpClients.put(task, mkSortedSet(PID_1, PID_2, PID_3));
+            tasksToClientByLag.put(task, mkOrderedSet(PID_1, PID_2, PID_3));
         }
 
         final ClientState client1 = getClientStateWithActiveAssignment(mkSet(TASK_0_0, TASK_1_0), allTasks, allTasks);
@@ -91,7 +91,7 @@ public class TaskMovementTest {
         final ClientState client2 = getClientStateWithActiveAssignment(mkSet(TASK_0_1, TASK_1_1), mkSet(), allTasks);
         final ClientState client3 = getClientStateWithActiveAssignment(mkSet(TASK_0_2, TASK_1_2), mkSet(), allTasks);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = mkMap(
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
             mkEntry(TASK_0_0, emptySortedSet()),
             mkEntry(TASK_0_1, emptySortedSet()),
             mkEntry(TASK_0_2, emptySortedSet()),
@@ -99,13 +99,13 @@ public class TaskMovementTest {
             mkEntry(TASK_1_1, emptySortedSet()),
             mkEntry(TASK_1_2, emptySortedSet())
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_0_2, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_1_0, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_1_1, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_1_2, mkOrderedSet(UUID_1, UUID_2, UUID_3))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
+            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_0_1, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_0_2, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_1_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_1_1, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_1_2, mkOrderedSet(PID_1, PID_2, PID_3))
         );
         assertThat(
             assignActiveTaskMovements(
@@ -126,17 +126,17 @@ public class TaskMovementTest {
         final ClientState client1 = getClientStateWithActiveAssignment(mkSet(TASK_0_0), mkSet(TASK_0_0), allTasks);
         final ClientState client2 = getClientStateWithActiveAssignment(mkSet(TASK_0_1), mkSet(TASK_0_2), allTasks);
         final ClientState client3 = getClientStateWithActiveAssignment(mkSet(TASK_0_2), mkSet(TASK_0_1), allTasks);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(UUID_1)),
-            mkEntry(TASK_0_1, mkSortedSet(UUID_3)),
-            mkEntry(TASK_0_2, mkSortedSet(UUID_2))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
+            mkEntry(TASK_0_0, mkSortedSet(PID_1)),
+            mkEntry(TASK_0_1, mkSortedSet(PID_3)),
+            mkEntry(TASK_0_2, mkSortedSet(PID_2))
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(UUID_3, UUID_1, UUID_2)),
-            mkEntry(TASK_0_2, mkOrderedSet(UUID_2, UUID_1, UUID_3))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
+            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+            mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
         assertThat(
@@ -173,17 +173,17 @@ public class TaskMovementTest {
         final ClientState client3 = getClientStateWithLags(mkSet(TASK_0_2), client3Lags);
         // To test when the task is already a standby on the most caught up node
         client3.assignStandby(TASK_0_1);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = mkMap(
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
                 mkEntry(TASK_0_0, mkSortedSet()),
                 mkEntry(TASK_0_1, mkSortedSet()),
                 mkEntry(TASK_0_2, mkSortedSet())
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = mkMap(
-                mkEntry(TASK_0_0, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-                mkEntry(TASK_0_1, mkOrderedSet(UUID_3, UUID_1, UUID_2)),
-                mkEntry(TASK_0_2, mkOrderedSet(UUID_2, UUID_3, UUID_1))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
+                mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+                mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+                mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_3, PID_1))
         );
 
         assertThat(
@@ -215,17 +215,17 @@ public class TaskMovementTest {
         final ClientState client1 = getClientStateWithActiveAssignment(mkSet(TASK_0_0), mkSet(TASK_0_0), allTasks);
         final ClientState client2 = getClientStateWithActiveAssignment(mkSet(TASK_0_1), mkSet(TASK_0_2), allTasks);
         final ClientState client3 = getClientStateWithActiveAssignment(mkSet(TASK_0_2), mkSet(TASK_0_1), allTasks);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(UUID_1)),
-            mkEntry(TASK_0_1, mkSortedSet(UUID_3)),
-            mkEntry(TASK_0_2, mkSortedSet(UUID_2))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
+            mkEntry(TASK_0_0, mkSortedSet(PID_1)),
+            mkEntry(TASK_0_1, mkSortedSet(PID_3)),
+            mkEntry(TASK_0_2, mkSortedSet(PID_2))
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(UUID_1, UUID_2, UUID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(UUID_3, UUID_1, UUID_2)),
-            mkEntry(TASK_0_2, mkOrderedSet(UUID_2, UUID_1, UUID_3))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
+            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+            mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
         assertThat(
@@ -257,13 +257,13 @@ public class TaskMovementTest {
         final ClientState client1 = getClientStateWithActiveAssignment(mkSet(), mkSet(TASK_0_0), allTasks);
         client1.assignStandby(TASK_0_0);
         final ClientState client2 = getClientStateWithActiveAssignment(mkSet(TASK_0_0), mkSet(), allTasks);
-        final Map<UUID, ClientState> clientStates = getClientStatesMap(client1, client2);
+        final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(UUID_1))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
+            mkEntry(TASK_0_0, mkSortedSet(PID_1))
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(UUID_1, UUID_2))
+        final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
+            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2))
         );
 
         assertThat(
@@ -315,9 +315,9 @@ public class TaskMovementTest {
     /**
      * Creates a SortedSet with the sort order being the order of elements in the parameter list
      */
-    private static SortedSet<UUID> mkOrderedSet(final UUID... clients) {
-        final List<UUID> clientList = asList(clients);
-        final SortedSet<UUID> set = new TreeSet<>(Comparator.comparing(clientList::indexOf));
+    private static SortedSet<ProcessId> mkOrderedSet(final ProcessId... clients) {
+        final List<ProcessId> clientList = asList(clients);
+        final SortedSet<ProcessId> set = new TreeSet<>(Comparator.comparing(clientList::indexOf));
         set.addAll(clientList);
         return set;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -201,7 +201,7 @@ public class StreamsUpgradeTest {
             } else {
                 return new FutureSubscriptionInfo(
                     usedSubscriptionMetadataVersion,
-                    taskManager.processId(),
+                    taskManager.processId().id(),
                     SubscriptionInfo.getActiveTasksFromTaskOffsetSumMap(taskManager.getTaskOffsetSums()),
                     SubscriptionInfo.getStandbyTasksFromTaskOffsetSumMap(taskManager.getTaskOffsetSums()),
                     userEndPoint())


### PR DESCRIPTION
This PR changes the assignment process to use `ProcessId` instead of `UUID`.
