### PR TITLE
KAFKA-16557 Implemented OffsetFetchRequestState toStringBase and added a test for it

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -490,7 +490,8 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         return result;
     }
 
-    private OffsetFetchRequestState createOffsetFetchRequest(final Set<TopicPartition> partitions,
+    // Visible for testing
+    protected OffsetFetchRequestState createOffsetFetchRequest(final Set<TopicPartition> partitions,
                                                              final long deadlineMs) {
         return jitter.isPresent() ?
             new OffsetFetchRequestState(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -865,6 +865,11 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             }
         }
 
+        @Override
+        public String toStringBase() {
+            return super.toStringBase() + ", " + memberInfo;
+        }
+
         abstract void onResponse(final ClientResponse response);
 
         abstract void removeRequest();
@@ -1080,7 +1085,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         @Override
         public String toStringBase() {
             return super.toStringBase() +
-                    ", memberInfo=" + memberInfo +
                     ", requestedPartitions=" + requestedPartitions +
                     ", future=" + future;
         }
@@ -1278,8 +1282,8 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
 
         @Override
         public String toString() {
-            return "MemberInfo{" + "memberId=" + memberId.orElse("undefined") +
-                    ", memberEpoch=" + (memberEpoch.isPresent() ? memberEpoch : "undefined") + "}";
+            return "memberId=" + memberId.orElse("undefined") +
+                    ", memberEpoch=" + (memberEpoch.isPresent() ? memberEpoch.get() : "undefined");
         }
 
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1284,10 +1284,5 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             return "memberId=" + memberId.orElse("undefined") +
                     ", memberEpoch=" + (memberEpoch.isPresent() ? memberEpoch.get() : "undefined");
         }
-
-        // Visible for testing
-        protected void setMemberEpoch(int memberEpoch) {
-            this.memberEpoch = Optional.of(memberEpoch);
-        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -491,7 +491,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
     }
 
     // Visible for testing
-    protected OffsetFetchRequestState createOffsetFetchRequest(final Set<TopicPartition> partitions,
+    OffsetFetchRequestState createOffsetFetchRequest(final Set<TopicPartition> partitions,
                                                              final long deadlineMs) {
         return jitter.isPresent() ?
             new OffsetFetchRequestState(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1085,8 +1085,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         @Override
         public String toStringBase() {
             return super.toStringBase() +
-                    ", requestedPartitions=" + requestedPartitions +
-                    ", future=" + future;
+                    ", requestedPartitions=" + requestedPartitions;
         }
     }
 
@@ -1286,5 +1285,9 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                     ", memberEpoch=" + (memberEpoch.isPresent() ? memberEpoch.get() : "undefined");
         }
 
+        // Visible for testing
+        protected void setMemberEpoch(int memberEpoch) {
+            this.memberEpoch = Optional.of(memberEpoch);
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1078,14 +1078,11 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         }
 
         @Override
-        public String toString() {
-            return "OffsetFetchRequestState{" +
-                    "requestedPartitions=" + requestedPartitions +
-                    ", memberId=" + memberInfo.memberId.orElse("undefined") +
-                    ", memberEpoch=" + (memberInfo.memberEpoch.isPresent() ? memberInfo.memberEpoch.get() : "undefined") +
-                    ", future=" + future +
-                    ", " + toStringBase() +
-                    '}';
+        public String toStringBase() {
+            return super.toStringBase() +
+                    ", memberInfo=" + memberInfo +
+                    ", requestedPartitions=" + requestedPartitions +
+                    ", future=" + future;
         }
     }
 
@@ -1278,5 +1275,12 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             this.memberId = Optional.empty();
             this.memberEpoch = Optional.empty();
         }
+
+        @Override
+        public String toString() {
+            return "MemberInfo{" + "memberId=" + memberId.orElse("undefined") +
+                    ", memberEpoch=" + (memberEpoch.isPresent() ? memberEpoch : "undefined") + "}";
+        }
+
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -162,6 +162,7 @@ public class CommitRequestManagerTest {
                 ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions;
 
         assertDoesNotThrow(timedRequestState::toString);
+        assertFalse(target.contains("Optional"));
         assertEquals(target, offsetFetchRequestState.toStringBase());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -127,7 +127,6 @@ public class CommitRequestManagerTest {
     public void testOffsetFetchRequestStateToStringBase() {
         ConsumerConfig config = mock(ConsumerConfig.class);
         CommitRequestManager.MemberInfo memberInfo = new CommitRequestManager.MemberInfo();
-        memberInfo.setMemberEpoch(1);
 
         CommitRequestManager commitRequestManager = new CommitRequestManager(
                 time,
@@ -140,6 +139,7 @@ public class CommitRequestManagerTest {
                 Optional.of("groupInstanceId"),
                 metrics);
 
+        commitRequestManager.onMemberEpochUpdated(Optional.of(1), Optional.empty());
         Set<TopicPartition> requestedPartitions = Collections.singleton(new TopicPartition("topic-1", 1));
 
         CommitRequestManager.OffsetFetchRequestState offsetFetchRequestState = commitRequestManager.new OffsetFetchRequestState(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -139,9 +139,7 @@ public class CommitRequestManagerTest {
                 Optional.of("groupInstanceId"),
                 metrics);
 
-        Set<TopicPartition> requestedPartitions = new HashSet<>();
-        TopicPartition topicPartition1 = new TopicPartition("topic-1", 1);
-        requestedPartitions.add(topicPartition1);
+        Set<TopicPartition> requestedPartitions = Collections.singleton(new TopicPartition("topic-1", 1));
 
         CommitRequestManager.OffsetFetchRequestState offsetFetchRequestState = commitRequestManager.new OffsetFetchRequestState(
                 requestedPartitions,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -161,7 +161,6 @@ public class CommitRequestManagerTest {
                 ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions +
                 ", future=" + offsetFetchRequestState.future();
 
-        System.out.println(offsetFetchRequestState.toStringBase());
         assertDoesNotThrow(timedRequestState::toString);
         assertEquals(target, offsetFetchRequestState.toStringBase());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -127,6 +127,7 @@ public class CommitRequestManagerTest {
     public void testOffsetFetchRequestStateToStringBase() {
         ConsumerConfig config = mock(ConsumerConfig.class);
         CommitRequestManager.MemberInfo memberInfo = new CommitRequestManager.MemberInfo();
+        memberInfo.setMemberEpoch(1);
 
         CommitRequestManager commitRequestManager = new CommitRequestManager(
                 time,
@@ -158,8 +159,7 @@ public class CommitRequestManagerTest {
 
         String target = timedRequestState.toStringBase() +
                 ", " + memberInfo +
-                ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions +
-                ", future=" + offsetFetchRequestState.future();
+                ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions;
 
         assertDoesNotThrow(timedRequestState::toString);
         assertEquals(target, offsetFetchRequestState.toStringBase());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -126,7 +126,6 @@ public class CommitRequestManagerTest {
     @Test
     public void testOffsetFetchRequestStateToStringBase() {
         ConsumerConfig config = mock(ConsumerConfig.class);
-        CommitRequestManager.MemberInfo memberInfo = new CommitRequestManager.MemberInfo();
 
         CommitRequestManager commitRequestManager = new CommitRequestManager(
                 time,
@@ -135,30 +134,30 @@ public class CommitRequestManagerTest {
                 config,
                 coordinatorRequestManager,
                 offsetCommitCallbackInvoker,
-                "groupId",
-                Optional.of("groupInstanceId"),
+                DEFAULT_GROUP_ID,
+                Optional.of(DEFAULT_GROUP_INSTANCE_ID),
+                retryBackoffMs,
+                retryBackoffMaxMs,
+                OptionalDouble.of(0),
                 metrics);
 
         commitRequestManager.onMemberEpochUpdated(Optional.of(1), Optional.empty());
         Set<TopicPartition> requestedPartitions = Collections.singleton(new TopicPartition("topic-1", 1));
 
-        CommitRequestManager.OffsetFetchRequestState offsetFetchRequestState = commitRequestManager.new OffsetFetchRequestState(
-                requestedPartitions,
-                retryBackoffMs,
-                retryBackoffMaxMs,
-                1000,
-                memberInfo);
+        CommitRequestManager.OffsetFetchRequestState offsetFetchRequestState = commitRequestManager.createOffsetFetchRequest(requestedPartitions, 0);
 
         TimedRequestState timedRequestState = new TimedRequestState(
                 logContext,
-                "CommitRequestManager",
+                CommitRequestManager.class.getSimpleName(),
                 retryBackoffMs,
+                2,
                 retryBackoffMaxMs,
+                0,
                 TimedRequestState.deadlineTimer(time, 0)
         );
 
         String target = timedRequestState.toStringBase() +
-                ", " + memberInfo +
+                ", " + offsetFetchRequestState.memberInfo +
                 ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions;
 
         assertDoesNotThrow(timedRequestState::toString);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -157,10 +157,11 @@ public class CommitRequestManagerTest {
         );
 
         String target = timedRequestState.toStringBase() +
-                ", memberInfo=" + memberInfo +
+                ", " + memberInfo +
                 ", requestedPartitions=" + offsetFetchRequestState.requestedPartitions +
                 ", future=" + offsetFetchRequestState.future();
 
+        System.out.println(offsetFetchRequestState.toStringBase());
         assertDoesNotThrow(timedRequestState::toString);
         assertEquals(target, offsetFetchRequestState.toStringBase());
     }


### PR DESCRIPTION
I changed OffsetFetchRequestState toString to toStringBase and added a toString() method for MemberInfo

I added a new test to CommitRequestManagerTest that tests the new toStringBase method. In the test, a string variable 'target' is instantiated and will be compared to the new toStringBase method. The test calls OffsetFetchRequestState toStringBase() and compares it to the target string. All tests in CommitRequestManagerTest pass.