### PR TITLE
KAFKA-16935: Automatically wait for cluster startup in embedded Connect integration tests

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -219,16 +219,12 @@ public class MirrorConnectorsIntegrationBaseTest {
                 .build();
         
         primary.start();
-        primary.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Workers of " + PRIMARY_CLUSTER_ALIAS + "-connect-cluster did not start in time.");
 
         waitForTopicCreated(primary, "mm2-status.backup.internal");
         waitForTopicCreated(primary, "mm2-offsets.backup.internal");
         waitForTopicCreated(primary, "mm2-configs.backup.internal");
 
         backup.start();
-        backup.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-            "Workers of " + BACKUP_CLUSTER_ALIAS + "-connect-cluster did not start in time.");
 
         primaryProducer = initializeProducer(primary);
         backupProducer = initializeProducer(backup);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -134,11 +134,6 @@ public class BlockingConnectorTest {
 
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-                NUM_WORKERS,
-                "Initial group of workers did not start in time"
-        );
     }
 
     @After

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -218,9 +218,6 @@ public class ConnectWorkerIntegrationTest {
         props.put(TASKS_MAX_CONFIG, Objects.toString(numTasks));
         props.put(CONNECTOR_CLIENT_PRODUCER_OVERRIDES_PREFIX + BOOTSTRAP_SERVERS_CONFIG, "nobrokerrunningatthisaddress");
 
-        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
-
         // Try to start the connector and its single task.
         connect.configureConnector(CONNECTOR_NAME, props);
 
@@ -257,9 +254,6 @@ public class ConnectWorkerIntegrationTest {
 
         // set up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
 
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);
@@ -312,9 +306,6 @@ public class ConnectWorkerIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
-
         // base connector props
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
         props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
@@ -351,8 +342,6 @@ public class ConnectWorkerIntegrationTest {
             .numBrokers(1)
             .build();
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(1, "Initial group of workers did not start in time.");
 
         // and when the connector is not configured to create topics
         Map<String, String> props = defaultSourceConnectorProps("nonexistenttopic");
@@ -404,9 +393,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
 
         // Want to make sure to use multiple tasks
         final int numTasks = 4;
@@ -497,9 +483,6 @@ public class ConnectWorkerIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
-
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
         // Fail the connector on startup
         props.put("connector.start.inject.error", "true");
@@ -572,11 +555,6 @@ public class ConnectWorkerIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-            NUM_WORKERS,
-            "Initial group of workers did not start in time."
-        );
-
         connect.configureConnector(CONNECTOR_NAME, defaultSourceConnectorProps(TOPIC_NAME));
         connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
             CONNECTOR_NAME,
@@ -599,9 +577,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-            "Initial group of workers did not start in time.");
 
         CreateConnectorRequest createConnectorRequest = new CreateConnectorRequest(
             CONNECTOR_NAME,
@@ -633,9 +608,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-            "Initial group of workers did not start in time.");
 
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
 
@@ -686,9 +658,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-            "Initial group of workers did not start in time.");
 
         // Create topic and produce 10 messages
         connect.kafka().createTopic(TOPIC_NAME);
@@ -754,9 +723,6 @@ public class ConnectWorkerIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-            "Initial group of workers did not start in time.");
-
         // Create a connector with PAUSED initial state
         CreateConnectorRequest createConnectorRequest = new CreateConnectorRequest(
             CONNECTOR_NAME,
@@ -805,9 +771,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
 
         connect.kafka().createTopic(TOPIC_NAME);
 
@@ -859,8 +822,6 @@ public class ConnectWorkerIntegrationTest {
                 .numWorkers(1)
                 .build();
         connect.start();
-        connect.assertions().assertAtLeastNumWorkersAreUp(1,
-                "Worker did not start in time");
 
         Map<String, String> connectorConfig1 = defaultSourceConnectorProps(TOPIC_NAME);
         Map<String, String> connectorConfig2 = new HashMap<>(connectorConfig1);
@@ -926,8 +887,6 @@ public class ConnectWorkerIntegrationTest {
             .build();
 
         connect.start();
-
-        connect.assertions().assertExactlyNumWorkersAreUp(1, "Worker not brought up in time");
 
         Map<String, String> connectorWithBlockingTaskStopConfig = new HashMap<>();
         connectorWithBlockingTaskStopConfig.put(CONNECTOR_CLASS_CONFIG, BlockingConnectorTest.BlockingSourceConnector.class.getName());
@@ -1007,11 +966,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-                NUM_WORKERS,
-                "Initial group of workers did not start in time."
-        );
 
         Map<String, String> connectorProps = defaultSourceConnectorProps(TOPIC_NAME);
         int maxTasks = 1;
@@ -1177,11 +1131,6 @@ public class ConnectWorkerIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-                numWorkers,
-                "Initial group of workers did not start in time."
-        );
-
         final String connectorTopic = "connector-topic";
         connect.kafka().createTopic(connectorTopic, 1);
 
@@ -1214,7 +1163,7 @@ public class ConnectWorkerIntegrationTest {
 
         connect.assertions().assertAtLeastNumWorkersAreUp(
                 numWorkers,
-                "Initial group of workers did not start in time."
+                "Workers did not start in time after cluster was rolled."
         );
 
         final TopicPartition connectorTopicPartition = new TopicPartition(connectorTopic, 0);
@@ -1269,11 +1218,6 @@ public class ConnectWorkerIntegrationTest {
                 .build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-                numWorkers,
-                "Initial group of workers did not start in time."
-        );
 
         final String firstConnectorTopic = "connector-topic-1";
         connect.kafka().createTopic(firstConnectorTopic);
@@ -1343,11 +1287,6 @@ public class ConnectWorkerIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(
-                NUM_WORKERS,
-                "Initial group of workers did not start in time."
-        );
 
         final String topic = "kafka9228";
         connect.kafka().createTopic(topic, 1);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -172,9 +172,6 @@ public class ConnectWorkerIntegrationTest {
         // set up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
-
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
@@ -121,8 +121,6 @@ public class ConnectorClientPolicyIntegrationTest {
 
         // start the clusters
         connect.start();
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
 
         return connect;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -113,8 +113,6 @@ public class ConnectorRestartApiIntegrationTest {
             connect.start();
             return connect;
         });
-        connect.assertions().assertExactlyNumWorkersAreUp(numWorkers,
-                "Initial group of workers did not start in time.");
     }
 
     @After

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
@@ -115,8 +115,6 @@ public class ConnectorTopicsIntegrationTest {
         connect.kafka().createTopic(FOO_TOPIC, NUM_TOPIC_PARTITIONS);
         connect.kafka().createTopic(BAR_TOPIC, NUM_TOPIC_PARTITIONS);
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
-
         connect.assertions().assertConnectorActiveTopics(FOO_CONNECTOR, Collections.emptyList(),
                 "Active topic set is not empty for connector: " + FOO_CONNECTOR);
 
@@ -179,8 +177,6 @@ public class ConnectorTopicsIntegrationTest {
         connect.kafka().createTopic(FOO_TOPIC, NUM_TOPIC_PARTITIONS);
         connect.kafka().createTopic(BAR_TOPIC, NUM_TOPIC_PARTITIONS);
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
-
         connect.assertions().assertConnectorActiveTopics(FOO_CONNECTOR, Collections.emptyList(),
                 "Active topic set is not empty for connector: " + FOO_CONNECTOR);
 
@@ -234,8 +230,6 @@ public class ConnectorTopicsIntegrationTest {
         // create test topic
         connect.kafka().createTopic(FOO_TOPIC, NUM_TOPIC_PARTITIONS);
         connect.kafka().createTopic(BAR_TOPIC, NUM_TOPIC_PARTITIONS);
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
 
         // start a source connector
         connect.configureConnector(FOO_CONNECTOR, defaultSourceConnectorProps(FOO_TOPIC));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -94,8 +94,6 @@ public class ErrorHandlingIntegrationTest {
 
         // start Connect cluster
         connect.start();
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
 
         // get connector handles before starting test.
         connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -500,9 +500,6 @@ public class ExactlyOnceSourceIntegrationTest {
         connectorHandle.expectedRecords(MINIMUM_MESSAGES);
         connectorHandle.expectedCommits(MINIMUM_MESSAGES);
 
-        // make sure the worker is actually up (otherwise, it may fence out our simulated zombie leader, instead of the other way around)
-        connect.assertions().assertExactlyNumWorkersAreUp(1, "Connect worker did not complete startup in time");
-
         // fence out the leader of the cluster
         Producer<?, ?> zombieLeader = transactionalProducer(
                 "simulated-zombie-leader",

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -72,8 +72,6 @@ public class InternalTopicsIntegrationTest {
 
         // Start the Connect cluster
         connect.start();
-        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Brokers did not start in time.");
-        connect.assertions().assertExactlyNumWorkersAreUp(numWorkers, "Worker did not start in time.");
         log.info("Completed startup of {} Kafka brokers and {} Connect workers", numBrokers, numWorkers);
 
         // Check the topics
@@ -111,9 +109,6 @@ public class InternalTopicsIntegrationTest {
 
         // Start the Connect cluster
         connect.start();
-        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
-        connect.assertions().assertAtLeastNumWorkersAreUp(numWorkers, "Worker did not start in time.");
-        log.info("Completed startup of {} Kafka brokers and {} Connect workers", numBrokers, numWorkers);
 
         // Check the topics
         log.info("Verifying the internal topics for Connect");
@@ -136,7 +131,7 @@ public class InternalTopicsIntegrationTest {
                                                       .build();
 
         // Start the brokers and Connect, but Connect should fail to create config and offset topic
-        connect.start();
+        connect.start(false);
         connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
         log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
 
@@ -169,7 +164,6 @@ public class InternalTopicsIntegrationTest {
         // Start the brokers but not Connect
         log.info("Starting {} Kafka brokers, but no Connect workers yet", numBrokers);
         connect.start();
-        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
         log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
 
         // Create the good topics
@@ -243,7 +237,6 @@ public class InternalTopicsIntegrationTest {
         // Start the brokers but not Connect
         log.info("Starting {} Kafka brokers, but no Connect workers yet", numBrokers);
         connect.start();
-        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
         log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
 
         // Create the valid internal topics w/o topic settings, so these will use the broker's

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -121,7 +121,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "3");
         workerProps.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "2");
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
-        int numWorkers = 1;
+        int numWorkers = 0;
         int numBrokers = 1;
         connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
                                                       .workerProps(workerProps)
@@ -131,12 +131,15 @@ public class InternalTopicsIntegrationTest {
                                                       .build();
 
         // Start the brokers and Connect, but Connect should fail to create config and offset topic
-        connect.start(false);
-        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
+        connect.start();
         log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
+
+        // Try to start a worker
+        connect.addWorker();
 
         // Verify that the offset and config topic don't exist;
         // the status topic may have been created if timing was right but we don't care
+        // TODO: Synchronously await and verify that the worker fails during startup
         log.info("Verifying the internal topics for Connect");
         connect.assertions().assertTopicsDoNotExist(configTopic(), offsetTopic());
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -143,15 +143,6 @@ public class OffsetsApiIntegrationTest {
 
             result.start();
 
-            try {
-                result.assertions().assertExactlyNumWorkersAreUp(
-                        NUM_WORKERS,
-                        "Workers did not complete startup in time"
-                );
-            } catch (InterruptedException e) {
-                throw new RuntimeException("Interrupted while awaiting cluster startup", e);
-            }
-
             return result;
         });
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -116,9 +116,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
-
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);
 
@@ -146,9 +143,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
 
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);
@@ -194,9 +188,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
-
         // start several source connectors
         IntStream.range(0, 4).forEachOrdered(i -> connect.configureConnector(CONNECTOR_NAME + i, props));
 
@@ -220,9 +211,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
 
         // start a source connector
         IntStream.range(0, 4).forEachOrdered(i -> connect.configureConnector(CONNECTOR_NAME + i, props));
@@ -250,9 +238,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
 
-        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
-
         // start a source connector
         IntStream.range(0, 4).forEachOrdered(i -> connect.configureConnector(CONNECTOR_NAME + i, props));
 
@@ -275,9 +260,6 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
         // setup up props for the source connector
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
-
-        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
-                "Connect workers did not start in time.");
 
         // start a source connector
         IntStream.range(0, 4).forEachOrdered(i -> connect.configureConnector(CONNECTOR_NAME + i, props));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
@@ -77,9 +77,6 @@ public class RestExtensionIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
-                "Initial group of workers did not start in time.");
-
         WorkerHandle worker = connect.workers().stream()
             .findFirst()
             .orElseThrow(() -> new AssertionError("At least one worker handle should be available"));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
@@ -19,9 +19,7 @@ package org.apache.kafka.connect.integration;
 import org.apache.kafka.connect.runtime.distributed.ConnectProtocolCompatibility;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
-import org.apache.kafka.connect.util.clusters.WorkerHandle;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,10 +96,6 @@ public class SessionedProtocolIntegrationTest {
         invalidSignatureHeaders.put(SIGNATURE_HEADER, "S2Fma2Flc3F1ZQ==");
         invalidSignatureHeaders.put(SIGNATURE_ALGORITHM_HEADER, "HmacSHA256");
 
-        TestUtils.waitForCondition(
-                () -> connect.workers().stream().allMatch(WorkerHandle::isRunning),
-                30000L, "Timed out waiting for workers to start");
-
         // We haven't created the connector yet, but this should still return a 400 instead of a 404
         // if the endpoint is secured
         log.info(
@@ -120,9 +114,10 @@ public class SessionedProtocolIntegrationTest {
                 + "expecting 403 error response",
             connectorTasksEndpoint
         );
-        TestUtils.waitForCondition(
-                () -> connect.requestPost(connectorTasksEndpoint, "[]", invalidSignatureHeaders).getStatus() == FORBIDDEN.getStatusCode(),
-                30000L, "Timed out waiting for workers to start");
+        assertEquals(
+                FORBIDDEN.getStatusCode(),
+                connect.requestPost(connectorTasksEndpoint, "[]", invalidSignatureHeaders).getStatus()
+        );
 
         // Create the connector now
         // setup up props for the sink connector

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
@@ -83,7 +83,6 @@ public class SinkConnectorsIntegrationTest {
                 .brokerProps(brokerProps)
                 .build();
         connect.start();
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
     }
 
     @After
@@ -209,7 +208,6 @@ public class SinkConnectorsIntegrationTest {
         final Collection<String> topics = Arrays.asList(topic1, topic2, topic3);
 
         Map<String, String> connectorProps = baseSinkConnectorProps(String.join(",", topics));
-        // Need an eager assignor here; round robin is as good as any
         connectorProps.put(
                 CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
                 CooperativeStickyAssignor.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
@@ -189,7 +189,7 @@ public class SourceConnectorsIntegrationTest {
         workerProps.put(TOPIC_CREATION_ENABLE_CONFIG, String.valueOf(true));
 
         IntStream.range(0, 3).forEach(i -> connect.addWorker());
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
+        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Workers did not start in time after cluster was rolled.");
 
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(FOO_CONNECTOR, NUM_TASKS,
                 "Connector tasks did not start in time.");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
@@ -103,8 +103,6 @@ public class SourceConnectorsIntegrationTest {
         // start the clusters
         connect.start();
 
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
-
         Map<String, String> fooProps = sourceConnectorPropsWithGroups(FOO_TOPIC);
 
         // start a source connector
@@ -127,8 +125,6 @@ public class SourceConnectorsIntegrationTest {
         connect = connectBuilder.build();
         // start the clusters
         connect.start();
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
 
         Map<String, String> fooProps = sourceConnectorPropsWithGroups(FOO_TOPIC);
 
@@ -159,8 +155,6 @@ public class SourceConnectorsIntegrationTest {
         connect.assertions().assertTopicsExist(BAR_TOPIC);
         connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR,
                 DEFAULT_PARTITIONS, "Topic " + BAR_TOPIC + " does not have the expected settings");
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
 
         Map<String, String> barProps = defaultSourceConnectorProps(BAR_TOPIC);
         // start a source connector with topic creation properties

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -115,8 +115,6 @@ public class TransformationIntegrationTest {
      */
     @Test
     public void testFilterOnTopicNameWithSinkConnector() throws Exception {
-        assertConnectReady();
-
         Map<String, Long> observedRecords = observeRecords();
 
         // create test topics
@@ -180,12 +178,6 @@ public class TransformationIntegrationTest {
         connect.deleteConnector(CONNECTOR_NAME);
     }
 
-    private void assertConnectReady() throws InterruptedException {
-        connect.assertions().assertExactlyNumBrokersAreUp(1, "Brokers did not start in time.");
-        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS, "Worker did not start in time.");
-        log.info("Completed startup of {} Kafka brokers and {} Connect workers", 1, NUM_WORKERS);
-    }
-
     private void assertConnectorRunning() throws InterruptedException {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
@@ -212,8 +204,6 @@ public class TransformationIntegrationTest {
      */
     @Test
     public void testFilterOnTombstonesWithSinkConnector() throws Exception {
-        assertConnectReady();
-
         Map<String, Long> observedRecords = observeRecords();
 
         // create test topics
@@ -273,8 +263,6 @@ public class TransformationIntegrationTest {
      */
     @Test
     public void testFilterOnHasHeaderKeyWithSourceConnectorAndTopicCreation() throws Exception {
-        assertConnectReady();
-
         // setup up props for the sink connector
         Map<String, String> props = new HashMap<>();
         props.put("name", CONNECTOR_NAME);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -118,9 +118,27 @@ abstract class EmbeddedConnect {
     };
 
     /**
-     * Start the connect cluster and the embedded Kafka and Zookeeper cluster.
+     * Start the Connect cluster and the embedded Kafka and Zookeeper cluster,
+     * and wait for the Kafka and Connect clusters to become healthy.
      */
     public void start() {
+        start(true);
+    }
+
+    /**
+     * Start the Connect cluster and the embedded Kafka and Zookeeper cluster.
+     * <p>
+     * Note that in most cases, {@link #start()} is preferable. This method should only
+     * be used if it is expected that either Connect or the underlying Kafka cluster will
+     * not be able to complete startup successfully.
+     *
+     * @param awaitStartupCompletion whether to
+     *                               {@link ConnectAssertions#assertExactlyNumBrokersAreUp(int, String) await}
+     *                               the successful startup of each broker in the Kafka cluster, and
+     *                               {@link ConnectAssertions#assertExactlyNumWorkersAreUp(int, String) await}
+     *                               the successful startup of each worker in the Connect cluster
+     */
+    public void start(boolean awaitStartupCompletion) {
         if (maskExitProcedures) {
             Exit.setExitProcedure(exitProcedure);
             Exit.setHaltProcedure(haltProcedure);
@@ -131,6 +149,29 @@ abstract class EmbeddedConnect {
             httpClient.start();
         } catch (Exception e) {
             throw new ConnectException("Failed to start HTTP client", e);
+        }
+
+        if (awaitStartupCompletion) {
+            try {
+                if (numBrokers > 0) {
+                    assertions().assertExactlyNumBrokersAreUp(
+                            numBrokers,
+                            "Kafka cluster did not start in time"
+                    );
+                    log.info("Completed startup of {} Kafka brokers", numBrokers);
+                }
+
+                int numWorkers = workers().size();
+                if (numWorkers > 0) {
+                    assertions().assertExactlyNumWorkersAreUp(
+                            numWorkers,
+                            "Connect cluster did not start in time"
+                    );
+                    log.info("Completed startup of {} Connect workers", numWorkers);
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted while awaiting cluster startup", e);
+            }
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -122,23 +122,6 @@ abstract class EmbeddedConnect {
      * and wait for the Kafka and Connect clusters to become healthy.
      */
     public void start() {
-        start(true);
-    }
-
-    /**
-     * Start the Connect cluster and the embedded Kafka and Zookeeper cluster.
-     * <p>
-     * Note that in most cases, {@link #start()} is preferable. This method should only
-     * be used if it is expected that either Connect or the underlying Kafka cluster will
-     * not be able to complete startup successfully.
-     *
-     * @param awaitStartupCompletion whether to
-     *                               {@link ConnectAssertions#assertExactlyNumBrokersAreUp(int, String) await}
-     *                               the successful startup of each broker in the Kafka cluster, and
-     *                               {@link ConnectAssertions#assertExactlyNumWorkersAreUp(int, String) await}
-     *                               the successful startup of each worker in the Connect cluster
-     */
-    public void start(boolean awaitStartupCompletion) {
         if (maskExitProcedures) {
             Exit.setExitProcedure(exitProcedure);
             Exit.setHaltProcedure(haltProcedure);
@@ -151,27 +134,25 @@ abstract class EmbeddedConnect {
             throw new ConnectException("Failed to start HTTP client", e);
         }
 
-        if (awaitStartupCompletion) {
-            try {
-                if (numBrokers > 0) {
-                    assertions().assertExactlyNumBrokersAreUp(
-                            numBrokers,
-                            "Kafka cluster did not start in time"
-                    );
-                    log.info("Completed startup of {} Kafka brokers", numBrokers);
-                }
-
-                int numWorkers = workers().size();
-                if (numWorkers > 0) {
-                    assertions().assertExactlyNumWorkersAreUp(
-                            numWorkers,
-                            "Connect cluster did not start in time"
-                    );
-                    log.info("Completed startup of {} Connect workers", numWorkers);
-                }
-            } catch (InterruptedException e) {
-                throw new RuntimeException("Interrupted while awaiting cluster startup", e);
+        try {
+            if (numBrokers > 0) {
+                assertions().assertExactlyNumBrokersAreUp(
+                        numBrokers,
+                        "Kafka cluster did not start in time"
+                );
+                log.info("Completed startup of {} Kafka brokers", numBrokers);
             }
+
+            int numWorkers = workers().size();
+            if (numWorkers > 0) {
+                assertions().assertExactlyNumWorkersAreUp(
+                        numWorkers,
+                        "Connect cluster did not start in time"
+                );
+                log.info("Completed startup of {} Connect workers", numWorkers);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while awaiting cluster startup", e);
         }
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-16935)

Alters the `EmbeddedConnect::start` method to automatically wait for the successful startup of both the embedded Kafka and Connect clusters.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
