### PR TITLE
KAFKA-17009: Add unit test to query nonexistent replica by describeReplicaLogDirs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
@@ -67,16 +67,10 @@ public class DescribeReplicaLogDirsResult {
     }
 
     public static class ReplicaLogDirInfo {
-        // The current log directory of the replica of this partition on the given broker.
-        // Null if no replica is not found for this partition on the given broker.
+        
         private final String currentReplicaLogDir;
-        // Defined as max(HW of partition - LEO of the replica, 0).
         private final long currentReplicaOffsetLag;
-        // The future log directory of the replica of this partition on the given broker.
-        // Null if the replica of this partition is not being moved to another log directory on the given broker.
         private final String futureReplicaLogDir;
-        // The LEO of the replica - LEO of the future log of this replica in the destination log directory.
-        // -1 if either there is not replica for this partition or the replica of this partition is not being moved to another log directory on the given broker.
         private final long futureReplicaOffsetLag;
 
         ReplicaLogDirInfo() {
@@ -93,18 +87,33 @@ public class DescribeReplicaLogDirsResult {
             this.futureReplicaOffsetLag = futureReplicaOffsetLag;
         }
 
+        /**
+         * The current log directory of the replica of this partition on the given broker.
+         * Null if no replica is not found for this partition on the given broker.
+         */
         public String getCurrentReplicaLogDir() {
             return currentReplicaLogDir;
         }
 
+        /**
+         * Defined as max(HW of partition - LEO of the replica, 0).
+         */
         public long getCurrentReplicaOffsetLag() {
             return currentReplicaOffsetLag;
         }
 
+        /**
+         * The future log directory of the replica of this partition on the given broker.
+         * Null if the replica of this partition is not being moved to another log directory on the given broker.
+         */
         public String getFutureReplicaLogDir() {
             return futureReplicaLogDir;
         }
 
+        /**
+         * The LEO of the replica - LEO of the future log of this replica in the destination log directory.
+         * -1 if either there is not replica for this partition or the replica of this partition is not being moved to another log directory on the given broker.
+         */
         public long getFutureReplicaOffsetLag() {
             return futureReplicaOffsetLag;
         }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6948,24 +6948,32 @@ public class KafkaAdminClientTest {
     }
     
     @Test
-    public void testDescribeLogDirsWithNonExistReplica() throws Exception {
+    public void testDescribeReplicaLogDirsWithNonExistReplica() throws Exception {
         int brokerId = 0;
         TopicPartitionReplica tpr1 = new TopicPartitionReplica("topic1", 12, brokerId);
         TopicPartitionReplica tpr2 = new TopicPartitionReplica("topic2", 12, brokerId);
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             String logDir = "/var/data/kafka0";
+            int offsetLag = 1;
+            int defaultOffsetLag = -1;
             env.kafkaClient().prepareResponseFrom(
                     new DescribeLogDirsResponse(
                             new DescribeLogDirsResponseData().setResults(singletonList(
-                                    prepareDescribeLogDirsResult(tpr1, logDir, 123456, 1, false)))),
+                                    prepareDescribeLogDirsResult(tpr1, logDir, 123456, offsetLag, false)))),
                     env.cluster().nodeById(brokerId));
 
             DescribeReplicaLogDirsResult result = env.adminClient().describeReplicaLogDirs(asList(tpr1, tpr2));
             Map<TopicPartitionReplica, KafkaFuture<DescribeReplicaLogDirsResult.ReplicaLogDirInfo>> values = result.values();
             
             assertEquals(logDir, values.get(tpr1).get().getCurrentReplicaLogDir());
+            assertNull(values.get(tpr1).get().getFutureReplicaLogDir());
+            assertEquals(offsetLag, values.get(tpr1).get().getCurrentReplicaOffsetLag());
+            assertEquals(defaultOffsetLag, values.get(tpr1).get().getFutureReplicaOffsetLag());
             assertNull(values.get(tpr2).get().getCurrentReplicaLogDir());
+            assertNull(values.get(tpr2).get().getFutureReplicaLogDir());
+            assertEquals(defaultOffsetLag, values.get(tpr2).get().getCurrentReplicaOffsetLag());
+            assertEquals(defaultOffsetLag, values.get(tpr2).get().getFutureReplicaOffsetLag());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6954,14 +6954,17 @@ public class KafkaAdminClientTest {
         TopicPartitionReplica tpr2 = new TopicPartitionReplica("topic2", 12, brokerId);
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            String logDir = "/var/data/kafka0";
             env.kafkaClient().prepareResponseFrom(
                     new DescribeLogDirsResponse(
                             new DescribeLogDirsResponseData().setResults(singletonList(
-                                    prepareDescribeLogDirsResult(tpr1, "/var/data/kafka0", 123456, 1, false)))),
+                                    prepareDescribeLogDirsResult(tpr1, logDir, 123456, 1, false)))),
                     env.cluster().nodeById(brokerId));
 
             DescribeReplicaLogDirsResult result = env.adminClient().describeReplicaLogDirs(asList(tpr1, tpr2));
             Map<TopicPartitionReplica, KafkaFuture<DescribeReplicaLogDirsResult.ReplicaLogDirInfo>> values = result.values();
+            
+            assertEquals(logDir, values.get(tpr1).get().getCurrentReplicaLogDir());
             assertNull(values.get(tpr2).get().getCurrentReplicaLogDir());
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6946,6 +6946,21 @@ public class KafkaAdminClientTest {
             assertNotNull(result.descriptions().get(1).get());
         }
     }
+    
+    @Test
+    public void testDescribeLogDirsWithNonExistReplica() throws Exception {
+        TopicPartitionReplica tp = new TopicPartitionReplica("topic", 12, 0);
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareResponseFrom(
+                    prepareDescribeLogDirsResponse(Errors.NONE, "/data"),
+                    env.cluster().nodeById(0));
+
+            Map<TopicPartitionReplica, String> replicas = singletonMap(tp, "/data");
+            AlterReplicaLogDirsResult result = env.adminClient().alterReplicaLogDirs(replicas);
+            assertNull(result.values().get(tp).get());
+        }
+    }
 
     @Test
     public void testUnregisterBrokerSuccess() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17009

add new test `testDescribeLogDirsWithNonExistReplica()`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
