### PR TITLE
KAFKA-16951 Notify TransactionManager of disconnects to proactively rediscover Coordinator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/DisconnectListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/DisconnectListener.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.errors.AuthenticationException;
+
+import java.util.Optional;
+
+/**
+ * The interface used for classes that need to respond to broker disconnections. The NetworkClient will inform
+ * any registered listeners of each broker disconnections via handleServerDisconnect.
+ */
+public interface DisconnectListener {
+
+    /**
+     * Handle a server disconnect.
+     *
+     * This provides a mechanism for the `NetworkClient` instance to notify the `DisconnectListener` implementation of
+     * broker disconnections. Signature identical to MetadataUpdater::handleServerDisconnect.
+     *
+     * @param now Current time in milliseconds
+     * @param nodeId The id of the node that disconnected
+     * @param maybeAuthException Optional authentication error
+     */
+    void handleServerDisconnect(long now, String nodeId, Optional<AuthenticationException> maybeAuthException);
+}

--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -213,4 +213,16 @@ public interface KafkaClient extends Closeable {
      */
     boolean active();
 
+    /**
+     * Register a `DisconnectListener` implementation to be notified on all broker disconnections
+     * @param listener the listener to add to notifications
+     */
+    void registerDisconnectListener(DisconnectListener listener);
+
+    /**
+     * Unregister a `DisconnectListener` implementation so it will no longer be notified of broker disconnections
+     * @param listener the listener to remove from notifications
+     */
+    void unregisterDisconnectListener(DisconnectListener listener);
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients;
 
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -33,7 +32,7 @@ import java.util.Optional;
  * <p>
  * This class is not thread-safe!
  */
-public interface MetadataUpdater extends Closeable {
+public interface MetadataUpdater extends Closeable, DisconnectListener {
 
     /**
      * Gets the current cluster info without blocking.
@@ -56,18 +55,6 @@ public interface MetadataUpdater extends Closeable {
      * factors like node availability, how long since the last metadata update, etc.
      */
     long maybeUpdate(long now);
-
-    /**
-     * Handle a server disconnect.
-     *
-     * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
-     * requests with special handling for disconnections of such requests.
-     *
-     * @param now Current time in milliseconds
-     * @param nodeId The id of the node that disconnected
-     * @param maybeAuthException Optional authentication error
-     */
-    void handleServerDisconnect(long now, String nodeId, Optional<AuthenticationException> maybeAuthException);
 
     /**
      * Handle a metadata request failure.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -158,6 +158,9 @@ public class Sender implements Runnable {
         this.apiVersions = apiVersions;
         this.transactionManager = transactionManager;
         this.inFlightBatches = new HashMap<>();
+        if (this.transactionManager != null) {
+            this.client.registerDisconnectListener(transactionManager);
+        }
     }
 
     public List<ProducerBatch> inFlightBatches(TopicPartition tp) {
@@ -548,6 +551,9 @@ public class Sender implements Runnable {
         // Ensure accumulator is closed first to guarantee that no more appends are accepted after
         // breaking from the sender loop. Otherwise, we may miss some callbacks when shutting down.
         this.accumulator.close();
+        if (transactionManager != null) {
+            client.unregisterDisconnectListener(transactionManager);
+        }
         this.running = false;
         this.wakeup();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.producer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.DisconnectListener;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.clients.consumer.CommitFailedException;
@@ -79,6 +80,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.PriorityQueue;
@@ -88,7 +90,7 @@ import java.util.function.Supplier;
 /**
  * A class which maintains state for transactions. Also keeps the state necessary to ensure idempotent production.
  */
-public class TransactionManager {
+public class TransactionManager implements DisconnectListener {
     private static final int NO_INFLIGHT_REQUEST_CORRELATION_ID = -1;
 
     private final Logger log;
@@ -185,6 +187,7 @@ public class TransactionManager {
     private int inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
     private Node transactionCoordinator;
     private Node consumerGroupCoordinator;
+    private String consumerGroupCoordinatorKey = null;
     private boolean coordinatorSupportsBumpingEpoch;
 
     private volatile State currentState = State.UNINITIALIZED;
@@ -853,6 +856,22 @@ public class TransactionManager {
         inFlightRequestCorrelationId = correlationId;
     }
 
+    @Override
+    public void handleServerDisconnect(long now, String nodeId, Optional<AuthenticationException> maybeAuthException) {
+        if (transactionCoordinator != null && transactionCoordinator.idString().equals(nodeId)) {
+            log.debug("Rediscovering transaction coordinator due to broker {} disconnection", nodeId);
+            lookupCoordinator(CoordinatorType.TRANSACTION, transactionalId);
+        }
+        if (consumerGroupCoordinator != null &&
+                consumerGroupCoordinatorKey != null &&
+                consumerGroupCoordinator.idString().equals(nodeId)) {
+            log.debug("Rediscovering group coordinator for group {} due to broker {} disconnection",
+                      consumerGroupCoordinatorKey,
+                      nodeId);
+            lookupCoordinator(CoordinatorType.GROUP, consumerGroupCoordinatorKey);
+        }
+    }
+
     private void clearInFlightCorrelationId() {
         inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
     }
@@ -1062,6 +1081,8 @@ public class TransactionManager {
         switch (type) {
             case GROUP:
                 consumerGroupCoordinator = null;
+                // Cache the consumer group key for rediscovery after disconnects
+                consumerGroupCoordinatorKey = coordinatorKey;
                 break;
             case TRANSACTION:
                 transactionCoordinator = null;
@@ -1224,8 +1245,7 @@ public class TransactionManager {
                 clearInFlightCorrelationId();
                 if (response.wasDisconnected()) {
                     log.debug("Disconnected from {}. Will retry.", response.destination());
-                    if (this.needsCoordinator())
-                        lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
+                    // disconnects are proactively handled via notifications, no need for explicit lookup here
                     reenqueue();
                 } else if (response.versionMismatch() != null) {
                     fatalError(response.versionMismatch());

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -33,8 +33,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -87,6 +89,7 @@ public class MockClient implements KafkaClient {
     private volatile boolean active = true;
     private volatile CompletableFuture<String> disconnectFuture;
     private volatile Consumer<Node> readyCallback;
+    private final List<DisconnectListener> disconnectListeners = new LinkedList<>();
 
     public MockClient(Time time) {
         this(time, new NoOpMetadataUpdater());
@@ -210,6 +213,7 @@ public class MockClient implements KafkaClient {
             curDisconnectFuture.complete(node);
         }
         connectionState(node).disconnect();
+        notifyDisconnectListeners(now, node, Optional.empty());
     }
 
     @Override
@@ -574,6 +578,20 @@ public class MockClient implements KafkaClient {
     @Override
     public boolean active() {
         return active;
+    }
+
+    @Override
+    public void registerDisconnectListener(DisconnectListener listener) {
+        disconnectListeners.add(listener);
+    }
+
+    @Override
+    public void unregisterDisconnectListener(DisconnectListener listener) {
+        disconnectListeners.remove(listener);
+    }
+
+    public void notifyDisconnectListeners(long now, String nodeId, Optional<AuthenticationException> maybeAuthException) {
+        disconnectListeners.forEach(l -> l.handleServerDisconnect(now, nodeId, maybeAuthException));
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -718,14 +718,16 @@ public class SenderTest {
         Node node = metadata.fetch().nodes().get(0);
         client.delayReady(node, REQUEST_TIMEOUT + 20);
         prepareFindCoordinatorResponse(Errors.NONE, "testNodeNotReady");
-        sender.runOnce();
-        sender.runOnce();
+
+        for (int i = 0; i < 5; i++) {
+            sender.runOnce();
+        }
         assertNotNull(transactionManager.coordinator(CoordinatorType.TRANSACTION), "Coordinator not found");
 
         client.throttle(node, REQUEST_TIMEOUT + 20);
         prepareFindCoordinatorResponse(Errors.NONE, "Coordinator not found");
         prepareInitProducerResponse(Errors.NONE, producerIdAndEpoch.producerId, producerIdAndEpoch.epoch);
-        waitForProducerId(transactionManager, producerIdAndEpoch);
+        waitForProducerIdOverTime(transactionManager, producerIdAndEpoch, time);
     }
 
     @Test
@@ -1574,12 +1576,17 @@ public class SenderTest {
         sendIdempotentProducerResponse(0, tp0, Errors.NOT_LEADER_OR_FOLLOWER, -1);
         sender.runOnce();  // receive first response
 
+        prepareFindCoordinatorResponse(Errors.NONE, txnManager.transactionalId());
         Node node = metadata.fetch().nodes().get(0);
         time.sleep(1000L);
         client.disconnect(node.idString());
         client.backoff(node, 10);
 
-        sender.runOnce(); // now expire the first batch.
+        for (int i = 0; i < 10 && !request1.isDone(); i++) {
+            sender.runOnce(); // now expire the first batch.
+            time.sleep(1000L);
+        }
+
         assertFutureFailure(request1, TimeoutException.class);
         assertTrue(txnManager.hasUnresolvedSequence(tp0));
 
@@ -3832,7 +3839,17 @@ public class SenderTest {
         assertTrue(transactionManager.hasProducerId());
         assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
     }
-    
+
+    private void waitForProducerIdOverTime(TransactionManager transactionManager, ProducerIdAndEpoch producerIdAndEpoch, MockTime time) {
+        for (int i = 0; i < 25 && !transactionManager.hasProducerId(); i++) {
+            sender.runOnce();
+            time.sleep(1000L);
+        }
+
+        assertTrue(transactionManager.hasProducerId());
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+    }
+
     private AddPartitionsToTxnResponse buildAddPartitionsToTxnResponseData(int throttleMs, Map<TopicPartition, Errors> errors) {
         AddPartitionsToTxnResponseData.AddPartitionsToTxnResult result = AddPartitionsToTxnResponse.resultForTransaction(
                 AddPartitionsToTxnResponse.V3_AND_BELOW_TXN_ID, errors);


### PR DESCRIPTION
When disconnected from a transaction or consumer group coordinator, immediately perform a lookup to ensure we still have the correct node marked as the coordinator. This allows pro-active discovery of coordinator changes during broker restarts.

Includes several test changes since the request/response flow has changed for disconnections so wait times, polling, and coordinator lookups all have slight adjustments.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
