### PR TITLE
KAFKA-15259: Processing must continue with flush() + commitTnx(commitOption)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -794,7 +794,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * errors, this method will throw the last received exception immediately and the transaction will not be committed.
      * It should be noted that if <code>flush()</code> is called explicitly beforehand, this method will NOT throw any
      * exception related to the {@link #send(ProducerRecord)} calls. Since <code>flush()</code> clears the last received
-     * exception and returns the transaction from the error state.
+     * exception and transits the transaction out of error state.
      * So all {@link #send(ProducerRecord)} calls in a transaction must succeed in order for this method to succeed.
      * <p>
      * If the transaction is committed successfully and this method returns without throwing an exception, it is guaranteed
@@ -1223,7 +1223,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * of <code>flush()</code> is that any previously sent record will have completed (e.g. <code>Future.isDone() == true</code>).
      * A request is considered completed when it is successfully acknowledged
      * according to the <code>acks</code> configuration you have specified or else it results in an error.
-     * Additionally, this method clears the last exception in the transaction and returns the transaction from the error state.
+     * Additionally, this method clears the last exception in the transaction and transits the transaction out of error state.
      * <p>
      * Other threads can continue sending records while one thread is blocked waiting for a flush call to complete,
      * however no guarantee is made about the completion of records sent after the flush call begins.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -792,6 +792,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * <p>
      * Further, if any of the {@link #send(ProducerRecord)} calls which were part of the transaction hit irrecoverable
      * errors, this method will throw the last received exception immediately and the transaction will not be committed.
+     * It should be noted that if <code>flush()</code> is called explicitly beforehand, this method will NOT throw any
+     * exception related to the {@link #send(ProducerRecord)} calls. Since <code>flush()</code> clears the last received
+     * exception and returns the transaction back from the error state.
      * So all {@link #send(ProducerRecord)} calls in a transaction must succeed in order for this method to succeed.
      * <p>
      * If the transaction is committed successfully and this method returns without throwing an exception, it is guaranteed
@@ -1220,6 +1223,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * of <code>flush()</code> is that any previously sent record will have completed (e.g. <code>Future.isDone() == true</code>).
      * A request is considered completed when it is successfully acknowledged
      * according to the <code>acks</code> configuration you have specified or else it results in an error.
+     * Additionally, this method clears the last exception in the transaction and returns the transaction back from the error state.
      * <p>
      * Other threads can continue sending records while one thread is blocked waiting for a flush call to complete,
      * however no guarantee is made about the completion of records sent after the flush call begins.
@@ -1257,6 +1261,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         this.sender.wakeup();
         try {
             this.accumulator.awaitFlushCompletion();
+            if (transactionManager != null) {
+                transactionManager.maybeClearLastError();
+            }
         } catch (InterruptedException e) {
             throw new InterruptException("Flush interrupted.", e);
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -794,7 +794,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * errors, this method will throw the last received exception immediately and the transaction will not be committed.
      * It should be noted that if <code>flush()</code> is called explicitly beforehand, this method will NOT throw any
      * exception related to the {@link #send(ProducerRecord)} calls. Since <code>flush()</code> clears the last received
-     * exception and returns the transaction back from the error state.
+     * exception and returns the transaction from the error state.
      * So all {@link #send(ProducerRecord)} calls in a transaction must succeed in order for this method to succeed.
      * <p>
      * If the transaction is committed successfully and this method returns without throwing an exception, it is guaranteed
@@ -1223,7 +1223,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * of <code>flush()</code> is that any previously sent record will have completed (e.g. <code>Future.isDone() == true</code>).
      * A request is considered completed when it is successfully acknowledged
      * according to the <code>acks</code> configuration you have specified or else it results in an error.
-     * Additionally, this method clears the last exception in the transaction and returns the transaction back from the error state.
+     * Additionally, this method clears the last exception in the transaction and returns the transaction from the error state.
      * <p>
      * Other threads can continue sending records while one thread is blocked waiting for a flush call to complete,
      * however no guarantee is made about the completion of records sent after the flush call begins.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -67,6 +67,14 @@ public interface Producer<K, V> extends Closeable {
     void commitTransaction() throws ProducerFencedException;
 
     /**
+     * See {@link KafkaProducer#commitTransaction(KafkaProducer.CommitOption)}
+     */
+    default void commitTransaction(KafkaProducer.CommitOption option) throws ProducerFencedException {
+        commitTransaction(option);
+    }
+
+
+    /**
      * See {@link KafkaProducer#abortTransaction()}
      */
     void abortTransaction() throws ProducerFencedException;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -662,10 +662,14 @@ public class TransactionManager {
             transitionToFatalError(exception);
         } else if (isTransactional()) {
             if (canBumpEpoch() && !isCompleting()) {
-                prevEpochBumpRequired = epochBumpRequired;
+                if (currentState != State.ABORTABLE_ERROR) {
+                    prevEpochBumpRequired = epochBumpRequired;
+                }
                 epochBumpRequired = true;
             }
-            prevState = currentState;
+            if (currentState != State.ABORTABLE_ERROR) {
+                prevState = currentState;
+            }
             transitionToAbortableError(exception);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -671,7 +671,7 @@ public class TransactionManager {
     }
 
     public synchronized void maybeClearLastError() {
-        if (isTransactional() && hasError()) {
+        if (isTransactional() && currentState == State.ABORTABLE_ERROR) {
             lastError = null;
             currentState = prevState;
             epochBumpRequired = prevEpochBumpRequired;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1402,7 +1402,7 @@ public class KafkaProducerTest {
         }
     }
     @Test
-    public void testFlushAndCommitTransactionWithRecordTooLargeException() throws Exception {
+    public void testCommitTransactionWithClearErrorOptionWithRecordTooLargeException() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
@@ -1426,9 +1426,10 @@ public class KafkaProducerTest {
 
             client.prepareResponse(endTxnResponse(Errors.NONE));
             producer.beginTransaction();
+
             TestUtils.assertFutureError(producer.send(largeRecord), RecordTooLargeException.class);
             producer.flush();
-            assertDoesNotThrow(producer::commitTransaction);
+            assertDoesNotThrow(() -> producer.commitTransaction(KafkaProducer.CommitOption.CLEAR_SEND_ERRORS));
         }
     }
 
@@ -1470,7 +1471,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testFlushAndCommitTransactionWithMetadataTimeoutForMissingTopic() throws Exception {
+    public void testCommitTransactionWithClearErrorOptionWithMetadataTimeoutForMissingTopic() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
@@ -1503,7 +1504,7 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
             producer.flush();
-            assertDoesNotThrow(producer::commitTransaction);
+            assertDoesNotThrow(() -> producer.commitTransaction(KafkaProducer.CommitOption.CLEAR_SEND_ERRORS));
         }
     }
 
@@ -1545,7 +1546,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testFlushAndCommitTransactionWithMetadataTimeoutForPartitionOutOfRange() throws Exception {
+    public void testCommitTransactionWithClearErrorOptionWithMetadataTimeoutForPartitionOutOfRange() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
@@ -1578,7 +1579,7 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
             producer.flush();
-            assertDoesNotThrow(producer::commitTransaction);
+            assertDoesNotThrow(() -> producer.commitTransaction(KafkaProducer.CommitOption.CLEAR_SEND_ERRORS));
         }
     }
 
@@ -1622,7 +1623,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testFlushAndCommitTransactionWithSendToInvalidTopic() throws Exception {
+    public void testCommitTransactionWithClearErrorOptionWithSendToInvalidTopic() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
@@ -1650,14 +1651,14 @@ public class KafkaProducerTest {
                 topicMetadata);
         client.prepareMetadataUpdate(updateResponse);
 
-        try (Producer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
                 new StringSerializer(), metadata, client, null, time)) {
             producer.initTransactions();
             producer.beginTransaction();
 
             TestUtils.assertFutureError(producer.send(record), InvalidTopicException.class);
             producer.flush();
-            assertDoesNotThrow(producer::commitTransaction);
+            assertDoesNotThrow(() -> producer.commitTransaction(KafkaProducer.CommitOption.CLEAR_SEND_ERRORS));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1401,6 +1401,36 @@ public class KafkaProducerTest {
             assertThrows(KafkaException.class, producer::commitTransaction);
         }
     }
+    @Test
+    public void testFlushAndCommitTransactionWithRecordTooLargeException() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        configs.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000);
+        Time time = new MockTime(1);
+        MetadataResponse initialUpdateResponse = RequestTestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
+        ProducerMetadata metadata = mock(ProducerMetadata.class);
+        MockClient client = new MockClient(time, metadata);
+        client.updateMetadata(initialUpdateResponse);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        when(metadata.fetch()).thenReturn(onePartitionCluster);
+
+        String largeString = IntStream.range(0, 1000).mapToObj(i -> "*").collect(Collectors.joining());
+        ProducerRecord<String, String> largeRecord = new ProducerRecord<>(topic, "large string", largeString);
+
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, time)) {
+            producer.initTransactions();
+
+            client.prepareResponse(endTxnResponse(Errors.NONE));
+            producer.beginTransaction();
+            TestUtils.assertFutureError(producer.send(largeRecord), RecordTooLargeException.class);
+            producer.flush();
+            assertDoesNotThrow(producer::commitTransaction);
+        }
+    }
 
     @Test
     public void testCommitTransactionWithMetadataTimeoutForMissingTopic() throws Exception {
@@ -1436,6 +1466,44 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
+        }
+    }
+
+    @Test
+    public void testFlushAndCommitTransactionWithMetadataTimeoutForMissingTopic() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 60000);
+
+        // Create a record for a not-yet-created topic
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
+        ProducerMetadata metadata = mock(ProducerMetadata.class);
+
+        MockTime mockTime = new MockTime();
+
+        MockClient client = new MockClient(mockTime, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        when(metadata.fetch()).then(invocation -> {
+            invocationCount.incrementAndGet();
+            if (invocationCount.get() > 5) {
+                mockTime.setCurrentTimeMs(mockTime.milliseconds() + 70000);
+            }
+
+            return emptyCluster;
+        });
+
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, mockTime)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
+            producer.flush();
+            assertDoesNotThrow(producer::commitTransaction);
         }
     }
 
@@ -1477,6 +1545,44 @@ public class KafkaProducerTest {
     }
 
     @Test
+    public void testFlushAndCommitTransactionWithMetadataTimeoutForPartitionOutOfRange() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 60000);
+
+        // Create a record with a partition higher than the initial (outdated) partition range
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, 2, null, "value");
+        ProducerMetadata metadata = mock(ProducerMetadata.class);
+
+        MockTime mockTime = new MockTime();
+
+        MockClient client = new MockClient(mockTime, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        when(metadata.fetch()).then(invocation -> {
+            invocationCount.incrementAndGet();
+            if (invocationCount.get() > 5) {
+                mockTime.setCurrentTimeMs(mockTime.milliseconds() + 70000);
+            }
+
+            return onePartitionCluster;
+        });
+
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, mockTime)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
+            producer.flush();
+            assertDoesNotThrow(producer::commitTransaction);
+        }
+    }
+
+    @Test
     public void testCommitTransactionWithSendToInvalidTopic() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
@@ -1512,6 +1618,46 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), InvalidTopicException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
+        }
+    }
+
+    @Test
+    public void testFlushAndCommitTransactionWithSendToInvalidTopic() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "15000");
+
+        Time time = new MockTime();
+        MetadataResponse initialUpdateResponse = RequestTestUtils.metadataUpdateWith(1, emptyMap());
+        ProducerMetadata metadata = newMetadata(0, 0, Long.MAX_VALUE);
+        metadata.updateWithCurrentRequestVersion(initialUpdateResponse, false, time.milliseconds());
+
+        MockClient client = new MockClient(time, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        String invalidTopicName = "topic abc"; // Invalid topic name due to space
+        ProducerRecord<String, String> record = new ProducerRecord<>(invalidTopicName, "HelloKafka");
+
+        List<MetadataResponse.TopicMetadata> topicMetadata = new ArrayList<>();
+        topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.INVALID_TOPIC_EXCEPTION,
+                invalidTopicName, false, Collections.emptyList()));
+        MetadataResponse updateResponse =  RequestTestUtils.metadataResponse(
+                new ArrayList<>(initialUpdateResponse.brokers()),
+                initialUpdateResponse.clusterId(),
+                initialUpdateResponse.controller().id(),
+                topicMetadata);
+        client.prepareMetadataUpdate(updateResponse);
+
+        try (Producer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, time)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record), InvalidTopicException.class);
+            producer.flush();
+            assertDoesNotThrow(producer::commitTransaction);
         }
     }
 


### PR DESCRIPTION
This PR aims at transiting the transaction out of error state to enable the user to commit the transaction even if the latest `send(ProducerRecord)` failed with an error. This change will fix the bug reported [here](https://issues.apache.org/jira/browse/KAFKA-15259 ).
