### PR TITLE
KAFKA-16967: NioEchoServer fails to register connection and causes flaky failure.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -227,6 +227,9 @@ public class NioEchoServer extends Thread {
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
                         String id = id(socketChannel);
+                        // This try-catch block prevents the NioEchoServer from crashing in a rare condition
+                        // when attempting to register new connections where a connection is already registered.
+                        // Without this, the test fails because the connection unexpectedly becomes idle and expires, leading to a timeout.
                         try {
                             selector.register(id, socketChannel);
                             socketChannels.add(socketChannel);

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -227,8 +227,13 @@ public class NioEchoServer extends Thread {
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
                         String id = id(socketChannel);
-                        selector.register(id, socketChannel);
-                        socketChannels.add(socketChannel);
+                        try {
+                            selector.register(id, socketChannel);
+                            socketChannels.add(socketChannel);
+                        } catch (IllegalStateException e) {
+                            LOG.warn("Failed to register new channel: {}", id, e);
+                            socketChannel.close();
+                        }
                     }
                     newChannels.clear();
                 }

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -229,16 +229,8 @@ public class NioEchoServer extends Thread {
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
                         String id = id();
-                        // This try-catch block prevents the NioEchoServer from crashing in a rare condition
-                        // when attempting to register new connections where a connection is already registered.
-                        // Without this, the test fails because the connection unexpectedly becomes idle and expires, leading to a timeout.
-                        try {
-                            selector.register(id, socketChannel);
-                            socketChannels.add(socketChannel);
-                        } catch (IllegalStateException e) {
-                            LOG.warn("Failed to register new channel: {}", id, e);
-                            socketChannel.close();
-                        }
+                        selector.register(id, socketChannel);
+                        socketChannels.add(socketChannel);
                     }
                     newChannels.clear();
                 }

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -89,7 +90,8 @@ public class NioEchoServer extends Thread {
     private volatile boolean closeKafkaChannels;
     private final DelegationTokenCache tokenCache;
     private final Time time;
-    
+    private final AtomicLong idGenerator = new AtomicLong();
+
     public NioEchoServer(ListenerName listenerName, SecurityProtocol securityProtocol, AbstractConfig config,
                          String serverHost, ChannelBuilder channelBuilder, CredentialCache credentialCache, Time time) throws Exception {
         this(listenerName, securityProtocol, config, serverHost, channelBuilder, credentialCache, 100, time);
@@ -226,7 +228,7 @@ public class NioEchoServer extends Thread {
                 selector.poll(100);
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
-                        String id = id(socketChannel);
+                        String id = id();
                         // This try-catch block prevents the NioEchoServer from crashing in a rare condition
                         // when attempting to register new connections where a connection is already registered.
                         // Without this, the test fails because the connection unexpectedly becomes idle and expires, leading to a timeout.
@@ -285,9 +287,8 @@ public class NioEchoServer extends Thread {
         return false;
     }
 
-    private String id(SocketChannel channel) {
-        return channel.socket().getLocalAddress().getHostAddress() + ":" + channel.socket().getLocalPort() + "-" +
-                channel.socket().getInetAddress().getHostAddress() + ":" + channel.socket().getPort();
+    private String id() {
+        return "connection-" + idGenerator.getAndIncrement();
     }
 
     private KafkaChannel channel(String id) {


### PR DESCRIPTION
The issue involves the `NioEchoServer` crashing when attempting to register new connections due to a connection already being registered. This problem is specifically in the test methods(`testUngracefulRemoteCloseDuringHandshakeRead`, `testUngracefulRemoteCloseDuringHandshakeWrite`) handling ungraceful remote closes during the handshake. The test fails because the connection becomes unexpectedly idle and expires, leading to a timeout.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
