### PR TITLE
KAFKA-16551: add integration test with bootstrap controller for ClusterTool

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
@@ -18,10 +18,12 @@ package org.apache.kafka.tools;
 
 import kafka.test.ClusterInstance;
 import kafka.test.annotation.ClusterTest;
+import kafka.test.annotation.Type;
 import kafka.test.junit.ClusterTestExtensions;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.errors.UnsupportedEndpointTypeException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -30,9 +32,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(value = 60)
@@ -65,6 +70,28 @@ public class ClusterToolTest {
         } else {
             assertTrue(output.contains("The target cluster does not support the broker unregistration API."));
         }
+    }
+
+    @ClusterTest(types = {Type.KRAFT, Type.CO_KRAFT})
+    public void testClusterIdWithBootstrapController(ClusterInstance clusterInstance) {
+        String output = ToolsTestUtils.captureStandardOut(() ->
+                assertDoesNotThrow(() -> ClusterTool.execute("cluster-id", "--bootstrap-controller", clusterInstance.bootstrapControllers())));
+        assertTrue(output.contains("Cluster ID: " + clusterInstance.clusterId()));
+    }
+
+    @ClusterTest(brokers = 3, types = {Type.KRAFT, Type.CO_KRAFT})
+    public void testUnregisterWithBootstrapController(ClusterInstance clusterInstance) {
+        Set<Integer> brokerIds = clusterInstance.brokerIds();
+        brokerIds.removeAll(clusterInstance.controllerIds());
+        int brokerId = assertDoesNotThrow(() -> brokerIds.stream().findFirst().get());
+        clusterInstance.shutdownBroker(brokerId);
+        ExecutionException exception =
+                assertThrows(ExecutionException.class,
+                        () -> ClusterTool.execute("unregister", "--bootstrap-controller", clusterInstance.bootstrapControllers(), "--id", String.valueOf(brokerId)));
+        assertNotNull(exception.getCause());
+        assertEquals(UnsupportedEndpointTypeException.class, exception.getCause().getClass());
+        assertEquals("This Admin API is not yet supported when communicating directly with " +
+                "the controller quorum.", exception.getCause().getMessage());
     }
 
     @Test


### PR DESCRIPTION
Add `testClusterIdWithBootstrapController` and `testUnregisterWithBootstrapController`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
