### PR TITLE
KAFKA-16547: Add test for DescribeConfigsOptions#includeDocumentation

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1001,6 +1001,30 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     assertTrue(assertThrows(classOf[ExecutionException], () => describeResult2.values.get(invalidTopic).get).getCause.isInstanceOf[InvalidTopicException])
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testIncludeDocumentation(quorum: String): Unit = {
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
+    client = createAdminClient
+
+    val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
+    val includeDescribe = new DescribeConfigsOptions().includeDocumentation(true)
+    var describeConfigs = client.describeConfigs(Collections.singletonList(resource), includeDescribe)
+    val pattern = """documentation=([^,]*?)\)""".r
+    var resourceToConfig = describeConfigs.all().get()
+    var matches = pattern.findAllMatchIn(resourceToConfig.toString)
+    var describes = matches.map(e => e.group(1)).toList
+    describes.foreach(e => assertNotNull(e))
+
+    val excludeDescribe = new DescribeConfigsOptions().includeDocumentation(false)
+    describeConfigs = client.describeConfigs(Collections.singletonList(resource), excludeDescribe)
+    resourceToConfig = describeConfigs.all().get()
+    matches = pattern.findAllMatchIn(resourceToConfig.toString)
+    describes = matches.map(e => e.group(1)).toList
+    describes.foreach(e => assertEquals("null", e))
+  }
+
   private def subscribeAndWaitForAssignment(topic: String, consumer: Consumer[Array[Byte], Array[Byte]]): Unit = {
     consumer.subscribe(Collections.singletonList(topic))
     TestUtils.pollUntilTrue(consumer, () => !consumer.assignment.isEmpty, "Expected non-empty assignment")

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1007,21 +1007,17 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     createTopic(topic)
     client = createAdminClient
 
-    val resources = Collections.singletonList(new ConfigResource(ConfigResource.Type.TOPIC, topic))
-    val includeDescribe = new DescribeConfigsOptions().includeDocumentation(true)
-    var describeConfigs = client.describeConfigs(resources, includeDescribe)
-    val pattern = """documentation=([^,]*?)\)""".r
-    var resourceToConfig = describeConfigs.all().get()
-    var matches = pattern.findAllMatchIn(resourceToConfig.toString)
-    var describes = matches.map(e => e.group(1)).toList
-    describes.foreach(e => assertNotEquals("null", e))
+    val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
+    val resources = Collections.singletonList(resource)
+    val includeDocumentation = new DescribeConfigsOptions().includeDocumentation(true)
+    var describeConfigs = client.describeConfigs(resources, includeDocumentation)
+    var configEntries = describeConfigs.values().get(resource).get().entries()
+    configEntries.forEach(e => assertNotNull(e.documentation()))
 
-    val excludeDescribe = new DescribeConfigsOptions().includeDocumentation(false)
-    describeConfigs = client.describeConfigs(resources, excludeDescribe)
-    resourceToConfig = describeConfigs.all().get()
-    matches = pattern.findAllMatchIn(resourceToConfig.toString)
-    describes = matches.map(e => e.group(1)).toList
-    describes.foreach(e => assertEquals("null", e))
+    val excludeDocumentation = new DescribeConfigsOptions().includeDocumentation(false)
+    describeConfigs = client.describeConfigs(resources, excludeDocumentation)
+    configEntries = describeConfigs.values().get(resource).get().entries()
+    configEntries.forEach(e => assertNull(e.documentation()))
   }
 
   private def subscribeAndWaitForAssignment(topic: String, consumer: Consumer[Array[Byte], Array[Byte]]): Unit = {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1004,13 +1004,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testIncludeDocumentation(quorum: String): Unit = {
-    val consumer = createConsumer()
-    subscribeAndWaitForAssignment(topic, consumer)
+    createTopic(topic)
     client = createAdminClient
 
-    val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
+    val resources = Collections.singletonList(new ConfigResource(ConfigResource.Type.TOPIC, topic))
     val includeDescribe = new DescribeConfigsOptions().includeDocumentation(true)
-    var describeConfigs = client.describeConfigs(Collections.singletonList(resource), includeDescribe)
+    var describeConfigs = client.describeConfigs(resources, includeDescribe)
     val pattern = """documentation=([^,]*?)\)""".r
     var resourceToConfig = describeConfigs.all().get()
     var matches = pattern.findAllMatchIn(resourceToConfig.toString)
@@ -1018,7 +1017,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     describes.foreach(e => assertNotEquals("null", e))
 
     val excludeDescribe = new DescribeConfigsOptions().includeDocumentation(false)
-    describeConfigs = client.describeConfigs(Collections.singletonList(resource), excludeDescribe)
+    describeConfigs = client.describeConfigs(resources, excludeDescribe)
     resourceToConfig = describeConfigs.all().get()
     matches = pattern.findAllMatchIn(resourceToConfig.toString)
     describes = matches.map(e => e.group(1)).toList

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1015,7 +1015,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     var resourceToConfig = describeConfigs.all().get()
     var matches = pattern.findAllMatchIn(resourceToConfig.toString)
     var describes = matches.map(e => e.group(1)).toList
-    describes.foreach(e => assertNotNull(e))
+    describes.foreach(e => assertNotEquals("null", e))
 
     val excludeDescribe = new DescribeConfigsOptions().includeDocumentation(false)
     describeConfigs = client.describeConfigs(Collections.singletonList(resource), excludeDescribe)


### PR DESCRIPTION
We currently do not have tests for the `includeDocumentation` query option.

If the option is set to false, `ConfigEntry[documentation]` should be null. Otherwise, it should return the configuration documentation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
