### PR TITLE
KAFKA-15774: use the default dsl store supplier for fkj subscriptions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.TopologyException;
@@ -71,13 +70,8 @@ import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
-import org.apache.kafka.streams.state.DslKeyValueParams;
-import org.apache.kafka.streams.state.DslStoreSuppliers;
-import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
-import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -71,6 +71,9 @@ import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
+import org.apache.kafka.streams.state.DslKeyValueParams;
+import org.apache.kafka.streams.state.DslStoreSuppliers;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -1184,25 +1187,20 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         copartitionedRepartitionSources.add(subscriptionSource.nodeName());
         builder.internalTopologyBuilder.copartitionSources(copartitionedRepartitionSources);
 
+        final String subscriptionStoreName = renamed
+            .suffixWithOrElseGet("-subscription-store", builder, FK_JOIN_STATE_STORE_NAME);
+        builder.addStateStore(
+            new SubscriptionStoreFactory<>(subscriptionStoreName, subscriptionWrapperSerde));
 
-        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>>> subscriptionStore =
-            Stores.timestampedKeyValueStoreBuilder(
-                Stores.persistentTimestampedKeyValueStore(
-                    renamed.suffixWithOrElseGet("-subscription-store", builder, FK_JOIN_STATE_STORE_NAME)
-                ),
-                new Serdes.BytesSerde(),
-                subscriptionWrapperSerde
-            );
-        builder.addStateStore(new StoreBuilderWrapper(subscriptionStore));
-
+        final String subscriptionReceiveName = renamed.suffixWithOrElseGet(
+            "-subscription-receive", builder, SUBSCRIPTION_PROCESSOR);
         final StatefulProcessorNode<KO, SubscriptionWrapper<K>> subscriptionReceiveNode =
             new StatefulProcessorNode<>(
+                subscriptionReceiveName,
                 new ProcessorParameters<>(
-                    new SubscriptionReceiveProcessorSupplier<>(subscriptionStore, combinedKeySchema),
-                    renamed.suffixWithOrElseGet("-subscription-receive", builder, SUBSCRIPTION_PROCESSOR)
-                ),
-                Collections.singleton(subscriptionStore),
-                Collections.emptySet()
+                    new SubscriptionReceiveProcessorSupplier<>(subscriptionStoreName, combinedKeySchema),
+                    subscriptionReceiveName),
+                new String[]{subscriptionStoreName}
             );
         builder.addGraphNode(subscriptionSource, subscriptionReceiveNode);
 
@@ -1220,13 +1218,14 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             );
         builder.addGraphNode(subscriptionReceiveNode, subscriptionJoinNode);
 
+        final String foreignTableJoinName = renamed
+            .suffixWithOrElseGet("-foreign-join-subscription", builder, SUBSCRIPTION_PROCESSOR);
         final StatefulProcessorNode<KO, Change<VO>> foreignTableJoinNode = new ForeignTableJoinNode<>(
             new ProcessorParameters<>(
-                new ForeignTableJoinProcessorSupplier<>(subscriptionStore, combinedKeySchema),
-                renamed.suffixWithOrElseGet("-foreign-join-subscription", builder, SUBSCRIPTION_PROCESSOR)
+                new ForeignTableJoinProcessorSupplier<>(subscriptionStoreName, combinedKeySchema),
+                foreignTableJoinName
             ),
-            Collections.singleton(subscriptionStore),
-            Collections.emptySet()
+            new String[]{subscriptionStoreName}
         );
         builder.addGraphNode(((KTableImpl<KO, VO, ?>) foreignKeyTable).graphNode, foreignTableJoinNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SubscriptionStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SubscriptionStoreFactory.java
@@ -1,0 +1,107 @@
+package org.apache.kafka.streams.kstream.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
+import org.apache.kafka.streams.state.DslKeyValueParams;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+
+public class SubscriptionStoreFactory<K> extends AbstractConfigurableStoreFactory {
+  private final String name;
+  private final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde;
+  private final Map<String, String> logConfig = new HashMap<>();
+  private boolean loggingEnabled = true;
+
+  public SubscriptionStoreFactory(
+      final String name,
+      final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde
+  ) {
+    super(null);
+    this.name = name;
+    this.subscriptionWrapperSerde = subscriptionWrapperSerde;
+  }
+
+  @Override
+  public StateStore build() {
+    StoreBuilder<?> builder;
+    if (dslStoreSuppliers() != null) {
+      builder = Stores.timestampedKeyValueStoreBuilder(
+          dslStoreSuppliers().keyValueStore(new DslKeyValueParams(name, true)),
+          new Serdes.BytesSerde(),
+          subscriptionWrapperSerde
+      );
+    } else {
+      builder = Stores.timestampedKeyValueStoreBuilder(
+          Stores.persistentTimestampedKeyValueStore(name),
+          new Serdes.BytesSerde(),
+          subscriptionWrapperSerde
+      );
+    }
+    if (loggingEnabled) {
+      builder = builder.withLoggingEnabled(logConfig);
+    } else {
+      builder = builder.withLoggingDisabled();
+    }
+    builder = builder.withCachingDisabled();
+    return builder.build();
+  }
+
+  @Override
+  public long retentionPeriod() {
+    throw new IllegalStateException("retentionPeriod is not supported when not a window store");
+  }
+
+  @Override
+  public long historyRetention() {
+    throw new IllegalStateException(
+        "historyRetention is not supported when not a versioned store");
+  }
+
+  @Override
+  public boolean loggingEnabled() {
+    return loggingEnabled;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public boolean isWindowStore() {
+    return false;
+  }
+
+  @Override
+  public boolean isVersionedStore() {
+    return false;
+  }
+
+  @Override
+  public Map<String, String> logConfig() {
+    return logConfig;
+  }
+
+  @Override
+  public StoreFactory withCachingDisabled() {
+    // caching is always disabled
+    return this;
+  }
+
+  @Override
+  public StoreFactory withLoggingDisabled() {
+    loggingEnabled = false;
+    return this;
+  }
+
+  @Override
+  public boolean isCompatibleWith(final StoreFactory other) {
+    return other instanceof SubscriptionStoreFactory
+        && ((SubscriptionStoreFactory) other).name.equals(name);
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SubscriptionStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SubscriptionStoreFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.streams.kstream.internals;
 
 import java.util.HashMap;
@@ -12,96 +29,88 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 
 public class SubscriptionStoreFactory<K> extends AbstractConfigurableStoreFactory {
-  private final String name;
-  private final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde;
-  private final Map<String, String> logConfig = new HashMap<>();
-  private boolean loggingEnabled = true;
+    private final String name;
+    private final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde;
+    private final Map<String, String> logConfig = new HashMap<>();
+    private boolean loggingEnabled = true;
 
-  public SubscriptionStoreFactory(
-      final String name,
-      final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde
-  ) {
-    super(null);
-    this.name = name;
-    this.subscriptionWrapperSerde = subscriptionWrapperSerde;
-  }
-
-  @Override
-  public StateStore build() {
-    StoreBuilder<?> builder;
-    if (dslStoreSuppliers() != null) {
-      builder = Stores.timestampedKeyValueStoreBuilder(
-          dslStoreSuppliers().keyValueStore(new DslKeyValueParams(name, true)),
-          new Serdes.BytesSerde(),
-          subscriptionWrapperSerde
-      );
-    } else {
-      builder = Stores.timestampedKeyValueStoreBuilder(
-          Stores.persistentTimestampedKeyValueStore(name),
-          new Serdes.BytesSerde(),
-          subscriptionWrapperSerde
-      );
+    public SubscriptionStoreFactory(
+        final String name,
+        final Serde<SubscriptionWrapper<K>> subscriptionWrapperSerde
+    ) {
+        super(null);
+        this.name = name;
+        this.subscriptionWrapperSerde = subscriptionWrapperSerde;
     }
-    if (loggingEnabled) {
-      builder = builder.withLoggingEnabled(logConfig);
-    } else {
-      builder = builder.withLoggingDisabled();
+
+    @Override
+    public StateStore build() {
+        StoreBuilder<?> builder;
+        builder = Stores.timestampedKeyValueStoreBuilder(
+            dslStoreSuppliers().keyValueStore(new DslKeyValueParams(name, true)),
+            new Serdes.BytesSerde(),
+            subscriptionWrapperSerde
+        );
+        if (loggingEnabled) {
+            builder = builder.withLoggingEnabled(logConfig);
+        } else {
+            builder = builder.withLoggingDisabled();
+        }
+        builder = builder.withCachingDisabled();
+        return builder.build();
     }
-    builder = builder.withCachingDisabled();
-    return builder.build();
-  }
 
-  @Override
-  public long retentionPeriod() {
-    throw new IllegalStateException("retentionPeriod is not supported when not a window store");
-  }
+    @Override
+    public long retentionPeriod() {
+        throw new IllegalStateException("retentionPeriod is not supported when not a window store");
+    }
 
-  @Override
-  public long historyRetention() {
-    throw new IllegalStateException(
-        "historyRetention is not supported when not a versioned store");
-  }
+    @Override
+    public long historyRetention() {
+        throw new IllegalStateException(
+            "historyRetention is not supported when not a versioned store");
+    }
 
-  @Override
-  public boolean loggingEnabled() {
-    return loggingEnabled;
-  }
+    @Override
+    public boolean loggingEnabled() {
+        return loggingEnabled;
+    }
 
-  @Override
-  public String name() {
-    return name;
-  }
+    @Override
+    public String name() {
+        return name;
+    }
 
-  @Override
-  public boolean isWindowStore() {
-    return false;
-  }
+    @Override
+    public boolean isWindowStore() {
+        return false;
+    }
 
-  @Override
-  public boolean isVersionedStore() {
-    return false;
-  }
+    @Override
+    public boolean isVersionedStore() {
+        return false;
+    }
 
-  @Override
-  public Map<String, String> logConfig() {
-    return logConfig;
-  }
+    @Override
+    public Map<String, String> logConfig() {
+        return logConfig;
+    }
 
-  @Override
-  public StoreFactory withCachingDisabled() {
-    // caching is always disabled
-    return this;
-  }
+    @Override
+    public StoreFactory withCachingDisabled() {
+        // caching is always disabled
+        return this;
+    }
 
-  @Override
-  public StoreFactory withLoggingDisabled() {
-    loggingEnabled = false;
-    return this;
-  }
+    @Override
+    public StoreFactory withLoggingDisabled() {
+        loggingEnabled = false;
+        return this;
+    }
 
-  @Override
-  public boolean isCompatibleWith(final StoreFactory other) {
-    return other instanceof SubscriptionStoreFactory
-        && ((SubscriptionStoreFactory) other).name.equals(name);
-  }
+    @Override
+    public boolean isCompatibleWith(final StoreFactory other) {
+        return other instanceof SubscriptionStoreFactory
+            && ((SubscriptionStoreFactory<?>) other).name.equals(name);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
@@ -41,15 +41,15 @@ import java.nio.ByteBuffer;
 public class ForeignTableJoinProcessorSupplier<K, KO, VO> implements
     ProcessorSupplier<KO, Change<VO>, K, SubscriptionResponseWrapper<VO>> {
     private static final Logger LOG = LoggerFactory.getLogger(ForeignTableJoinProcessorSupplier.class);
-    private final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>>> storeBuilder;
+    private final String storeName;
     private final CombinedKeySchema<KO, K> keySchema;
     private boolean useVersionedSemantics = false;
 
     public ForeignTableJoinProcessorSupplier(
-        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>>> storeBuilder,
+        final String storeName,
         final CombinedKeySchema<KO, K> keySchema) {
 
-        this.storeBuilder = storeBuilder;
+        this.storeName = storeName;
         this.keySchema = keySchema;
     }
 
@@ -80,7 +80,7 @@ public class ForeignTableJoinProcessorSupplier<K, KO, VO> implements
                 internalProcessorContext.taskId().toString(),
                 internalProcessorContext.metrics()
             );
-            subscriptionStore = internalProcessorContext.getStateStore(storeBuilder);
+            subscriptionStore = internalProcessorContext.getStateStore(storeName);
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
@@ -39,14 +39,14 @@ public class SubscriptionReceiveProcessorSupplier<K, KO>
     implements ProcessorSupplier<KO, SubscriptionWrapper<K>, CombinedKey<KO, K>, Change<ValueAndTimestamp<SubscriptionWrapper<K>>>> {
     private static final Logger LOG = LoggerFactory.getLogger(SubscriptionReceiveProcessorSupplier.class);
 
-    private final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>>> storeBuilder;
+    private final String storeName;
     private final CombinedKeySchema<KO, K> keySchema;
 
     public SubscriptionReceiveProcessorSupplier(
-        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>>> storeBuilder,
+        final String storeName,
         final CombinedKeySchema<KO, K> keySchema) {
 
-        this.storeBuilder = storeBuilder;
+        this.storeName = storeName;
         this.keySchema = keySchema;
     }
 
@@ -68,7 +68,7 @@ public class SubscriptionReceiveProcessorSupplier<K, KO>
                     internalProcessorContext.taskId().toString(),
                     internalProcessorContext.metrics()
                 );
-                store = internalProcessorContext.getStateStore(storeBuilder);
+                store = internalProcessorContext.getStateStore(storeName);
 
                 keySchema.init(context);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
@@ -25,9 +25,8 @@ import org.apache.kafka.streams.state.StoreBuilder;
 public class ForeignTableJoinNode<K, V> extends StatefulProcessorNode<K, V> implements VersionedSemanticsGraphNode {
 
     public ForeignTableJoinNode(final ProcessorParameters<K, V, ?, ?> processorParameters,
-                                final Set<StoreBuilder<?>> preRegisteredStores,
-                                final Set<KTableValueGetterSupplier<?, ?>> valueGetterSuppliers) {
-        super(processorParameters, preRegisteredStores, valueGetterSuppliers);
+                                final String[] storeNames) {
+        super(processorParameters.processorName(), processorParameters, storeNames);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
@@ -16,11 +16,8 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import java.util.Set;
-import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.ForeignTableJoinProcessorSupplier;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
-import org.apache.kafka.streams.state.StoreBuilder;
 
 public class ForeignTableJoinNode<K, V> extends StatefulProcessorNode<K, V> implements VersionedSemanticsGraphNode {
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplierTests.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplierTests.java
@@ -70,7 +70,7 @@ public class ForeignTableJoinProcessorSupplierTests {
         context = new MockInternalNewProcessorContext<>(props, new TaskId(0, 0), stateDir);
 
         final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
-        processor = new ForeignTableJoinProcessorSupplier<String, String, String>(storeBuilder(), COMBINED_KEY_SCHEMA).get();
+        processor = new ForeignTableJoinProcessorSupplier<String, String, String>(storeBuilder().name(), COMBINED_KEY_SCHEMA).get();
         stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplierTest.java
@@ -505,7 +505,7 @@ public class SubscriptionReceiveProcessorSupplierTest {
     private SubscriptionReceiveProcessorSupplier<String, String> supplier(
         final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder) {
 
-        return new SubscriptionReceiveProcessorSupplier<>(storeBuilder, COMBINED_KEY_SCHEMA);
+        return new SubscriptionReceiveProcessorSupplier<>(storeBuilder.name(), COMBINED_KEY_SCHEMA);
     }
 
     private StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder() {


### PR DESCRIPTION
Foreign key joins have an additional "internal" state store used for subscriptions, which is not exposed for configuration via Materialized or StoreBuilder which means there is no way to plug in a different store implementation via the DSL operator. However, we should respect the configured default dsl store supplier if one is configured, to allow these stores to be customized and conform to the store type selection logic used for other DSL operator stores