### PR TITLE
KAFKA-16518; Adding standalone argument for storage

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -243,8 +243,8 @@ object StorageTool extends Logging {
     formatParser.addArgument("--add-scram", "-S").
       action(append()).
       help("""A SCRAM_CREDENTIAL to add to the __cluster_metadata log e.g.
-             |'SCRAM-SHA-256=[name=alice,password=alice-secret]'
-             |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
+              |'SCRAM-SHA-256=[name=alice,password=alice-secret]'
+              |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
     formatParser.addArgument("--ignore-formatted", "-g").
       action(storeTrue())
     formatParser.addArgument("--release-version", "-r").
@@ -275,10 +275,10 @@ object StorageTool extends Logging {
   private def configToSelfManagedMode(config: KafkaConfig): Boolean = config.processRoles.nonEmpty
 
   def getMetadataVersion(
-                          namespace: Namespace,
-                          featureNamesAndLevelsMap: Map[String, java.lang.Short],
-                          defaultVersionString: Option[String]
-                        ): MetadataVersion = {
+    namespace: Namespace,
+    featureNamesAndLevelsMap: Map[String, java.lang.Short],
+    defaultVersionString: Option[String]
+  ): MetadataVersion = {
     val defaultValue = defaultVersionString match {
       case Some(versionString) => MetadataVersion.fromVersionString(versionString)
       case None => MetadataVersion.LATEST_PRODUCTION
@@ -300,9 +300,9 @@ object StorageTool extends Logging {
   }
 
   private def getUserScramCredentialRecord(
-                                            mechanism: String,
-                                            config: String
-                                          ) : UserScramCredentialRecord = {
+    mechanism: String,
+    config: String
+  ) : UserScramCredentialRecord = {
     /*
      * Remove  '[' amd ']'
      * Split K->V pairs on ',' and no K or V should contain ','
@@ -310,9 +310,9 @@ object StorageTool extends Logging {
      * Create Map of K to V and replace all " in V
      */
     val argMap = config.substring(1, config.length - 1)
-      .split(",")
-      .map(_.split("=(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"))
-      .map(args => args(0) -> args(1).replaceAll("\"", "")).toMap
+                       .split(",")
+                       .map(_.split("=(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"))
+                       .map(args => args(0) -> args(1).replaceAll("\"", "")).toMap
 
     val scramMechanism = ScramMechanism.forMechanismName(mechanism)
 
@@ -335,10 +335,10 @@ object StorageTool extends Logging {
       if (argMap.contains("salt")) {
         val iterations = argMap("iterations").toInt
         if (iterations < scramMechanism.minIterations()) {
-          throw new TerseFailure(s"The 'iterations' value must be >= ${scramMechanism.minIterations()} for add-scram")
+            throw new TerseFailure(s"The 'iterations' value must be >= ${scramMechanism.minIterations()} for add-scram")
         }
         if (iterations > scramMechanism.maxIterations()) {
-          throw new TerseFailure(s"The 'iterations' value must be <= ${scramMechanism.maxIterations()} for add-scram")
+            throw new TerseFailure(s"The 'iterations' value must be <= ${scramMechanism.maxIterations()} for add-scram")
         }
         iterations
       } else {
@@ -347,22 +347,22 @@ object StorageTool extends Logging {
     }
 
     def getSaltedPassword(
-                           argMap: Map[String,String],
-                           scramMechanism : ScramMechanism,
-                           salt : Array[Byte],
-                           iterations: Int
-                         ) : Array[Byte] = {
+      argMap: Map[String,String],
+      scramMechanism : ScramMechanism,
+      salt : Array[Byte],
+      iterations: Int
+    ) : Array[Byte] = {
       if (argMap.contains("password")) {
         if (argMap.contains("saltedpassword")) {
-          throw new TerseFailure(s"You must only supply one of 'password' or 'saltedpassword' to add-scram")
+            throw new TerseFailure(s"You must only supply one of 'password' or 'saltedpassword' to add-scram")
         }
         new ScramFormatter(scramMechanism).saltedPassword(argMap("password"), salt, iterations)
       } else {
         if (!argMap.contains("saltedpassword")) {
-          throw new TerseFailure(s"You must supply one of 'password' or 'saltedpassword' to add-scram")
+            throw new TerseFailure(s"You must supply one of 'password' or 'saltedpassword' to add-scram")
         }
         if (!argMap.contains("salt")) {
-          throw new TerseFailure(s"You must supply 'salt' with 'saltedpassword' to add-scram")
+            throw new TerseFailure(s"You must supply 'salt' with 'saltedpassword' to add-scram")
         }
         Base64.getDecoder.decode(argMap("saltedpassword"))
       }
@@ -377,12 +377,12 @@ object StorageTool extends Logging {
       val formatter = new ScramFormatter(scramMechanism)
 
       new UserScramCredentialRecord()
-        .setName(name)
-        .setMechanism(scramMechanism.`type`)
-        .setSalt(salt)
-        .setStoredKey(formatter.storedKey(formatter.clientKey(saltedPassword)))
-        .setServerKey(formatter.serverKey(saltedPassword))
-        .setIterations(iterations)
+           .setName(name)
+           .setMechanism(scramMechanism.`type`)
+           .setSalt(salt)
+           .setStoredKey(formatter.storedKey(formatter.clientKey(saltedPassword)))
+           .setServerKey(formatter.serverKey(saltedPassword))
+           .setIterations(iterations)
     } catch {
       case e: Throwable =>
         throw new TerseFailure(s"Error attempting to create UserScramCredentialRecord: ${e.getMessage}")
@@ -506,8 +506,8 @@ object StorageTool extends Logging {
 
     val metadataRecords = new util.ArrayList[ApiMessageAndVersion]
     metadataRecords.add(new ApiMessageAndVersion(new FeatureLevelRecord().
-      setName(MetadataVersion.FEATURE_NAME).
-      setFeatureLevel(metadataVersion.featureLevel()), 0.toShort))
+                        setName(MetadataVersion.FEATURE_NAME).
+                        setFeatureLevel(metadataVersion.featureLevel()), 0.toShort))
 
     metadataOptionalArguments.foreach { metadataArguments =>
       for (record <- metadataArguments) metadataRecords.add(record)
@@ -518,9 +518,9 @@ object StorageTool extends Logging {
 
 
   def buildMetadataProperties(
-                               clusterIdStr: String,
-                               config: KafkaConfig
-                             ): MetaProperties = {
+    clusterIdStr: String,
+    config: KafkaConfig
+  ): MetaProperties = {
     val effectiveClusterId = try {
       Uuid.fromString(clusterIdStr)
     } catch {
@@ -537,29 +537,29 @@ object StorageTool extends Logging {
   }
 
   def formatCommand(
-                     stream: PrintStream,
-                     directories: Seq[String],
-                     metaProperties: MetaProperties,
-                     metadataVersion: MetadataVersion,
-                     ignoreFormatted: Boolean,
-                     advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
-                     controllersQuorumVoters: String
-                   ): Int = {
+    stream: PrintStream,
+    directories: Seq[String],
+    metaProperties: MetaProperties,
+    metadataVersion: MetadataVersion,
+    ignoreFormatted: Boolean,
+    advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
+    controllersQuorumVoters: String
+  ): Int = {
     val bootstrapMetadata = buildBootstrapMetadata(metadataVersion, None, "format command")
     formatCommand(stream, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted,
       advertisedListenerEndpoints, controllersQuorumVoters)
   }
 
   def formatCommand(
-                     stream: PrintStream,
-                     directories: Seq[String],
-                     metaProperties: MetaProperties,
-                     bootstrapMetadata: BootstrapMetadata,
-                     metadataVersion: MetadataVersion,
-                     ignoreFormatted: Boolean,
-                     advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
-                     controllersQuorumVoters: String
-                   ): Int = {
+    stream: PrintStream,
+    directories: Seq[String],
+    metaProperties: MetaProperties,
+    bootstrapMetadata: BootstrapMetadata,
+    metadataVersion: MetadataVersion,
+    ignoreFormatted: Boolean,
+    advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
+    controllersQuorumVoters: String
+  ): Int = {
     if (directories.isEmpty) {
       throw new TerseFailure("No log directories found in the configuration.")
     }

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -19,13 +19,14 @@ package kafka.tools
 
 import kafka.server.KafkaConfig
 
-import java.io.PrintStream
+import java.io.{File, PrintStream}
 import java.nio.file.{Files, Paths}
 import kafka.utils.{Exit, Logging}
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments.{append, store, storeTrue}
 import net.sourceforge.argparse4j.inf.Namespace
 import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.feature.SupportedVersionRange
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, Features, MetadataVersion}
@@ -36,10 +37,18 @@ import org.apache.kafka.common.security.scram.internals.ScramFormatter
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.VerificationFlag
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
+import org.apache.kafka.raft.internals.{ReplicaKey, StringSerde, VoterSet}
 import org.apache.kafka.server.common.FeatureVersion
+import org.apache.kafka.snapshot.{FileRawSnapshotWriter, RecordsSnapshotWriter}
+import org.apache.kafka.common.internals.Topic.CLUSTER_METADATA_TOPIC_NAME
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.raft.QuorumConfig.{parseVoterConnections, validateControllerQuorumVoters}
+import org.apache.kafka.snapshot.Snapshots.BOOTSTRAP_SNAPSHOT_ID
 
+import java.net.InetSocketAddress
 import java.util
-import java.util.{Base64, Collections, Optional}
+import java.util.{Base64, Collections, Optional, OptionalInt}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -102,6 +111,24 @@ object StorageTool extends Logging {
       setClusterId(clusterId).
       setNodeId(config.nodeId).
       build()
+    val standaloneMode = namespace.getBoolean("standalone")
+    var advertisedListenerEndpoints: collection.Seq[kafka.cluster.EndPoint] = List()
+
+    if (standaloneMode) {
+      advertisedListenerEndpoints = config.effectiveAdvertisedListeners
+    }
+
+    // effectiveAdvertisedControllerListeners to be added
+
+    val controllersQuorumVoters = namespace.getString("controller_quorum_voters")
+    if(standaloneMode && controllersQuorumVoters != null) {
+      throw new TerseFailure("Both --standalone and --controller-quorum-voters were set. Only one of the two flags can be set.")
+    }
+
+    if(!validateControllerQuorumVoters(controllersQuorumVoters)) {
+      throw new TerseFailure("Expected schema for --controller-quorum-voters is <replica-id>[-<replica-directory-id>]@<host>:<port>")
+    }
+
     val metadataRecords : ArrayBuffer[ApiMessageAndVersion] = ArrayBuffer()
     val specifiedFeatures: util.List[String] = namespace.getList("feature")
     val releaseVersionFlagSpecified = namespace.getString("release_version") != null
@@ -137,7 +164,7 @@ object StorageTool extends Logging {
         "a legacy cluster. Formatting is only supported for clusters in KRaft mode.")
     }
     formatCommand(System.out, directories, metaProperties, bootstrapMetadata,
-      metadataVersion,ignoreFormatted)
+      metadataVersion, ignoreFormatted, advertisedListenerEndpoints, controllersQuorumVoters)
   }
 
   private def validateMetadataVersion(metadataVersion: MetadataVersion, config: KafkaConfig): Unit = {
@@ -226,7 +253,15 @@ object StorageTool extends Logging {
       help(s"A KRaft release version to use for the initial metadata.version. The minimum is ${MetadataVersion.IBP_3_0_IV0}, the default is ${MetadataVersion.LATEST_PRODUCTION}")
     formatParser.addArgument("--feature", "-f").
       help("A feature upgrade we should perform, in feature=level format. For example: `metadata.version=5`.").
-      action(append());
+      action(append())
+    formatParser.addArgument("--standalone", "-s").
+      help("This flag will bootstrap the controller in standalone as the only KRaft controller if the Kafka" +
+        " cluster. Use the --controller-quorum-voters flag instead to bootstrap a controller cluster with more than one" +
+        " controller.").
+      action(storeTrue())
+    formatParser.addArgument("--controller-quorum-voters", "-q").
+      help("This flag will bootstrap a controller cluster with more than one controller.").
+      action(append())
 
     parser.parseArgsOrFail(args)
   }
@@ -507,10 +542,13 @@ object StorageTool extends Logging {
     directories: Seq[String],
     metaProperties: MetaProperties,
     metadataVersion: MetadataVersion,
-    ignoreFormatted: Boolean
+    ignoreFormatted: Boolean,
+    advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
+    controllersQuorumVoters: String
   ): Int = {
     val bootstrapMetadata = buildBootstrapMetadata(metadataVersion, None, "format command")
-    formatCommand(stream, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted)
+    formatCommand(stream, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted,
+      advertisedListenerEndpoints, controllersQuorumVoters)
   }
 
   def formatCommand(
@@ -519,7 +557,9 @@ object StorageTool extends Logging {
     metaProperties: MetaProperties,
     bootstrapMetadata: BootstrapMetadata,
     metadataVersion: MetadataVersion,
-    ignoreFormatted: Boolean
+    ignoreFormatted: Boolean,
+    advertisedListenerEndpoints: scala.collection.Seq[kafka.cluster.EndPoint],
+    controllersQuorumVoters: String
   ): Int = {
     if (directories.isEmpty) {
       throw new TerseFailure("No log directories found in the configuration.")
@@ -563,6 +603,28 @@ object StorageTool extends Logging {
         })
       })
       copier.writeLogDirChanges()
+      if (advertisedListenerEndpoints.nonEmpty) {
+        metaPropertiesEnsemble.emptyLogDirs().forEach(logDir => {
+          val listeners: java.util.Map[ListenerName, InetSocketAddress] = new util.HashMap()
+          advertisedListenerEndpoints.foreach(endpoint => {
+            listeners.put(endpoint.listenerName, new InetSocketAddress(endpoint.host, endpoint.port))
+          })
+          writeCheckpointFile(stream, logDir, copier.logDirProps().get(logDir), listeners)
+        })
+      }else if (controllersQuorumVoters != null) {
+        metaPropertiesEnsemble.emptyLogDirs().forEach(logDir => {
+          val nodeId = copier.logDirProps().get(logDir).nodeId()
+          val voterMap: util.Map[Integer, InetSocketAddress] = parseVoterConnections(Collections.singletonList(controllersQuorumVoters))
+          val listeners: java.util.Map[ListenerName, InetSocketAddress] = new util.HashMap()
+          voterMap.keySet().forEach(replicaId => {
+            if (nodeId.getAsInt == replicaId){
+              listeners.put(new ListenerName(SecurityProtocol.PLAINTEXT.name), voterMap.get(replicaId))
+            }
+          })
+          // write only once for all listeners
+          writeCheckpointFile(stream, logDir, copier.logDirProps().get(logDir), listeners)
+        })
+      }
     }
     0
   }
@@ -589,4 +651,47 @@ object StorageTool extends Logging {
       (nameAndLevel._1, nameAndLevel._2)
     }.toMap
   }
+
+  def writeCheckpointFile(stream: PrintStream, logDir: String, metaProperties: MetaProperties,
+                          listeners: java.util.Map[ListenerName, InetSocketAddress]): Unit = {
+    val snapshotDir = createLogDirectory(new File(logDir), CLUSTER_METADATA_TOPIC_NAME)
+    // Create the raw snapshot writer
+    val rawSnapshotWriter = FileRawSnapshotWriter.create(snapshotDir.toPath, BOOTSTRAP_SNAPSHOT_ID)
+
+    if(!listeners.isEmpty){
+      if (!metaProperties.nodeId().isPresent) {
+        throw new TerseFailure(s"Error while formatting. node.id is missing in the meta.properties")
+      }
+
+      val voterSet: VoterSet = getVoterSet(metaProperties.nodeId(), metaProperties.directoryId().get(), listeners)
+      val builder = new RecordsSnapshotWriter.Builder()
+        .setKraftVersion(1)
+        .setVoterSet(Optional.of(voterSet))
+        .setRawSnapshotWriter(rawSnapshotWriter)
+        .build(new StringSerde)
+      try{
+        builder.freeze()
+      } finally{
+        // Close the builder to finalize the snapshot
+        builder.close()
+        stream.println(s"Snapshot written to $snapshotDir")
+      }
+    }
+  }
+
+  private def getVoterSet(nodeId: OptionalInt, directoryId: Uuid, listeners: java.util.Map[ListenerName, InetSocketAddress]) = {
+    val voters: util.Map[Integer, VoterSet.VoterNode] = new util.HashMap[Integer, VoterSet.VoterNode]()
+    voters.put(nodeId.getAsInt, new VoterSet.VoterNode(ReplicaKey.of(nodeId.getAsInt, directoryId), listeners,
+      new SupportedVersionRange(0, 1)))
+    val voterSet = VoterSet.fromMap(voters)
+    voterSet
+  }
+
+  private def createLogDirectory(logDir: File, logDirName: String): File = {
+    val logDirPath = logDir.getAbsolutePath
+    val dir = new File(logDirPath, logDirName)
+    Files.createDirectories(dir.toPath)
+    dir
+  }
+
 }

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -199,7 +199,7 @@ object StorageTool extends Logging {
       val level: java.lang.Short = specifiedFeatures.getOrElse(feature.featureName, feature.defaultValue(metadataVersionForDefault))
       // Only set feature records for levels greater than 0. 0 is assumed if there is no record. Throw an error if level < 0.
       if (level != 0) {
-        allNonZeroFeaturesAndLevels.append(feature.fromFeatureLevel(level, unstableFeatureVersionsEnabled))
+       allNonZeroFeaturesAndLevels.append(feature.fromFeatureLevel(level, unstableFeatureVersionsEnabled))
       }
     }
     val featuresMap = Features.featureImplsToMap(allNonZeroFeaturesAndLevels.asJava)

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -260,7 +260,7 @@ object StorageTool extends Logging {
       action(storeTrue())
     formatParser.addArgument("--controller-quorum-voters", "-q").
       help("This flag will bootstrap a controller cluster with more than one controller.").
-      action(append())
+      action(store())
 
     parser.parseArgsOrFail(args)
   }
@@ -610,9 +610,12 @@ object StorageTool extends Logging {
           controllerQuorumVoterMap.keySet().forEach(replicaId => {
             if (nodeId.getAsInt == replicaId){
               val listenerNameOption = advertisedListenerEndpoints.
-                find(endpoint =>
-                endpoint.port == controllerQuorumVoterMap.get(replicaId).getPort &&
-                endpoint.host == controllerQuorumVoterMap.get(replicaId).getHostString).
+                find {
+                  endpoint =>
+                    endpoint.port == controllerQuorumVoterMap.get(replicaId).getPort &&
+                      (controllerQuorumVoterMap.get(replicaId).getHostString.split("//").contains(endpoint.host)
+                    || (endpoint.host == null && controllerQuorumVoterMap.get(replicaId).getHostString.contains("localhost")))
+                }.
                 map(_.listenerName)
               listenerNameOption match {
                 case Some(listenerName) =>

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -683,7 +683,7 @@ object StorageTool extends Logging {
 
   private def getVoterSet(nodeId: OptionalInt, directoryId: Uuid, listeners: java.util.Map[ListenerName, InetSocketAddress]) = {
     val voters: util.Map[Integer, VoterSet.VoterNode] = new util.HashMap[Integer, VoterSet.VoterNode]()
-    voters.put(nodeId.getAsInt, new VoterSet.VoterNode(ReplicaKey.of(nodeId.getAsInt, Optional.of(directoryId)), listeners,
+    voters.put(nodeId.getAsInt, new VoterSet.VoterNode(ReplicaKey.of(nodeId.getAsInt, directoryId), listeners,
       new SupportedVersionRange(0, 1)))
     val voterSet = VoterSet.fromMap(voters)
     voterSet

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -26,7 +26,6 @@ import java.util
 import java.util.{Collections, Properties}
 import org.apache.kafka.common.{DirectoryId, KafkaException}
 import kafka.server.KafkaConfig
-import kafka.tools.StorageTool.clusterMetadataDir
 import kafka.utils.Exit
 import kafka.utils.TestUtils
 import net.sourceforge.argparse4j.inf.Namespace
@@ -193,10 +192,14 @@ Found problem:
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
 <<<<<<< HEAD
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
 =======
           MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = false,
+>>>>>>> 484aa1a709 (From review)
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
 >>>>>>> b626dbfe9d (Update voterset, test)
       assertTrue(stringAfterFirstLine(stream.toString()).startsWith("Formatting %s".format(tempDir)))
@@ -204,10 +207,14 @@ Found problem:
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties,
 <<<<<<< HEAD
+<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)) catch {
 =======
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+=======
+          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
+>>>>>>> 484aa1a709 (From review)
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])) catch {
 >>>>>>> b626dbfe9d (Update voterset, test)
         case e: TerseFailure => assertEquals(s"Log directory ${tempDir} is already " +
@@ -219,10 +226,14 @@ Found problem:
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
 <<<<<<< HEAD
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = true,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
 =======
           MetadataVersion.latestTesting(), ignoreFormatted = true, standaloneMode = false,
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = true,
+>>>>>>> 484aa1a709 (From review)
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
 >>>>>>> b626dbfe9d (Update voterset, test)
       assertEquals("All of the log directories are already formatted.%n".format(), stringAfterFirstLine(stream2.toString()))
@@ -250,6 +261,7 @@ Found problem:
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
 <<<<<<< HEAD
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           updatedAdvertisedListenerEndpoints, null))
       val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
@@ -263,6 +275,13 @@ Found problem:
         "\n" + "Formatting %s".format(tempDir)))
       val checkpointFilePath = Paths.get(checkpointDir + "/"+ checkpointFileName)
 >>>>>>> b626dbfe9d (Update voterset, test)
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = false,
+          updatedAdvertisedListenerEndpoints))
+      val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
+      assertTrue(stringAfterFirstLine(stream.toString()).contains("Snapshot written to %s".format(checkpointDir)))
+      val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
+>>>>>>> 484aa1a709 (From review)
       assertTrue(checkpointFilePath.toFile.exists)
       assertTrue(Utils.readFileAsString(checkpointFilePath.toFile.getPath).contains(host))
     } finally Utils.delete(tempDir)
@@ -282,10 +301,14 @@ Found problem:
     val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
     StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata,
 <<<<<<< HEAD
+<<<<<<< HEAD
       MetadataVersion.latestTesting(), ignoreFormatted,
       advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)
 =======
       MetadataVersion.latestTesting(), ignoreFormatted, standaloneMode = false,
+=======
+      MetadataVersion.latestTesting(), ignoreFormatted,
+>>>>>>> 484aa1a709 (From review)
       advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])
 >>>>>>> b626dbfe9d (Update voterset, test)
   }
@@ -688,10 +711,14 @@ Found problem:
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), Seq(tempDir.toString), metaProperties,
 <<<<<<< HEAD
+<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
 =======
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+=======
+          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
+>>>>>>> 484aa1a709 (From review)
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
 >>>>>>> b626dbfe9d (Update voterset, test)
 

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -137,7 +137,7 @@ Found problem:
           "version=1",
           "node.id=1",
           "cluster.id=XcZZOzUqS4yHOjhMQB6JLQ")).
-          getBytes(StandardCharsets.UTF_8))
+            getBytes(StandardCharsets.UTF_8))
       assertEquals(1, StorageTool.
         infoCommand(new PrintStream(stream), false, Seq(tempDir.toString)))
       assertEquals(s"""Found log directory:
@@ -310,8 +310,8 @@ Found problem:
     val config = new KafkaConfig(newSelfManagedProperties())
     assertEquals("Cluster ID string invalid does not appear to be a valid UUID: " +
       "Input string `invalid` decoded as 5 bytes, which is not equal to the expected " +
-      "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
-      () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
+        "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
+          () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
   }
 
   @Test
@@ -523,9 +523,9 @@ Found problem:
 
     // Validate we can add multiple SCRAM creds.
     scramRecords = parseAddScram("-S",
-      "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
-      "-S",
-      "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
+    "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
+    "-S",
+    "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
 
     assertEquals(2, scramRecords.get.size)
 
@@ -638,7 +638,7 @@ Found problem:
       StorageTool.main(args)
     } catch {
       case e: StorageToolTestException => assertEquals("", exitString)
-        assertEquals(0, exitStatus)
+      assertEquals(0, exitStatus)
     } finally {
       Exit.resetExitProcedure()
     }
@@ -663,7 +663,7 @@ Found problem:
       assertTrue(metaPropertiesFile.exists())
       val metaProps = new MetaProperties.Builder(
         PropertiesUtils.readPropertiesFile(metaPropertiesFile.getAbsolutePath())).
-        build()
+          build()
       assertTrue(metaProps.directoryId().isPresent())
       assertFalse(DirectoryId.reserved(metaProps.directoryId().get()))
     } finally Utils.delete(tempDir)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -397,8 +397,6 @@ Found problem:
     val logDir2 = "/tmp/other2"
     properties.setProperty(ServerLogConfigs.LOG_DIRS_CONFIG, logDir1 + "," + logDir2)
     properties.setProperty("listeners", "PLAINTEXT://localhost:9092")
-//    properties.setProperty(KRaftConfigs.NODE_ID_CONFIG, "3")
-//    properties.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, s"3@localhost:9092")
     val config = new KafkaConfig(properties)
     try{
       val exitCode = StorageTool.runFormatCommand(namespace, config)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -137,7 +137,7 @@ Found problem:
           "version=1",
           "node.id=1",
           "cluster.id=XcZZOzUqS4yHOjhMQB6JLQ")).
-          getBytes(StandardCharsets.UTF_8))
+            getBytes(StandardCharsets.UTF_8))
       assertEquals(1, StorageTool.
         infoCommand(new PrintStream(stream), false, Seq(tempDir.toString)))
       assertEquals(s"""Found log directory:
@@ -342,8 +342,8 @@ Found problem:
     val config = new KafkaConfig(newSelfManagedProperties())
     assertEquals("Cluster ID string invalid does not appear to be a valid UUID: " +
       "Input string `invalid` decoded as 5 bytes, which is not equal to the expected " +
-      "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
-      () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
+        "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
+          () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
   }
 
   @Test
@@ -598,9 +598,9 @@ Found problem:
 
     // Validate we can add multiple SCRAM creds.
     scramRecords = parseAddScram("-S",
-      "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
-      "-S",
-      "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
+    "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
+    "-S",
+    "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
 
     assertEquals(2, scramRecords.get.size)
 
@@ -634,7 +634,7 @@ Found problem:
     assertEquals(1, parseAddScram("-S", "SCRAM-SHA-256=[name=alice,password=alice,iterations=4096]").get.size)
 
     // Require 4096 <= iterations <= 16384
-    try assertEquals(1, parseAddScram("-S",
+    try assertEquals(1, parseAddScram("-S", 
       "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",password=alice,iterations=16385]"))
     catch {
       case e: TerseFailure => assertEquals(s"The 'iterations' value must be <= 16384 for add-scram", e.getMessage)
@@ -713,7 +713,7 @@ Found problem:
       StorageTool.main(args)
     } catch {
       case e: StorageToolTestException => assertEquals("", exitString)
-        assertEquals(0, exitStatus)
+      assertEquals(0, exitStatus)
     } finally {
       Exit.resetExitProcedure()
     }

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -26,6 +26,7 @@ import java.util
 import java.util.{Collections, Properties}
 import org.apache.kafka.common.{DirectoryId, KafkaException}
 import kafka.server.KafkaConfig
+import kafka.tools.StorageTool.clusterMetadataDir
 import kafka.utils.Exit
 import kafka.utils.TestUtils
 import net.sourceforge.argparse4j.inf.Namespace
@@ -65,6 +66,7 @@ class StorageToolTest {
   }
 
   val allFeatures = Features.FEATURES.toList
+  val checkpointFileName: String = "00000000000000000000-0000000000.checkpoint"
 
   @Test
   def testConfigToLogDirectories(): Unit = {
@@ -190,14 +192,24 @@ Found problem:
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
+>>>>>>> b626dbfe9d (Update voterset, test)
       assertTrue(stringAfterFirstLine(stream.toString()).startsWith("Formatting %s".format(tempDir)))
 
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties,
+<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)) catch {
+=======
+          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])) catch {
+>>>>>>> b626dbfe9d (Update voterset, test)
         case e: TerseFailure => assertEquals(s"Log directory ${tempDir} is already " +
           "formatted. Use --ignore-formatted to ignore this directory and format the " +
           "others.", e.getMessage)
@@ -206,8 +218,13 @@ Found problem:
       val stream2 = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = true,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = true, standaloneMode = false,
+          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
+>>>>>>> b626dbfe9d (Update voterset, test)
       assertEquals("All of the log directories are already formatted.%n".format(), stringAfterFirstLine(stream2.toString()))
     } finally Utils.delete(tempDir)
   }
@@ -232,11 +249,20 @@ Found problem:
 
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
+<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           updatedAdvertisedListenerEndpoints, null))
       val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
       assertTrue(stringAfterFirstLine(stream.toString()).contains("Snapshot written to %s".format(checkpointDir)))
       val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
+=======
+          MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = true,
+          updatedAdvertisedListenerEndpoints))
+      val checkpointDir = tempDir + clusterMetadataDir
+      assertTrue(stringAfterFirstLine(stream.toString()).startsWith("Snapshot written to %s".format(checkpointDir) +
+        "\n" + "Formatting %s".format(tempDir)))
+      val checkpointFilePath = Paths.get(checkpointDir + "/"+ checkpointFileName)
+>>>>>>> b626dbfe9d (Update voterset, test)
       assertTrue(checkpointFilePath.toFile.exists)
       assertTrue(Utils.readFileAsString(checkpointFilePath.toFile.getPath).contains(host))
     } finally Utils.delete(tempDir)
@@ -255,8 +281,13 @@ Found problem:
       build()
     val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
     StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata,
+<<<<<<< HEAD
       MetadataVersion.latestTesting(), ignoreFormatted,
       advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)
+=======
+      MetadataVersion.latestTesting(), ignoreFormatted, standaloneMode = false,
+      advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])
+>>>>>>> b626dbfe9d (Update voterset, test)
   }
 
   @Test
@@ -656,8 +687,13 @@ Found problem:
         buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), Seq(tempDir.toString), metaProperties,
+<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
+=======
+          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
+          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
+>>>>>>> b626dbfe9d (Update voterset, test)
 
       val metaPropertiesFile = Paths.get(tempDir.toURI).resolve(MetaPropertiesEnsemble.META_PROPERTIES_NAME).toFile
       assertTrue(metaPropertiesFile.exists())

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -65,7 +65,6 @@ class StorageToolTest {
   }
 
   val allFeatures = Features.FEATURES.toList
-  val checkpointFileName: String = "00000000000000000000-0000000000.checkpoint"
 
   @Test
   def testConfigToLogDirectories(): Unit = {

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -379,21 +379,30 @@ Found problem:
     assertEquals(0, exitCode)
   }
 
+//  @Test TODO
+//  def testControllerQuorumVotersWithArguments(): Unit = {
+//    val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yQQjhMQB6JAT",
+//      "--controller-quorum-voters", "1@localhost:9092"))
+//    val config = Mockito.spy(new KafkaConfig(TestUtils.createBrokerConfig(1, null)))
+//    val exitCode = StorageTool.runFormatCommand(namespace, config)
+//    val tempDirs = config.logDirs
+//    tempDirs.foreach(tempDir => {
+//      val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
+//      val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
+//      assertTrue(checkpointFilePath.toFile.exists)
+//      assertTrue(Utils.readFileAsString(checkpointFilePath.toFile.getPath).contains("localhost"))
+//      Utils.delete(new File(tempDir))
+//    })
+//    assertEquals(0, exitCode)
+//  }
+
   @Test
-  def testControllerQuorumVotersWithArguments(): Unit = {
+  def testWithStandaloneAndControllerQuorumVotersFailure(): Unit = {
     val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yPOjhMQB6JAT",
-      "--controller-quorum-voters", "1@localhost:9092"))
+      "-s", "--controller-quorum-voters", "1@localhost:9092"))
     val config = Mockito.spy(new KafkaConfig(TestUtils.createBrokerConfig(1, null)))
-    val exitCode = StorageTool.runFormatCommand(namespace, config)
-    val tempDirs = config.logDirs
-    tempDirs.foreach(tempDir => {
-      val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
-      val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
-      assertTrue(checkpointFilePath.toFile.exists)
-      assertTrue(Utils.readFileAsString(checkpointFilePath.toFile.getPath).contains("localhost"))
-      Utils.delete(new File(tempDir))
-    })
-    assertEquals(0, exitCode)
+    assertEquals("Both --standalone and --controller-quorum-voters were set. Only one of the two flags can be set.",
+      assertThrows(classOf[TerseFailure], () => StorageTool.runFormatCommand(namespace, config)).getMessage)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -137,7 +137,7 @@ Found problem:
           "version=1",
           "node.id=1",
           "cluster.id=XcZZOzUqS4yHOjhMQB6JLQ")).
-            getBytes(StandardCharsets.UTF_8))
+          getBytes(StandardCharsets.UTF_8))
       assertEquals(1, StorageTool.
         infoCommand(new PrintStream(stream), false, Seq(tempDir.toString)))
       assertEquals(s"""Found log directory:
@@ -190,32 +190,14 @@ Found problem:
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
-<<<<<<< HEAD
-<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = false,
->>>>>>> 484aa1a709 (From review)
-          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
->>>>>>> b626dbfe9d (Update voterset, test)
       assertTrue(stringAfterFirstLine(stream.toString()).startsWith("Formatting %s".format(tempDir)))
 
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties,
-<<<<<<< HEAD
-<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)) catch {
-=======
-          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
-=======
-          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
->>>>>>> 484aa1a709 (From review)
-          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])) catch {
->>>>>>> b626dbfe9d (Update voterset, test)
         case e: TerseFailure => assertEquals(s"Log directory ${tempDir} is already " +
           "formatted. Use --ignore-formatted to ignore this directory and format the " +
           "others.", e.getMessage)
@@ -224,17 +206,8 @@ Found problem:
       val stream2 = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
-<<<<<<< HEAD
-<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = true,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = true, standaloneMode = false,
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = true,
->>>>>>> 484aa1a709 (From review)
-          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
->>>>>>> b626dbfe9d (Update voterset, test)
       assertEquals("All of the log directories are already formatted.%n".format(), stringAfterFirstLine(stream2.toString()))
     } finally Utils.delete(tempDir)
   }
@@ -259,28 +232,11 @@ Found problem:
 
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, bootstrapMetadata,
-<<<<<<< HEAD
-<<<<<<< HEAD
           MetadataVersion.latestTesting(), ignoreFormatted = false,
           updatedAdvertisedListenerEndpoints, null))
       val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
       assertTrue(stringAfterFirstLine(stream.toString()).contains("Snapshot written to %s".format(checkpointDir)))
       val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = true,
-          updatedAdvertisedListenerEndpoints))
-      val checkpointDir = tempDir + clusterMetadataDir
-      assertTrue(stringAfterFirstLine(stream.toString()).startsWith("Snapshot written to %s".format(checkpointDir) +
-        "\n" + "Formatting %s".format(tempDir)))
-      val checkpointFilePath = Paths.get(checkpointDir + "/"+ checkpointFileName)
->>>>>>> b626dbfe9d (Update voterset, test)
-=======
-          MetadataVersion.latestTesting(), ignoreFormatted = false,
-          updatedAdvertisedListenerEndpoints))
-      val checkpointDir = tempDir + "/" + CLUSTER_METADATA_TOPIC_NAME
-      assertTrue(stringAfterFirstLine(stream.toString()).contains("Snapshot written to %s".format(checkpointDir)))
-      val checkpointFilePath = Snapshots.snapshotPath(Paths.get(checkpointDir), BOOTSTRAP_SNAPSHOT_ID)
->>>>>>> 484aa1a709 (From review)
       assertTrue(checkpointFilePath.toFile.exists)
       assertTrue(Utils.readFileAsString(checkpointFilePath.toFile.getPath).contains(host))
     } finally Utils.delete(tempDir)
@@ -299,17 +255,8 @@ Found problem:
       build()
     val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
     StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata,
-<<<<<<< HEAD
-<<<<<<< HEAD
       MetadataVersion.latestTesting(), ignoreFormatted,
       advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null)
-=======
-      MetadataVersion.latestTesting(), ignoreFormatted, standaloneMode = false,
-=======
-      MetadataVersion.latestTesting(), ignoreFormatted,
->>>>>>> 484aa1a709 (From review)
-      advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint])
->>>>>>> b626dbfe9d (Update voterset, test)
   }
 
   @Test
@@ -363,8 +310,8 @@ Found problem:
     val config = new KafkaConfig(newSelfManagedProperties())
     assertEquals("Cluster ID string invalid does not appear to be a valid UUID: " +
       "Input string `invalid` decoded as 5 bytes, which is not equal to the expected " +
-        "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
-          () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
+      "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
+      () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
   }
 
   @Test
@@ -576,9 +523,9 @@ Found problem:
 
     // Validate we can add multiple SCRAM creds.
     scramRecords = parseAddScram("-S",
-    "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
-    "-S",
-    "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
+      "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]",
+      "-S",
+      "SCRAM-SHA-256=[name=george,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\",iterations=8192]")
 
     assertEquals(2, scramRecords.get.size)
 
@@ -691,7 +638,7 @@ Found problem:
       StorageTool.main(args)
     } catch {
       case e: StorageToolTestException => assertEquals("", exitString)
-      assertEquals(0, exitStatus)
+        assertEquals(0, exitStatus)
     } finally {
       Exit.resetExitProcedure()
     }
@@ -709,23 +656,14 @@ Found problem:
         buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), Seq(tempDir.toString), metaProperties,
-<<<<<<< HEAD
-<<<<<<< HEAD
           bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
           advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint], null))
-=======
-          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false, standaloneMode = false,
-=======
-          bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false,
->>>>>>> 484aa1a709 (From review)
-          advertisedListenerEndpoints = scala.collection.Seq.empty[kafka.cluster.EndPoint]))
->>>>>>> b626dbfe9d (Update voterset, test)
 
       val metaPropertiesFile = Paths.get(tempDir.toURI).resolve(MetaPropertiesEnsemble.META_PROPERTIES_NAME).toFile
       assertTrue(metaPropertiesFile.exists())
       val metaProps = new MetaProperties.Builder(
         PropertiesUtils.readPropertiesFile(metaPropertiesFile.getAbsolutePath())).
-          build()
+        build()
       assertTrue(metaProps.directoryId().isPresent())
       assertFalse(DirectoryId.reserved(metaProps.directoryId().get()))
     } finally Utils.delete(tempDir)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -634,7 +634,7 @@ Found problem:
     assertEquals(1, parseAddScram("-S", "SCRAM-SHA-256=[name=alice,password=alice,iterations=4096]").get.size)
 
     // Require 4096 <= iterations <= 16384
-    try assertEquals(1, parseAddScram("-S", 
+    try assertEquals(1, parseAddScram("-S",
       "SCRAM-SHA-256=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\",password=alice,iterations=16385]"))
     catch {
       case e: TerseFailure => assertEquals(s"The 'iterations' value must be <= 16384 for add-scram", e.getMessage)
@@ -738,7 +738,7 @@ Found problem:
       assertTrue(metaPropertiesFile.exists())
       val metaProps = new MetaProperties.Builder(
         PropertiesUtils.readPropertiesFile(metaPropertiesFile.getAbsolutePath())).
-        build()
+          build()
       assertTrue(metaProps.directoryId().isPresent())
       assertFalse(DirectoryId.reserved(metaProps.directoryId().get()))
     } finally Utils.delete(tempDir)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1178,7 +1178,7 @@ object TestUtils extends Logging {
     try {
       out = new PrintStream(stream)
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(metadataVersion, optionalMetadataRecords, "format command")
-      if (StorageTool.formatCommand(out, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted = false) != 0) {
+      if (StorageTool.formatCommand(out, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted = false, null, null) != 0) {
         throw new RuntimeException(stream.toString())
       }
       debug(s"Formatted storage directory(ies) ${directories}")

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1178,7 +1178,7 @@ object TestUtils extends Logging {
     try {
       out = new PrintStream(stream)
       val bootstrapMetadata = StorageTool.buildBootstrapMetadata(metadataVersion, optionalMetadataRecords, "format command")
-      if (StorageTool.formatCommand(out, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted = false, null, null) != 0) {
+      if (StorageTool.formatCommand(out, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted = false, listeners = null) != 0) {
         throw new RuntimeException(stream.toString())
       }
       debug(s"Formatted storage directory(ies) ${directories}")

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
@@ -269,6 +271,14 @@ public class QuorumConfig {
             .filter(Objects::nonNull)
             .map(entry -> new Node(entry.getKey(), entry.getValue().getHostString(), entry.getValue().getPort()))
             .collect(Collectors.toList());
+    }
+
+    //  to match pattern <replica-id>[-<replica-directory-id>]@<host>:<port>   replica-directory-id is optional
+    public static boolean validateControllerQuorumVoters(String controllerQuorumVoters) {
+        String regex = "(\\d+)(-\\d+)?@([a-zA-Z0-9.-]+):(\\d{1,5})";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(controllerQuorumVoters);
+        return matcher.matches();
     }
 
     public static class ControllerQuorumVotersValidator implements ConfigDef.Validator {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -416,12 +416,17 @@ public final class VoterSet {
     }
 
     /**
-     * Creates a voter set from a map of socket addresses.
+     * Creates a voter set from endpoints, node id and directory id.
      *
-     * @param voters the VoterNode by voter id
+     * @param endpoints endpoints
+     * @param nodeId node id
+     * @param directoryId directory id
      * @return the voter set
      */
-    public static VoterSet fromMap(Map<Integer, VoterNode> voters) {
+    public static VoterSet fromMap(Endpoints endpoints, int nodeId, Uuid directoryId) {
+        Map<Integer, VoterSet.VoterNode> voters = new HashMap<>();
+        voters.put(nodeId, new VoterSet.VoterNode(ReplicaKey.of(nodeId, directoryId), endpoints,
+                new SupportedVersionRange((short) 0, (short) 1)));
         return new VoterSet(voters);
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -16,14 +16,6 @@
  */
 package org.apache.kafka.raft.internals;
 
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.feature.SupportedVersionRange;
-import org.apache.kafka.common.message.VotersRecord;
-import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.raft.Endpoints;
-
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,6 +29,13 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.VotersRecord;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.utils.Utils;
 
 /**
  * A type for representing the set of voters for a topic partition.
@@ -98,19 +97,28 @@ public final class VoterSet {
     /**
      * Returns if the node is a voter in the set of voters.
      *
-     * If the voter set includes the directory id, the {@code replicaKey} directory id must match the
+     * If the voter set includes the directory id, the {@code nodeKey} directory id must match the
      * directory id specified by the voter set.
      *
      * If the voter set doesn't include the directory id ({@code Optional.empty()}), a node is in
      * the voter set as long as the node id matches. The directory id is not checked.
      *
-     * @param replicaKey the node's id and directory id
+     * @param nodeKey the node's id and directory id
      * @return true if the node is a voter in the voter set, otherwise false
      */
-    public boolean isVoter(ReplicaKey replicaKey) {
-        return Optional.ofNullable(voters.get(replicaKey.id()))
-            .map(node -> node.isVoter(replicaKey))
-            .orElse(false);
+    public boolean isVoter(ReplicaKey nodeKey) {
+        VoterNode node = voters.get(nodeKey.id());
+        if (node != null) {
+            if (node.voterKey().directoryId().isPresent()) {
+                return node.voterKey().directoryId().equals(nodeKey.directoryId());
+            } else {
+                // configured voter set doesn't include a directory id so it is a voter as long as the node id
+                // matches
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -130,39 +138,8 @@ public final class VoterSet {
         return voters.keySet();
     }
 
-    /**
-     * Returns all of the voters.
-     */
-    public Set<ReplicaKey> voterKeys() {
-        return voters
-            .values()
-            .stream()
-            .map(VoterNode::voterKey)
-            .collect(Collectors.toSet());
-    }
-
-    /**
-     * Returns all of the voters.
-     */
-    public Set<VoterNode> voterNodes() {
-        return voters
-            .values()
-            .stream()
-            .collect(Collectors.toSet());
-    }
-
-    /**
-     * Returns all of the endpoints for a voter id.
-     *
-     * {@code Endpoints.empty()} is returned if the id is not a voter.
-     *
-     * @param voterId the id of the voter
-     * @return the endpoints for the voter
-     */
-    public Endpoints listeners(int voterId) {
-        return Optional.ofNullable(voters.get(voterId))
-            .map(VoterNode::listeners)
-            .orElse(Endpoints.empty());
+    public Map<Integer, VoterNode> voters() {
+        return voters;
     }
 
     /**
@@ -217,7 +194,15 @@ public final class VoterSet {
         Function<VoterNode, VotersRecord.Voter> voterConvertor = voter -> {
             Iterator<VotersRecord.Endpoint> endpoints = voter
                 .listeners()
-                .votersRecordEndpoints();
+                .entrySet()
+                .stream()
+                .map(entry ->
+                    new VotersRecord.Endpoint()
+                        .setName(entry.getKey().value())
+                        .setHost(entry.getValue().getHostString())
+                        .setPort(entry.getValue().getPort())
+                )
+                .iterator();
 
             VotersRecord.KRaftVersionFeature kraftVersionFeature = new VotersRecord.KRaftVersionFeature()
                 .setMinSupportedVersion(voter.supportedKRaftVersion().min())
@@ -254,8 +239,17 @@ public final class VoterSet {
      * @return true if they have an overlapping majority, false otherwise
      */
     public boolean hasOverlappingMajority(VoterSet that) {
-        Set<ReplicaKey> thisReplicaKeys = voterKeys();
-        Set<ReplicaKey> thatReplicaKeys = that.voterKeys();
+        Set<ReplicaKey> thisReplicaKeys = voters
+            .values()
+            .stream()
+            .map(VoterNode::voterKey)
+            .collect(Collectors.toSet());
+
+        Set<ReplicaKey> thatReplicaKeys = that.voters
+            .values()
+            .stream()
+            .map(VoterNode::voterKey)
+            .collect(Collectors.toSet());
 
         if (Utils.diff(HashSet::new, thisReplicaKeys, thatReplicaKeys).size() > 1) return false;
         return Utils.diff(HashSet::new, thatReplicaKeys, thisReplicaKeys).size() <= 1;
@@ -283,12 +277,12 @@ public final class VoterSet {
 
     public static final class VoterNode {
         private final ReplicaKey voterKey;
-        private final Endpoints listeners;
+        private final Map<ListenerName, InetSocketAddress> listeners;
         private final SupportedVersionRange supportedKRaftVersion;
 
-        VoterNode(
+        public VoterNode(
             ReplicaKey voterKey,
-            Endpoints listeners,
+            Map<ListenerName, InetSocketAddress> listeners,
             SupportedVersionRange supportedKRaftVersion
         ) {
             this.voterKey = voterKey;
@@ -300,31 +294,7 @@ public final class VoterSet {
             return voterKey;
         }
 
-        /**
-         * Returns if the provided replica key matches this voter node.
-         *
-         * If the voter node includes the directory id, the {@code replicaKey} directory id must
-         * match the directory id specified by the voter set.
-         *
-         * If the voter node doesn't include the directory id ({@code Optional.empty()}), a replica
-         * is the voter as long as the node id matches. The directory id is not checked.
-         *
-         * @param replicaKey the replica key
-         * @return true if the replica key is the voter, otherwise false
-         */
-        public boolean isVoter(ReplicaKey replicaKey) {
-            if (voterKey.id() != replicaKey.id()) return false;
-
-            if (voterKey.directoryId().isPresent()) {
-                return voterKey.directoryId().equals(replicaKey.directoryId());
-            } else {
-                // configured voter set doesn't include a directory id so it is a voter as long as
-                // the ids match
-                return true;
-            }
-        }
-
-        Endpoints listeners() {
+        Map<ListenerName, InetSocketAddress> listeners() {
             return listeners;
         }
 
@@ -334,7 +304,7 @@ public final class VoterSet {
 
 
         Optional<InetSocketAddress> address(ListenerName listener) {
-            return listeners.address(listener);
+            return Optional.ofNullable(listeners.get(listener));
         }
 
         @Override
@@ -374,11 +344,26 @@ public final class VoterSet {
     public static VoterSet fromVotersRecord(VotersRecord voters) {
         HashMap<Integer, VoterNode> voterNodes = new HashMap<>(voters.voters().size());
         for (VotersRecord.Voter voter: voters.voters()) {
+            final Optional<Uuid> directoryId;
+            if (!voter.voterDirectoryId().equals(Uuid.ZERO_UUID)) {
+                directoryId = Optional.of(voter.voterDirectoryId());
+            } else {
+                directoryId = Optional.empty();
+            }
+
+            Map<ListenerName, InetSocketAddress> listeners = new HashMap<>(voter.endpoints().size());
+            for (VotersRecord.Endpoint endpoint : voter.endpoints()) {
+                listeners.put(
+                    ListenerName.normalised(endpoint.name()),
+                    InetSocketAddress.createUnresolved(endpoint.host(), endpoint.port())
+                );
+            }
+
             voterNodes.put(
                 voter.voterId(),
                 new VoterNode(
-                    ReplicaKey.of(voter.voterId(), voter.voterDirectoryId()),
-                    Endpoints.fromVotersRecordEndpoints(voter.endpoints()),
+                    ReplicaKey.of(voter.voterId(), directoryId),
+                    listeners,
                     new SupportedVersionRange(
                         voter.kRaftVersionFeature().minSupportedVersion(),
                         voter.kRaftVersionFeature().maxSupportedVersion()
@@ -405,24 +390,13 @@ public final class VoterSet {
                 Collectors.toMap(
                     Map.Entry::getKey,
                     entry -> new VoterNode(
-                        ReplicaKey.of(entry.getKey(), Uuid.ZERO_UUID),
-                        Endpoints.fromInetSocketAddresses(Collections.singletonMap(listener, entry.getValue())),
+                        ReplicaKey.of(entry.getKey(), Optional.empty()),
+                        Collections.singletonMap(listener, entry.getValue()),
                         new SupportedVersionRange((short) 0, (short) 0)
                     )
                 )
             );
 
         return new VoterSet(voterNodes);
-    }
-
-
-    /**
-     * Creates a voter set from a map of socket addresses.
-     *
-     * @param voters the VoterNode by voter id
-     * @return the voter set
-     */
-    public static VoterSet fromMap(Map<Integer, VoterNode> voters) {
-        return new VoterSet(voters);
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -16,6 +16,14 @@
  */
 package org.apache.kafka.raft.internals;
 
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.VotersRecord;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.Endpoints;
+
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,13 +37,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.feature.SupportedVersionRange;
-import org.apache.kafka.common.message.VotersRecord;
-import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.utils.Utils;
 
 /**
  * A type for representing the set of voters for a topic partition.
@@ -97,28 +98,19 @@ public final class VoterSet {
     /**
      * Returns if the node is a voter in the set of voters.
      *
-     * If the voter set includes the directory id, the {@code nodeKey} directory id must match the
+     * If the voter set includes the directory id, the {@code replicaKey} directory id must match the
      * directory id specified by the voter set.
      *
      * If the voter set doesn't include the directory id ({@code Optional.empty()}), a node is in
      * the voter set as long as the node id matches. The directory id is not checked.
      *
-     * @param nodeKey the node's id and directory id
+     * @param replicaKey the node's id and directory id
      * @return true if the node is a voter in the voter set, otherwise false
      */
-    public boolean isVoter(ReplicaKey nodeKey) {
-        VoterNode node = voters.get(nodeKey.id());
-        if (node != null) {
-            if (node.voterKey().directoryId().isPresent()) {
-                return node.voterKey().directoryId().equals(nodeKey.directoryId());
-            } else {
-                // configured voter set doesn't include a directory id so it is a voter as long as the node id
-                // matches
-                return true;
-            }
-        } else {
-            return false;
-        }
+    public boolean isVoter(ReplicaKey replicaKey) {
+        return Optional.ofNullable(voters.get(replicaKey.id()))
+            .map(node -> node.isVoter(replicaKey))
+            .orElse(false);
     }
 
     /**
@@ -138,8 +130,39 @@ public final class VoterSet {
         return voters.keySet();
     }
 
-    public Map<Integer, VoterNode> voters() {
-        return voters;
+    /**
+     * Returns all of the voters.
+     */
+    public Set<ReplicaKey> voterKeys() {
+        return voters
+            .values()
+            .stream()
+            .map(VoterNode::voterKey)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns all of the voters.
+     */
+    public Set<VoterNode> voterNodes() {
+        return voters
+            .values()
+            .stream()
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns all of the endpoints for a voter id.
+     *
+     * {@code Endpoints.empty()} is returned if the id is not a voter.
+     *
+     * @param voterId the id of the voter
+     * @return the endpoints for the voter
+     */
+    public Endpoints listeners(int voterId) {
+        return Optional.ofNullable(voters.get(voterId))
+            .map(VoterNode::listeners)
+            .orElse(Endpoints.empty());
     }
 
     /**
@@ -194,15 +217,7 @@ public final class VoterSet {
         Function<VoterNode, VotersRecord.Voter> voterConvertor = voter -> {
             Iterator<VotersRecord.Endpoint> endpoints = voter
                 .listeners()
-                .entrySet()
-                .stream()
-                .map(entry ->
-                    new VotersRecord.Endpoint()
-                        .setName(entry.getKey().value())
-                        .setHost(entry.getValue().getHostString())
-                        .setPort(entry.getValue().getPort())
-                )
-                .iterator();
+                .votersRecordEndpoints();
 
             VotersRecord.KRaftVersionFeature kraftVersionFeature = new VotersRecord.KRaftVersionFeature()
                 .setMinSupportedVersion(voter.supportedKRaftVersion().min())
@@ -239,17 +254,8 @@ public final class VoterSet {
      * @return true if they have an overlapping majority, false otherwise
      */
     public boolean hasOverlappingMajority(VoterSet that) {
-        Set<ReplicaKey> thisReplicaKeys = voters
-            .values()
-            .stream()
-            .map(VoterNode::voterKey)
-            .collect(Collectors.toSet());
-
-        Set<ReplicaKey> thatReplicaKeys = that.voters
-            .values()
-            .stream()
-            .map(VoterNode::voterKey)
-            .collect(Collectors.toSet());
+        Set<ReplicaKey> thisReplicaKeys = voterKeys();
+        Set<ReplicaKey> thatReplicaKeys = that.voterKeys();
 
         if (Utils.diff(HashSet::new, thisReplicaKeys, thatReplicaKeys).size() > 1) return false;
         return Utils.diff(HashSet::new, thatReplicaKeys, thisReplicaKeys).size() <= 1;
@@ -277,12 +283,12 @@ public final class VoterSet {
 
     public static final class VoterNode {
         private final ReplicaKey voterKey;
-        private final Map<ListenerName, InetSocketAddress> listeners;
+        private final Endpoints listeners;
         private final SupportedVersionRange supportedKRaftVersion;
 
-        public VoterNode(
+        VoterNode(
             ReplicaKey voterKey,
-            Map<ListenerName, InetSocketAddress> listeners,
+            Endpoints listeners,
             SupportedVersionRange supportedKRaftVersion
         ) {
             this.voterKey = voterKey;
@@ -294,7 +300,31 @@ public final class VoterSet {
             return voterKey;
         }
 
-        Map<ListenerName, InetSocketAddress> listeners() {
+        /**
+         * Returns if the provided replica key matches this voter node.
+         *
+         * If the voter node includes the directory id, the {@code replicaKey} directory id must
+         * match the directory id specified by the voter set.
+         *
+         * If the voter node doesn't include the directory id ({@code Optional.empty()}), a replica
+         * is the voter as long as the node id matches. The directory id is not checked.
+         *
+         * @param replicaKey the replica key
+         * @return true if the replica key is the voter, otherwise false
+         */
+        public boolean isVoter(ReplicaKey replicaKey) {
+            if (voterKey.id() != replicaKey.id()) return false;
+
+            if (voterKey.directoryId().isPresent()) {
+                return voterKey.directoryId().equals(replicaKey.directoryId());
+            } else {
+                // configured voter set doesn't include a directory id so it is a voter as long as
+                // the ids match
+                return true;
+            }
+        }
+
+        Endpoints listeners() {
             return listeners;
         }
 
@@ -304,7 +334,7 @@ public final class VoterSet {
 
 
         Optional<InetSocketAddress> address(ListenerName listener) {
-            return Optional.ofNullable(listeners.get(listener));
+            return listeners.address(listener);
         }
 
         @Override
@@ -344,26 +374,11 @@ public final class VoterSet {
     public static VoterSet fromVotersRecord(VotersRecord voters) {
         HashMap<Integer, VoterNode> voterNodes = new HashMap<>(voters.voters().size());
         for (VotersRecord.Voter voter: voters.voters()) {
-            final Optional<Uuid> directoryId;
-            if (!voter.voterDirectoryId().equals(Uuid.ZERO_UUID)) {
-                directoryId = Optional.of(voter.voterDirectoryId());
-            } else {
-                directoryId = Optional.empty();
-            }
-
-            Map<ListenerName, InetSocketAddress> listeners = new HashMap<>(voter.endpoints().size());
-            for (VotersRecord.Endpoint endpoint : voter.endpoints()) {
-                listeners.put(
-                    ListenerName.normalised(endpoint.name()),
-                    InetSocketAddress.createUnresolved(endpoint.host(), endpoint.port())
-                );
-            }
-
             voterNodes.put(
                 voter.voterId(),
                 new VoterNode(
-                    ReplicaKey.of(voter.voterId(), directoryId),
-                    listeners,
+                    ReplicaKey.of(voter.voterId(), voter.voterDirectoryId()),
+                    Endpoints.fromVotersRecordEndpoints(voter.endpoints()),
                     new SupportedVersionRange(
                         voter.kRaftVersionFeature().minSupportedVersion(),
                         voter.kRaftVersionFeature().maxSupportedVersion()
@@ -390,13 +405,23 @@ public final class VoterSet {
                 Collectors.toMap(
                     Map.Entry::getKey,
                     entry -> new VoterNode(
-                        ReplicaKey.of(entry.getKey(), Optional.empty()),
-                        Collections.singletonMap(listener, entry.getValue()),
+                        ReplicaKey.of(entry.getKey(), Uuid.ZERO_UUID),
+                        Endpoints.fromInetSocketAddresses(Collections.singletonMap(listener, entry.getValue())),
                         new SupportedVersionRange((short) 0, (short) 0)
                     )
                 )
             );
 
         return new VoterSet(voterNodes);
+    }
+
+    /**
+     * Creates a voter set from a map of socket addresses.
+     *
+     * @param voters the VoterNode by voter id
+     * @return the voter set
+     */
+    public static VoterSet fromMap(Map<Integer, VoterNode> voters) {
+        return new VoterSet(voters);
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -414,4 +414,15 @@ public final class VoterSet {
 
         return new VoterSet(voterNodes);
     }
+
+
+    /**
+     * Creates a voter set from a map of socket addresses.
+     *
+     * @param voters the VoterNode by voter id
+     * @return the voter set
+     */
+    public static VoterSet fromMap(Map<Integer, VoterNode> voters) {
+        return new VoterSet(voters);
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -37,6 +37,8 @@ public final class Snapshots {
     private static final Logger log = LoggerFactory.getLogger(Snapshots.class);
     public static final String SUFFIX = ".checkpoint";
     private static final String PARTIAL_SUFFIX = String.format("%s.part", SUFFIX);
+
+    public static final OffsetAndEpoch BOOTSTRAP_SNAPSHOT_ID = new OffsetAndEpoch(0, 0);
     public static final String DELETE_SUFFIX = String.format("%s.deleted", SUFFIX);
 
     private static final NumberFormat OFFSET_FORMATTER = NumberFormat.getInstance();

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumConfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QuorumConfigTest {
+
+    @Test
+    public void testValidControllerQuorumVoters() {
+        assertTrue(QuorumConfig.validateControllerQuorumVoters("1@hostname:12345"));
+        assertTrue(QuorumConfig.validateControllerQuorumVoters("1-2@hostname:12345")); // with replica directory id
+        assertTrue(QuorumConfig.validateControllerQuorumVoters("123@domain.com:54321"));
+        assertTrue(QuorumConfig.validateControllerQuorumVoters("10-20@sub.domain.com:8080")); // with replica directory id
+    }
+
+    @Test
+    public void testInvalidControllerQuorumVoters() {
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("1@hostname:123456")); // Port number too long
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("1@hostname:")); // Missing port number
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("1@hostname")); // Missing port number
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("hostname:12345")); // Missing replica id, @
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("1-2-3@hostname:12345")); // Invalid replica id range
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("1@host name:12345")); // Invalid hostname
+        assertFalse(QuorumConfig.validateControllerQuorumVoters("@hostname:12345")); // Missing replica id
+    }
+}


### PR DESCRIPTION
Resolves : https://issues.apache.org/jira/browse/KAFKA-16518

Adds a new argument "standalone" to kafka-storage.sh
If standalone mode, creates a checkpoint file in metadata dir ${kafkaConfig.metadataLogDir}/__cluster_metadata-0/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
