### PR TITLE
KAFKA-16946: Utils.getHost/getPort cannot parse SASL_PLAINTEXT://host:port

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -94,7 +94,7 @@ public final class Utils {
 
     // This matches URIs of formats: host:port and protocol://host:port
     // IPv6 is supported with [ip] pattern
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z][a-zA-Z\\d+_.-]*://)?\\[?([0-9a-zA-Z\\-._%:]+)]?:([0-9]+)$");
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z0-9+_.%-]*://)?\\[?([0-9a-zA-Z\\-._%:]+)]?:([0-9]+)$");
 
     private static final Pattern VALID_HOST_CHARACTERS = Pattern.compile("([0-9a-zA-Z\\-%._:]*)");
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -94,7 +94,7 @@ public final class Utils {
 
     // This matches URIs of formats: host:port and protocol://host:port
     // IPv6 is supported with [ip] pattern
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z][a-zA-Z\\d+-.]*://)?\\[?([0-9a-zA-Z\\-._%:]+)\\]?:([0-9]+)$");
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z][a-zA-Z\\d+_.-]*://)?\\[?([0-9a-zA-Z\\-._%:]+)]?:([0-9]+)$");
 
     private static final Pattern VALID_HOST_CHARACTERS = Pattern.compile("([0-9a-zA-Z\\-%._:]*)");
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -94,7 +94,7 @@ public final class Utils {
 
     // This matches URIs of formats: host:port and protocol://host:port
     // IPv6 is supported with [ip] pattern
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z0-9+_.%-]*://)?\\[?([0-9a-zA-Z\\-._%:]+)]?:([0-9]+)$");
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[0-9a-zA-Z\\-%._]*://)?\\[?([0-9a-zA-Z\\-%._:]*)]?:([0-9]+)");
 
     private static final Pattern VALID_HOST_CHARACTERS = Pattern.compile("([0-9a-zA-Z\\-%._:]*)");
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.Closeable;
@@ -106,45 +108,33 @@ public class UtilsTest {
         }
     }
 
-    @Test
-    public void testGetHost() {
-        // valid
-        assertEquals("127.0.0.1", getHost("127.0.0.1:8000"));
-        assertEquals("mydomain.com", getHost("PLAINTEXT://mydomain.com:8080"));
-        assertEquals("MyDomain.com", getHost("PLAINTEXT://MyDomain.com:8080"));
-        assertEquals("My_Domain.com", getHost("PLAINTEXT://My_Domain.com:8080"));
-        assertEquals("mydomain.com", getHost("SASL_PLAINTEXT://mydomain.com:8080"));
-        assertEquals("MyDomain.com", getHost("SASL_PLAINTEXT://MyDomain.com:8080"));
-        assertEquals("My_Domain.com", getHost("SASL_PLAINTEXT://My_Domain.com:8080"));
-        assertEquals("::1", getHost("[::1]:1234"));
-        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
-        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
-        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("SASL_PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("SASL_PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
-        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("SASL_PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
+    @ParameterizedTest
+    @CsvSource(value = {"PLAINTEXT", "SASL_PLAINTEXT", "SSL", "SASL_SSL"})
+    public void testGetHostValid(String protocol) {
+        assertEquals("mydomain.com", getHost(protocol + "://mydomain.com:8080"));
+        assertEquals("MyDomain.com", getHost(protocol + "://MyDomain.com:8080"));
+        assertEquals("My_Domain.com", getHost(protocol + "://My_Domain.com:8080"));
+        assertEquals("::1", getHost(protocol + "://[::1]:1234"));
+        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost(protocol + "://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost(protocol + "://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
+        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost(protocol + "://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
+    }
 
-        // invalid
-        assertNull(getHost("PLAINTEXT://mydo)main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo(main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo()main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo(main).com:8080"));
-        assertNull(getHost("SASL_PLAINTEXT://mydo)main.com:8080"));
-        assertNull(getHost("SASL_PLAINTEXT://mydo(main.com:8080"));
-        assertNull(getHost("SASL_PLAINTEXT://mydo()main.com:8080"));
-        assertNull(getHost("SASL_PLAINTEXT://mydo(main).com:8080"));
+    @ParameterizedTest
+    @CsvSource(value = {"PLAINTEXT", "SASL_PLAINTEXT", "SSL", "SASL_SSL"})
+    public void testGetHostInvalid(String protocol) {
+        assertNull(getHost(protocol + "://mydo)main.com:8080"));
+        assertNull(getHost(protocol + "://mydo(main.com:8080"));
+        assertNull(getHost(protocol + "://mydo()main.com:8080"));
+        assertNull(getHost(protocol + "://mydo(main).com:8080"));
+        assertNull(getHost(protocol + "://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost(protocol + "://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost(protocol + "://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost(protocol + "://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
         assertNull(getHost("ho)st:9092"));
         assertNull(getHost("ho(st:9092"));
         assertNull(getHost("ho()st:9092"));
         assertNull(getHost("ho(st):9092"));
-        assertNull(getHost("PLAINTEXT://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("SASL_PLAINTEXT://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("SASL_PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("SASL_PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("SASL_PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -113,16 +113,26 @@ public class UtilsTest {
         assertEquals("mydomain.com", getHost("PLAINTEXT://mydomain.com:8080"));
         assertEquals("MyDomain.com", getHost("PLAINTEXT://MyDomain.com:8080"));
         assertEquals("My_Domain.com", getHost("PLAINTEXT://My_Domain.com:8080"));
+        assertEquals("mydomain.com", getHost("SASL_PLAINTEXT://mydomain.com:8080"));
+        assertEquals("MyDomain.com", getHost("SASL_PLAINTEXT://MyDomain.com:8080"));
+        assertEquals("My_Domain.com", getHost("SASL_PLAINTEXT://My_Domain.com:8080"));
         assertEquals("::1", getHost("[::1]:1234"));
         assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
         assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
         assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
+        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("SASL_PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("SASL_PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
+        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("SASL_PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
 
         // invalid
         assertNull(getHost("PLAINTEXT://mydo)main.com:8080"));
         assertNull(getHost("PLAINTEXT://mydo(main.com:8080"));
         assertNull(getHost("PLAINTEXT://mydo()main.com:8080"));
         assertNull(getHost("PLAINTEXT://mydo(main).com:8080"));
+        assertNull(getHost("SASL_PLAINTEXT://mydo)main.com:8080"));
+        assertNull(getHost("SASL_PLAINTEXT://mydo(main.com:8080"));
+        assertNull(getHost("SASL_PLAINTEXT://mydo()main.com:8080"));
+        assertNull(getHost("SASL_PLAINTEXT://mydo(main).com:8080"));
         assertNull(getHost("ho)st:9092"));
         assertNull(getHost("ho(st:9092"));
         assertNull(getHost("ho()st:9092"));
@@ -131,6 +141,10 @@ public class UtilsTest {
         assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
         assertNull(getHost("PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
         assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("SASL_PLAINTEXT://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("SASL_PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("SASL_PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("SASL_PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -118,6 +118,8 @@ public class UtilsTest {
         assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost(protocol + "://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
         assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost(protocol + "://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
         assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost(protocol + "://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
+        assertEquals("127.0.0.1", getHost("127.0.0.1:8000"));
+        assertEquals("::1", getHost("[::1]:1234"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
In previous PR(#16048), I mistakenly excluded the underscore (_) from the set of valid characters for the protocol, resulting in the inability to correctly parse the connection string for SASL_PLAINTEXT. This bug fix addresses the issue and includes corresponding tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
