### PR TITLE
KAFKA-10787: Apply spotless to `streams:examples` and `streams-scala`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,9 +204,7 @@ def determineCommitId() {
 def excludedSpotlessModules = [':clients',
                                ':connect:runtime',
                                ':core',
-                               ':streams',
-                               ':streams:examples',
-                               ':streams:streams-scala']
+                               ':streams']
 
 
 apply from: file('wrapper.gradle')

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonTimestampExtractor.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonTimestampExtractor.java
@@ -16,9 +16,10 @@
  */
 package org.apache.kafka.streams.examples.pageview;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.TimestampExtractor;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A timestamp extractor implementation that tries to extract event time from

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewTypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewTypedDemo.java
@@ -16,9 +16,6 @@
  */
 package org.apache.kafka.streams.examples.pageview;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -30,11 +27,15 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -16,10 +16,6 @@
  */
 package org.apache.kafka.streams.examples.pageview;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.time.Duration;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -27,17 +23,22 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.json.JsonDeserializer;
 import org.apache.kafka.connect.json.JsonSerializer;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.Duration;
 import java.util.Properties;
 
 /**

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
@@ -16,12 +16,6 @@
  */
 package org.apache.kafka.streams.examples.wordcount;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
@@ -35,6 +29,13 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Demonstrates, using the low-level Processor APIs, how to implement the WordCount program

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/docs/DeveloperGuideTesting.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/docs/DeveloperGuideTesting.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountDemoTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountDemoTest.java
@@ -22,10 +22,11 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.test.TestUtils;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountTransformerTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountTransformerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.processor.api.MockProcessorContext;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.StoreBuilder;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;


### PR DESCRIPTION
This PR is sub PR from https://github.com/apache/kafka/pull/16097.
It is part of a series of changes to progressively apply [spotless plugin(import-order)] across all modules. In this step, the plugin is activated in the 
* stream:test-utils
* streams:upgrade-system-tests-0100

## Module and history 

> Please see the table below for the historical changes related to applying the Spotless plugin

| module        | apply |  related PR  |
| -------------- | ------------------- | ------------------- |
| :clients | ❌    | future |
| :connect:api | ✅    | https://github.com/apache/kafka/pull/16299 |
| :connect:basic-auth-extension | ✅    | https://github.com/apache/kafka/pull/16299 |
| :connect:file | ✅    | https://github.com/apache/kafka/pull/16299 |
| :connect:json | ✅   | https://github.com/apache/kafka/pull/16299 |
| :connect:mirror | ✅   | https://github.com/apache/kafka/pull/16299 |
| :connect:mirror-client | ✅   | https://github.com/apache/kafka/pull/16299 |
| :connect:runtime | ❌    | future |
| :connect:test-plugins | ✅   | https://github.com/apache/kafka/pull/16299 |
| :connect:transforms | ✅   | https://github.com/apache/kafka/pull/16299 |
| :core | ❌    | future |
| :examples |  ✅    | https://github.com/apache/kafka/pull/16296 |
| :generator |  ✅     | https://github.com/apache/kafka/pull/16296 |
| :group-coordinator:group-coordinator-api | ✅   | https://github.com/apache/kafka/pull/16298 |
| :group-coordinator | ✅  | https://github.com/apache/kafka/pull/16298 |
| :jmh-benchmarks |  ✅     | https://github.com/apache/kafka/pull/16296 |
| :log4j-appender |  ✅     | https://github.com/apache/kafka/pull/16296 |
| :metadata | ✅     | https://github.com/apache/kafka/pull/16297 |
| :server | ✅     | https://github.com/apache/kafka/pull/16297 |
| :shell |  ✅     | https://github.com/apache/kafka/pull/16296 |
| :storage | ✅     | https://github.com/apache/kafka/pull/16297 |
| :storage:storage-api | ✅     | https://github.com/apache/kafka/pull/16297 |
| :streams | ❌     | future |
| :streams:examples |  ✅   | https://github.com/apache/kafka/pull/16378 |
| :streams:streams-scala | ✅    | https://github.com/apache/kafka/pull/16378 |
| :streams:test-utils |  ✅     | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-0100 |  ✅     | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-0101 | ✅    | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-0102 | ✅    | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-0110 | ✅    | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-10 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-11 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-20 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-21 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-22 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-23 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-24 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-25 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-26 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-27 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-28 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-30 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-31 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-32 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-33 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-34 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-35 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-36 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :streams:upgrade-system-tests-37 | ✅   | https://github.com/apache/kafka/pull/16357 |
| :trogdor |  ✅       | https://github.com/apache/kafka/pull/16296 |
| :raft |  ✅    | https://github.com/apache/kafka/pull/16278 |
| :server-common | ✅    | https://github.com/apache/kafka/pull/16172 |
| :transaction-coordinator | ✅    | https://github.com/apache/kafka/pull/16172 |
| :tools |  ✅   |  https://github.com/apache/kafka/pull/16262  |
| :tools:tools-api | ✅   | https://github.com/apache/kafka/pull/16262 |

## How to test:
We can run `./gradlew spotlessCheck`  check for code that does not meet requirements. 
If we get report that error , we can run `./gradlew spotlessApply` to review my code.
In this PR, all change(exclude `build.gradle`) ` by `spotlessApply` 