### PR TITLE
KAFKA-16740: Added additional APIs for Share Partition

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -479,6 +479,55 @@ public class SharePartition {
         return future;
     }
 
+    /**
+     * Updates the cached state, start and end offsets of the share partition as per the new log
+     * start offset. The method is called when the log start offset is moved for the share partition.
+     *
+     * @param logStartOffset The new log start offset.
+     */
+    void updateCacheAndOffsets(long logStartOffset) {
+        // TODO: Provide implementation to update cache and offsets on LSO movement.
+    }
+
+    /**
+     * Checks if the number of records between startOffset and endOffset exceeds the record max
+     * in-flight limit.
+     *
+     * @return A boolean which indicates whether additional messages can be fetched for share partition.
+     */
+    boolean canFetchRecords() {
+        lock.readLock().lock();
+        long numRecords;
+        try {
+            if (cachedState.isEmpty()) {
+                numRecords = 0;
+            } else {
+                numRecords = this.endOffset - this.startOffset + 1;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+        return numRecords < maxInFlightMessages;
+    }
+
+    /**
+     * Prior to fetching records from the leader, the fetch lock is acquired to ensure that the same
+     * share partition does not enter a fetch queue while another one is being fetched within the queue.
+     * The fetch lock is released once the records are fetched from the leader.
+     *
+     * @return A boolean which indicates whether the fetch lock is acquired.
+     */
+    boolean maybeAcquireFetchLock() {
+        return fetchLock.compareAndSet(false, true);
+    }
+
+    /**
+     * Release the fetch lock once the records are fetched from the leader.
+     */
+    void releaseFetchLock() {
+        fetchLock.set(false);
+    }
+
     private void initialize() {
         // Initialize the partition.
         log.debug("Initializing share partition: {}-{}", groupId, topicIdPartition);


### PR DESCRIPTION
Added additional APIs for SharePartition which shall be used by SharePartitionManager.

The lock API on SharePartition helps not issuing concurrent fetch request on replica manager for same SharePartition. The updateCacheAndOffsets API helps to update the cache and corresponding offsets when an exception is encountered in SharePartitionManager because of movement of Log Start Offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
