### PR TITLE
KAFKA-16995 The listeners broker parameter incorrect documentation

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -791,7 +791,10 @@ object KafkaConfig {
     " Examples of legal listener lists:\n" +
     " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>\n" +
     " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>\n" +
-    " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>\n"
+    " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>\n" +
+    " But there is a special case, if you want to bind to the same port number on both the " +
+    " IPv4 wildcard addresses(0.0.0.0) and IPv6 wildcard addresses([::])," +
+    " you can make listener lists like <code>PLAINTEXT://[::]:9092, not PLAINTEXT://0.0.0.0:9092,PLAINTEXT://[::]:9092."
   val AdvertisedListenersDoc = s"Listeners to publish to ZooKeeper for clients to use, if different than the <code>$ListenersProp</code> config property." +
     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
     s" If this is not set, the value for <code>$ListenersProp</code> will be used." +

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -792,9 +792,10 @@ object KafkaConfig {
     " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>\n" +
     " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>\n" +
     " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>\n" +
-    " But there is a special case, if you want to bind to the same port number on both the " +
-    " IPv4 wildcard addresses(0.0.0.0) and IPv6 wildcard addresses([::])," +
-    " you can make listener lists like <code>PLAINTEXT://[::]:9092, not PLAINTEXT://0.0.0.0:9092,PLAINTEXT://[::]:9092."
+    " But there is a special case, if you want to bind to the same port number on both\n" +
+    " IPv4 wildcard addresses(0.0.0.0) and IPv6 wildcard addresses([::]),\n" +
+    " you can make listener lists like <code>PLAINTEXT://[::]:9092</code>,\n" +
+    " not <code>PLAINTEXT://0.0.0.0:9092,PLAINTEXT://[::]:9092</code>."
   val AdvertisedListenersDoc = s"Listeners to publish to ZooKeeper for clients to use, if different than the <code>$ListenersProp</code> config property." +
     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
     s" If this is not set, the value for <code>$ListenersProp</code> will be used." +


### PR DESCRIPTION
[KAFKA-16995](https://issues.apache.org/jira/browse/KAFKA-16995) The listeners broker parameter incorrect documentation
For wildcard addresses, the IPV6_V6ONLY operator not be support in Java. if you create two listen in 0.0.0.0:port and [::]:port, you will get an error "the port already bind". that because for dual-stack systems, if you bind to the IPv6 wildcard address, it will listen on both IPv4 and IPv6.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
