### PR TITLE
KAFKA-16973; Fix caught-up condition

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -60,7 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
@@ -900,9 +899,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 if (currentBatch != null) {
                     currentBatch.deferredEvents.add(event);
                 } else {
-                    OptionalLong pendingOffset = deferredEventQueue.highestPendingOffset();
-                    if (pendingOffset.isPresent()) {
-                        deferredEventQueue.add(pendingOffset.getAsLong(), event);
+                    if (coordinator.lastCommittedOffset() < coordinator.lastWrittenOffset()) {
+                        deferredEventQueue.add(coordinator.lastWrittenOffset(), event);
                     } else {
                         event.complete(null);
                     }


### PR DESCRIPTION
When a write operation does not have any records, the coordinator runtime checked whether the state machine is caught-up to decide whether the operation should wait until the state machine is committed up to the operation point or the operation should be completed. The current implementation assumes that there will always be a pending write operation waiting in the deferred queue when the state machine is not fully caught-up yet. This is true except when the state machine is just loaded and not caught-up yet.

This patch fixes the issue by always comparing the last written offset and the last committed offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
