### PR TITLE
KAFKA-16448: Add ErrorHandlerContext in deserialization exception handler

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
@@ -37,7 +37,7 @@ public interface DeserializationExceptionHandler extends Configurable {
      * @param context processor context
      * @param record record that failed deserialization
      * @param exception the actual exception
-     * @deprecated Please {@link #handle(ErrorHandlerContext, ConsumerRecord, Exception)}
+     * @deprecated Since 3.9. Use Please {@link #handle(ErrorHandlerContext, ConsumerRecord, Exception)}
      */
     @Deprecated
     default DeserializationHandlerResponse handle(final ProcessorContext context,
@@ -56,7 +56,7 @@ public interface DeserializationExceptionHandler extends Configurable {
     default DeserializationHandlerResponse handle(final ErrorHandlerContext context,
                                                   final ConsumerRecord<byte[], byte[]> record,
                                                   final Exception exception) {
-        return handle(((DefaultErrorHandlerContext) context).processorContext(), record, exception);
+        return handle(((DefaultErrorHandlerContext) context).processorContext().orElse(null), record, exception);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.streams.errors.internals.DefaultErrorHandlerContext;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
 /**
@@ -37,11 +37,27 @@ public interface DeserializationExceptionHandler extends Configurable {
      * @param context processor context
      * @param record record that failed deserialization
      * @param exception the actual exception
+     * @deprecated Please {@link #handle(ErrorHandlerContext, ConsumerRecord, Exception)}
      */
-    @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-    DeserializationHandlerResponse handle(final ProcessorContext context,
-                                          final ConsumerRecord<byte[], byte[]> record,
-                                          final Exception exception);
+    @Deprecated
+    default DeserializationHandlerResponse handle(final ProcessorContext context,
+                                                  final ConsumerRecord<byte[], byte[]> record,
+                                                  final Exception exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Inspect a record and the exception received.
+     *
+     * @param context error handler context
+     * @param record record that failed deserialization
+     * @param exception the actual exception
+     */
+    default DeserializationHandlerResponse handle(final ErrorHandlerContext context,
+                                                  final ConsumerRecord<byte[], byte[]> record,
+                                                  final Exception exception) {
+        return handle(((DefaultErrorHandlerContext) context).processorContext(), record, exception);
+    }
 
     /**
      * Enumeration that describes the response from the exception handler.

--- a/streams/src/main/java/org/apache/kafka/streams/errors/ErrorHandlerContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/ErrorHandlerContext.java
@@ -90,34 +90,6 @@ public interface ErrorHandlerContext {
     Headers headers();
 
     /**
-     * Return the non-deserialized byte[] of the input message key if the context has been triggered by a message.
-     *
-     * <p> If this method is invoked within a {@link Punctuator#punctuate(long)
-     * punctuation callback}, or while processing a record that was forwarded by a punctuation
-     * callback, it will return {@code null}.
-     *
-     * <p> If this method is invoked in a sub-topology due to a repartition, the returned key would be one sent
-     * to the repartition topic.
-     *
-     * @return the raw byte of the key of the source message
-     */
-    byte[] sourceRawKey();
-
-    /**
-     * Return the non-deserialized byte[] of the input message value if the context has been triggered by a message.
-     *
-     * <p> If this method is invoked within a {@link Punctuator#punctuate(long)
-     * punctuation callback}, or while processing a record that was forwarded by a punctuation
-     * callback, it will return {@code null}.
-     *
-     * <p> If this method is invoked in a sub-topology due to a repartition, the returned value would be one sent
-     * to the repartition topic.
-     *
-     * @return the raw byte of the value of the source message
-     */
-    byte[] sourceRawValue();
-
-    /**
      * Return the current processor node ID.
      *
      * @return the processor node ID

--- a/streams/src/main/java/org/apache/kafka/streams/errors/LogAndContinueExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/LogAndContinueExceptionHandler.java
@@ -32,8 +32,22 @@ import java.util.Map;
 public class LogAndContinueExceptionHandler implements DeserializationExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(LogAndContinueExceptionHandler.class);
 
+    @Deprecated
     @Override
     public DeserializationHandlerResponse handle(final ProcessorContext context,
+                                                 final ConsumerRecord<byte[], byte[]> record,
+                                                 final Exception exception) {
+
+        log.warn("Exception caught during Deserialization, " +
+                 "taskId: {}, topic: {}, partition: {}, offset: {}",
+                 context.taskId(), record.topic(), record.partition(), record.offset(),
+                 exception);
+
+        return DeserializationHandlerResponse.CONTINUE;
+    }
+
+    @Override
+    public DeserializationHandlerResponse handle(final ErrorHandlerContext context,
                                                  final ConsumerRecord<byte[], byte[]> record,
                                                  final Exception exception) {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/LogAndFailExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/LogAndFailExceptionHandler.java
@@ -33,7 +33,21 @@ public class LogAndFailExceptionHandler implements DeserializationExceptionHandl
     private static final Logger log = LoggerFactory.getLogger(LogAndFailExceptionHandler.class);
 
     @Override
+    @Deprecated
     public DeserializationHandlerResponse handle(final ProcessorContext context,
+                                                 final ConsumerRecord<byte[], byte[]> record,
+                                                 final Exception exception) {
+
+        log.error("Exception caught during Deserialization, " +
+                  "taskId: {}, topic: {}, partition: {}, offset: {}",
+                  context.taskId(), record.topic(), record.partition(), record.offset(),
+                  exception);
+
+        return DeserializationHandlerResponse.FAIL;
+    }
+
+    @Override
+    public DeserializationHandlerResponse handle(final ErrorHandlerContext context,
                                                  final ConsumerRecord<byte[], byte[]> record,
                                                  final Exception exception) {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.errors.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.TaskId;
 
 /**
@@ -32,6 +33,7 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
     private final byte[] sourceRawValue;
     private final String processorNodeId;
     private final TaskId taskId;
+    private ProcessorContext processorContext;
 
     public DefaultErrorHandlerContext(final String topic,
                                       final int partition,
@@ -49,6 +51,19 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
         this.sourceRawValue = sourceRawValue;
         this.processorNodeId = processorNodeId;
         this.taskId = taskId;
+    }
+
+    public DefaultErrorHandlerContext(final ProcessorContext processorContext,
+                                      final String topic,
+                                      final int partition,
+                                      final long offset,
+                                      final Headers headers,
+                                      final byte[] sourceRawKey,
+                                      final byte[] sourceRawValue,
+                                      final String processorNodeId,
+                                      final TaskId taskId) {
+        this(topic, partition, offset, headers, sourceRawKey, sourceRawValue, processorNodeId, taskId);
+        this.processorContext = processorContext;
     }
 
     @Override
@@ -89,5 +104,9 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
     @Override
     public TaskId taskId() {
         return taskId;
+    }
+
+    public ProcessorContext processorContext() {
+        return this.processorContext;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
@@ -21,6 +21,8 @@ import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.TaskId;
 
+import java.util.Optional;
+
 /**
  * Default implementation of {@link ErrorHandlerContext} that provides access to the metadata of the record that caused the error.
  */
@@ -35,7 +37,8 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
     private final TaskId taskId;
     private ProcessorContext processorContext;
 
-    public DefaultErrorHandlerContext(final String topic,
+    public DefaultErrorHandlerContext(final ProcessorContext processorContext,
+                                      final String topic,
                                       final int partition,
                                       final long offset,
                                       final Headers headers,
@@ -51,18 +54,6 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
         this.sourceRawValue = sourceRawValue;
         this.processorNodeId = processorNodeId;
         this.taskId = taskId;
-    }
-
-    public DefaultErrorHandlerContext(final ProcessorContext processorContext,
-                                      final String topic,
-                                      final int partition,
-                                      final long offset,
-                                      final Headers headers,
-                                      final byte[] sourceRawKey,
-                                      final byte[] sourceRawValue,
-                                      final String processorNodeId,
-                                      final TaskId taskId) {
-        this(topic, partition, offset, headers, sourceRawKey, sourceRawValue, processorNodeId, taskId);
         this.processorContext = processorContext;
     }
 
@@ -106,7 +97,7 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
         return taskId;
     }
 
-    public ProcessorContext processorContext() {
-        return this.processorContext;
+    public Optional<ProcessorContext> processorContext() {
+        return Optional.ofNullable(processorContext);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/DefaultErrorHandlerContext.java
@@ -31,8 +31,6 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
     private final int partition;
     private final long offset;
     private final Headers headers;
-    private final byte[] sourceRawKey;
-    private final byte[] sourceRawValue;
     private final String processorNodeId;
     private final TaskId taskId;
     private ProcessorContext processorContext;
@@ -42,16 +40,12 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
                                       final int partition,
                                       final long offset,
                                       final Headers headers,
-                                      final byte[] sourceRawKey,
-                                      final byte[] sourceRawValue,
                                       final String processorNodeId,
                                       final TaskId taskId) {
         this.topic = topic;
         this.partition = partition;
         this.offset = offset;
         this.headers = headers;
-        this.sourceRawKey = sourceRawKey;
-        this.sourceRawValue = sourceRawValue;
         this.processorNodeId = processorNodeId;
         this.taskId = taskId;
         this.processorContext = processorContext;
@@ -75,16 +69,6 @@ public class DefaultErrorHandlerContext implements ErrorHandlerContext {
     @Override
     public Headers headers() {
         return headers;
-    }
-
-    @Override
-    public byte[] sourceRawKey() {
-        return sourceRawKey;
-    }
-
-    @Override
-    public byte[] sourceRawValue() {
-        return sourceRawValue;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 public class CorruptedRecord extends StampedRecord {
 
     CorruptedRecord(final ConsumerRecord<byte[], byte[]> rawRecord) {
-        super(rawRecord, ConsumerRecord.NO_TIMESTAMP, rawRecord);
+        super(rawRecord, ConsumerRecord.NO_TIMESTAMP);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -307,8 +307,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                             record.offset(),
                             record.partition(),
                             record.topic(),
-                            record.headers(),
-                            record);
+                            record.headers());
                     globalProcessorContext.setRecordContext(recordContext);
 
                     try {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -113,8 +113,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
                     deserialized.offset(),
                     deserialized.partition(),
                     deserialized.topic(),
-                    deserialized.headers(),
-                    record);
+                    deserialized.headers());
             processorContext.setRecordContext(recordContext);
             processorContext.setCurrentNode(sourceNodeAndDeserializer.sourceNode());
             final Record<Object, Object> toProcess = new Record<>(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorAdapter.java
@@ -66,8 +66,7 @@ public final class ProcessorAdapter<KIn, VIn, KOut, VOut> implements Processor<K
                 context.offset(),
                 context.partition(),
                 context.topic(),
-                record.headers(),
-                processorRecordContext.rawRecord()
+                record.headers()
             ));
             delegate.process(record.key(), record.value());
         } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -261,8 +261,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext<Object, Objec
                     recordContext.offset(),
                     recordContext.partition(),
                     recordContext.topic(),
-                    record.headers(),
-                    recordContext.rawRecord());
+                    record.headers());
             }
 
             if (childName == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -205,6 +205,7 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
             throw e;
         } catch (final Exception e) {
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
+                null,
                 internalProcessorContext.topic(),
                 internalProcessorContext.partition(),
                 internalProcessorContext.offset(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -210,8 +210,6 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                 internalProcessorContext.partition(),
                 internalProcessorContext.offset(),
                 internalProcessorContext.headers(),
-                internalProcessorContext.recordContext().rawRecord().key(),
-                internalProcessorContext.recordContext().rawRecord().value(),
                 internalProcessorContext.currentNode().name(),
                 internalProcessorContext.taskId());
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -38,28 +37,17 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     private final String topic;
     private final int partition;
     private final Headers headers;
-    private final ConsumerRecord<byte[], byte[]> rawRecord;
 
     public ProcessorRecordContext(final long timestamp,
                                   final long offset,
                                   final int partition,
                                   final String topic,
                                   final Headers headers) {
-        this(timestamp, offset, partition, topic, headers, null);
-    }
-
-    public ProcessorRecordContext(final long timestamp,
-                                  final long offset,
-                                  final int partition,
-                                  final String topic,
-                                  final Headers headers,
-                                  final ConsumerRecord<byte[], byte[]> rawRecord) {
         this.timestamp = timestamp;
         this.offset = offset;
         this.topic = topic;
         this.partition = partition;
         this.headers = Objects.requireNonNull(headers);
-        this.rawRecord = rawRecord;
     }
 
     @Override
@@ -85,10 +73,6 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     @Override
     public Headers headers() {
         return headers;
-    }
-
-    public ConsumerRecord<byte[], byte[]> rawRecord() {
-        return rawRecord;
     }
 
     public long residentMemorySizeEstimate() {
@@ -189,7 +173,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             headers = new RecordHeaders(headerArr);
         }
 
-        return new ProcessorRecordContext(timestamp, offset, partition, topic, headers, null);
+        return new ProcessorRecordContext(timestamp, offset, partition, topic, headers);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -99,8 +99,6 @@ public class RecordDeserializer {
                 rawRecord.partition(),
                 rawRecord.offset(),
                 rawRecord.headers(),
-                rawRecord.key(),
-                rawRecord.value(),
                 sourceNodeName,
                 processorContext.taskId());
             response = deserializationExceptionHandler.handle(errorHandlerContext, rawRecord, deserializationException);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.internals.DefaultErrorHandlerContext;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public class RecordDeserializer {
                 Optional.empty()
             );
         } catch (final Exception deserializationException) {
-            handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor);
+            handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor, sourceNode().name());
             return null; //  'handleDeserializationFailure' would either throw or swallow -- if we swallow we need to skip the record by returning 'null'
         }
     }
@@ -80,12 +81,29 @@ public class RecordDeserializer {
                                                     final ConsumerRecord<byte[], byte[]> rawRecord,
                                                     final Logger log,
                                                     final Sensor droppedRecordsSensor) {
+        handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor, null);
+    }
+
+    public static void handleDeserializationFailure(final DeserializationExceptionHandler deserializationExceptionHandler,
+                                                    final ProcessorContext<?, ?> processorContext,
+                                                    final Exception deserializationException,
+                                                    final ConsumerRecord<byte[], byte[]> rawRecord,
+                                                    final Logger log,
+                                                    final Sensor droppedRecordsSensor,
+                                                    final String sourceNodeName) {
         final DeserializationExceptionHandler.DeserializationHandlerResponse response;
         try {
-            response = deserializationExceptionHandler.handle(
+            final DefaultErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 (InternalProcessorContext<?, ?>) processorContext,
-                rawRecord,
-                deserializationException);
+                rawRecord.topic(),
+                rawRecord.partition(),
+                rawRecord.offset(),
+                rawRecord.headers(),
+                rawRecord.key(),
+                rawRecord.value(),
+                sourceNodeName,
+                processorContext.taskId());
+            response = deserializationExceptionHandler.handle(errorHandlerContext, rawRecord, deserializationException);
         } catch (final Exception fatalUserException) {
             log.error(
                 "Deserialization error callback failed after deserialization error for record {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -230,7 +230,7 @@ public class RecordQueue {
                 droppedRecordsSensor.record();
                 continue;
             }
-            headRecord = new StampedRecord(deserialized, timestamp, raw);
+            headRecord = new StampedRecord(deserialized, timestamp);
             headRecordSizeInBytes = consumerRecordSizeInBytes(raw);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -88,8 +88,7 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
                 context.offset(),
                 context.partition(),
                 context.topic(),
-                record.headers(),
-                context.recordContext().rawRecord()
+                record.headers()
             );
 
         final String topic = topicExtractor.extract(key, value, contextForExtraction);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -20,11 +20,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 
 public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
-    private final ConsumerRecord<byte[], byte[]> rawRecord;
 
-    public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp, final ConsumerRecord<byte[], byte[]> rawRecord) {
+    public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp) {
         super(record, timestamp);
-        this.rawRecord = rawRecord;
     }
 
     public String topic() {
@@ -49,20 +47,6 @@ public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
     public Headers headers() {
         return value.headers();
-    }
-
-    public ConsumerRecord<byte[], byte[]> rawRecord() {
-        return rawRecord;
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        return super.equals(other);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -844,8 +844,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             record.offset(),
             record.partition(),
             record.topic(),
-            record.headers(),
-            record.rawRecord()
+            record.headers()
         );
         updateProcessorContext(currNode, wallClockTime, recordContext);
 
@@ -906,8 +905,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             -1L,
             -1,
             null,
-            new RecordHeaders(),
-            null
+            new RecordHeaders()
         );
         updateProcessorContext(node, time.milliseconds(), recordContext);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -176,8 +176,6 @@ public class ProcessingExceptionHandlerIntegrationTest {
     }
 
     private static void assertProcessingExceptionHandlerInputs(final ErrorHandlerContext context, final Record<?, ?> record, final Exception exception) {
-        assertTrue(Arrays.asList("ID123-2-ERR", "ID123-5-ERR").contains(new String(context.sourceRawKey())));
-        assertTrue(Arrays.asList("ID123-A2", "ID123-A5").contains(new String(context.sourceRawValue())));
         assertTrue(Arrays.asList("ID123-2-ERR", "ID123-5-ERR").contains((String) record.key()));
         assertTrue(Arrays.asList("ID123-A2", "ID123-A5").contains((String) record.value()));
         assertEquals("TOPIC_NAME", context.topic());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -314,8 +313,7 @@ public class ProcessorNodeTest {
                 OFFSET,
                 PARTITION,
                 TOPIC,
-                new RecordHeaders(),
-                new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, KEY.getBytes(), VALUE.getBytes())));
+                new RecordHeaders()));
         when(internalProcessorContext.currentNode()).thenReturn(new ProcessorNode<>(NAME));
 
         return internalProcessorContext;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -58,7 +58,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -337,8 +336,6 @@ public class ProcessorNodeTest {
             assertEquals(internalProcessorContext.topic(), context.topic());
             assertEquals(internalProcessorContext.partition(), context.partition());
             assertEquals(internalProcessorContext.offset(), context.offset());
-            assertArrayEquals(internalProcessorContext.recordContext().rawRecord().key(), context.sourceRawKey());
-            assertArrayEquals(internalProcessorContext.recordContext().rawRecord().value(), context.sourceRawValue());
             assertEquals(internalProcessorContext.currentNode().name(), context.processorNodeId());
             assertEquals(internalProcessorContext.taskId(), context.taskId());
             assertEquals(KEY, record.key());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -24,16 +24,29 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.test.InternalMockProcessorContext;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RecordDeserializerTest {
-
-    private final RecordHeaders headers = new RecordHeaders(new Header[] {new RecordHeader("key", "value".getBytes())});
+    private final String sourceNodeName = "source-node";
+    private final TaskId taskId = new TaskId(0, 0);
+    private final RecordHeaders headers = new RecordHeaders(new Header[]{new RecordHeader("key", "value".getBytes())});
     private final ConsumerRecord<byte[], byte[]> rawRecord = new ConsumerRecord<>("topic",
         1,
         1,
@@ -46,13 +59,17 @@ public class RecordDeserializerTest {
         headers,
         Optional.empty());
 
+    private final InternalProcessorContext<Void, Void> context = new InternalMockProcessorContext<>();
+
     @Test
     public void shouldReturnConsumerRecordWithDeserializedValueWhenNoExceptions() {
         final RecordDeserializer recordDeserializer = new RecordDeserializer(
             new TheSourceNode(
+                sourceNodeName,
                 false,
                 false,
-                "key", "value"
+                "key",
+                "value"
             ),
             null,
             new LogContext(),
@@ -69,17 +86,82 @@ public class RecordDeserializerTest {
         assertEquals(rawRecord.headers(), record.headers());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "true, true",
+        "true, false",
+        "false, true",
+    })
+    public void shouldThrowStreamsExceptionWhenDeserializationFailsAndExceptionHandlerRepliesWithFail(final boolean keyThrowsException,
+                                                                                                      final boolean valueThrowsException) {
+        final RecordDeserializer recordDeserializer = new RecordDeserializer(
+            new TheSourceNode(
+                sourceNodeName,
+                keyThrowsException,
+                valueThrowsException,
+                "key",
+                "value"
+            ),
+            new DeserializationExceptionHandlerMock(
+                DeserializationExceptionHandler.DeserializationHandlerResponse.FAIL,
+                rawRecord,
+                sourceNodeName,
+                taskId
+            ),
+            new LogContext(),
+            new Metrics().sensor("dropped-records")
+        );
+
+        final StreamsException e = assertThrows(StreamsException.class, () -> recordDeserializer.deserialize(context, rawRecord));
+        assertEquals(e.getMessage(), "Deserialization exception handler is set "
+                + "to fail upon a deserialization error. "
+                + "If you would rather have the streaming pipeline "
+                + "continue after a deserialization error, please set the "
+                + "default.deserialization.exception.handler appropriately.");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, true",
+        "true, false",
+        "false, true"
+    })
+    public void shouldNotThrowStreamsExceptionWhenDeserializationFailsAndExceptionHandlerRepliesWithContinue(final boolean keyThrowsException,
+                                                                                                             final boolean valueThrowsException) {
+        final RecordDeserializer recordDeserializer = new RecordDeserializer(
+            new TheSourceNode(
+                sourceNodeName,
+                keyThrowsException,
+                valueThrowsException,
+                "key",
+                "value"
+            ),
+            new DeserializationExceptionHandlerMock(
+                DeserializationExceptionHandler.DeserializationHandlerResponse.CONTINUE,
+                rawRecord,
+                sourceNodeName,
+                taskId
+            ),
+            new LogContext(),
+            new Metrics().sensor("dropped-records")
+        );
+
+        final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(context, rawRecord);
+        assertNull(record);
+    }
+
     static class TheSourceNode extends SourceNode<Object, Object> {
         private final boolean keyThrowsException;
         private final boolean valueThrowsException;
         private final Object key;
         private final Object value;
 
-        TheSourceNode(final boolean keyThrowsException,
+        TheSourceNode(final String name,
+                      final boolean keyThrowsException,
                       final boolean valueThrowsException,
                       final Object key,
                       final Object value) {
-            super("", null, null);
+            super(name, null, null);
             this.keyThrowsException = keyThrowsException;
             this.valueThrowsException = valueThrowsException;
             this.key = key;
@@ -89,7 +171,7 @@ public class RecordDeserializerTest {
         @Override
         public Object deserializeKey(final String topic, final Headers headers, final byte[] data) {
             if (keyThrowsException) {
-                throw new RuntimeException();
+                throw new RuntimeException("KABOOM!");
             }
             return key;
         }
@@ -97,10 +179,48 @@ public class RecordDeserializerTest {
         @Override
         public Object deserializeValue(final String topic, final Headers headers, final byte[] data) {
             if (valueThrowsException) {
-                throw new RuntimeException();
+                throw new RuntimeException("KABOOM!");
             }
             return value;
         }
     }
 
+    public static class DeserializationExceptionHandlerMock implements DeserializationExceptionHandler {
+        private final DeserializationHandlerResponse response;
+        private final ConsumerRecord<byte[], byte[]> expectedRecord;
+        private final String expectedProcessorNodeId;
+        private final TaskId expectedTaskId;
+
+        public DeserializationExceptionHandlerMock(final DeserializationHandlerResponse response,
+                                                   final ConsumerRecord<byte[], byte[]> record,
+                                                   final String processorNodeId,
+                                                   final TaskId taskId) {
+            this.response = response;
+            this.expectedRecord = record;
+            this.expectedProcessorNodeId = processorNodeId;
+            this.expectedTaskId = taskId;
+        }
+
+        @Override
+        public DeserializationHandlerResponse handle(final ErrorHandlerContext context,
+                                                     final ConsumerRecord<byte[], byte[]> record,
+                                                     final Exception exception) {
+            assertEquals(expectedRecord.topic(), context.topic());
+            assertEquals(expectedRecord.partition(), context.partition());
+            assertEquals(expectedRecord.offset(), context.offset());
+            assertArrayEquals(expectedRecord.key(), context.sourceRawKey());
+            assertArrayEquals(expectedRecord.value(), context.sourceRawValue());
+            assertEquals(expectedProcessorNodeId, context.processorNodeId());
+            assertEquals(expectedTaskId, context.taskId());
+            assertEquals(expectedRecord, record);
+            assertInstanceOf(RuntimeException.class, exception);
+            assertEquals("KABOOM!", exception.getMessage());
+            return response;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs) {
+            // do nothing
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -208,8 +207,6 @@ public class RecordDeserializerTest {
             assertEquals(expectedRecord.topic(), context.topic());
             assertEquals(expectedRecord.partition(), context.partition());
             assertEquals(expectedRecord.offset(), context.offset());
-            assertArrayEquals(expectedRecord.key(), context.sourceRawKey());
-            assertArrayEquals(expectedRecord.value(), context.sourceRawValue());
             assertEquals(expectedProcessorNodeId, context.processorNodeId());
             assertEquals(expectedTaskId, context.taskId());
             assertEquals(expectedRecord, record);


### PR DESCRIPTION
This PR is part of [KAFKA-16448](https://issues.apache.org/jira/browse/KAFKA-16448) which aims to bring a ProcessingExceptionHandler to Kafka Streams in order to deal with exceptions that occur during processing.

This PR expose the new ErrorHandlerContext as a parameter to the Deserialization exception handlers and deprecate the previous handle signatur

Jira: https://issues.apache.org/jira/browse/KAFKA-16448.

Contributors
@Dabz
@sebastienviale 
@loicgreffier