### PR TITLE
KAFKA-16637: AsyncKafkaConsumer removes offset fetch responses from cache too aggressively

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1693,7 +1693,10 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             refreshCommittedOffsets(offsets, metadata, subscriptions);
             return true;
         } catch (TimeoutException e) {
-            log.error("Couldn't refresh committed offsets before timeout expired");
+            log.debug(
+                "The committed offsets for the following partition(s) could not be refreshed within the timeout: {} ",
+                initializingPartitions
+            );
             return false;
         } catch (InterruptException e) {
             throw e;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1675,8 +1675,8 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         // case it times out, subsequent attempts will also use the event in order to wait for the results.
         if (!canReusePendingOffsetFetchEvent(initializingPartitions)) {
             // Give the event a reasonable amount of time to complete.
-            long timeoutMs = Math.max(defaultApiTimeoutMs, timer.remainingMs());
-            long deadlineMs = calculateDeadlineMs(time, timeoutMs);
+            final long timeoutMs = Math.max(defaultApiTimeoutMs, timer.remainingMs());
+            final long deadlineMs = calculateDeadlineMs(time, timeoutMs);
             pendingOffsetFetchEvent = new FetchCommittedOffsetsEvent(initializingPartitions, deadlineMs);
             applicationEventHandler.add(pendingOffsetFetchEvent);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1697,7 +1697,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             log.error("Couldn't refresh committed offsets before timeout expired");
             return false;
         } catch (InterruptException e) {
-            throw ConsumerUtils.maybeWrapAsKafkaException(e);
+            throw e;
         } catch (Throwable t) {
             // Clear the pending event on errors that are not timeout-related.
             shouldClearPendingEvent = true;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1699,7 +1699,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         } catch (InterruptException e) {
             throw e;
         } catch (Throwable t) {
-            // Clear the pending event on errors that are not timeout-related.
+            // Clear the pending event on errors that are not timeout- or interrupt-related.
             shouldClearPendingEvent = true;
             throw ConsumerUtils.maybeWrapAsKafkaException(t);
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -2009,8 +2009,8 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         return subscriptions;
     }
 
-    FetchCommittedOffsetsEvent pendingOffsetFetch() {
-        return pendingOffsetFetch;
+    boolean hasPendingOffsetFetch() {
+        return pendingOffsetFetch != null;
     }
 
     private void maybeUpdateSubscriptionMetadata() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1670,9 +1670,10 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             final FetchCommittedOffsetsEvent event =
                 new FetchCommittedOffsetsEvent(
                     initializingPartitions,
-                    calculateDeadlineMs(timer));
+                    Long.MAX_VALUE);
             wakeupTrigger.setActiveTask(event.future());
-            final Map<TopicPartition, OffsetAndMetadata> offsets = applicationEventHandler.addAndGet(event);
+            applicationEventHandler.add(event);
+            final Map<TopicPartition, OffsetAndMetadata> offsets = ConsumerUtils.getResult(event.future(), time.timer(1));
             refreshCommittedOffsets(offsets, metadata, subscriptions);
             return true;
         } catch (TimeoutException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1676,7 +1676,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         if (!canReusePendingOffsetFetchEvent(initializingPartitions)) {
             // Give the event a reasonable amount of time to complete.
             long timeoutMs = Math.max(defaultApiTimeoutMs, timer.remainingMs());
-            long deadlineMs = time.milliseconds() + timeoutMs;
+            long deadlineMs = calculateDeadlineMs(time, timeoutMs);
             pendingOffsetFetchEvent = new FetchCommittedOffsetsEvent(initializingPartitions, deadlineMs);
             applicationEventHandler.add(pendingOffsetFetchEvent);
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -832,18 +832,18 @@ public class AsyncKafkaConsumerTest {
 
     // ArgumentCaptor's type-matching does not work reliably with Java 8, so we cannot directly capture the AsyncCommitEvent
     // Instead, we capture the super-class CompletableApplicationEvent and fetch the last captured event.
+    private <T> CompletableFuture<T> getLastEnqueuedEventFuture() {
+        final CompletableApplicationEvent<T> lastEvent = getLastEnqueuedEvent();
+        return lastEvent.future();
+    }
+
+    // ArgumentCaptor's type-matching does not work reliably with Java 8, so we cannot directly capture the AsyncCommitEvent
+    // Instead, we capture the super-class CompletableApplicationEvent and fetch the last captured event.
     private <T> CompletableApplicationEvent<T> getLastEnqueuedEvent() {
         final ArgumentCaptor<CompletableApplicationEvent<T>> eventArgumentCaptor = ArgumentCaptor.forClass(CompletableApplicationEvent.class);
         verify(applicationEventHandler, atLeast(1)).add(eventArgumentCaptor.capture());
         final List<CompletableApplicationEvent<T>> allValues = eventArgumentCaptor.getAllValues();
         return allValues.get(allValues.size() - 1);
-    }
-
-    // ArgumentCaptor's type-matching does not work reliably with Java 8, so we cannot directly capture the AsyncCommitEvent
-    // Instead, we capture the super-class CompletableApplicationEvent and fetch the last captured event.
-    private <T> CompletableFuture<T> getLastEnqueuedEventFuture() {
-        final CompletableApplicationEvent<T> lastEvent = getLastEnqueuedEvent();
-        return lastEvent.future();
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1754,13 +1754,13 @@ public class AsyncKafkaConsumerTest {
         if (committedOffsetsEnabled) {
             // Verify there was an FetchCommittedOffsets event and no ResetPositions event
             verify(applicationEventHandler, atLeast(1))
-                .addAndGet(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
+                .add(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
             verify(applicationEventHandler, never())
                 .addAndGet(ArgumentMatchers.isA(ResetPositionsEvent.class));
         } else {
             // Verify there was not any FetchCommittedOffsets event but there should be a ResetPositions
             verify(applicationEventHandler, never())
-                .addAndGet(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
+                .add(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
             verify(applicationEventHandler, atLeast(1))
                 .addAndGet(ArgumentMatchers.isA(ResetPositionsEvent.class));
         }
@@ -1779,7 +1779,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, atLeast(1))
             .addAndGet(ArgumentMatchers.isA(ValidatePositionsEvent.class));
         verify(applicationEventHandler, atLeast(1))
-            .addAndGet(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
+            .add(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
         verify(applicationEventHandler, atLeast(1))
             .addAndGet(ArgumentMatchers.isA(ResetPositionsEvent.class));
     }
@@ -2005,6 +2005,12 @@ public class AsyncKafkaConsumerTest {
         doReturn(committedOffsets)
             .when(applicationEventHandler)
             .addAndGet(any(FetchCommittedOffsetsEvent.class));
+
+        doAnswer(invocation -> {
+            FetchCommittedOffsetsEvent event = invocation.getArgument(0);
+            event.future().complete(committedOffsets);
+            return null;
+        }).when(applicationEventHandler).add(ArgumentMatchers.isA(FetchCommittedOffsetsEvent.class));
     }
 
     private void completeFetchedCommittedOffsetApplicationEventExceptionally(Exception ex) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -686,7 +686,7 @@ public class AsyncKafkaConsumerTest {
     }
 
     @Test
-    public void testOffsetFetchInterruptKeepsPendingEvent() {
+    public void testOffsetFetchInterruptExceptionKeepsPendingEvent() {
         consumer = newConsumer();
         long timeoutMs = 0;
         doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -580,7 +580,6 @@ public class AsyncKafkaConsumerTest {
         consumer = newConsumer();
         long timeoutMs = 0;
         doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
-
         consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
 
         // The first attempt at poll() creates an event, enqueues it, but its Future does not complete within the
@@ -638,9 +637,7 @@ public class AsyncKafkaConsumerTest {
     public void testOffsetFetchDoesNotReuseExpiredPendingEvent() {
         consumer = newConsumer();
         long timeoutMs = 0;
-
         doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
-
         consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
 
         // The first attempt at poll() creates an event, enqueues it, but its Future does not complete within

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -588,7 +588,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event.future(), time.timer(timeoutMs)));
-        assertNotNull(consumer.pendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetch());
 
         // For the second attempt, the event is reused, and this time the Future returns successfully, clearing
         // the pending fetch. Verify that the number of FetchCommittedOffsetsEvent enqueued remains at 1.
@@ -596,7 +596,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         assertDoesNotThrow(() -> ConsumerUtils.getResult(event.future(), time.timer(timeoutMs)));
-        assertNull(consumer.pendingOffsetFetch());
+        assertFalse(consumer.hasPendingOffsetFetch());
     }
 
     @Test
@@ -612,7 +612,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event1.future(), time.timer(timeoutMs)));
-        assertNotNull(consumer.pendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetch());
 
         // For the second attempt, the set of partitions is reassigned, causing the pending offset to be replaced.
         // Verify that the number of FetchCommittedOffsetsEvent enqueued is updated to 2.
@@ -621,7 +621,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertNotNull(consumer.pendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetch());
 
         // For the third attempt, the event from attempt 2 is reused, so make the Future return successfully. This
         // will finally clear out the pending fetch. Verify that the number of FetchCommittedOffsetsEvent
@@ -630,7 +630,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         assertDoesNotThrow(() -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertNull(consumer.pendingOffsetFetch());
+        assertFalse(consumer.hasPendingOffsetFetch());
     }
 
     @Test
@@ -646,18 +646,17 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event1.future(), time.timer(timeoutMs)));
-        assertNotNull(consumer.pendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetch());
 
         // Sleep past the event's expiration, causing the poll() to *not* reuse the pending fetch. A new event
         // is created and added to the application event queue.
         time.sleep(event1.deadlineMs() - time.milliseconds());
         consumer.poll(Duration.ofMillis(timeoutMs));
-        assertNotNull(consumer.pendingOffsetFetch());
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
         assertNotEquals(event1.id(), event2.id());
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertNotNull(consumer.pendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetch());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -620,6 +620,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
+        assertNotEquals(event1, event2);
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
         assertTrue(consumer.hasPendingOffsetFetchEvent());
 
@@ -629,6 +630,8 @@ public class AsyncKafkaConsumerTest {
         event2.future().complete(Collections.emptyMap());
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
+        CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2Still = getLastEnqueuedEvent();
+        assertEquals(event2, event2Still);
         assertDoesNotThrow(() -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
         assertFalse(consumer.hasPendingOffsetFetchEvent());
     }
@@ -654,7 +657,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
-        assertNotEquals(event1.id(), event2.id());
+        assertNotEquals(event1, event2);
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
         assertTrue(consumer.hasPendingOffsetFetchEvent());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -153,7 +153,6 @@ public class AsyncKafkaConsumerTest {
     private final ConsumerMetadata metadata = mock(ConsumerMetadata.class);
     private final LinkedBlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
     private final CompletableEventReaper backgroundEventReaper = mock(CompletableEventReaper.class);
-    private MockedStatic<ConsumerUtils> consumerUtilsMockedStatic;
 
     @AfterEach
     public void resetAll() {
@@ -162,11 +161,6 @@ public class AsyncKafkaConsumerTest {
             consumer.close(Duration.ZERO);
         }
         consumer = null;
-
-        if (consumerUtilsMockedStatic != null) {
-            consumerUtilsMockedStatic.close();
-            consumerUtilsMockedStatic = null;
-        }
 
         Mockito.framework().clearInlineMocks();
         MockConsumerInterceptor.resetCounters();
@@ -674,53 +668,56 @@ public class AsyncKafkaConsumerTest {
         assertTrue(consumer.hasPendingOffsetFetchEvent());
     }
 
-    @ParameterizedTest
-    @MethodSource("offsetFetchExceptionSupplier")
-    public void testOffsetFetchPendingEventErrors(Throwable reportedFailure,
-                                                  boolean expectErrorFromPoll,
-                                                  boolean expectPending) {
-        // Interrupt the thread and then clear it so that the interrupt flag is in a known good state before starting.
-        try {
-            Thread.currentThread().interrupt();
-        } finally {
-            assertTrue(Thread.interrupted());
-        }
-
+    @Test
+    public void testOffsetFetchTimeoutExceptionKeepsPendingEvent() {
         consumer = newConsumer();
         long timeoutMs = 0;
         doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
         consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
 
-        // Set up a pending offset fetch event.
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler).add(any(FetchCommittedOffsetsEvent.class));
-        CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();
-        assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event1.future(), time.timer(timeoutMs)));
+        CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event = getLastEnqueuedEvent();
         assertTrue(consumer.hasPendingOffsetFetchEvent());
 
-        clearInvocations(applicationEventHandler);
-
-        assertNull(consumerUtilsMockedStatic);
-        consumerUtilsMockedStatic = mockStatic(ConsumerUtils.class);
-        consumerUtilsMockedStatic.when(() -> ConsumerUtils.getResult(any(Future.class), any(Timer.class))).thenThrow(reportedFailure);
-        consumerUtilsMockedStatic.when(() -> ConsumerUtils.getResult(any(Future.class))).thenThrow(reportedFailure);
-        consumerUtilsMockedStatic.when(() -> ConsumerUtils.maybeWrapAsKafkaException(any(Throwable.class))).thenCallRealMethod();
-
-        if (expectErrorFromPoll)
-            assertThrows(reportedFailure.getClass(), () -> consumer.poll(Duration.ofMillis(timeoutMs)));
-        else
-            assertDoesNotThrow(() -> consumer.poll(Duration.ofMillis(timeoutMs)));
-
-        verify(applicationEventHandler, never()).add(any(FetchCommittedOffsetsEvent.class));
-        assertEquals(expectPending, consumer.hasPendingOffsetFetchEvent());
+        event.future().completeExceptionally(new TimeoutException("Test error"));
+        assertDoesNotThrow(() -> consumer.poll(Duration.ofMillis(timeoutMs)));
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
     }
 
-    private static Stream<Arguments> offsetFetchExceptionSupplier() {
-        return Stream.of(
-            Arguments.of(new TimeoutException("Test exception"), false, true),
-            Arguments.of(new InterruptException("Test exception"), true, true),
-            Arguments.of(new KafkaException(new NullPointerException(("Test exception"))), true, false)
-        );
+    @Test
+    public void testOffsetFetchInterruptKeepsPendingEvent() {
+        consumer = newConsumer();
+        long timeoutMs = 0;
+        doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
+        consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
+
+        consumer.poll(Duration.ofMillis(timeoutMs));
+        verify(applicationEventHandler).add(any(FetchCommittedOffsetsEvent.class));
+        CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event = getLastEnqueuedEvent();
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
+
+        event.future().completeExceptionally(new InterruptException("Test error"));
+        assertThrows(InterruptException.class, () -> consumer.poll(Duration.ofMillis(timeoutMs)));
+        assertTrue(Thread.interrupted());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
+    }
+
+    @Test
+    public void testOffsetFetchUnexpectedExceptionClearsPendingEvent() {
+        consumer = newConsumer();
+        long timeoutMs = 0;
+        doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
+        consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
+
+        consumer.poll(Duration.ofMillis(timeoutMs));
+        verify(applicationEventHandler).add(any(FetchCommittedOffsetsEvent.class));
+        CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event = getLastEnqueuedEvent();
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
+
+        event.future().completeExceptionally(new NullPointerException("Test error"));
+        assertThrows(KafkaException.class, () -> consumer.poll(Duration.ofMillis(timeoutMs)));
+        assertFalse(consumer.hasPendingOffsetFetchEvent());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -588,7 +588,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event.future(), time.timer(timeoutMs)));
-        assertTrue(consumer.hasPendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
 
         // For the second attempt, the event is reused, and this time the Future returns successfully, clearing
         // the pending fetch. Verify that the number of FetchCommittedOffsetsEvent enqueued remains at 1.
@@ -596,7 +596,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         assertDoesNotThrow(() -> ConsumerUtils.getResult(event.future(), time.timer(timeoutMs)));
-        assertFalse(consumer.hasPendingOffsetFetch());
+        assertFalse(consumer.hasPendingOffsetFetchEvent());
     }
 
     @Test
@@ -612,7 +612,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event1.future(), time.timer(timeoutMs)));
-        assertTrue(consumer.hasPendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
 
         // For the second attempt, the set of partitions is reassigned, causing the pending offset to be replaced.
         // Verify that the number of FetchCommittedOffsetsEvent enqueued is updated to 2.
@@ -621,7 +621,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertTrue(consumer.hasPendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
 
         // For the third attempt, the event from attempt 2 is reused, so make the Future return successfully. This
         // will finally clear out the pending fetch. Verify that the number of FetchCommittedOffsetsEvent
@@ -630,7 +630,7 @@ public class AsyncKafkaConsumerTest {
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(2)).add(any(FetchCommittedOffsetsEvent.class));
         assertDoesNotThrow(() -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertFalse(consumer.hasPendingOffsetFetch());
+        assertFalse(consumer.hasPendingOffsetFetchEvent());
     }
 
     @Test
@@ -646,7 +646,7 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event1.future(), time.timer(timeoutMs)));
-        assertTrue(consumer.hasPendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
 
         // Sleep past the event's expiration, causing the poll() to *not* reuse the pending fetch. A new event
         // is created and added to the application event queue.
@@ -656,7 +656,7 @@ public class AsyncKafkaConsumerTest {
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event2 = getLastEnqueuedEvent();
         assertNotEquals(event1.id(), event2.id());
         assertThrows(TimeoutException.class, () -> ConsumerUtils.getResult(event2.future(), time.timer(timeoutMs)));
-        assertTrue(consumer.hasPendingOffsetFetch());
+        assertTrue(consumer.hasPendingOffsetFetchEvent());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -817,7 +817,7 @@ public class AsyncKafkaConsumerTest {
         assertDoesNotThrow(() -> consumer.commitSync(Collections.singletonMap(tp, new OffsetAndMetadata(20)), Duration.ofMillis(100)));
     }
 
-    private <T> CompletableFuture<T> setUpConsumerWithIncompleteAsyncCommit(TopicPartition tp) {
+    private CompletableFuture<Void> setUpConsumerWithIncompleteAsyncCommit(TopicPartition tp) {
         time = new MockTime(1);
         consumer = newConsumer();
 
@@ -827,14 +827,8 @@ public class AsyncKafkaConsumerTest {
         consumer.seek(tp, 20);
         consumer.commitAsync();
 
-        return getLastEnqueuedEventFuture();
-    }
-
-    // ArgumentCaptor's type-matching does not work reliably with Java 8, so we cannot directly capture the AsyncCommitEvent
-    // Instead, we capture the super-class CompletableApplicationEvent and fetch the last captured event.
-    private <T> CompletableFuture<T> getLastEnqueuedEventFuture() {
-        final CompletableApplicationEvent<T> lastEvent = getLastEnqueuedEvent();
-        return lastEvent.future();
+        CompletableApplicationEvent<Void> event = getLastEnqueuedEvent();
+        return event.future();
     }
 
     // ArgumentCaptor's type-matching does not work reliably with Java 8, so we cannot directly capture the AsyncCommitEvent

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -645,7 +645,6 @@ public class AsyncKafkaConsumerTest {
 
         // The first attempt at poll() creates an event, enqueues it, but its Future does not complete within
         // the timeout, leaving a pending fetch.
-        consumer.assign(Collections.singleton(new TopicPartition("topic1", 0)));
         consumer.poll(Duration.ofMillis(timeoutMs));
         verify(applicationEventHandler, times(1)).add(any(FetchCommittedOffsetsEvent.class));
         CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> event1 = getLastEnqueuedEvent();


### PR DESCRIPTION
Allow the committed offsets fetch to run for as long as needed. This handles the case where a user invokes `Consumer.poll()` with a very small timeout (including zero).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
