### PR TITLE
MINOR: Add readiness check for connector and separate Kafka cluster in ExactlyOnceSourceIntegrationTest::testSeparateOffsetsTopic

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -99,6 +99,7 @@ import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.EXA
 import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.CONNECTOR;
 import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.INTERVAL;
 import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.POLL;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -750,9 +751,18 @@ public class ExactlyOnceSourceIntegrationTest {
         workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, globalOffsetsTopic);
 
         startConnect();
-        EmbeddedKafkaCluster connectorTargetedCluster = new EmbeddedKafkaCluster(1, brokerProps);
+
+        int numConnectorTargetedBrokers = 1;
+        EmbeddedKafkaCluster connectorTargetedCluster = new EmbeddedKafkaCluster(numConnectorTargetedBrokers, brokerProps);
         try (Closeable clusterShutdown = connectorTargetedCluster::stop) {
             connectorTargetedCluster.start();
+            // Wait for the connector-targeted Kafka cluster to get on its feet
+            waitForCondition(
+                    () -> connectorTargetedCluster.runningBrokers().size() == numConnectorTargetedBrokers,
+                    ConnectAssertions.WORKER_SETUP_DURATION_MS,
+                    "Separate Kafka cluster did not start in time"
+            );
+
             String topic = "test-topic";
             connectorTargetedCluster.createTopic(topic, 3);
 
@@ -780,6 +790,11 @@ public class ExactlyOnceSourceIntegrationTest {
 
             // start a source connector
             connect.configureConnector(CONNECTOR_NAME, props);
+            connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+                    CONNECTOR_NAME,
+                    numTasks,
+                    "connector and tasks did not start in time"
+            );
 
             log.info("Waiting for records to be provided to worker by task");
             // wait for the connector tasks to produce enough records


### PR DESCRIPTION
Similar to https://github.com/apache/kafka/pull/16286.

This test is pretty flaky and has failed on 7% of all trunk builds in the last 90 days (see [Gradle Enterprise](https://ge.apache.org/scans/tests?search.startTimeMax=1718207141545&search.startTimeMin=1710388800000&search.tags=trunk&search.timeZoneId=America%2FNew_York&tests.container=org.apache.kafka.connect.integration.ExactlyOnceSourceIntegrationTest&tests.sortField=FLAKY)).

Part of this test includes bringing up a separate Kafka cluster that is targeted by a source connector. We do not currently wait on the successful startup of that Kafka cluster before starting that connector, and we do not wait on the successful startup of the connector and its tasks before waiting for the connector to produce records within a bounded timeout.

By adding assertions that the separate Kafka cluster and the connector+tasks are healthy before waiting for the connector to produce records, we accomplish two things:
- We reduce the chance of flaky failures by allowing more time to pass for more resource-intensive operations to complete (5 minutes for Kafka cluster startup and 2 minutes for connector+tasks startup, vs. 30 seconds for record production)
- We also provide more granularity into possible causes of failure; if the separate Kafka cluster or the connector+tasks fail to start, tests should report that failure directly, instead of simply reporting that not enough records were produced in time

Although there is a decent chance that this change will reduce flakiness for the affected test, the second benefit (more informative failure messages) is IMO significant enough that a close examination of logs for failed builds, multiple CI runs with this change, or other time-consuming efforts are not warranted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
