### PR TITLE
KAFKA-16219: set SO_TIMEOUT in EchoServer

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
@@ -41,6 +41,8 @@ class EchoServer extends Thread {
     // JDK has a bug where sockets may get blocked on a read operation if they are closed during a TLS handshake.
     // While rare, this would cause the CI pipeline to hang. We set a reasonably high SO_TIMEOUT to avoid blocking reads
     // indefinitely.
+    // The JDK bug is similar to JDK-8274524, but it affects the else branch of SSLSocketImpl::bruteForceCloseInput
+    // which wasn't fixed in it. Please refer to the comments in KAFKA-16219 for more information.
     private static final int SO_TIMEOUT_MS = 30_000;
 
     public final int port;


### PR DESCRIPTION
We observed some runs of the test suite caused CI pipelines to stall.

A thread dump revealed that the test runner was blocked trying to read from a socket, while attempting to close the socket [[0]]. It turns out this is due to a bug in JDK which is very similar to [JDK-8274524](https://bugs.openjdk.org/browse/JDK-8274524), but it affects the else branch of `SSLSocketImpl::bruteForceCloseInput` [[1]] which wasn't fixed in JDK-8274524.

Since the blocking happens in a native call, the test runner's timeouts have no effect as the blocked test runner thread doesn't seem to respond to interrupts.

As a mitigation in Kafka's test suite, this change adds `SO_TIMEOUT` of 30 seconds to all the TLS sockets handled by `EchoServer`. The timeout is reasonably high for tests and a finite upper bound avoids infinite blocking of the test suite.

[0]: https://issues.apache.org/jira/secure/attachment/13066427/timeout.log
[1]: https://github.com/openjdk/jdk/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java#L808



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
