### PR TITLE
KAFKA-16921: migrate connect module to junit 5

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStoreTest.java
@@ -32,9 +32,11 @@ import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.LoggingContext;
 import org.apache.kafka.connect.util.TopicAdmin;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -49,16 +51,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class ConnectorOffsetBackingStoreTest {
 
     // Serialized
@@ -388,7 +391,7 @@ public class ConnectorOffsetBackingStoreTest {
     }
 
     private void assertNoPrematureCallbackInvocation(AtomicBoolean callbackInvoked) {
-        assertFalse("Store callback should not be invoked before underlying producer callback", callbackInvoked.get());
+        assertFalse(callbackInvoked.get(), "Store callback should not be invoked before underlying producer callback");
     }
 
     private void assertFlushFailure(AtomicBoolean callbackInvoked, AtomicReference<Object> callbackResult, AtomicReference<Throwable> callbackError, Future<Void> setFuture, boolean timeout) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -21,11 +21,13 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.util.Callback;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,9 +42,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.isNull;
@@ -51,7 +54,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class FileOffsetBackingStoreTest {
 
     private FileOffsetBackingStore store;
@@ -69,14 +73,14 @@ public class FileOffsetBackingStoreTest {
         FIRST_SET.put(null, null);
     }
 
-    @Before
-    public void setup() throws IOException {
+    @BeforeEach
+    public void setup() {
         converter = mock(Converter.class);
         // This is only needed for storing deserialized connector partitions, which we don't test in most of the cases here
         when(converter.toConnectData(anyString(), any(byte[].class))).thenReturn(new SchemaAndValue(null,
                 Arrays.asList("connector", Collections.singletonMap("partitionKey", "dummy"))));
         store = new FileOffsetBackingStore(converter);
-        tempFile = File.createTempFile("fileoffsetbackingstore", null);
+        tempFile = assertDoesNotThrow(() -> File.createTempFile("fileoffsetbackingstore", null));
         Map<String, String> props = new HashMap<>();
         props.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, tempFile.getAbsolutePath());
         props.put(StandaloneConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
@@ -84,9 +88,11 @@ public class FileOffsetBackingStoreTest {
         config = new StandaloneConfig(props);
         store.configure(config);
         store.start();
+        assertTrue(((ThreadPoolExecutor) store.executor).getThreadFactory()
+                .newThread(EMPTY_RUNNABLE).getName().startsWith(FileOffsetBackingStore.class.getSimpleName()));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws IOException {
         Files.deleteIfExists(tempFile.toPath());
     }
@@ -119,12 +125,6 @@ public class FileOffsetBackingStoreTest {
         Map<ByteBuffer, ByteBuffer> values = restore.get(Collections.singletonList(buffer("key"))).get();
         assertEquals(buffer("value"), values.get(buffer("key")));
         verify(setCallback).onCompletion(isNull(), isNull());
-    }
-
-    @Test
-    public void testThreadName() {
-        assertTrue(((ThreadPoolExecutor) store.executor).getThreadFactory()
-                .newThread(EMPTY_RUNNABLE).getName().startsWith(FileOffsetBackingStore.class.getSimpleName()));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -46,14 +46,16 @@ import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.AdditionalMatchers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 import java.time.Duration;
@@ -82,12 +84,12 @@ import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.INCLUDE_T
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.ONLY_FAILED_FIELD_NAME;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.READ_WRITE_TOTAL_TIMEOUT_MS;
 import static org.apache.kafka.connect.storage.KafkaConfigBackingStore.RESTART_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -103,7 +105,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class KafkaConfigBackingStoreTest {
     private static final String CLIENT_ID_BASE = "test-client-id-";
     private static final String TOPIC = "connect-configs";
@@ -228,7 +231,7 @@ public class KafkaConfigBackingStoreTest {
         configStorage.setUpdateListener(configUpdateListener);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         createStore();
     }
@@ -1314,11 +1317,9 @@ public class KafkaConfigBackingStoreTest {
         verify(configLog).start();
 
         ClusterConfigState configState = configStorage.snapshot();
-        expectRead(TARGET_STATE_KEYS.get(0), CONFIGS_SERIALIZED.get(0), TARGET_STATE_STARTED);
         // Should see a single connector with initial state paused
         assertEquals(TargetState.STARTED, configState.targetState(CONNECTOR_IDS.get(0)));
 
-        expectRead(TARGET_STATE_KEYS.get(0), CONFIGS_SERIALIZED.get(0), TARGET_STATE_STARTED);
         // on resume update listener shouldn't be called
         verify(configUpdateListener, never()).onConnectorTargetStateChange(anyString());
 
@@ -1629,7 +1630,6 @@ public class KafkaConfigBackingStoreTest {
                                         final Struct value) throws Exception {
         doReturn(serialized).when(converter).fromConnectData(eq(TOPIC), eq(valueSchema), eq(value));
         doReturn(producerFuture).when(configLog).sendWithReceipt(eq(configKey), eq(serialized));
-        doReturn(null).when(producerFuture).get(anyLong(), any(TimeUnit.class));
         doReturn(new SchemaAndValue(null, structToMap(value))).when(converter).toConnectData(eq(TOPIC), eq(serialized));
     }
 
@@ -1641,7 +1641,6 @@ public class KafkaConfigBackingStoreTest {
         final ArgumentCaptor<Struct> capturedRecord = ArgumentCaptor.forClass(Struct.class);
         when(converter.fromConnectData(eq(TOPIC), eq(valueSchema), capturedRecord.capture())).thenReturn(serialized);
         when(configLog.sendWithReceipt(configKey, serialized)).thenReturn(producerFuture);
-        when(producerFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(null);
         when(converter.toConnectData(TOPIC, serialized)).thenAnswer(invocation -> {
             assertEquals(dataFieldValue, capturedRecord.getValue().get(dataFieldName));
             // Note null schema because default settings for internal serialization are schema-less

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -32,14 +32,15 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -58,14 +59,14 @@ import java.util.function.Supplier;
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -76,7 +77,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class KafkaOffsetBackingStoreTest {
     private static final String CLIENT_ID_BASE = "test-client-id-";
     private static final String TOPIC = "connect-offsets";
@@ -132,8 +134,7 @@ public class KafkaOffsetBackingStoreTest {
     @Captor
     private ArgumentCaptor<Callback<Void>> storeLogCallbackArgumentCaptor;
 
-    @Before
-    public void setup() throws Exception {
+    public void setup(Boolean mockKeyConverter) {
         Supplier<TopicAdmin> adminSupplier = () -> {
             fail("Should not attempt to instantiate admin in these tests");
             // Should never be reached; only add this thrown exception to satisfy the compiler
@@ -141,8 +142,10 @@ public class KafkaOffsetBackingStoreTest {
         };
         Supplier<String> clientIdBase = () -> CLIENT_ID_BASE;
 
-        when(keyConverter.toConnectData(any(), any())).thenReturn(new SchemaAndValue(null,
-                Arrays.asList("connector", Collections.singletonMap("partitionKey", "dummy"))));
+        if (mockKeyConverter) {
+            when(keyConverter.toConnectData(any(), any())).thenReturn(new SchemaAndValue(null,
+                    Arrays.asList("connector", Collections.singletonMap("partitionKey", "dummy"))));
+        }
         store = spy(new KafkaOffsetBackingStore(adminSupplier, clientIdBase, keyConverter));
 
         doReturn(storeLog).when(store).createKafkaBasedLog(capturedTopic.capture(), capturedProducerProps.capture(),
@@ -150,7 +153,7 @@ public class KafkaOffsetBackingStoreTest {
                 capturedNewTopic.capture(), capturedAdminSupplier.capture(), any(), any());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         verifyNoMoreInteractions(storeLog);
     }
@@ -163,6 +166,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testStartStop() {
+        setup(false);
         props.put("offset.storage.min.insync.replicas", "3");
         props.put("offset.storage.max.message.bytes", "1001");
 
@@ -188,6 +192,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testReloadOnStart() {
+        setup(true);
         doAnswer(invocation -> {
             capturedConsumedCallback.getValue().onCompletion(null, new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TP0_KEY.array(), TP0_VALUE.array(),
                     new RecordHeaders(), Optional.empty()));
@@ -214,6 +219,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testGetSet() throws Exception {
+        setup(true);
         store.configure(mockConfig(props));
         store.start();
 
@@ -291,6 +297,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testGetSetNull() throws Exception {
+        setup(true);
         // Second get() should get the produced data and return the new values
         doAnswer(invocation -> {
             capturedConsumedCallback.getValue().onCompletion(null,
@@ -370,6 +377,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testSetFailure() {
+        setup(false);
         store.configure(mockConfig(props));
         store.start();
 
@@ -414,6 +422,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testConsumerPropertiesInsertedByDefaultWithExactlyOnceSourceEnabled() {
+        setup(false);
         props.put(EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "enabled");
         props.remove(ISOLATION_LEVEL_CONFIG);
 
@@ -427,6 +436,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testConsumerPropertiesOverrideUserSuppliedValuesWithExactlyOnceSourceEnabled() {
+        setup(false);
         props.put(EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "enabled");
         props.put(ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_UNCOMMITTED.toString());
 
@@ -440,6 +450,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testConsumerPropertiesNotInsertedByDefaultWithoutExactlyOnceSourceEnabled() {
+        setup(false);
         props.put(EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "disabled");
         props.remove(ISOLATION_LEVEL_CONFIG);
 
@@ -450,6 +461,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testConsumerPropertiesDoNotOverrideUserSuppliedValuesWithoutExactlyOnceSourceEnabled() {
+        setup(false);
         props.put(EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "disabled");
         props.put(ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_UNCOMMITTED.toString());
 
@@ -464,6 +476,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Test
     public void testClientIds() {
+        setup(false);
         store.configure(mockConfig(props));
 
         final String expectedClientId = CLIENT_ID_BASE + "offsets";

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
@@ -26,11 +26,13 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.TopicStatus;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,15 +48,16 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class KafkaStatusBackingStoreFormatTest {
 
     private static final String STATUS_TOPIC = "status-topic";
@@ -67,7 +70,7 @@ public class KafkaStatusBackingStoreFormatTest {
 
     private final KafkaBasedLog<String, byte[]> kafkaBasedLog = mock(KafkaBasedLog.class);
 
-    @Before
+    @BeforeEach
     public void setup() {
         time = new MockTime();
         JsonConverter converter = new JsonConverter();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -34,11 +34,13 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,10 +50,10 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -64,7 +66,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class KafkaStatusBackingStoreTest {
 
     private static final String STATUS_TOPIC = "status-topic";
@@ -78,7 +81,7 @@ public class KafkaStatusBackingStoreTest {
     Converter converter = mock(Converter.class);
     WorkerConfig workerConfig = mock(WorkerConfig.class);
 
-    @Before
+    @BeforeEach
     public void setup() {
         store = new KafkaStatusBackingStore(new MockTime(), converter, STATUS_TOPIC, () -> null, kafkaBasedLog);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryConfigBackingStoreTest.java
@@ -18,11 +18,13 @@ package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.util.ConnectorTaskId;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,10 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -44,7 +46,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class MemoryConfigBackingStoreTest {
 
     private static final List<String> CONNECTOR_IDS = Arrays.asList("connector1", "connector2");
@@ -60,7 +63,7 @@ public class MemoryConfigBackingStoreTest {
     private ConfigBackingStore.UpdateListener configUpdateListener;
     private final MemoryConfigBackingStore configStore = new MemoryConfigBackingStore();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         configStore.setUpdateListener(configUpdateListener);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/MemoryStatusBackingStoreTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.connect.storage;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.TaskStatus;
 import org.apache.kafka.connect.util.ConnectorTaskId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MemoryStatusBackingStoreTest {
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
@@ -17,12 +17,14 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.connect.util.Callback;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -42,11 +44,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class OffsetStorageWriterTest {
     private static final String NAMESPACE = "namespace";
     // Connect format - any types should be accepted here
@@ -66,13 +69,13 @@ public class OffsetStorageWriterTest {
 
     private ExecutorService service;
 
-    @Before
+    @BeforeEach
     public void setup() {
         writer = new OffsetStorageWriter(store, NAMESPACE, keyConverter, valueConverter);
         service = Executors.newFixedThreadPool(1);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         service.shutdownNow();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -32,8 +32,8 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OffsetUtilsTest {
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/test/util/ConcurrencyUtils.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/test/util/ConcurrencyUtils.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.test.util;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConcurrencyUtils {
 
@@ -33,7 +33,7 @@ public class ConcurrencyUtils {
      */
     public static void awaitLatch(CountDownLatch latch, long timeoutMs, String message) {
         try {
-            assertTrue(message, latch.await(timeoutMs, TimeUnit.MILLISECONDS));
+            assertTrue(latch.await(timeoutMs, TimeUnit.MILLISECONDS), message);
         } catch (InterruptedException e) {
             throw new AssertionError(message, e);
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -20,9 +20,11 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,12 +32,13 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class ConnectUtilsTest {
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.connect.util;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -29,17 +29,17 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConvertingFutureCallbackTest {
 
     private ExecutorService executor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         executor = Executors.newSingleThreadExecutor();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -38,12 +38,14 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,12 +64,12 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -76,7 +78,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class KafkaBasedLogTest {
 
     private static final String TOPIC = "connect-log";
@@ -134,7 +137,7 @@ public class KafkaBasedLogTest {
         records.add(record);
     };
 
-    @Before
+    @BeforeEach
     public void setUp() {
         store = new KafkaBasedLog<String, String>(TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, topicAdminSupplier, consumedCallback, time, initializer) {
             @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.connect.util;
 
 import org.apache.kafka.connect.util.LoggingContext.Scope;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -27,10 +27,10 @@ import org.slf4j.MDC;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LoggingContextTest {
 
@@ -47,7 +47,7 @@ public class LoggingContextTest {
 
     private Map<String, String> mdc;
 
-    @Before
+    @BeforeEach
     public void setup() {
         mdc = new HashMap<>();
         Map<String, String> existing = MDC.getCopyOfContextMap();
@@ -58,7 +58,7 @@ public class LoggingContextTest {
         MDC.put(EXTRA_KEY2, EXTRA_VALUE2);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         MDC.clear();
         MDC.setContextMap(mdc);
@@ -176,20 +176,20 @@ public class LoggingContextTest {
         String context = MDC.get(LoggingContext.CONNECTOR_CONTEXT);
         if (context != null) {
             assertEquals(
-                "Context should begin with connector name when the connector name is non-null",
                 connectorName != null,
-                context.startsWith("[" + connectorName)
+                context.startsWith("[" + connectorName),
+                "Context should begin with connector name when the connector name is non-null"
             );
             if (scope != null) {
-                assertTrue("Context should contain the scope", context.contains(scope.toString()));
+                assertTrue(context.contains(scope.toString()), "Context should contain the scope");
             }
             if (taskId != null) {
-                assertTrue("Context should contain the taskId", context.contains(taskId.toString()));
+                assertTrue(context.contains(taskId.toString()), "Context should contain the taskId");
             }
         } else {
-            assertNull("No logging context found, expected null connector name", connectorName);
-            assertNull("No logging context found, expected null task ID", taskId);
-            assertNull("No logging context found, expected null scope", scope);
+            assertNull(connectorName, "No logging context found, expected null connector name");
+            assertNull(taskId, "No logging context found, expected null task ID");
+            assertNull(scope, "No logging context found, expected null scope");
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -21,21 +21,24 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class RetryUtilTest {
 
     private final Time mockTime = new MockTime(10);
@@ -44,7 +47,7 @@ public class RetryUtilTest {
     private final Supplier<String> testMsg = () -> "Test";
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         mockCallable = Mockito.mock(Callable.class);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/SharedTopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/SharedTopicAdminTest.java
@@ -17,11 +17,12 @@
 package org.apache.kafka.connect.util;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -29,31 +30,27 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.kafka.connect.util.SharedTopicAdmin.DEFAULT_CLOSE_DURATION;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class SharedTopicAdminTest {
 
     private static final Map<String, Object> EMPTY_CONFIG = Collections.emptyMap();
 
     @Mock private TopicAdmin mockTopicAdmin;
     @Mock private Function<Map<String, Object>, TopicAdmin> factory;
-    private SharedTopicAdmin sharedAdmin;
-
-    @Before
-    public void beforeEach() {
-        when(factory.apply(anyMap())).thenReturn(mockTopicAdmin);
-        sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
-    }
 
     @Test
     public void shouldCloseWithoutBeingUsed() {
+        SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
+
         // When closed before being used
         sharedAdmin.close();
         // Then should not create or close admin
@@ -62,6 +59,9 @@ public class SharedTopicAdminTest {
 
     @Test
     public void shouldCloseAfterTopicAdminUsed() {
+        when(factory.apply(anyMap())).thenReturn(mockTopicAdmin);
+        SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
+
         // When used and then closed
         assertSame(mockTopicAdmin, sharedAdmin.topicAdmin());
         sharedAdmin.close();
@@ -71,6 +71,9 @@ public class SharedTopicAdminTest {
 
     @Test
     public void shouldCloseAfterTopicAdminUsedMultipleTimes() {
+        when(factory.apply(anyMap())).thenReturn(mockTopicAdmin);
+        SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
+
         // When used many times and then closed
         for (int i = 0; i != 10; ++i) {
             assertSame(mockTopicAdmin, sharedAdmin.topicAdmin());
@@ -82,6 +85,9 @@ public class SharedTopicAdminTest {
 
     @Test
     public void shouldCloseWithDurationAfterTopicAdminUsed() {
+        when(factory.apply(anyMap())).thenReturn(mockTopicAdmin);
+        SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
+
         // When used and then closed with a custom timeout
         Duration timeout = Duration.ofSeconds(1);
         assertSame(mockTopicAdmin, sharedAdmin.topicAdmin());
@@ -92,6 +98,8 @@ public class SharedTopicAdminTest {
 
     @Test
     public void shouldFailToGetTopicAdminAfterClose() {
+        SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(EMPTY_CONFIG, factory);
+
         // When closed
         sharedAdmin.close();
         // Then using the admin should fail

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/SinkUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/SinkUtilsTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,10 +28,10 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SinkUtilsTest {
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TableTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TableTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.kafka.connect.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TableTest {
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -56,7 +56,7 @@ import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.Duration;
@@ -73,14 +73,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("ClassDataAbstractionCoupling")
 public class TopicAdminTest {
@@ -541,10 +541,10 @@ public class TopicAdminTest {
             );
 
             Throwable cause = exception.getCause();
-            assertNotNull("cause of failure should be preserved", cause);
+            assertNotNull(cause, "cause of failure should be preserved");
             assertTrue(
-                    "cause of failure should be accurately reported; expected topic authorization error, but was " + cause,
-                    cause instanceof TopicAuthorizationException
+                    cause instanceof TopicAuthorizationException,
+                    "cause of failure should be accurately reported; expected topic authorization error, but was " + cause
             );
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicCreationTest.java
@@ -27,8 +27,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.transforms.Cast;
 import org.apache.kafka.connect.transforms.RegexRouter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,10 +63,10 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TopicCreationTest {
 
@@ -87,7 +87,7 @@ public class TopicCreationTest {
     Map<String, String> sourceProps;
     SourceConnectorConfig sourceConfig;
 
-    @Before
+    @BeforeEach
     public void setup() {
         workerProps = defaultWorkerProps();
         workerConfig = new DistributedConfig(workerProps);


### PR DESCRIPTION
* org.apache.kafka.connect.storage
* org.apache.kafka.connect.test.util
* org.apache.kafka.connect.util

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
