### PR TITLE
KAFKA-17017: AsyncKafkaConsumer#unsubscribe does not clean the assigned partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -663,6 +663,7 @@ public class MembershipManagerImpl implements MembershipManager {
                 clearAssignment();
                 transitionTo(MemberState.UNSUBSCRIBED);
             }
+            subscriptions.unsubscribe();
             return CompletableFuture.completedFuture(null);
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -298,6 +298,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(
                     logContext,
                     metadata,
+                    subscriptions,
                     requestManagersSupplier
             );
 
@@ -398,6 +399,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(
                 logContext,
                 metadata,
+                subscriptions,
                 requestManagersSupplier
         );
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -439,7 +439,7 @@ public class KafkaConsumerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = GroupProtocol.class, names = "CLASSIC")
+    @EnumSource(GroupProtocol.class)
     public void testSubscription(GroupProtocol groupProtocol) {
         consumer = newConsumer(groupProtocol, groupId);
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -2077,6 +2077,15 @@ public class AsyncKafkaConsumerTest {
         verify(backgroundEventReaper).reap(time.milliseconds());
     }
 
+    @Test
+    public void testUnsubscribeWithoutGroupId() {
+        consumer = newConsumerWithoutGroupId();
+
+        completeUnsubscribeApplicationEventSuccessfully();
+        consumer.unsubscribe();
+        verify(applicationEventHandler).add(ArgumentMatchers.isA(UnsubscribeEvent.class));
+    }
+
     private void verifyUnsubscribeEvent(SubscriptionState subscriptions) {
         // Check that an unsubscribe event was generated, and that the consumer waited for it to
         // complete processing background events.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -271,7 +271,8 @@ public class ConsumerTestBuilder implements Closeable {
         this.applicationEventProcessor = spy(new ApplicationEventProcessor(
                 logContext,
                 requestManagers,
-                metadata
+                metadata,
+                subscriptions
             )
         );
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -180,6 +180,7 @@ public class MembershipManagerImplTest {
         receiveEmptyAssignment(manager);
         mockLeaveGroup();
         manager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, manager.state());
         manager.onHeartbeatRequestSent();
         assertEquals(MemberState.UNSUBSCRIBED, manager.state());
@@ -235,6 +236,9 @@ public class MembershipManagerImplTest {
         membershipManager.transitionToFatal();
         assertEquals(MemberState.FATAL, membershipManager.state());
         verify(subscriptionState).assignFromSubscribed(Collections.emptySet());
+
+        membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
     }
 
     @Test
@@ -286,6 +290,7 @@ public class MembershipManagerImplTest {
 
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
         verify(listener).onMemberEpochUpdated(Optional.empty(), Optional.empty());
     }
@@ -394,6 +399,7 @@ public class MembershipManagerImplTest {
         // Start leaving group.
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
 
         // Get fenced while leaving. Member should not trigger any callback or try to
@@ -420,6 +426,7 @@ public class MembershipManagerImplTest {
         MembershipManagerImpl membershipManager = createMemberInStableState("instance1");
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
         assertEquals(ConsumerGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH,
                 membershipManager.memberEpoch());
@@ -428,6 +435,7 @@ public class MembershipManagerImplTest {
         membershipManager = createMemberInStableState(null);
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
         assertEquals(ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH,
                 membershipManager.memberEpoch());
@@ -883,6 +891,7 @@ public class MembershipManagerImplTest {
         mockLeaveGroup();
 
         CompletableFuture<Void> leaveResult = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
 
         membershipManager.onHeartbeatSuccess(createConsumerGroupHeartbeatResponse(createAssignment(true)).data());
 
@@ -962,6 +971,7 @@ public class MembershipManagerImplTest {
         // callbacks complete and the heartbeat is sent out.
         mockLeaveGroup();
         CompletableFuture<Void> leaveResult1 = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertFalse(leaveResult1.isDone());
         assertEquals(MemberState.LEAVING, membershipManager.state());
         verify(subscriptionState).assignFromSubscribed(Collections.emptySet());
@@ -972,6 +982,7 @@ public class MembershipManagerImplTest {
         // leave operation completes.
         mockLeaveGroup();
         CompletableFuture<Void> leaveResult2 = membershipManager.leaveGroup();
+        verify(subscriptionState, never()).unsubscribe();
         verify(subscriptionState, never()).rebalanceListener();
         assertFalse(leaveResult2.isDone());
 
@@ -993,6 +1004,7 @@ public class MembershipManagerImplTest {
         // Leave group triggered and completed
         mockLeaveGroup();
         CompletableFuture<Void> leaveResult1 = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
         membershipManager.onHeartbeatRequestSent();
         assertEquals(MemberState.UNSUBSCRIBED, membershipManager.state());
@@ -1005,6 +1017,7 @@ public class MembershipManagerImplTest {
         // no assignment updated)
         mockLeaveGroup();
         CompletableFuture<Void> leaveResult2 = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertTrue(leaveResult2.isDone());
         assertFalse(leaveResult2.isCompletedExceptionally());
         assertEquals(MemberState.UNSUBSCRIBED, membershipManager.state());
@@ -1021,6 +1034,7 @@ public class MembershipManagerImplTest {
 
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.UNSUBSCRIBED, membershipManager.state());
         verify(subscriptionState).assignFromSubscribed(Collections.emptySet());
 
@@ -1035,6 +1049,7 @@ public class MembershipManagerImplTest {
 
         mockLeaveGroup();
         CompletableFuture<Void> leaveResult1 = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertTrue(leaveResult1.isDone());
         assertEquals(MemberState.STALE, membershipManager.state());
     }
@@ -1076,6 +1091,7 @@ public class MembershipManagerImplTest {
         // Start leaving group.
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
 
         // Get fatal failure while waiting to send the heartbeat to leave. Member should
@@ -1095,6 +1111,7 @@ public class MembershipManagerImplTest {
         // Start leaving group.
         mockLeaveGroup();
         membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
         assertEquals(MemberState.LEAVING, membershipManager.state());
 
         // Last heartbeat sent.
@@ -2121,6 +2138,7 @@ public class MembershipManagerImplTest {
         assertTrue(membershipManager.currentAssignment().isNone());
         assertTrue(membershipManager.topicsAwaitingReconciliation().isEmpty());
         assertEquals(LEAVE_GROUP_MEMBER_EPOCH, membershipManager.memberEpoch());
+        verify(subscriptionState, never()).unsubscribe();
     }
 
     @Test
@@ -2665,6 +2683,7 @@ public class MembershipManagerImplTest {
         mockLeaveGroup();
 
         CompletableFuture<Void> leaveResult = membershipManager.leaveGroup();
+        verify(subscriptionState).unsubscribe();
 
         assertEquals(MemberState.LEAVING, membershipManager.state());
         assertFalse(leaveResult.isDone(), "Leave group result should not complete until the " +

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
@@ -213,7 +213,8 @@ public class ShareConsumerTestBuilder implements Closeable {
         this.applicationEventProcessor = spy(new ApplicationEventProcessor(
                         logContext,
                         requestManagers,
-                        metadata
+                        metadata,
+                        subscriptions
                 )
         );
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -25,60 +25,70 @@ import org.apache.kafka.clients.consumer.internals.MembershipManager;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate;
 import org.apache.kafka.clients.consumer.internals.OffsetsRequestManager;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
+import org.apache.kafka.clients.consumer.internals.SubscriptionState;
 import org.apache.kafka.clients.consumer.internals.TopicMetadataRequestManager;
 import org.apache.kafka.common.utils.LogContext;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ApplicationEventProcessorTest {
-    private final ConsumerMetadata metadata = mock(ConsumerMetadata.class);
+    private final CommitRequestManager commitRequestManager = mock(CommitRequestManager.class);
+    private final HeartbeatRequestManager heartbeatRequestManager = mock(HeartbeatRequestManager.class);
+    private final MembershipManager membershipManager = mock(MembershipManager.class);
+    private final SubscriptionState subscriptionState = mock(SubscriptionState.class);
     private ApplicationEventProcessor processor;
-    private CommitRequestManager commitRequestManager;
-    private HeartbeatRequestManager heartbeatRequestManager;
-    private MembershipManager membershipManager;
 
-    @BeforeEach
-    public void setup() {
-        LogContext logContext = new LogContext();
-        OffsetsRequestManager offsetsRequestManager = mock(OffsetsRequestManager.class);
-        TopicMetadataRequestManager topicMetadataRequestManager = mock(TopicMetadataRequestManager.class);
-        FetchRequestManager fetchRequestManager = mock(FetchRequestManager.class);
-        CoordinatorRequestManager coordinatorRequestManager = mock(CoordinatorRequestManager.class);
-        commitRequestManager = mock(CommitRequestManager.class);
-        heartbeatRequestManager = mock(HeartbeatRequestManager.class);
-        membershipManager = mock(MembershipManager.class);
+    private void setupProcessor(boolean withGroupId) {
         RequestManagers requestManagers = new RequestManagers(
-            logContext,
-            offsetsRequestManager,
-            topicMetadataRequestManager,
-            fetchRequestManager,
-            Optional.of(coordinatorRequestManager),
-            Optional.of(commitRequestManager),
-            Optional.of(heartbeatRequestManager),
-            Optional.of(membershipManager)
-        );
+                new LogContext(),
+                mock(OffsetsRequestManager.class),
+                mock(TopicMetadataRequestManager.class),
+                mock(FetchRequestManager.class),
+                withGroupId ? Optional.of(mock(CoordinatorRequestManager.class)) : Optional.empty(),
+                withGroupId ? Optional.of(commitRequestManager) : Optional.empty(),
+                withGroupId ? Optional.of(heartbeatRequestManager) : Optional.empty(),
+                withGroupId ? Optional.of(membershipManager) : Optional.empty());
         processor = new ApplicationEventProcessor(
-            new LogContext(),
-            requestManagers,
-            metadata
+                new LogContext(),
+                requestManagers,
+                mock(ConsumerMetadata.class),
+                subscriptionState
         );
     }
 
     @Test
     public void testPrepClosingCommitEvents() {
+        setupProcessor(true);
         List<NetworkClientDelegate.UnsentRequest> results = mockCommitResults();
         doReturn(new NetworkClientDelegate.PollResult(100, results)).when(commitRequestManager).pollOnClose();
         processor.process(new CommitOnCloseEvent());
         verify(commitRequestManager).signalClose();
+    }
+
+    @Test
+    public void testProcessUnsubscribeEventWithGroupId() {
+        setupProcessor(true);
+        when(heartbeatRequestManager.membershipManager()).thenReturn(membershipManager);
+        when(membershipManager.leaveGroup()).thenReturn(CompletableFuture.completedFuture(null));
+        processor.process(new UnsubscribeEvent(0));
+        verify(membershipManager).leaveGroup();
+    }
+
+    @Test
+    public void testProcessUnsubscribeEventWithoutGroupId() {
+        setupProcessor(false);
+        processor.process(new UnsubscribeEvent(0));
+        verify(subscriptionState).unsubscribe();
     }
 
     private List<NetworkClientDelegate.UnsentRequest> mockCommitResults() {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -693,6 +693,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer2.unsubscribe()
     consumer3.unsubscribe()
 
+    assertTrue(consumer1.assignment().isEmpty)
+    assertTrue(consumer2.assignment().isEmpty)
+    assertTrue(consumer3.assignment().isEmpty)
+
     consumer1.close()
     consumer2.close()
     consumer3.close()


### PR DESCRIPTION
* Add `subscriptions.unsubscribe` to `AsyncKafkaConsumer#unsubscribe` when there is no group id.
* Add `subscriptions.unsubscribe` to `MembershipManagerImpl#leaveGroup` when `isNotInGroup` is true.
* Add related unit test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
