### PR TITLE
Bump the default Consumer group command timeout default to 30 sec

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandOptions.java
@@ -149,7 +149,7 @@ public class ConsumerGroupCommandOptions extends CommandDefaultOptions {
             .withRequiredArg()
             .describedAs("timeout (ms)")
             .ofType(Long.class)
-            .defaultsTo(5000L);
+            .defaultsTo(30000L);
         commandConfigOpt = parser.accepts("command-config", COMMAND_CONFIG_DOC)
             .withRequiredArg()
             .describedAs("command config property file")


### PR DESCRIPTION
It is quite often the case that we have to override the default 5sec timeout for any large cluster when we perform a consumer group list action on a cluster

The default 5 second timeout is not enough for that full sequence
- Bootstrap
- Collect Metadata
- Collect ListGroup response from each broker (requests are sent to all brokers at the same time still, but those 5sec need to account for the full connection duration + API_VERSION/METADATA/LIST_GROUPS and could last for a bit longer for a broker)

30 sec is more inline with the default request.timeout.ms and is still very acceptable for a CLI interaction in my opinion

Thank you

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
