### PR TITLE
MINOR: consumer log fixes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -694,7 +694,9 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             }
             if (memberInfo.memberEpoch.isPresent()) {
                 data = data.setGenerationIdOrMemberEpoch(memberInfo.memberEpoch.get());
-                lastEpochSentOnCommit = Optional.of(memberInfo.memberEpoch.get());
+                lastEpochSentOnCommit = memberInfo.memberEpoch;
+            } else {
+                lastEpochSentOnCommit = Optional.empty();
             }
 
             OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(data);
@@ -758,7 +760,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                     } else if (error == Errors.STALE_MEMBER_EPOCH) {
                         log.error("OffsetCommit failed for member {} with stale member epoch error. Last epoch sent: {}",
                             memberInfo.memberId.orElse("undefined"),
-                            lastEpochSentOnCommit.isPresent() ? lastEpochSentOnCommit.get() : "None");
+                            lastEpochSentOnCommit.isPresent() ? lastEpochSentOnCommit.get() : "undefined");
                         future.completeExceptionally(error.exception());
                         return;
                     } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
@@ -802,6 +804,13 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             }
         }
     }
+
+    // Visible for testing
+    Optional<Integer> lastEpochSentOnCommit() {
+        return lastEpochSentOnCommit;
+    }
+
+
 
     /**
      * Represents a request that can be retried or aborted, based on member ID and epoch

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -810,8 +810,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         return lastEpochSentOnCommit;
     }
 
-
-
     /**
      * Represents a request that can be retried or aborted, based on member ID and epoch
      * information.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -362,7 +362,7 @@ public class MembershipManagerImpl implements MembershipManager {
             metricsManager.recordRebalanceStarted(time.milliseconds());
         }
 
-        log.trace("Member {} with epoch {} transitioned from {} to {}.", memberId, memberEpoch, state, nextState);
+        log.info("Member {} with epoch {} transitioned from {} to {}.", memberId, memberEpoch, state, nextState);
         this.state = nextState;
     }
 
@@ -679,11 +679,11 @@ public class MembershipManagerImpl implements MembershipManager {
         CompletableFuture<Void> callbackResult = invokeOnPartitionsRevokedOrLostToReleaseAssignment();
         callbackResult.whenComplete((result, error) -> {
             if (error != null) {
-                log.error("Member {} callback to release assignment failed. Member will proceed " +
-                    "to send leave group heartbeat", memberId, error);
+                log.error("Member {} callback to release assignment failed. It will proceed " +
+                    "to clear its assignment and send a leave group heartbeat", memberId, error);
             } else {
-                log.debug("Member {} completed callback to release assignment and will send leave " +
-                    "group heartbeat", memberId);
+                log.info("Member {} completed callback to release assignment. It will proceed " +
+                    "to clear its assignment and send a leave group heartbeat", memberId);
             }
             // Clear the subscription, no matter if the callback execution failed or succeeded.
             subscriptions.unsubscribe();
@@ -718,7 +718,7 @@ public class MembershipManagerImpl implements MembershipManager {
         SortedSet<TopicPartition> droppedPartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
         droppedPartitions.addAll(subscriptions.assignedPartitions());
 
-        log.debug("Member {} is triggering callbacks to release assignment {} and leave group",
+        log.info("Member {} is triggering callbacks to release assignment {} and leave group",
             memberId, droppedPartitions);
 
         CompletableFuture<Void> callbackResult;
@@ -965,8 +965,8 @@ public class MembershipManagerImpl implements MembershipManager {
                         "\tCurrent owned partitions:                  {}\n" +
                         "\tAdded partitions (assigned - owned):       {}\n" +
                         "\tRevoked partitions (owned - assigned):     {}\n",
-                memberId,
                 resolvedAssignment.localEpoch,
+                memberId,
                 assignedTopicPartitions,
                 ownedPartitions,
                 addedPartitions,


### PR DESCRIPTION
Log improvements identified after running some stress tests:
- fix log that was showing member ID and epoch inverted
- adjust level for log tracking member transitions
- add last epoch provided in commit requests (to better track Stale epoch failures on auto-commit)
