### PR TITLE
KAFKA-16989: Use StringBuilder instead of String concatenation

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
@@ -134,7 +134,7 @@ public class ClientQuotasImageNode implements MetadataNode {
                         case ')':
                             entries.put(type, value.toString());
                             type = null;
-                            value.delete(0, value.length());
+                            value = new StringBuilder();
                             break;
                         case '\\':
                             escaping = true;

--- a/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
@@ -106,7 +106,7 @@ public class ClientQuotasImageNode implements MetadataNode {
     static ClientQuotaEntity decodeEntity(String input) {
         Map<String, String> entries = new HashMap<>();
         String type = null;
-        String value = "";
+        StringBuilder value = new StringBuilder();
         boolean escaping = false;
         int i = 0;
         while (true) {
@@ -127,20 +127,20 @@ public class ClientQuotasImageNode implements MetadataNode {
             } else {
                 char c = input.charAt(i++);
                 if (escaping) {
-                    value += c;
+                    value.append(c);
                     escaping = false;
                 } else {
                     switch (c) {
                         case ')':
-                            entries.put(type, value);
+                            entries.put(type, value.toString());
                             type = null;
-                            value = "";
+                            value.delete(0, value.length());
                             break;
                         case '\\':
                             escaping = true;
                             break;
                         default:
-                            value += c;
+                            value.append(c);
                             break;
                     }
                 }


### PR DESCRIPTION
Currently, the String concatenation in `ClientQuotasImageNode` might be a heavy cost, so it should be replace with `StringBuilder`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
