### PR TITLE
KAFKA-16848: Reverting KRaft migration for "Migrating brokers to KRaft" state is wrong

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4129,9 +4129,10 @@ listeners=CONTROLLER://:9093
             <li>
               On each broker, remove the <code>process.roles</code> configuration,
               replace the <code>node.id</code> with <code>broker.id</code> and
-              restore the <code>zookeeper.connect</code> configuration to its previous value.
+              restore the <code>zookeeper.connect</code> as well as <code>zookeeper.metadata.migration.enable</code> configuration to its previous value.
               If your cluster requires other ZooKeeper configurations for brokers, such as
               <code>zookeeper.ssl.protocol</code>, re-add those configurations as well.
+              If your broker has authorization configured via the <code>authorizer.class.name</code> property make sure to restore it to its previous value.
               Then perform a rolling restart of all brokers.
             </li>
             <li>


### PR DESCRIPTION
Add two additional steps for the **KRaft** to **Zookeeper** reverting instructions in the _Migrating brokers to KRaft_ section.

The current documentation for **Kafka 3.7.0** is missing two steps for successful reverting.
Without these steps, the rollback results in an error.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
