### PR TITLE
MINOR: pass in timeout to Admin.close()

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1513,7 +1513,7 @@ public class KafkaStreams implements AutoCloseable {
             }
 
             stateDirectory.close();
-            adminClient.close();
+            adminClient.close(Duration.ofMillis(timeoutMs));
 
             streamsMetrics.removeAllClientLevelSensorsAndMetrics();
             metrics.close();

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1513,6 +1513,8 @@ public class KafkaStreams implements AutoCloseable {
             }
 
             stateDirectory.close();
+            // passing in `timeoutMs` here is a quick fix to avoid blocking forever
+            // cf https://issues.apache.org/jira/browse/KAFKA-7996
             adminClient.close(Duration.ofMillis(timeoutMs));
 
             streamsMetrics.removeAllClientLevelSensorsAndMetrics();

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1515,7 +1515,11 @@ public class KafkaStreams implements AutoCloseable {
             stateDirectory.close();
             // passing in `timeoutMs` here is a quick fix to avoid blocking forever
             // cf https://issues.apache.org/jira/browse/KAFKA-7996
-            adminClient.close(Duration.ofMillis(timeoutMs));
+            if (timeoutMs >= 0) {
+                adminClient.close(Duration.ofMillis(timeoutMs));
+            } else {
+                adminClient.close();
+            }
 
             streamsMetrics.removeAllClientLevelSensorsAndMetrics();
             metrics.close();


### PR DESCRIPTION
We observed system test failures, due to infinite blocking of `admin.close()` when Kafka Streams shuts down, while the broker was shut down previously. If Admin client loses its connection to the broker, `admin.close()` might block forever.