### PR TITLE
MINOR: Fix flaky test ConnectWorkerIntegrationTest::testReconfigureConnectorWithFailingTaskConfigs

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -1298,7 +1298,6 @@ public class ConnectWorkerIntegrationTest {
         // since failure to reconfigure the tasks (which may occur if the bug this test was written
         // to help catch resurfaces) will not cause existing tasks to fail or stop running
         StartAndStopLatch restarts = connectorHandle.expectedStarts(1);
-        connectorHandle.expectedCommits(NUM_TASKS * 2);
 
         final String secondConnectorTopic = "connector-topic-2";
         connect.kafka().createTopic(secondConnectorTopic, 1);
@@ -1312,6 +1311,9 @@ public class ConnectWorkerIntegrationTest {
                 "Connector tasks were not restarted in time",
                 restarts.await(10, TimeUnit.SECONDS)
         );
+
+        // Wait for at least one task to commit offsets after being restarted
+        connectorHandle.expectedCommits(1);
         connectorHandle.awaitCommits(offsetCommitIntervalMs * 3);
 
         final long endOffset = connect.kafka().endOffset(new TopicPartition(secondConnectorTopic, 0));


### PR DESCRIPTION
This test has been flaky since it was merged to trunk. To date, there have been 566 successful runs and 8 flaky failures (see [Gradle Enterprise analysis](https://ge.apache.org/scans/tests?search.relativeStartTime=P28D&search.rootProjectNames=kafka&search.timeZoneId=America%2FNew_York&tests.container=org.apache.kafka.connect.integration.ConnectWorkerIntegrationTest&tests.expandedTests=Wzhd&tests.test=testReconfigureConnectorWithFailingTaskConfigs)).

One possible cause of this is that we establish an expectation on the number of offset commits that need to take place (two per task) before reconfiguring the connector, but the assumption in the test is that these commits will take place after the tasks have been restarted. In some rare cases, it's possible that these commits will have already taken place before the tasks are restarted, which causes an assertion failure with the message "java.lang.AssertionError: Source connector should have published at least one record to new Kafka topic after being reconfigured".

This patch should resolve those failures by establishing the expected number of offset commits _after_ the connector has been reconfigured and its tasks have been restarted, which should guarantee that the offset commits are performed by tasks with the updated connector configuration.

In addition, the number of expected offset commits is reduced to one, since a single commit is all that we need in order to expect at least one record is present in the new Kafka topic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
