### PR TITLE
MINOR: Remove extra synchronized block in SharePartitionManager

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -284,10 +284,8 @@ public class SharePartitionManager implements AutoCloseable {
                     throw Errors.INVALID_REQUEST.exception();
                 }
                 context = new FinalContext();
-                synchronized (cache) {
-                    if (cache.remove(key) != null) {
-                        log.debug("Removed share session with key {}", key);
-                    }
+                if (cache.remove(key) != null) {
+                    log.debug("Removed share session with key {}", key);
                 }
             } else {
                 if (cache.remove(key) != null) {


### PR DESCRIPTION
### About
Removed an extra synchronized block encapsulating `cache.remove(key)`. `remove(ShareSessionKey key)` function is already a synchronized method, hence we don't need it.