### PR TITLE
KAFKA-10190: Set dynamic broker configs for entity default

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -245,14 +245,12 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
     val updatedDynamicBrokerConfigs = brokerConfig.dynamicConfig.currentDynamicBrokerConfigs
     val updatedDynamicDefaultConfigs = brokerConfig.dynamicConfig.currentDynamicDefaultConfigs
 
-    def getOrDefault(prop: String): Long = {
-      updatedDynamicBrokerConfigs get prop match {
-        case Some(value) => value.toLong
-        case None => {
-          updatedDynamicDefaultConfigs get prop match {
-            case Some(defaultValue) => defaultValue.toLong
-            case None => QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
-          }
+    def getOrDefault(prop: String): Long = updatedDynamicBrokerConfigs get prop match {
+      case Some(value) => value.toLong
+      case None => {
+        updatedDynamicDefaultConfigs get prop match {
+          case Some(defaultValue) => defaultValue.toLong
+          case None => QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
         }
       }
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -247,11 +247,9 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
 
     def getOrDefault(prop: String): Long = updatedDynamicBrokerConfigs get prop match {
       case Some(value) => value.toLong
-      case None => {
-        updatedDynamicDefaultConfigs get prop match {
-          case Some(defaultValue) => defaultValue.toLong
-          case None => QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
-        }
+      case None => updatedDynamicDefaultConfigs get prop match {
+        case Some(defaultValue) => defaultValue.toLong
+        case None => QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
       }
     }
     quotaManagers.leader.updateQuota(upperBound(getOrDefault(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -237,25 +237,28 @@ class IpConfigHandler(private val connectionQuotas: ConnectionQuotas) extends Co
 class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
                           private val quotaManagers: QuotaManagers) extends ConfigHandler with Logging {
   def processConfigChanges(brokerId: String, properties: Properties): Unit = {
-    def updateQuota(prop: String, quotaManager: ReplicationQuotaManager): Unit = {
-      brokerConfig.dynamicConfig.currentDynamicBrokerConfigs get prop match {
-        case Some(value) => quotaManager.updateQuota(upperBound(value.toLong.toDouble))
-        case None => {
-          brokerConfig.dynamicConfig.currentDynamicDefaultConfigs get prop match {
-            case Some(defaultValue) => quotaManager.updateQuota(upperBound(defaultValue.toLong.toDouble))
-            case None => return
-          }
-        }
-      }
-    }
     if (brokerId == ZooKeeperInternals.DEFAULT_STRING)
       brokerConfig.dynamicConfig.updateDefaultConfig(properties)
     else if (brokerConfig.brokerId == brokerId.trim.toInt) {
       brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, properties)
     }
-    updateQuota(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, quotaManagers.leader)
-    updateQuota(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, quotaManagers.follower)
-    updateQuota(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, quotaManagers.alterLogDirs)
+    val updatedDynamicBrokerConfigs = brokerConfig.dynamicConfig.currentDynamicBrokerConfigs
+    val updatedDynamicDefaultConfigs = brokerConfig.dynamicConfig.currentDynamicDefaultConfigs
+
+    def getOrDefault(prop: String): Long = {
+      updatedDynamicBrokerConfigs get prop match {
+        case Some(value) => value.toLong
+        case None => {
+          updatedDynamicDefaultConfigs get prop match {
+            case Some(defaultValue) => defaultValue.toLong
+            case None => QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
+          }
+        }
+      }
+    }
+    quotaManagers.leader.updateQuota(upperBound(getOrDefault(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
+    quotaManagers.follower.updateQuota(upperBound(getOrDefault(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
+    quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG).toDouble))
   }
 }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -503,22 +503,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
-  def testBrokerIdConfigChange(quorum: String): Unit = {
-    val newValue: Long = 100000L
-    val brokerId: String = this.brokers.head.config.brokerId.toString
-    setBrokerConfigs(brokerId, newValue)
-    for (b <- this.brokers) {
-      val value = if (b.config.brokerId.toString == brokerId) newValue else QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
-      TestUtils.retry(10000) {
-        assertEquals(value, b.quotaManagers.leader.upperBound)
-        assertEquals(value, b.quotaManagers.follower.upperBound)
-        assertEquals(value, b.quotaManagers.alterLogDirs.upperBound)
-      }
-    }
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
   def testBrokerIdConfigChangeAndDelete(quorum: String): Unit = {
     val newValue: Long = 100000L
     val brokerId: String = this.brokers.head.config.brokerId.toString
@@ -537,21 +521,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
         assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.leader.upperBound)
         assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.follower.upperBound)
         assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.alterLogDirs.upperBound)
-      }
-    }
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
-  def testDefaultBrokerIdConfigChange(quorum: String): Unit = {
-    val newValue: Long = 100000L
-    val brokerId: String = ""
-    setBrokerConfigs(brokerId, newValue)
-    for (b <- this.brokers) {
-      TestUtils.retry(10000) {
-        assertEquals(newValue, b.quotaManagers.leader.upperBound)
-        assertEquals(newValue, b.quotaManagers.follower.upperBound)
-        assertEquals(newValue, b.quotaManagers.alterLogDirs.upperBound)
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -25,7 +25,7 @@ import kafka.utils.TestUtils.random
 import kafka.utils._
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
-import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, Config, ConfigEntry}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{InvalidRequestException, UnknownTopicOrPartitionException}
@@ -83,10 +83,10 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       try {
         val resource = new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())
         val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, newVal.toString),
-          SET)
+          OpType.SET)
         val resource2 = new ConfigResource(ConfigResource.Type.BROKER, "")
         val op2 = new AlterConfigOp(new ConfigEntry(ServerLogConfigs.LOG_FLUSH_INTERVAL_MS_CONFIG, newVal.toString),
-          SET)
+          OpType.SET)
         admin.incrementalAlterConfigs(Map(
           resource -> List(op).asJavaCollection,
           resource2 -> List(op2).asJavaCollection,
@@ -124,7 +124,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       try {
         val resource = new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())
         val op = new AlterConfigOp(new ConfigEntry(TopicConfig.SEGMENT_BYTES_CONFIG, newSegmentSize.toString),
-          SET)
+          OpType.SET)
         admin.incrementalAlterConfigs(Map(resource -> List(op).asJavaCollection).asJava).all.get
       } finally {
         admin.close()
@@ -399,7 +399,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val admin = createAdminClient()
     try {
       val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
-      val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, "10000"), SET)
+      val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, "10000"), OpType.SET)
       admin.incrementalAlterConfigs(Map(resource -> List(op).asJavaCollection).asJava).all.get
       fail("Should fail with UnknownTopicOrPartitionException for topic doesn't exist")
     } catch {
@@ -449,7 +449,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val admin = createAdminClient()
     try {
       val resource = new ConfigResource(ConfigResource.Type.TOPIC, "")
-      val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, "200000"), SET)
+      val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, "200000"), OpType.SET)
       val future = admin.incrementalAlterConfigs(Map(resource -> List(op).asJavaCollection).asJava).all
       TestUtils.assertFutureExceptionTypeEquals(future, classOf[InvalidRequestException])
     } finally {
@@ -472,26 +472,30 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     }
   }
 
-  private def alterBrokerConfigs(brokerId: String, newValue: java.lang.Long): Unit = {
+  private def setBrokerConfigs(brokerId: String, newValue: Long): Unit = alterBrokerConfigs(brokerId, newValue, OpType.SET)
+  private def deleteBrokerConfigs(brokerId: String): Unit = alterBrokerConfigs(brokerId, 0, OpType.DELETE)
+  private def alterBrokerConfigs(brokerId: String, newValue: Long, op: OpType): Unit = {
     if (isKRaftTest()) {
       val admin = createAdminClient()
       try {
         val resource = new ConfigResource(ConfigResource.Type.BROKER, brokerId)
-        val configEntry = new ConfigEntry(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-        val configEntry2 = new ConfigEntry(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-        val configEntry3 = new ConfigEntry(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, newValue.toString)
-        val config = new Config(List(configEntry, configEntry2, configEntry3).asJavaCollection)
-        admin.alterConfigs(Map(
-          resource -> config,
+        val configOp = new AlterConfigOp(new ConfigEntry(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString), op)
+        val configOp2 = new AlterConfigOp(new ConfigEntry(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString), op)
+        val configOp3 = new AlterConfigOp(new ConfigEntry(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, newValue.toString), op)
+        val configOps = List(configOp, configOp2, configOp3).asJavaCollection
+        admin.incrementalAlterConfigs(Map(
+          resource -> configOps,
         ).asJava).all.get
       } finally {
         admin.close()
       }
     } else {
       val newProps = new Properties()
-      newProps.put(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-      newProps.put(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-      newProps.put(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, newValue.toString)
+      if (op == OpType.SET) {
+        newProps.put(QuotaConfigs.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
+        newProps.put(QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
+        newProps.put(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, newValue.toString)
+      }
       val brokerIdOption = if (brokerId != "") Option(brokerId.toInt) else None
       adminZkClient.changeBrokerConfig(brokerIdOption, newProps)
     }
@@ -500,9 +504,9 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testBrokerIdConfigChange(quorum: String): Unit = {
-    val newValue: java.lang.Long = 100000L
+    val newValue: Long = 100000L
     val brokerId: String = this.brokers.head.config.brokerId.toString
-    alterBrokerConfigs(brokerId, newValue)
+    setBrokerConfigs(brokerId, newValue)
     for (b <- this.brokers) {
       val value = if (b.config.brokerId.toString == brokerId) newValue else QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
       TestUtils.retry(10000) {
@@ -515,10 +519,34 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
+  def testBrokerIdConfigChangeAndDelete(quorum: String): Unit = {
+    val newValue: Long = 100000L
+    val brokerId: String = this.brokers.head.config.brokerId.toString
+    setBrokerConfigs(brokerId, newValue)
+    for (b <- this.brokers) {
+      val value = if (b.config.brokerId.toString == brokerId) newValue else QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT
+      TestUtils.retry(10000) {
+        assertEquals(value, b.quotaManagers.leader.upperBound)
+        assertEquals(value, b.quotaManagers.follower.upperBound)
+        assertEquals(value, b.quotaManagers.alterLogDirs.upperBound)
+      }
+    }
+    deleteBrokerConfigs(brokerId)
+    for (b <- this.brokers) {
+      TestUtils.retry(10000) {
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.leader.upperBound)
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.follower.upperBound)
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.alterLogDirs.upperBound)
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
   def testDefaultBrokerIdConfigChange(quorum: String): Unit = {
-    val newValue: java.lang.Long = 100000L
+    val newValue: Long = 100000L
     val brokerId: String = ""
-    alterBrokerConfigs(brokerId, newValue)
+    setBrokerConfigs(brokerId, newValue)
     for (b <- this.brokers) {
       TestUtils.retry(10000) {
         assertEquals(newValue, b.quotaManagers.leader.upperBound)
@@ -530,12 +558,35 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
+  def testDefaultBrokerIdConfigChangeAndDelete(quorum: String): Unit = {
+    val newValue: Long = 100000L
+    val brokerId: String = ""
+    setBrokerConfigs(brokerId, newValue)
+    for (b <- this.brokers) {
+      TestUtils.retry(10000) {
+        assertEquals(newValue, b.quotaManagers.leader.upperBound)
+        assertEquals(newValue, b.quotaManagers.follower.upperBound)
+        assertEquals(newValue, b.quotaManagers.alterLogDirs.upperBound)
+      }
+    }
+    deleteBrokerConfigs(brokerId)
+    for (b <- this.brokers) {
+      TestUtils.retry(10000) {
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.leader.upperBound)
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.follower.upperBound)
+        assertEquals(QuotaConfigs.QUOTA_BYTES_PER_SECOND_DEFAULT, b.quotaManagers.alterLogDirs.upperBound)
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
   def testDefaultAndBrokerIdConfigChange(quorum: String): Unit = {
-    val newValue: java.lang.Long = 100000L
+    val newValue: Long = 100000L
     val brokerId: String = this.brokers.head.config.brokerId.toString
-    alterBrokerConfigs(brokerId, newValue)
-    val newDefaultValue: java.lang.Long = 200000L
-    alterBrokerConfigs("", newDefaultValue)
+    setBrokerConfigs(brokerId, newValue)
+    val newDefaultValue: Long = 200000L
+    setBrokerConfigs("", newDefaultValue)
     for (b <- this.brokers) {
       val value = if (b.config.brokerId.toString == brokerId) newValue else newDefaultValue
       TestUtils.retry(10000) {


### PR DESCRIPTION
Fixes issue with dynamic broker configurations where entity default value is never applied. This is a copy of https://github.com/apache/kafka/pull/8906 which was abandoned.

Unit tests have been added to test the BrokerConfigHandler.

Suggested reviewers: @mimaison @chia7712 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
