### PR TITLE
KAFKA-17011: SupportedFeatures.MinVersion incorrectly blocks v0 (3.8)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -260,14 +260,13 @@ public class ApiVersionsResponse extends AbstractResponse {
         final boolean zkMigrationEnabled
     ) {
         Features<SupportedVersionRange> backwardsCompatibleFeatures = Features.supportedFeatures(latestSupportedFeatures.features().entrySet()
-            .stream()
+            .stream().filter(entry -> {
+                SupportedVersionRange supportedVersionRange = entry.getValue();
+                return supportedVersionRange.min() != 0;
+            })
             .collect(Collectors.toMap(
                 entry -> entry.getKey(),
-                entry -> {
-                    short newMin = entry.getValue().min() == 0 ? 1 : entry.getValue().min();
-                    short newMax = entry.getValue().max() == 0 ? 1 : entry.getValue().max();
-                    return new SupportedVersionRange(newMin, newMax);
-                }
+                entry -> entry.getValue()
             ))
         );
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -259,6 +259,9 @@ public class ApiVersionsResponse extends AbstractResponse {
         final long finalizedFeaturesEpoch,
         final boolean zkMigrationEnabled
     ) {
+        // Older versions do not support 0 version in SupportedVersionRange. If an older broker receives a response with a zero version, it will fail with
+        // IllegalArgumentException. In order to not block upgrades, filter out features with 0 versions from the response.
+        // Future versions will bump the ApiVersionsRequest to handle this case and return features with version 0, but that version bump is not in 3.8.
         Features<SupportedVersionRange> backwardsCompatibleFeatures = Features.supportedFeatures(latestSupportedFeatures.features().entrySet()
             .stream().filter(entry -> {
                 SupportedVersionRange supportedVersionRange = entry.getValue();

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.feature.Features;
 import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ApiMessageType.ListenerType;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionCollection;
 import org.apache.kafka.common.message.ApiVersionsResponseData.FinalizedFeatureKey;
@@ -273,6 +274,27 @@ public class ApiVersionsResponseTest {
         assertEquals(expected, ApiVersionsResponse.intersect(thisVersion, other).get());
         // test for symmetric
         assertEquals(expected, ApiVersionsResponse.intersect(other, thisVersion).get());
+    }
+
+    @Test
+    public void testZeroVersionNotReturned() {
+        String featureName = "test.feature.version";
+        ApiVersionsResponse response = ApiVersionsResponse.createApiVersionsResponse(
+            10,
+            RecordVersion.V1,
+            Features.supportedFeatures(Collections.singletonMap(featureName, new SupportedVersionRange((short) 0, (short) 0))),
+            Collections.emptyMap(),
+            ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH,
+            null,
+            ListenerType.BROKER,
+            true,
+            false,
+            false
+        );
+
+        ApiVersionsResponseData.SupportedFeatureKey feature = response.data().supportedFeatures().find(featureName);
+        assertEquals(1, feature.maxVersion());
+        assertEquals(1, feature.minVersion());
     }
 
     private void verifyVersions(short forwardableAPIKey,

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.feature.Features;
 import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ApiMessageType.ListenerType;
-import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionCollection;
 import org.apache.kafka.common.message.ApiVersionsResponseData.FinalizedFeatureKey;
@@ -282,19 +281,18 @@ public class ApiVersionsResponseTest {
         ApiVersionsResponse response = ApiVersionsResponse.createApiVersionsResponse(
             10,
             RecordVersion.V1,
-            Features.supportedFeatures(Collections.singletonMap(featureName, new SupportedVersionRange((short) 0, (short) 0))),
+            Features.supportedFeatures(Collections.singletonMap(featureName, new SupportedVersionRange((short) 0, (short) 1))),
             Collections.emptyMap(),
             ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH,
             null,
             ListenerType.BROKER,
             true,
             false,
-            false
+            true
         );
 
-        ApiVersionsResponseData.SupportedFeatureKey feature = response.data().supportedFeatures().find(featureName);
-        assertEquals(1, feature.maxVersion());
-        assertEquals(1, feature.minVersion());
+        // Feature should not be in the supported features due to the 0 version.
+        assertEquals(null, response.data().supportedFeatures().find(featureName));
     }
 
     private void verifyVersions(short forwardableAPIKey,

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.record.RecordVersion
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse, RequestUtils}
 import org.apache.kafka.common.utils.Utils
-import org.apache.kafka.server.common.{GroupVersion, MetadataVersion}
+import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Tag
@@ -69,12 +69,10 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       assertEquals(MetadataVersion.latestTesting().featureLevel(), apiVersionsResponse.data().finalizedFeatures().find(MetadataVersion.FEATURE_NAME).minVersionLevel())
       assertEquals(MetadataVersion.latestTesting().featureLevel(), apiVersionsResponse.data().finalizedFeatures().find(MetadataVersion.FEATURE_NAME).maxVersionLevel())
 
-      assertEquals(2, apiVersionsResponse.data().supportedFeatures().size())
+      // Since the min version of group version is 0, it is not included in the response.
+      assertEquals(1, apiVersionsResponse.data().supportedFeatures().size())
       assertEquals(MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(MetadataVersion.FEATURE_NAME).minVersion())
       assertEquals(MetadataVersion.latestTesting().featureLevel(), apiVersionsResponse.data().supportedFeatures().find(MetadataVersion.FEATURE_NAME).maxVersion())
-
-      assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).minVersion())
-      assertEquals(GroupVersion.GV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).maxVersion())
     }
     val expectedApis = if (!cluster.isKRaftTest) {
       ApiVersionsResponse.collectApis(

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -64,12 +64,9 @@ public class FeatureCommandTest {
 
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
-
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(0)));
     }
 
     @ClusterTest(types = {Type.KRAFT}, metadataVersion = MetadataVersion.IBP_3_7_IV4)
@@ -80,12 +77,9 @@ public class FeatureCommandTest {
 
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
-
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.7-IV4\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.7-IV4\t", outputWithoutEpoch(features.get(0)));
     }
 
     @ClusterTest(types = {Type.ZK}, metadataVersion = MetadataVersion.IBP_3_3_IV1)


### PR DESCRIPTION
For 3.8 we can't implement a new ApiVersions bump, so for now we will omit the feature in the response in order to be backwards compatible. 

Without this change, when interacting with an old version of kafka, we see the following error:

```
java.lang.IllegalArgumentException: Expected minValue >= 1, maxValue >= 1 and maxValue >= minValue, but received minValue: 0, maxValue: 0
    at org.apache.kafka.common.feature.BaseVersionRange.<init>(BaseVersionRange.java:65)
    at org.apache.kafka.common.feature.SupportedVersionRange.<init>(SupportedVersionRange.java:32)
    at org.apache.kafka.clients.NodeApiVersions.<init>(NodeApiVersions.java:114)
    at org.apache.kafka.clients.NetworkClient.handleApiVersionsResponse(NetworkClient.java:960)
    at org.apache.kafka.clients.NetworkClient.handleCompletedReceives(NetworkClient.java:927)
    at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:580)
    at kafka.common.InterBrokerSendThread.pollOnce(InterBrokerSendThread.scala:78)
    at kafka.common.InterBrokerSendThread.doWork(InterBrokerSendThread.scala:98)
    at org.apache.kafka.server.util.ShutdownableThread.run(ShutdownableThread.java:127)
  ```