### PR TITLE
KAFKA-15133: only tick messageConversionsTimeMs if there are conversions

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -262,7 +262,9 @@ object RequestChannel extends Logging {
         m.responseSendTimeHist.update(Math.round(responseSendTimeMs))
         m.totalTimeHist.update(Math.round(totalTimeMs))
         m.requestBytesHist.update(sizeOfBodyInBytes)
-        m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
+        if (messageConversionsTimeMs > 0) {
+          m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
+        }
         m.tempMemoryBytesHist.foreach(_.update(temporaryMemoryBytes))
       }
 


### PR DESCRIPTION
RequestMetrics MessageConversionsTimeMs 
count was ticked even when no conversion occurs

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
