### PR TITLE
KAFKA-15045: (KIP-924 pt. 26) Only assign changelogged standbys by default

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -729,7 +729,7 @@ public final class TaskAssignmentUtils {
         final ConstrainedPrioritySet standbyTaskClientsByTaskLoad = standbyTaskPriorityListByLoad(streamStates, assignments);
 
         final Set<TaskId> statefulTaskIds = applicationState.allTasks().values().stream()
-            .filter(TaskInfo::isStateful)
+            .filter(taskInfo -> taskInfo.topicPartitions().stream().anyMatch(TaskTopicPartition::isChangelog))
             .map(TaskInfo::id)
             .collect(Collectors.toSet());
         final Map<TaskId, Integer> tasksToRemainingStandbys = statefulTaskIds.stream()
@@ -775,7 +775,7 @@ public final class TaskAssignmentUtils {
         final Map<ProcessId, KafkaStreamsState> streamStates = applicationState.kafkaStreamsStates(false);
 
         final Set<TaskId> statefulTaskIds = applicationState.allTasks().values().stream()
-            .filter(TaskInfo::isStateful)
+            .filter(taskInfo -> taskInfo.topicPartitions().stream().anyMatch(TaskTopicPartition::isChangelog))
             .map(TaskInfo::id)
             .collect(Collectors.toSet());
         final Map<TaskId, Integer> tasksToRemainingStandbys = statefulTaskIds.stream()


### PR DESCRIPTION
With KIP 924 enabled the default standby task assignment will now only assign standby tasks for changelogged tasks, instead of all stateful tasks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
