### PR TITLE
KAFKA-16943: Synchronously verify Connect worker startup failure in InternalTopicsIntegrationTest

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -36,7 +36,7 @@ public class Connect<H extends Herder> {
     private static final Logger log = LoggerFactory.getLogger(Connect.class);
 
     private final H herder;
-    private Future<?> distributedHerderFuture;
+    private Future<?> herderTask;
     private final ConnectRestServer rest;
     private final CountDownLatch startLatch = new CountDownLatch(1);
     private final CountDownLatch stopLatch = new CountDownLatch(1);
@@ -50,9 +50,12 @@ public class Connect<H extends Herder> {
         shutdownHook = new ShutdownHook();
     }
 
-    // public for testing
-    public Future<?> getDistributedHerderFuture() {
-        return this.distributedHerderFuture;
+    /**
+     * Track task status which have been submitted to work thread.
+     * @return {@link DistributedHerder#herderTask} to track status or null if the herder type doesn't have a separate work thread
+     */
+    public Future<?> herderTask() {
+        return this.herderTask;
     }
 
     public H herder() {
@@ -68,7 +71,7 @@ public class Connect<H extends Herder> {
             rest.initializeResources(herder);
 
             if (herder instanceof DistributedHerder) {
-                distributedHerderFuture = ((DistributedHerder) herder).herderFuture;
+                herderTask = ((DistributedHerder) herder).herderTask();
             }
 
             log.info("Kafka Connect started");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -233,8 +233,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     private final DistributedConfig config;
 
-    // visible for testing
-    public Future<?> herderFuture;
+    private Future<?> herderTask;
 
     /**
      * Create a herder that will form a Connect cluster with other {@link DistributedHerder} instances (in this or other JVMs)
@@ -367,7 +366,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     @Override
     public void start() {
-        herderFuture = this.herderExecutor.submit(this);
+        herderTask = this.herderExecutor.submit(this);
     }
 
     @Override
@@ -398,6 +397,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             Utils.closeQuietly(this::stopServices, "herder services");
             Exit.exit(1);
         }
+    }
+
+    // public for testing
+    public Future<?> herderTask() {
+        return herderTask;
     }
 
     // public for testing

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -99,6 +99,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -232,6 +233,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     private final DistributedConfig config;
 
+    // visible for testing
+    public Future<?> herderFuture;
+
     /**
      * Create a herder that will form a Connect cluster with other {@link DistributedHerder} instances (in this or other JVMs)
      * that have the same group ID.
@@ -363,7 +367,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     @Override
     public void start() {
-        this.herderExecutor.submit(this);
+        herderFuture = this.herderExecutor.submit(this);
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -38,11 +38,11 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Response;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration test for the creation of internal topics.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
@@ -38,9 +38,12 @@ public class WorkerHandle {
         this.worker = worker;
     }
 
-    // public for testing
-    public Future<?> getDistributedHerderFuture() {
-        return worker.getDistributedHerderFuture();
+    /**
+     * Track the worker status during startup.
+     * @return {@link Connect#herderTask} to track or null
+     */
+    public Future<?> herderTask() {
+        return worker.herderTask();
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.runtime.rest.RestServer;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Future;
 
 /**
  * A handle to a worker executing in a Connect cluster.
@@ -35,6 +36,11 @@ public class WorkerHandle {
     protected WorkerHandle(String workerName, Connect<?> worker) {
         this.workerName = workerName;
         this.worker = worker;
+    }
+
+    // public for testing
+    public Future<?> getDistributedHerderFuture() {
+        return worker.getDistributedHerderFuture();
     }
 
     /**


### PR DESCRIPTION
Synchronously verify worker status when created

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
