### PR TITLE
MINOR: Wait for embedded clusters to start before using them in Connect OffsetsApiIntegrationTest

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -143,6 +143,15 @@ public class OffsetsApiIntegrationTest {
 
             result.start();
 
+            try {
+                result.assertions().assertExactlyNumWorkersAreUp(
+                        NUM_WORKERS,
+                        "Workers did not complete startup in time"
+                );
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted while awaiting cluster startup", e);
+            }
+
             return result;
         });
     }


### PR DESCRIPTION
There are some flaky failures for the `OffsetsApiIntegrationTest:: testResetSourceConnectorOffsetsExactlyOnceSupportEnabled` case (see [Gradle Enterprise](https://ge.apache.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=America%2FNew_York&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.expandedTests=WzMsMiwwXQ&tests.sortField=FLAKY&tests.test=testResetSourceConnectorOffsetsExactlyOnceSupportEnabled)). Every failure was either unrelated to Kafka Connect, or was caused by the very first REST request to the cluster timing out.

By adding an assertion that the cluster has started before issuing REST requests to it, we 1) give the cluster more time to get on its feet (five minutes vs. ninety seconds) and 2) help narrow down potential causes of failure in the future if this test becomes or remains flaky.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
