### PR TITLE
KAFKA-17029: handle primitive types in SetSchemaMetadata

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
@@ -79,6 +79,7 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
         requireSchema(schema, "updating schema metadata");
         final boolean isArray = schema.type() == Schema.Type.ARRAY;
         final boolean isMap = schema.type() == Schema.Type.MAP;
+        final boolean isStruct = value instanceof Struct;
         final Schema updatedSchema = new ConnectSchema(
                 schema.type(),
                 schema.isOptional(),
@@ -87,7 +88,7 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
                 schemaVersion != null ? schemaVersion : schema.version(),
                 schema.doc(),
                 schema.parameters(),
-                schema.fields(),
+                isStruct ? schema.fields() : null,
                 isMap ? schema.keySchema() : null,
                 isMap || isArray ? schema.valueSchema() : null
         );

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
@@ -164,6 +164,26 @@ public class SetSchemaMetadataTest {
         assertEquals(AppInfoParser.getVersion(), xform.version());
     }
 
+    @Test
+    public void schemaMetadataUpdateWithPrimitiveType() {
+        final Map<String, String> props = new HashMap<>();
+        props.put("schema.name", "foo");
+        props.put("schema.version", "42");
+
+        xform.configure(props);
+
+        final Schema schema = Schema.STRING_SCHEMA;
+        final String value = "test-string";
+
+        final SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+        final SinkRecord updatedRecord = xform.apply(record);
+
+        assertEquals("foo", updatedRecord.valueSchema().name());
+        assertEquals(Integer.valueOf(42), updatedRecord.valueSchema().version());
+        assertEquals(value, updatedRecord.value());
+    }
+
     protected void assertMatchingSchema(Struct value, Schema schema) {
         assertSame(schema, value.schema());
         assertEquals(schema.name(), value.schema().name());


### PR DESCRIPTION
fix for [KAFKA-17029
](https://issues.apache.org/jira/browse/KAFKA-17029)
### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
