### PR TITLE
KAFKA-10840: Propagating Authentication errors when client setup fails with AuthenticationException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1078,12 +1078,13 @@ public class NetworkClient implements KafkaClient {
                     new InetSocketAddress(address, node.port()),
                     this.socketSendBuffer,
                     this.socketReceiveBuffer);
-        } catch (IOException e) {
+        } catch (IOException | AuthenticationException e) {
             log.warn("Error connecting to node {}", node, e);
             // Attempt failed, we'll try again after the backoff
             connectionStates.disconnected(nodeConnectionId, now);
             // Notify metadata updater of the connection failure
-            metadataUpdater.handleServerDisconnect(now, nodeConnectionId, Optional.empty());
+            metadataUpdater.handleServerDisconnect(now, nodeConnectionId,
+                e instanceof AuthenticationException ? Optional.of((AuthenticationException) e) : Optional.empty());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -365,6 +365,10 @@ public class Selector implements Selectable, AutoCloseable {
             // Ideally, these resources are closed by the KafkaChannel but if the KafkaChannel is not created to an
             // error, this builder should close the resources it has created instead.
             Utils.closeQuietly(metadataRegistry, "metadataRegistry");
+            // If an Authentication Failure is encountered, throw that error directly.
+            if (e instanceof AuthenticationException) {
+                throw e;
+            }
             throw new IOException("Channel could not be created for socket " + socketChannel, e);
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.memory.SimpleMemoryPool;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -445,6 +446,29 @@ public class SelectorTest {
             socketChannel.configureBlocking(false);
             IOException e = assertThrows(IOException.class, () -> selector.register(channelId, socketChannel));
             assertTrue(e.getCause().getMessage().contains("Test exception"), "Unexpected exception: " + e);
+            assertFalse(socketChannel.isOpen(), "Socket not closed");
+            // Ideally, metadataRegistry is closed by the KafkaChannel but if the KafkaChannel is not created due to
+            // an error such as in a case like this, the Selector should be closing the metadataRegistry instead.
+            verify(mockedMetadataRegistry.constructed().get(0)).close();
+            selector.close();
+        }
+    }
+
+    @Test
+    public void registerAuthenticationFailure() throws Exception {
+        final String channelId = "1";
+
+        final ChannelBuilder channelBuilder = mock(ChannelBuilder.class);
+
+        when(channelBuilder.buildChannel(eq(channelId), any(SelectionKey.class), anyInt(), any(MemoryPool.class),
+            any(ChannelMetadataRegistry.class))).thenThrow(new SaslAuthenticationException("Authentication Failure"));
+
+        try (MockedConstruction<Selector.SelectorChannelMetadataRegistry> mockedMetadataRegistry =
+                 mockConstruction(Selector.SelectorChannelMetadataRegistry.class)) {
+            Selector selector = new Selector(CONNECTION_MAX_IDLE_MS, new Metrics(), new MockTime(), "MetricGroup", channelBuilder, new LogContext());
+            final SocketChannel socketChannel = SocketChannel.open();
+            socketChannel.configureBlocking(false);
+            assertThrows(SaslAuthenticationException.class, () -> selector.register(channelId, socketChannel));
             assertFalse(socketChannel.isOpen(), "Socket not closed");
             // Ideally, metadataRegistry is closed by the KafkaChannel but if the KafkaChannel is not created due to
             // an error such as in a case like this, the Selector should be closing the metadataRegistry instead.


### PR DESCRIPTION
Problem description is [KAFKA-10840](https://issues.apache.org/jira/browse/KAFKA-10840).

The implication of this behaviour is that users of Producer client never fail and keep retrying. This is true for connect for example where `max.block.ms` is set to Long.MAX_VALUE and in environments where the value can't be reduced, this causes confusion to users (connect task would report status as `RUNNING` but the underneath producer would keep retrying and failing). 

This PR throws propagates the Authentication failures instead of wrapping them in IOException as was being done previously. 

Stacktrace for reference:

```
2024-04-26 13:27:58,226] WARN [connector|task-0] [Producer clientId=connector-producer-xxx] Bootstrap broker xxx:9093 (id: -1 rack: null) disconnected (org.apache.kafka.clients.NetworkClient:1191)
[2024-04-26 13:27:58,373] INFO [connector|task-0] [Producer clientId=connector-producer-xxx] Failed to create channel due to  (org.apache.kafka.common.network.SaslChannelBuilder:270)
org.apache.kafka.common.errors.SaslAuthenticationException: Failed to configure SaslClientAuthenticator
Caused by: org.apache.kafka.common.errors.SaslAuthenticationException: Failed to create SaslClient with mechanism GSSAPI
Caused by: javax.security.sasl.SaslException: Failure to initialize security context [Caused by GSSException: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)]
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.GssKrb5Client.<init>(GssKrb5Client.java:170)
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.FactoryImpl.createSaslClient(FactoryImpl.java:63)
	at java.security.sasl/javax.security.sasl.Sasl.createSaslClient(Sasl.java:434)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.lambda$createSaslClient$0(SaslClientAuthenticator.java:224)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:439)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.createSaslClient(SaslClientAuthenticator.java:220)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.<init>(SaslClientAuthenticator.java:211)
	at org.apache.kafka.common.network.SaslChannelBuilder.buildClientAuthenticator(SaslChannelBuilder.java:327)
	at org.apache.kafka.common.network.SaslChannelBuilder.lambda$buildChannel$1(SaslChannelBuilder.java:255)
	at org.apache.kafka.common.network.KafkaChannel.<init>(KafkaChannel.java:246)
	at org.apache.kafka.common.network.SaslChannelBuilder.buildChannel(SaslChannelBuilder.java:264)
	at org.apache.kafka.common.network.Selector.buildAndAttachKafkaChannel(Selector.java:427)
	at org.apache.kafka.common.network.Selector.registerChannel(Selector.java:416)
	at org.apache.kafka.common.network.Selector.connect(Selector.java:343)
	at org.apache.kafka.clients.NetworkClient.initiateConnect(NetworkClient.java:1110)
	at org.apache.kafka.clients.NetworkClient.access$700(NetworkClient.java:87)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1289)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1177)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:641)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:328)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:243)
	at java.base/java.lang.Thread.run(Thread.java:833)
	at org.apache.kafka.common.utils.KafkaThread.run(KafkaThread.java:64)
Caused by: GSSException: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)
	at java.security.jgss/sun.security.jgss.krb5.Krb5NameElement.getInstance(Krb5NameElement.java:127)
	at java.security.jgss/sun.security.jgss.krb5.Krb5MechFactory.getNameElement(Krb5MechFactory.java:99)
	at java.security.jgss/sun.security.jgss.GSSManagerImpl.getNameElement(GSSManagerImpl.java:184)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.getElement(GSSNameImpl.java:469)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.init(GSSNameImpl.java:202)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.<init>(GSSNameImpl.java:171)
	at java.security.jgss/sun.security.jgss.GSSManagerImpl.createName(GSSManagerImpl.java:119)
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.GssKrb5Client.<init>(GssKrb5Client.java:108)
	... 23 more
[2024-04-26 13:27:58,373] WARN [connector|task-0] [Producer clientId=connector-producer-xxx-0] Error connecting to node xxx:9093 (id: -1 rack: null) (org.apache.kafka.clients.NetworkClient:1115)
java.io.IOException: Channel could not be created for socket java.nio.channels.SocketChannel[closed]
	at org.apache.kafka.common.network.Selector.buildAndAttachKafkaChannel(Selector.java:437)
	at org.apache.kafka.common.network.Selector.registerChannel(Selector.java:416)
	at org.apache.kafka.common.network.Selector.connect(Selector.java:343)
	at org.apache.kafka.clients.NetworkClient.initiateConnect(NetworkClient.java:1110)
	at org.apache.kafka.clients.NetworkClient.access$700(NetworkClient.java:87)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1289)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1177)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:641)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:328)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:243)
	at java.base/java.lang.Thread.run(Thread.java:833)
	at org.apache.kafka.common.utils.KafkaThread.run(KafkaThread.java:64)
Caused by: org.apache.kafka.common.KafkaException: org.apache.kafka.common.errors.SaslAuthenticationException: Failed to configure SaslClientAuthenticator
	at org.apache.kafka.common.network.SaslChannelBuilder.buildChannel(SaslChannelBuilder.java:271)
	at org.apache.kafka.common.network.Selector.buildAndAttachKafkaChannel(Selector.java:427)
	... 11 more
Caused by: org.apache.kafka.common.errors.SaslAuthenticationException: Failed to configure SaslClientAuthenticator
Caused by: org.apache.kafka.common.errors.SaslAuthenticationException: Failed to create SaslClient with mechanism GSSAPI
Caused by: javax.security.sasl.SaslException: Failure to initialize security context [Caused by GSSException: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)]
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.GssKrb5Client.<init>(GssKrb5Client.java:170)
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.FactoryImpl.createSaslClient(FactoryImpl.java:63)
	at java.security.sasl/javax.security.sasl.Sasl.createSaslClient(Sasl.java:434)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.lambda$createSaslClient$0(SaslClientAuthenticator.java:224)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:439)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.createSaslClient(SaslClientAuthenticator.java:220)
	at org.apache.kafka.common.security.authenticator.SaslClientAuthenticator.<init>(SaslClientAuthenticator.java:211)
	at org.apache.kafka.common.network.SaslChannelBuilder.buildClientAuthenticator(SaslChannelBuilder.java:327)
	at org.apache.kafka.common.network.SaslChannelBuilder.lambda$buildChannel$1(SaslChannelBuilder.java:255)
	at org.apache.kafka.common.network.KafkaChannel.<init>(KafkaChannel.java:246)
	at org.apache.kafka.common.network.SaslChannelBuilder.buildChannel(SaslChannelBuilder.java:264)
	at org.apache.kafka.common.network.Selector.buildAndAttachKafkaChannel(Selector.java:427)
	at org.apache.kafka.common.network.Selector.registerChannel(Selector.java:416)
	at org.apache.kafka.common.network.Selector.connect(Selector.java:343)
	at org.apache.kafka.clients.NetworkClient.initiateConnect(NetworkClient.java:1110)
	at org.apache.kafka.clients.NetworkClient.access$700(NetworkClient.java:87)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1289)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1177)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:641)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:328)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:243)
	at java.base/java.lang.Thread.run(Thread.java:833)
	at org.apache.kafka.common.utils.KafkaThread.run(KafkaThread.java:64)
Caused by: GSSException: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)
	at java.security.jgss/sun.security.jgss.krb5.Krb5NameElement.getInstance(Krb5NameElement.java:127)
	at java.security.jgss/sun.security.jgss.krb5.Krb5MechFactory.getNameElement(Krb5MechFactory.java:99)
	at java.security.jgss/sun.security.jgss.GSSManagerImpl.getNameElement(GSSManagerImpl.java:184)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.getElement(GSSNameImpl.java:469)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.init(GSSNameImpl.java:202)
	at java.security.jgss/sun.security.jgss.GSSNameImpl.<init>(GSSNameImpl.java:171)
	at java.security.jgss/sun.security.jgss.GSSManagerImpl.createName(GSSManagerImpl.java:119)
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.GssKrb5Client.<init>(GssKrb5Client.java:108)
	... 23 more
```
