### PR TITLE
KAFKA-16791: Add thread detection to ClusterTestExtensions

### DIFF
--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -185,12 +185,12 @@ public class ClusterTestExtensionsTest implements BeforeAllCallback, AfterAllCal
         @ClusterTest(types = {Type.ZK, Type.KRAFT, Type.CO_KRAFT}, disksPerBroker = 2),
     })
     public void testClusterTestWithDisksPerBroker() throws ExecutionException, InterruptedException {
-        try (Admin admin = clusterInstance.createAdminClient()) {
-            DescribeLogDirsResult result = admin.describeLogDirs(clusterInstance.brokerIds());
-            result.allDescriptions().get().forEach((brokerId, logDirDescriptionMap) -> {
-                Assertions.assertEquals(clusterInstance.config().numDisksPerBroker(), logDirDescriptionMap.size());
-            });
-        }
+        Admin admin = clusterInstance.createAdminClient();
+
+        DescribeLogDirsResult result = admin.describeLogDirs(clusterInstance.brokerIds());
+        result.allDescriptions().get().forEach((brokerId, logDirDescriptionMap) -> {
+            Assertions.assertEquals(clusterInstance.config().numDisksPerBroker(), logDirDescriptionMap.size());
+        });
     }
 
     @ClusterTest(autoStart = AutoStart.NO)


### PR DESCRIPTION
`TestUtils.verifyNoUnexpectedThreads()` will verify there's no remaining threads that might affect the consequent test cases, which should be checked before and after all test cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
