### PR TITLE
KAFKA-16970: Fix hash implementation of `ScramCredentialValue`, `ScramCredentialData`, and `ContextualRecord`

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ScramControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ScramControlManager.java
@@ -131,7 +131,12 @@ public class ScramControlManager {
 
         @Override
         public int hashCode() {
-            return Objects.hash(salt, storedKey, serverKey, iterations);
+            return Objects.hash(
+                Arrays.hashCode(salt),
+                Arrays.hashCode(storedKey),
+                Arrays.hashCode(serverKey),
+                iterations
+            );
         }
 
         @Override

--- a/metadata/src/main/java/org/apache/kafka/metadata/ScramCredentialData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/ScramCredentialData.java
@@ -92,7 +92,12 @@ public final class ScramCredentialData {
 
     @Override
     public int hashCode() {
-        return Objects.hash(salt, storedKey, serverKey, iterations);
+        return Objects.hash(
+            Arrays.hashCode(salt),
+            Arrays.hashCode(storedKey),
+            Arrays.hashCode(serverKey),
+            iterations
+        );
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/ScramCredentialValueTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ScramCredentialValueTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.kafka.controller.ScramControlManager.ScramCredentialValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ScramCredentialValueTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        byte[] salt1 = {1, 2, 3};
+        byte[] storedKey1 = {4, 5, 6};
+        byte[] serverKey1 = {7, 8, 9};
+        int iterations1 = 1000;
+
+        byte[] salt2 = {1, 2, 3};
+        byte[] storedKey2 = {4, 5, 6};
+        byte[] serverKey2 = {7, 8, 9};
+        int iterations2 = 1000;
+
+        ScramCredentialValue credential1 = new ScramCredentialValue(salt1, storedKey1, serverKey1, iterations1);
+        ScramCredentialValue credential2 = new ScramCredentialValue(salt2, storedKey2, serverKey2, iterations2);
+
+        assertEquals(credential1, credential2);
+        assertEquals(credential1.hashCode(), credential2.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsDifferentContent() {
+        byte[] salt1 = {1, 2, 3};
+        byte[] storedKey1 = {4, 5, 6};
+        byte[] serverKey1 = {7, 8, 9};
+        int iterations1 = 1000;
+
+        byte[] salt2 = {9, 8, 7};
+        byte[] storedKey2 = {6, 5, 4};
+        byte[] serverKey2 = {3, 2, 1};
+        int iterations2 = 2000;
+
+        ScramCredentialValue credential1 = new ScramCredentialValue(salt1, storedKey1, serverKey1, iterations1);
+        ScramCredentialValue credential2 = new ScramCredentialValue(salt2, storedKey2, serverKey2, iterations2);
+
+        assertNotEquals(credential1, credential2);
+        assertNotEquals(credential1.hashCode(), credential2.hashCode());
+    }
+
+    @Test
+    public void testEqualsSameInstance() {
+        byte[] salt = {1, 2, 3};
+        byte[] storedKey = {4, 5, 6};
+        byte[] serverKey = {7, 8, 9};
+        int iterations = 1000;
+
+        ScramCredentialValue credential = new ScramCredentialValue(salt, storedKey, serverKey, iterations);
+
+        // Test equals method for same instance
+        assertEquals(credential, credential);
+        assertEquals(credential.hashCode(), credential.hashCode());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
@@ -95,6 +95,59 @@ public class ScramCredentialDataTest {
         testRoundTrip(SCRAMCREDENTIALDATA.get(2));
     }
 
+    @Test
+    public void testEqualsAndHashCode() {
+        byte[] salt1 = {1, 2, 3};
+        byte[] storedKey1 = {4, 5, 6};
+        byte[] serverKey1 = {7, 8, 9};
+        int iterations1 = 1000;
+
+        byte[] salt2 = {1, 2, 3};
+        byte[] storedKey2 = {4, 5, 6};
+        byte[] serverKey2 = {7, 8, 9};
+        int iterations2 = 1000;
+
+        ScramCredentialData data1 = new ScramCredentialData(salt1, storedKey1, serverKey1, iterations1);
+        ScramCredentialData data2 = new ScramCredentialData(salt2, storedKey2, serverKey2, iterations2);
+
+        assertEquals(data1, data2);
+        assertEquals(data1.hashCode(), data2.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsDifferentContent() {
+        byte[] salt1 = {1, 2, 3};
+        byte[] storedKey1 = {4, 5, 6};
+        byte[] serverKey1 = {7, 8, 9};
+        int iterations1 = 1000;
+
+        byte[] salt2 = {9, 8, 7};
+        byte[] storedKey2 = {6, 5, 4};
+        byte[] serverKey2 = {3, 2, 1};
+        int iterations2 = 2000;
+
+        ScramCredentialData data1 = new ScramCredentialData(salt1, storedKey1, serverKey1, iterations1);
+        ScramCredentialData data2 = new ScramCredentialData(salt2, storedKey2, serverKey2, iterations2);
+
+        assertNotEquals(data1, data2);
+        assertNotEquals(data1.hashCode(), data2.hashCode());
+    }
+
+    @Test
+    public void testEqualsSameInstance() {
+        byte[] salt = {1, 2, 3};
+        byte[] storedKey = {4, 5, 6};
+        byte[] serverKey = {7, 8, 9};
+        int iterations = 1000;
+
+        ScramCredentialData data = new ScramCredentialData(salt, storedKey, serverKey, iterations);
+
+        // Test equals method for same instance
+        assertEquals(data, data);
+        assertEquals(data.hashCode(), data.hashCode());
+    }
+
+
     private void testRoundTrip(ScramCredentialData scramCredentialData) {
         ApiMessageAndVersion messageAndVersion = new ApiMessageAndVersion(
             scramCredentialData.toRecord("alice", ScramMechanism.SCRAM_SHA_256), (short) 0);

--- a/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
@@ -147,7 +147,6 @@ public class ScramCredentialDataTest {
         assertEquals(data.hashCode(), data.hashCode());
     }
 
-
     private void testRoundTrip(ScramCredentialData scramCredentialData) {
         ApiMessageAndVersion messageAndVersion = new ApiMessageAndVersion(
             scramCredentialData.toRecord("alice", ScramMechanism.SCRAM_SHA_256), (short) 0);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ContextualRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ContextualRecord.java
@@ -67,7 +67,6 @@ public class ContextualRecord {
     /**
      * See {@link ProcessorRecordContext#hashCode()}
      */
-    @Deprecated
     @Override
     public int hashCode() {
         throw new UnsupportedOperationException("ContextualRecord.ProcessorRecordContext is unsafe for use in Hash collections "

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ContextualRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ContextualRecord.java
@@ -64,9 +64,14 @@ public class ContextualRecord {
             Objects.equals(recordContext, that.recordContext);
     }
 
+    /**
+     * See {@link ProcessorRecordContext#hashCode()}
+     */
+    @Deprecated
     @Override
     public int hashCode() {
-        return Objects.hash(value, recordContext);
+        throw new UnsupportedOperationException("ContextualRecord.ProcessorRecordContext is unsafe for use in Hash collections "
+            + "due to the mutable Headers field");
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ContextualRecordTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ContextualRecordTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ContextualRecordTest {
+
+    @Test
+    public void testEquals() {
+        final byte[] value1 = {1, 2, 3};
+        final byte[] value2 = {1, 2, 3};
+        final long timestamp = Time.SYSTEM.milliseconds();
+        final ProcessorRecordContext context1 = new ProcessorRecordContext(timestamp, 12345L, 0, "test-topic", new RecordHeaders());
+        final ProcessorRecordContext context2 = new ProcessorRecordContext(timestamp, 12345L, 0, "test-topic", new RecordHeaders());
+
+        final ContextualRecord record1 = new ContextualRecord(value1, context1);
+        final ContextualRecord record2 = new ContextualRecord(value2, context2);
+
+        assertEquals(record1, record2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentContent() {
+        final byte[] value1 = {1, 2, 3};
+        final byte[] value2 = {4, 5, 6};
+        final long timestamp = Time.SYSTEM.milliseconds();
+        final ProcessorRecordContext context1 = new ProcessorRecordContext(timestamp, 12345L, 0, "test-topic", new RecordHeaders());
+        final ProcessorRecordContext context2 = new ProcessorRecordContext(timestamp, 12345L, 0, "test-topic", new RecordHeaders());
+
+        final ContextualRecord record1 = new ContextualRecord(value1, context1);
+        final ContextualRecord record2 = new ContextualRecord(value2, context2);
+
+        assertNotEquals(record1, record2);
+    }
+
+    @Test
+    public void testEqualsSameInstance() {
+        final byte[] value = {1, 2, 3};
+        final ProcessorRecordContext context = new ProcessorRecordContext(Time.SYSTEM.milliseconds(), 12345L, 0, "test-topic", new RecordHeaders());
+
+        final ContextualRecord record = new ContextualRecord(value, context);
+
+        // Test equals method for same instance
+        assertEquals(record, record);
+    }
+
+    @Test
+    public void testHashCodeThrowsException() {
+        final byte[] value = {1, 2, 3};
+        final ProcessorRecordContext context = new ProcessorRecordContext(Time.SYSTEM.milliseconds(), 12345L, 0, "test-topic", new RecordHeaders());
+        final ContextualRecord record = new ContextualRecord(value, context);
+
+        assertThrows(UnsupportedOperationException.class, record::hashCode);
+    }
+}


### PR DESCRIPTION
All of them derive the hash code from the reference of Array rather than the content of Array, which does not adhere to best practices. If `equals` returns true, they should have the same hash code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
