### PR TITLE
KAFKA-16673: Simplify `GroupMetadataManager#toTopicPartitions` by using `ConsumerProtocolSubscription` instead of `ConsumerPartitionAssignor.Subscription`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
@@ -164,6 +164,11 @@ public class ConsumerProtocol {
         return MessageUtil.toVersionPrefixedByteBuffer(version, data);
     }
 
+    public static ByteBuffer serializeAssignment(final ConsumerProtocolAssignment assignment, short version) {
+        version = checkAssignmentVersion(version);
+        return MessageUtil.toVersionPrefixedByteBuffer(version, assignment);
+    }
+
     public static Assignment deserializeAssignment(final ByteBuffer buffer, short version) {
         version = checkAssignmentVersion(version);
 
@@ -188,6 +193,23 @@ public class ConsumerProtocol {
 
     public static Assignment deserializeAssignment(final ByteBuffer buffer) {
         return deserializeAssignment(buffer, deserializeVersion(buffer));
+    }
+
+    public static ConsumerProtocolAssignment deserializeConsumerProtocolAssignment(
+        final ByteBuffer buffer,
+        short version
+    ) {
+        version = checkAssignmentVersion(version);
+
+        try {
+            return new ConsumerProtocolAssignment(new ByteBufferAccessor(buffer), version);
+        } catch (BufferUnderflowException e) {
+            throw new SchemaException("Buffer underflow while parsing consumer protocol's assignment", e);
+        }
+    }
+
+    public static ConsumerProtocolAssignment deserializeConsumerProtocolAssignment(final ByteBuffer buffer) {
+        return deserializeConsumerProtocolAssignment(buffer, deserializeVersion(buffer));
     }
 
     private static short checkSubscriptionVersion(final short version) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
@@ -125,6 +125,25 @@ public class ConsumerProtocol {
         return deserializeSubscription(buffer, deserializeVersion(buffer));
     }
 
+    public static ConsumerProtocolSubscription deserializeConsumerProtocolSubscription(
+        final ByteBuffer buffer,
+        short version
+    ) {
+        version = checkSubscriptionVersion(version);
+
+        try {
+            return new ConsumerProtocolSubscription(new ByteBufferAccessor(buffer), version);
+        } catch (BufferUnderflowException e) {
+            throw new SchemaException("Buffer underflow while parsing consumer protocol's subscription", e);
+        }
+    }
+
+    public static ConsumerProtocolSubscription deserializeConsumerProtocolSubscription(
+        final ByteBuffer buffer
+    ) {
+        return deserializeConsumerProtocolSubscription(buffer, deserializeVersion(buffer));
+    }
+
     public static ByteBuffer serializeAssignment(final Assignment assignment) {
         return serializeAssignment(assignment, ConsumerProtocolAssignment.HIGHEST_SUPPORTED_VERSION);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -207,6 +207,29 @@ public class ConsumerProtocolTest {
     }
 
     @Test
+    public void serializeDeserializeConsumerProtocolAssignmentAllVersions() {
+        ConsumerProtocolAssignment assignment = new ConsumerProtocolAssignment()
+            .setAssignedPartitions(
+                new ConsumerProtocolAssignment.TopicPartitionCollection(Arrays.asList(
+                    new ConsumerProtocolAssignment.TopicPartition()
+                        .setTopic(tp1.topic())
+                        .setPartitions(Collections.singletonList(tp1.partition())),
+                    new ConsumerProtocolAssignment.TopicPartition()
+                        .setTopic(tp2.topic())
+                        .setPartitions(Collections.singletonList(tp2.partition()))
+                ).iterator())
+            )
+            .setUserData(ByteBuffer.wrap("hello".getBytes()));
+
+        for (short version = ConsumerProtocolAssignment.LOWEST_SUPPORTED_VERSION; version <= ConsumerProtocolAssignment.HIGHEST_SUPPORTED_VERSION; version++) {
+            ByteBuffer buffer = ConsumerProtocol.serializeAssignment(assignment, version);
+            ConsumerProtocolAssignment parsedAssignment = ConsumerProtocol.deserializeConsumerProtocolAssignment(buffer);
+            assertEquals(toSet(assignment.assignedPartitions()), toSet(parsedAssignment.assignedPartitions()));
+            assertEquals(assignment.userData(), parsedAssignment.userData());
+        }
+    }
+
+    @Test
     public void serializeDeserializeAssignment() {
         List<TopicPartition> partitions = Arrays.asList(tp1, tp2);
         ByteBuffer buffer = ConsumerProtocol.serializeAssignment(new Assignment(partitions, ByteBuffer.wrap(new byte[0])));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -133,6 +133,7 @@ import static org.apache.kafka.coordinator.group.CoordinatorRecordHelpers.newTar
 import static org.apache.kafka.coordinator.group.Utils.assignmentToString;
 import static org.apache.kafka.coordinator.group.Utils.ofSentinel;
 import static org.apache.kafka.coordinator.group.Utils.toConsumerProtocolAssignment;
+import static org.apache.kafka.coordinator.group.Utils.toTopicPartitions;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupMember.EMPTY_ASSIGNMENT;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
@@ -1300,27 +1301,6 @@ public class GroupMetadataManager {
         } catch (SchemaException e) {
             throw new IllegalStateException("Malformed embedded consumer protocol in subscription deserialization.");
         }
-    }
-
-    /**
-     * @return The ConsumerGroupHeartbeatRequestData.TopicPartitions list converted from the TopicPartitions collection.
-     */
-    private static List<ConsumerGroupHeartbeatRequestData.TopicPartitions> toTopicPartitions(
-        ConsumerProtocolSubscription.TopicPartitionCollection topicPartitionCollection,
-        TopicsImage topicsImage
-    ) {
-        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> res = new ArrayList<>();
-        for (ConsumerProtocolSubscription.TopicPartition tp : topicPartitionCollection) {
-            TopicImage topicImage = topicsImage.getTopic(tp.topic());
-            if (topicImage != null) {
-                res.add(
-                    new ConsumerGroupHeartbeatRequestData.TopicPartitions()
-                        .setTopicId(topicImage.id())
-                        .setPartitions(tp.partitions())
-                );
-            }
-        }
-        return res;
     }
 
     private ConsumerGroupHeartbeatResponseData.Assignment createResponseAssignment(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -91,7 +91,6 @@ import org.apache.kafka.coordinator.group.runtime.CoordinatorTimer;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.TopicImage;
-import org.apache.kafka.image.TopicsImage;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineHashSet;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerProtocolAssignment;
+import org.apache.kafka.common.message.ConsumerProtocolSubscription;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
 
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -129,5 +132,30 @@ public class Utils {
             }
         });
         return topicPartitionMap;
+    }
+
+    /**
+     * Converts a ConsumerProtocolSubscription.TopicPartitionCollection to a list of ConsumerGroupHeartbeatRequestData.TopicPartitions.
+     *
+     * @param topicPartitionCollection  The TopicPartitionCollection to convert.
+     * @param topicsImage               The TopicsImage.
+     * @return a list of ConsumerGroupHeartbeatRequestData.TopicPartitions.
+     */
+    public static List<ConsumerGroupHeartbeatRequestData.TopicPartitions> toTopicPartitions(
+        ConsumerProtocolSubscription.TopicPartitionCollection topicPartitionCollection,
+        TopicsImage topicsImage
+    ) {
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> res = new ArrayList<>();
+        for (ConsumerProtocolSubscription.TopicPartition tp : topicPartitionCollection) {
+            TopicImage topicImage = topicsImage.getTopic(tp.topic());
+            if (topicImage != null) {
+                res.add(
+                    new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                        .setTopicId(topicImage.id())
+                        .setPartitions(tp.partitions())
+                );
+            }
+        }
+        return res;
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
@@ -17,9 +17,16 @@
 package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ConsumerProtocolAssignment;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -68,5 +75,59 @@ public class Utils {
         }
         builder.append("]");
         return builder.toString();
+    }
+
+    /**
+     * @return An Optional containing the provided string if it is not null and not empty,
+     *         otherwise an empty Optional.
+     */
+    public static Optional<String> toOptional(String str) {
+        return str == null || str.isEmpty() ? Optional.empty() : Optional.of(str);
+    }
+
+    /**
+     * Converts a map of topic id and partition set to a ConsumerProtocolAssignment.
+     *
+     * @param assignment    The map to convert.
+     * @param topicsImage   The TopicsImage.
+     * @return The converted ConsumerProtocolAssignment.
+     */
+    public static ConsumerProtocolAssignment toConsumerProtocolAssignment(
+        Map<Uuid, Set<Integer>> assignment,
+        TopicsImage topicsImage
+    ) {
+        ConsumerProtocolAssignment.TopicPartitionCollection collection =
+            new ConsumerProtocolAssignment.TopicPartitionCollection();
+        assignment.forEach((topicId, partitions) -> {
+            TopicImage topicImage = topicsImage.getTopic(topicId);
+            if (topicImage != null) {
+                collection.add(new ConsumerProtocolAssignment.TopicPartition()
+                    .setTopic(topicImage.name())
+                    .setPartitions(new ArrayList<>(partitions)));
+            }
+        });
+        return new ConsumerProtocolAssignment()
+            .setAssignedPartitions(collection);
+    }
+
+    /**
+     * Converts a map of topic id and partition set to a ConsumerProtocolAssignment.
+     *
+     * @param consumerProtocolAssignment    The ConsumerProtocolAssignment.
+     * @param topicsImage                   The TopicsImage.
+     * @return The converted map.
+     */
+    public static Map<Uuid, Set<Integer>> toTopicPartitionMap(
+        ConsumerProtocolAssignment consumerProtocolAssignment,
+        TopicsImage topicsImage
+    ) {
+        Map<Uuid, Set<Integer>> topicPartitionMap = new HashMap<>();
+        consumerProtocolAssignment.assignedPartitions().forEach(topicPartition -> {
+            TopicImage topicImage = topicsImage.getTopic(topicPartition.topic());
+            if (topicImage != null) {
+                topicPartitionMap.put(topicImage.id(), new HashSet<>(topicPartition.partitions()));
+            }
+        });
+        return topicPartitionMap;
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -16,10 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.classic;
 
-import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
@@ -44,13 +41,10 @@ import org.apache.kafka.coordinator.group.CoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.image.MetadataImage;
-import org.apache.kafka.image.TopicImage;
-import org.apache.kafka.image.TopicsImage;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -66,6 +60,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.coordinator.group.Utils.toConsumerProtocolAssignment;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.EMPTY;
@@ -1189,7 +1184,7 @@ public class ClassicGroup implements Group {
                     ByteBuffer buffer = ByteBuffer.wrap(member.metadata(protocolName.get()));
                     ConsumerProtocol.deserializeVersion(buffer);
                     allSubscribedTopics.addAll(new HashSet<>(
-                        ConsumerProtocol.deserializeSubscription(buffer, (short) 0).topics()
+                        ConsumerProtocol.deserializeConsumerProtocolSubscription(buffer, (short) 0).topics()
                     ));
                 });
                 return Optional.of(allSubscribedTopics);
@@ -1417,10 +1412,10 @@ public class ClassicGroup implements Group {
             // Set the assignment with serializing the ConsumerGroup's targetAssignment.
             // The serializing version should align with that of the member's JoinGroupRequestProtocol.
             byte[] assignment = Utils.toArray(ConsumerProtocol.serializeAssignment(
-                new ConsumerPartitionAssignor.Assignment(ClassicGroup.topicPartitionListFromMap(
+                toConsumerProtocolAssignment(
                     consumerGroup.targetAssignment().get(classicGroupMember.memberId()).partitions(),
                     metadataImage.topics()
-                )),
+                ),
                 ConsumerProtocol.deserializeVersion(
                     ByteBuffer.wrap(classicGroupMember.metadata(classicGroup.protocolName().orElse("")))
                 )
@@ -1448,23 +1443,6 @@ public class ClassicGroup implements Group {
         );
 
         records.add(CoordinatorRecordHelpers.newGroupMetadataRecord(this, assignments, metadataVersion));
-    }
-
-    /**
-     * @return The list of TopicPartition converted from the map of topic id and partition set.
-     */
-    private static List<TopicPartition> topicPartitionListFromMap(
-        Map<Uuid, Set<Integer>> topicPartitions,
-        TopicsImage topicsImage
-    ) {
-        List<TopicPartition> topicPartitionList = new ArrayList<>();
-        topicPartitions.forEach((topicId, partitionSet) -> {
-            TopicImage topicImage = topicsImage.getTopic(topicId);
-            if (topicImage != null) {
-                partitionSet.forEach(partition -> topicPartitionList.add(new TopicPartition(topicImage.name(), partition)));
-            }
-        });
-        return topicPartitionList;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -16,9 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.consumer;
 
-import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
@@ -26,6 +24,7 @@ import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.message.ConsumerProtocolSubscription;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.coordinator.group.Group;
@@ -56,6 +55,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.kafka.coordinator.group.Utils.toOptional;
+import static org.apache.kafka.coordinator.group.Utils.toTopicPartitionMap;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
 import static org.apache.kafka.coordinator.group.consumer.ConsumerGroup.ConsumerGroupState.ASSIGNING;
@@ -1311,12 +1312,13 @@ public class ConsumerGroup implements Group {
         consumerGroup.setTargetAssignmentEpoch(classicGroup.generationId());
 
         classicGroup.allMembers().forEach(classicGroupMember -> {
-            ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.deserializeAssignment(
-                ByteBuffer.wrap(classicGroupMember.assignment())
+            Map<Uuid, Set<Integer>> assignedPartitions = toTopicPartitionMap(
+                ConsumerProtocol.deserializeConsumerProtocolAssignment(
+                    ByteBuffer.wrap(classicGroupMember.assignment())
+                ),
+                topicsImage
             );
-            Map<Uuid, Set<Integer>> partitions = topicPartitionMapFromList(assignment.partitions(), topicsImage);
-
-            ConsumerPartitionAssignor.Subscription subscription = ConsumerProtocol.deserializeSubscription(
+            ConsumerProtocolSubscription subscription = ConsumerProtocol.deserializeConsumerProtocolSubscription(
                 ByteBuffer.wrap(classicGroupMember.metadata(classicGroup.protocolName().get()))
             );
 
@@ -1329,12 +1331,12 @@ public class ConsumerGroup implements Group {
                 .setState(MemberState.STABLE)
                 .setPreviousMemberEpoch(classicGroup.generationId())
                 .setInstanceId(classicGroupMember.groupInstanceId().orElse(null))
-                .setRackId(subscription.rackId().orElse(null))
+                .setRackId(toOptional(subscription.rackId()).orElse(null))
                 .setRebalanceTimeoutMs(classicGroupMember.rebalanceTimeoutMs())
                 .setClientId(classicGroupMember.clientId())
                 .setClientHost(classicGroupMember.clientHost())
                 .setSubscribedTopicNames(subscription.topics())
-                .setAssignedPartitions(partitions)
+                .setAssignedPartitions(assignedPartitions)
                 .setClassicMemberMetadata(
                     new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
                         .setSessionTimeoutMs(classicGroupMember.sessionTimeoutMs())
@@ -1343,7 +1345,7 @@ public class ConsumerGroup implements Group {
                         ))
                 )
                 .build();
-            consumerGroup.updateTargetAssignment(newMember.memberId(), new Assignment(partitions));
+            consumerGroup.updateTargetAssignment(newMember.memberId(), new Assignment(assignedPartitions));
             consumerGroup.updateMember(newMember);
         });
 
@@ -1377,25 +1379,6 @@ public class ConsumerGroup implements Group {
         members().forEach((__, consumerGroupMember) ->
             records.add(CoordinatorRecordHelpers.newCurrentAssignmentRecord(groupId(), consumerGroupMember))
         );
-    }
-
-    /**
-     * @return The map of topic id and partition set converted from the list of TopicPartition.
-     */
-    private static Map<Uuid, Set<Integer>> topicPartitionMapFromList(
-        List<TopicPartition> partitions,
-        TopicsImage topicsImage
-    ) {
-        Map<Uuid, Set<Integer>> topicPartitionMap = new HashMap<>();
-        partitions.forEach(topicPartition -> {
-            TopicImage topicImage = topicsImage.getTopic(topicPartition.topic());
-            if (topicImage != null) {
-                topicPartitionMap
-                    .computeIfAbsent(topicImage.id(), __ -> new HashSet<>())
-                    .add(topicPartition.partition());
-            }
-        });
-        return topicPartitionMap;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -540,27 +540,15 @@ public class ConsumerGroupMember {
     ) {
         List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitions = new ArrayList<>();
         partitions.forEach((topicId, partitionSet) -> {
-            String topicName = lookupTopicNameById(topicId, topicsImage);
-            if (topicName != null) {
+            TopicImage topicImage = topicsImage.getTopic(topicId);
+            if (topicImage != null) {
                 topicPartitions.add(new ConsumerGroupDescribeResponseData.TopicPartitions()
                     .setTopicId(topicId)
-                    .setTopicName(topicName)
+                    .setTopicName(topicImage.name())
                     .setPartitions(new ArrayList<>(partitionSet)));
             }
         });
         return topicPartitions;
-    }
-
-    private static String lookupTopicNameById(
-        Uuid topicId,
-        TopicsImage topicsImage
-    ) {
-        TopicImage topicImage = topicsImage.getTopic(topicId);
-        if (topicImage != null) {
-            return topicImage.name();
-        } else {
-            return null;
-        }
     }
 
     /**


### PR DESCRIPTION
In `GroupMetadataManager#toTopicPartitions`, we generate a list of `ConsumerGroupHeartbeatRequestData.TopicPartitions` from the input deserialized subscription. Currently the input subscription is `ConsumerPartitionAssignor.Subscription`, where the topic partitions are stored as (topic-partition) pairs, whereas in `ConsumerGroupHeartbeatRequestData.TopicPartitions`, we need the topic partitions to be stored as (topic-partition list) pairs.

`ConsumerProtocolSubscription` is an intermediate data structure in the deserialization where the topic partitions are stored as (topic-partition list) pairs. This pr uses `ConsumerProtocolSubscription` instead as the input subscription to make `toTopicPartitions` more efficient. 

JIRA: https://issues.apache.org/jira/browse/KAFKA-16673

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
