### PR TITLE
MINOR: Improve TaskAssignor#onAssignmentComputed() javadoc

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
@@ -71,11 +71,11 @@ public interface TaskAssignor extends Configurable {
      * that was returned from the TaskAssignor's {@link #assign}. If this occurs, the {@link GroupAssignment} passed
      * in to this callback will contain an empty map instead of the consumer assignments.
      *
-     * @param assignment:   the final consumer assignments returned to the kafka broker, or an empty assignment map if
-     *                      an error prevented the assignor from converting the TaskAssignment into a GroupAssignment
-     * @param subscription: the original consumer subscriptions passed into the assignor
-     * @param error:        the corresponding error type if one was detected while processing the returned assignment,
-     *                      or AssignmentError.NONE if the returned assignment was valid
+     * @param assignment   the final consumer assignments returned to the kafka broker, or an empty assignment map if
+     *                     an error prevented the assignor from converting the TaskAssignment into a GroupAssignment
+     * @param subscription the original consumer subscriptions passed into the assignor
+     * @param error        the corresponding error type if one was detected while processing the returned assignment,
+     *                     or AssignmentError.NONE if the returned assignment was valid
      */
     default void onAssignmentComputed(GroupAssignment assignment, GroupSubscription subscription, AssignmentError error) {}
 


### PR DESCRIPTION
MINOR: Improve TaskAssignor#onAssignmentComputed() javadoc,eliminate warning logs during compilation

warning info：
[2024-06-24T02:22:41.423Z] /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-16413/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java:80: warning - @param argument "assignment:" is not a parameter name.
[2024-06-24T02:22:41.423Z] /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-16413/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java:80: warning - @param argument "subscription:" is not a parameter name.
[2024-06-24T02:22:41.423Z] /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-16413/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java:80: warning - @param argument "error:" is not a parameter name.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
