### PR TITLE
KAFKA-17026: Implement updateCacheAndOffsets functionality on LSO movement

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -45,7 +45,6 @@
               files="(KafkaClusterTestKit).java"/>
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
-              files="RemoteLogManagerTest.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="SharePartitionManagerTest"/>
 
     <!-- server tests -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -44,6 +44,7 @@
     <suppress checks="MethodLength"
               files="(KafkaClusterTestKit).java"/>
     <suppress checks="JavaNCSS"
+              files="(RemoteLogManagerTest|SharePartitionTest).java"/>
               files="RemoteLogManagerTest.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="SharePartitionManagerTest"/>
 

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -758,10 +758,10 @@ public class SharePartition {
                         inFlightBatch.maybeInitializeOffsetStateUpdate();
                     }
                     isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset(), logStartOffset - 1);
-                } else {
-                    // The in-flight batch is a full match hence change the state of the complete batch.
-                    isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch);
+                    continue;
                 }
+                // The in-flight batch is a full match hence change the state of the complete batch.
+                isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch);
             }
             return isAnyOffsetArchived || isAnyBatchArchived;
         } finally {

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -1023,7 +1023,8 @@ public class SharePartition {
      * @return True if the start offset has moved and within the request first and last offset, false otherwise.
      */
     private boolean checkForStartOffsetWithinBatch(long batchFirstOffset, long batchLastOffset) {
-        return batchFirstOffset < startOffset && batchLastOffset >= startOffset;
+        long localStartOffset = startOffset();
+        return batchFirstOffset < localStartOffset && batchLastOffset >= localStartOffset;
     }
 
     private Map<Long, RecordState> fetchRecordStateMapForAcknowledgementBatch(

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -689,7 +689,127 @@ public class SharePartition {
      * @param logStartOffset The new log start offset.
      */
     void updateCacheAndOffsets(long logStartOffset) {
-        // TODO: Provide implementation to update cache and offsets on LSO movement.
+        lock.writeLock().lock();
+        try {
+            if (logStartOffset <= startOffset()) {
+                log.error("The log start offset: {} is not greater than the start offset: {} for the share partition: {}-{}",
+                        logStartOffset, startOffset(), groupId, topicIdPartition);
+                return;
+            }
+            log.debug("Updating start offset for share partition: {}-{} from: {} to: {} since LSO has moved to: {}",
+                    groupId, topicIdPartition, startOffset(), logStartOffset, logStartOffset);
+            if (cachedState.isEmpty()) {
+                // If the cached state is empty, then the start and end offset will be the new log start offset.
+                // This can occur during the initialization of share partition if LSO has moved.
+                startOffset = logStartOffset;
+                endOffset = logStartOffset;
+                return;
+            }
+
+            // Archive the available records in the cached state that are before the new log start offset.
+            boolean anyRecordArchived = archiveAvailableRecordsOnLsoMovement(logStartOffset);
+            // If we have transitioned the state of any batch/offset from AVAILABLE to ARCHIVED,
+            // then there is a chance that the next fetch offset can change.
+            if (anyRecordArchived) {
+                findNextFetchOffset.set(true);
+            }
+
+            // The new startOffset will be the log start offset.
+            startOffset = logStartOffset;
+            if (endOffset < startOffset()) {
+                // This case means that the cached state is completely fresh now.
+                // Example scenario - batch of 0-10 in acquired state in cached state, then LSO moves to 15,
+                // then endOffset should be 15 as well.
+                endOffset = startOffset();
+            }
+
+            // Note -
+            // 1. We will be writing the new starOffset lazily during acknowledge/release acquired records API call.
+            // 2. We will not be writing the archived state batches to the persister.
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private boolean archiveAvailableRecordsOnLsoMovement(long logStartOffset) {
+        lock.writeLock().lock();
+        try {
+            boolean isAnyOffsetArchived = false, isAnyBatchArchived = false;
+            for (Map.Entry<Long, InFlightBatch> entry : cachedState.entrySet()) {
+                long batchStartOffset = entry.getKey();
+                // We do not need to transition state of batches/offsets that are later than the new log start offset.
+                if (batchStartOffset >= logStartOffset) {
+                    break;
+                }
+                InFlightBatch inFlightBatch = entry.getValue();
+                boolean fullMatch = checkForFullMatch(inFlightBatch, startOffset(), logStartOffset - 1);
+
+                // Maintain state per offset if the inflight batch is not a full match or the offset state is managed.
+                if (!fullMatch || inFlightBatch.offsetState() != null) {
+                    log.debug("Subset or offset tracked batch record found while trying to update offsets and cached" +
+                                    " state map due to LSO movement, batch: {}, offsets to update - " +
+                                    "first: {}, last: {} for the share partition: {}-{}", inFlightBatch, startOffset(),
+                            logStartOffset - 1, groupId, topicIdPartition);
+
+                    if (inFlightBatch.offsetState() == null) {
+                        if (inFlightBatch.batchState() != RecordState.AVAILABLE) {
+                            continue;
+                        }
+                        inFlightBatch.maybeInitializeOffsetStateUpdate();
+                    }
+                    isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset(), logStartOffset - 1);
+                } else {
+                    // The in-flight batch is a full match hence change the state of the complete batch.
+                    isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch);
+                }
+            }
+            return isAnyOffsetArchived || isAnyBatchArchived;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private boolean archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,
+                                                 long startOffsetToArchive,
+                                                 long endOffsetToArchive) {
+        lock.writeLock().lock();
+        try {
+            boolean isAnyOffsetArchived = false;
+            log.trace("Archiving offset tracked batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
+            for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState().entrySet()) {
+                if (offsetState.getKey() < startOffsetToArchive) {
+                    continue;
+                }
+                if (offsetState.getKey() > endOffsetToArchive) {
+                    // No further offsets to process.
+                    break;
+                }
+                if (offsetState.getValue().state != RecordState.AVAILABLE) {
+                    continue;
+                }
+
+                offsetState.getValue().archive(EMPTY_MEMBER_ID);
+                isAnyOffsetArchived = true;
+            }
+            return isAnyOffsetArchived;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private boolean archiveCompleteBatch(InFlightBatch inFlightBatch) {
+        lock.writeLock().lock();
+        try {
+            log.trace("Archiving complete batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
+            if (inFlightBatch.batchState() == RecordState.AVAILABLE) {
+                // Change the state of complete batch since the same state exists for the entire inFlight batch.
+                inFlightBatch.archiveBatch(EMPTY_MEMBER_ID);
+                return true;
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+        return false;
     }
 
     /**
@@ -903,7 +1023,7 @@ public class SharePartition {
      * @return True if the start offset has moved and within the request first and last offset, false otherwise.
      */
     private boolean checkForStartOffsetWithinBatch(long batchFirstOffset, long batchLastOffset) {
-        return batchFirstOffset < startOffset && batchLastOffset >= startOffset;
+        return batchFirstOffset < startOffset() && batchLastOffset >= startOffset();
     }
 
     private Map<Long, RecordState> fetchRecordStateMapForAcknowledgementBatch(
@@ -1018,7 +1138,7 @@ public class SharePartition {
                 // Determine if the in-flight batch is a full match from the request batch.
                 boolean fullMatch = checkForFullMatch(inFlightBatch, batch.firstOffset(), batch.lastOffset());
                 boolean isPerOffsetClientAck = batch.acknowledgeTypes().size() > 1;
-                boolean hasStartOffsetMoved = checkForStartOffsetWithinBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset);
+                boolean hasStartOffsetMoved = checkForStartOffsetWithinBatch(inFlightBatch.firstOffset(), inFlightBatch.lastOffset());
 
                 // Maintain state per offset if the inflight batch is not a full match or the
                 // offset state is managed or client sent individual offsets state or
@@ -1707,6 +1827,13 @@ public class SharePartition {
             return offsetState;
         }
 
+        private void archiveBatch(String newMemberId) {
+            if (batchState == null) {
+                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
+            }
+            batchState.archive(newMemberId);
+        }
+
         private InFlightState tryUpdateBatchState(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount, String newMemberId) {
             if (batchState == null) {
                 throw new IllegalStateException("The batch state update is not available as the offset state is maintained");
@@ -1851,6 +1978,11 @@ public class SharePartition {
                 log.error("Failed to update state of the records", e);
                 return null;
             }
+        }
+
+        private void archive(String newMemberId) {
+            state = RecordState.ARCHIVED;
+            memberId = newMemberId;
         }
 
         private InFlightState startStateTransition(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount, String newMemberId) {

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -621,7 +621,8 @@ public class SharePartitionManager implements AutoCloseable {
      *
      * @return The offset for the earliest timestamp.
      */
-    private long offsetForEarliestTimestamp(TopicIdPartition topicIdPartition) {
+    // Visible for testing.
+    long offsetForEarliestTimestamp(TopicIdPartition topicIdPartition) {
         // TODO: We need to know the isolation level from group configs, for now we are passing Option.empty() for isolationLevel
         Option<TimestampAndOffset> timestampAndOffset = replicaManager.fetchOffsetForTimestamp(
             topicIdPartition.topicPartition(), ListOffsetsRequest.EARLIEST_TIMESTAMP, Option.empty(),

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -33,9 +33,11 @@ import org.apache.kafka.common.message.ShareFetchResponseData.PartitionData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+//import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
+//import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
 import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
@@ -79,6 +81,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+//import scala.Some;
 import scala.Tuple2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,9 +92,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyBoolean;
+//import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -1525,6 +1531,116 @@ public class SharePartitionManagerTest {
         assertEquals(3, result.get(tp).partitionIndex());
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp).errorCode());
     }
+
+//    @Test
+//    public void testProcessFetchResponseWithLsoMovementForTopicPartition() {
+//        String groupId = "grp";
+//        Uuid fooId = Uuid.randomUuid();
+//        TopicIdPartition tp0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
+//        TopicIdPartition tp1 = new TopicIdPartition(fooId, new TopicPartition("foo", 1));
+//
+//        Map<TopicIdPartition, Integer> partitionMaxBytes = new HashMap<>();
+//        partitionMaxBytes.put(tp0, PARTITION_MAX_BYTES);
+//        partitionMaxBytes.put(tp1, PARTITION_MAX_BYTES);
+//
+//        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+//        SharePartition sp0 = Mockito.mock(SharePartition.class);
+//        SharePartition sp1 = Mockito.mock(SharePartition.class);
+//        // Mocking the fetchOffsetForTimestamp method to return a valid offset for the timestamp.
+//        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+//                new Some<>(new FileRecords.TimestampAndOffset(
+//                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 10, Optional.of(0))));
+//
+//        Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
+//        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp0), sp0);
+//        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
+//
+//        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+//                .withPartitionCacheMap(partitionCacheMap).withReplicaManager(replicaManager).build();
+//
+//        when(sp0.nextFetchOffset()).thenReturn((long) 0, (long) 5);
+//        when(sp1.nextFetchOffset()).thenReturn((long) 4, (long) 4);
+//
+//        when(sp0.acquire(any(), any())).thenReturn(
+//                CompletableFuture.completedFuture(Collections.emptyList()),
+//                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+//                        .setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1))));
+//        when(sp1.acquire(any(), any())).thenReturn(
+//                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+//                        .setFirstOffset(100).setLastOffset(103).setDeliveryCount((short) 1))),
+//                CompletableFuture.completedFuture(Collections.emptyList()));
+//
+//        doNothing().when(sp1).updateCacheAndOffsets(any(Long.class));
+//        doNothing().when(sp0).updateCacheAndOffsets(any(Long.class));
+//
+//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
+//        SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
+//                new FetchParams(ApiKeys.SHARE_FETCH.latestVersion(), FetchRequest.ORDINARY_CONSUMER_ID, -1, 0,
+//                        1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()),
+//                groupId, Uuid.randomUuid().toString(), Arrays.asList(tp0, tp1), future, partitionMaxBytes);
+//
+//        MemoryRecords records1 = MemoryRecords.withRecords(Compression.NONE,
+//                new SimpleRecord("0".getBytes(), "v".getBytes()),
+//                new SimpleRecord("1".getBytes(), "v".getBytes()),
+//                new SimpleRecord("2".getBytes(), "v".getBytes()),
+//                new SimpleRecord(null, "value".getBytes()));
+//
+//        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData1 = new ArrayList<>();
+//        responseData1.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.OFFSET_OUT_OF_RANGE, 0L, 0L,
+//                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false)));
+//        responseData1.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+//                records1, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false)));
+//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result1 =
+//                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData1);
+//
+//        assertTrue(result1.isDone());
+//        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData1 = result1.join();
+//        assertEquals(2, resultData1.size());
+//        assertTrue(resultData1.containsKey(tp0));
+//        assertTrue(resultData1.containsKey(tp1));
+//        assertEquals(0, resultData1.get(tp0).partitionIndex());
+//        assertEquals(1, resultData1.get(tp1).partitionIndex());
+//        assertEquals(Errors.NONE.code(), resultData1.get(tp0).errorCode());
+//        assertEquals(Errors.NONE.code(), resultData1.get(tp1).errorCode());
+//
+//        // Since we have OFFSET_OUT_OF_RANGE exception for tp1 and no exception for tp2 from SharePartition class,
+//        // we should have 1 call for updateCacheAndOffsets for tp0 and 0 calls for tp1.
+//        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any());
+//        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any());
+//
+//        MemoryRecords records2 = MemoryRecords.withRecords(100L, Compression.NONE,
+//                new SimpleRecord("0".getBytes(), "v".getBytes()),
+//                new SimpleRecord("1".getBytes(), "v".getBytes()),
+//                new SimpleRecord("2".getBytes(), "v".getBytes()),
+//                new SimpleRecord(null, "value".getBytes()));
+//
+//        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData2 = new ArrayList<>();
+//        responseData2.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.NONE, 0L, 0L,
+//                records2, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false)));
+//        responseData2.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+//                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false)));
+//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result2 =
+//                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData2);
+//
+//        assertTrue(result2.isDone());
+//        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData2 = result2.join();
+//        assertEquals(2, resultData2.size());
+//        assertTrue(resultData2.containsKey(tp0));
+//        assertTrue(resultData2.containsKey(tp1));
+//        assertEquals(0, resultData2.get(tp0).partitionIndex());
+//        assertEquals(1, resultData2.get(tp1).partitionIndex());
+//        assertEquals(Errors.NONE.code(), resultData2.get(tp0).errorCode());
+//        assertEquals(Errors.NONE.code(), resultData2.get(tp1).errorCode());
+//
+//        // Since we don't see any exception for tp1 and tp2 from SharePartition class,
+//        // the updateCacheAndOffsets calls should remain the same as the previous case.
+//        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any());
+//        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any());
+//    }
 
     private ShareFetchResponseData.PartitionData noErrorShareFetchResponse() {
         return new ShareFetchResponseData.PartitionData().setPartitionIndex(0);

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -33,11 +33,9 @@ import org.apache.kafka.common.message.ShareFetchResponseData.PartitionData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-//import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
-//import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
 import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
@@ -81,7 +79,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-//import scala.Some;
 import scala.Tuple2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -92,12 +89,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyBoolean;
-//import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -1532,115 +1527,116 @@ public class SharePartitionManagerTest {
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp).errorCode());
     }
 
-//    @Test
-//    public void testProcessFetchResponseWithLsoMovementForTopicPartition() {
-//        String groupId = "grp";
-//        Uuid fooId = Uuid.randomUuid();
-//        TopicIdPartition tp0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
-//        TopicIdPartition tp1 = new TopicIdPartition(fooId, new TopicPartition("foo", 1));
-//
-//        Map<TopicIdPartition, Integer> partitionMaxBytes = new HashMap<>();
-//        partitionMaxBytes.put(tp0, PARTITION_MAX_BYTES);
-//        partitionMaxBytes.put(tp1, PARTITION_MAX_BYTES);
-//
-//        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-//        SharePartition sp0 = Mockito.mock(SharePartition.class);
-//        SharePartition sp1 = Mockito.mock(SharePartition.class);
-//        // Mocking the fetchOffsetForTimestamp method to return a valid offset for the timestamp.
-//        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
-//                new Some<>(new FileRecords.TimestampAndOffset(
-//                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 10, Optional.of(0))));
-//
-//        Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
-//        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp0), sp0);
-//        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
-//
-//        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
-//                .withPartitionCacheMap(partitionCacheMap).withReplicaManager(replicaManager).build();
-//
-//        when(sp0.nextFetchOffset()).thenReturn((long) 0, (long) 5);
-//        when(sp1.nextFetchOffset()).thenReturn((long) 4, (long) 4);
-//
-//        when(sp0.acquire(any(), any())).thenReturn(
-//                CompletableFuture.completedFuture(Collections.emptyList()),
-//                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
-//                        .setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1))));
-//        when(sp1.acquire(any(), any())).thenReturn(
-//                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
-//                        .setFirstOffset(100).setLastOffset(103).setDeliveryCount((short) 1))),
-//                CompletableFuture.completedFuture(Collections.emptyList()));
-//
-//        doNothing().when(sp1).updateCacheAndOffsets(any(Long.class));
-//        doNothing().when(sp0).updateCacheAndOffsets(any(Long.class));
-//
-//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
-//        SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
-//                new FetchParams(ApiKeys.SHARE_FETCH.latestVersion(), FetchRequest.ORDINARY_CONSUMER_ID, -1, 0,
-//                        1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()),
-//                groupId, Uuid.randomUuid().toString(), Arrays.asList(tp0, tp1), future, partitionMaxBytes);
-//
-//        MemoryRecords records1 = MemoryRecords.withRecords(Compression.NONE,
-//                new SimpleRecord("0".getBytes(), "v".getBytes()),
-//                new SimpleRecord("1".getBytes(), "v".getBytes()),
-//                new SimpleRecord("2".getBytes(), "v".getBytes()),
-//                new SimpleRecord(null, "value".getBytes()));
-//
-//        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData1 = new ArrayList<>();
-//        responseData1.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.OFFSET_OUT_OF_RANGE, 0L, 0L,
-//                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false)));
-//        responseData1.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
-//                records1, Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false)));
-//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result1 =
-//                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData1);
-//
-//        assertTrue(result1.isDone());
-//        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData1 = result1.join();
-//        assertEquals(2, resultData1.size());
-//        assertTrue(resultData1.containsKey(tp0));
-//        assertTrue(resultData1.containsKey(tp1));
-//        assertEquals(0, resultData1.get(tp0).partitionIndex());
-//        assertEquals(1, resultData1.get(tp1).partitionIndex());
-//        assertEquals(Errors.NONE.code(), resultData1.get(tp0).errorCode());
-//        assertEquals(Errors.NONE.code(), resultData1.get(tp1).errorCode());
-//
-//        // Since we have OFFSET_OUT_OF_RANGE exception for tp1 and no exception for tp2 from SharePartition class,
-//        // we should have 1 call for updateCacheAndOffsets for tp0 and 0 calls for tp1.
-//        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any());
-//        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any());
-//
-//        MemoryRecords records2 = MemoryRecords.withRecords(100L, Compression.NONE,
-//                new SimpleRecord("0".getBytes(), "v".getBytes()),
-//                new SimpleRecord("1".getBytes(), "v".getBytes()),
-//                new SimpleRecord("2".getBytes(), "v".getBytes()),
-//                new SimpleRecord(null, "value".getBytes()));
-//
-//        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData2 = new ArrayList<>();
-//        responseData2.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.NONE, 0L, 0L,
-//                records2, Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false)));
-//        responseData2.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
-//                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false)));
-//        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result2 =
-//                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData2);
-//
-//        assertTrue(result2.isDone());
-//        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData2 = result2.join();
-//        assertEquals(2, resultData2.size());
-//        assertTrue(resultData2.containsKey(tp0));
-//        assertTrue(resultData2.containsKey(tp1));
-//        assertEquals(0, resultData2.get(tp0).partitionIndex());
-//        assertEquals(1, resultData2.get(tp1).partitionIndex());
-//        assertEquals(Errors.NONE.code(), resultData2.get(tp0).errorCode());
-//        assertEquals(Errors.NONE.code(), resultData2.get(tp1).errorCode());
-//
-//        // Since we don't see any exception for tp1 and tp2 from SharePartition class,
-//        // the updateCacheAndOffsets calls should remain the same as the previous case.
-//        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any());
-//        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any());
-//    }
+    @Test
+    public void testProcessFetchResponseWithLsoMovementForTopicPartition() {
+        String groupId = "grp";
+        Uuid fooId = Uuid.randomUuid();
+        TopicIdPartition tp0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
+        TopicIdPartition tp1 = new TopicIdPartition(fooId, new TopicPartition("foo", 1));
+
+        Map<TopicIdPartition, Integer> partitionMaxBytes = new HashMap<>();
+        partitionMaxBytes.put(tp0, PARTITION_MAX_BYTES);
+        partitionMaxBytes.put(tp1, PARTITION_MAX_BYTES);
+
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        SharePartition sp0 = Mockito.mock(SharePartition.class);
+        SharePartition sp1 = Mockito.mock(SharePartition.class);
+
+        Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
+        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp0), sp0);
+        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
+
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).withReplicaManager(replicaManager).build();
+
+        SharePartitionManager sharePartitionManagersSpy = Mockito.spy(sharePartitionManager);
+
+        // Mocking the offsetForEarliestTimestamp method to return a valid LSO.
+        Mockito.doReturn(1L).when(sharePartitionManagersSpy).offsetForEarliestTimestamp(any(TopicIdPartition.class));
+
+        when(sp0.nextFetchOffset()).thenReturn((long) 0, (long) 5);
+        when(sp1.nextFetchOffset()).thenReturn((long) 4, (long) 4);
+
+        when(sp0.acquire(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Collections.emptyList()),
+                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+                        .setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1))));
+        when(sp1.acquire(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+                        .setFirstOffset(100).setLastOffset(103).setDeliveryCount((short) 1))),
+                CompletableFuture.completedFuture(Collections.emptyList()));
+
+        doNothing().when(sp1).updateCacheAndOffsets(any(Long.class));
+        doNothing().when(sp0).updateCacheAndOffsets(any(Long.class));
+
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
+        SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
+                new FetchParams(ApiKeys.SHARE_FETCH.latestVersion(), FetchRequest.ORDINARY_CONSUMER_ID, -1, 0,
+                        1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()),
+                groupId, Uuid.randomUuid().toString(), Arrays.asList(tp0, tp1), future, partitionMaxBytes);
+
+        MemoryRecords records1 = MemoryRecords.withRecords(Compression.NONE,
+                new SimpleRecord("0".getBytes(), "v".getBytes()),
+                new SimpleRecord("1".getBytes(), "v".getBytes()),
+                new SimpleRecord("2".getBytes(), "v".getBytes()),
+                new SimpleRecord(null, "value".getBytes()));
+
+        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData1 = new ArrayList<>();
+        responseData1.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.OFFSET_OUT_OF_RANGE, 0L, 0L,
+                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        responseData1.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                records1, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result1 =
+                sharePartitionManagersSpy.processFetchResponse(shareFetchPartitionData, responseData1);
+
+        assertTrue(result1.isDone());
+        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData1 = result1.join();
+        assertEquals(2, resultData1.size());
+        assertTrue(resultData1.containsKey(tp0));
+        assertTrue(resultData1.containsKey(tp1));
+        assertEquals(0, resultData1.get(tp0).partitionIndex());
+        assertEquals(1, resultData1.get(tp1).partitionIndex());
+        assertEquals(Errors.NONE.code(), resultData1.get(tp0).errorCode());
+        assertEquals(Errors.NONE.code(), resultData1.get(tp1).errorCode());
+
+        // Since we have OFFSET_OUT_OF_RANGE exception for tp1 and no exception for tp2 from SharePartition class,
+        // we should have 1 call for updateCacheAndOffsets for tp0 and 0 calls for tp1.
+        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any(Long.class));
+        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any(Long.class));
+
+        MemoryRecords records2 = MemoryRecords.withRecords(100L, Compression.NONE,
+                new SimpleRecord("0".getBytes(), "v".getBytes()),
+                new SimpleRecord("1".getBytes(), "v".getBytes()),
+                new SimpleRecord("2".getBytes(), "v".getBytes()),
+                new SimpleRecord(null, "value".getBytes()));
+
+        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData2 = new ArrayList<>();
+        responseData2.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                records2, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        responseData2.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result2 =
+                sharePartitionManagersSpy.processFetchResponse(shareFetchPartitionData, responseData2);
+
+        assertTrue(result2.isDone());
+        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData2 = result2.join();
+        assertEquals(2, resultData2.size());
+        assertTrue(resultData2.containsKey(tp0));
+        assertTrue(resultData2.containsKey(tp1));
+        assertEquals(0, resultData2.get(tp0).partitionIndex());
+        assertEquals(1, resultData2.get(tp1).partitionIndex());
+        assertEquals(Errors.NONE.code(), resultData2.get(tp0).errorCode());
+        assertEquals(Errors.NONE.code(), resultData2.get(tp1).errorCode());
+
+        // Since we don't see any exception for tp1 and tp2 from SharePartition class,
+        // the updateCacheAndOffsets calls should remain the same as the previous case.
+        Mockito.verify(sp0, times(1)).updateCacheAndOffsets(any(Long.class));
+        Mockito.verify(sp1, times(0)).updateCacheAndOffsets(any(Long.class));
+    }
 
     private ShareFetchResponseData.PartitionData noErrorShareFetchResponse() {
         return new ShareFetchResponseData.PartitionData().setPartitionIndex(0);

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -82,7 +82,7 @@ public class SharePartitionTest {
     private static final Time MOCK_TIME = new MockTime();
     private static final short MAX_IN_FLIGHT_MESSAGES = 200;
     private static final int ACQUISITION_LOCK_TIMEOUT_MS = 100;
-    private static final int DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS = 200;
+    private static final int DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS = 300;
 
     @BeforeEach
     public void setUp() {

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -2469,6 +2469,1113 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.timer().size());
     }
 
+    @Test
+    public void testLsoMovementOnInitializationSharePartition() {
+        // LSO is at 0.
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+        sharePartition.updateCacheAndOffsets(0);
+        assertEquals(0, sharePartition.nextFetchOffset());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(0, sharePartition.endOffset());
+
+        // LSO is at 5.
+        sharePartition.updateCacheAndOffsets(5);
+        assertEquals(5, sharePartition.nextFetchOffset());
+        assertEquals(5, sharePartition.startOffset());
+        assertEquals(5, sharePartition.endOffset());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingBatches() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7),
+                Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 12), Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 17), Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 22), Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 27), Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 32), Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new ShareAcknowledgementBatch(2, 6, Collections.singletonList((byte) 1)),
+                new ShareAcknowledgementBatch(12, 16, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(22, 26, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(27, 31, Collections.singletonList((byte) 3))
+        ));
+
+        // LSO is at 20.
+        sharePartition.updateCacheAndOffsets(20);
+
+        assertEquals(22, sharePartition.nextFetchOffset());
+        assertEquals(20, sharePartition.startOffset());
+        assertEquals(36, sharePartition.endOffset());
+
+        // For cached state corresponding to entry 2, the batch state will be ACKNOWLEDGED, hence it will be cleared as part of acknowledgment().
+        assertEquals(6, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+        assertNotNull(sharePartition.cachedState().get(7L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(12L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(12L).batchState());
+        assertNull(sharePartition.cachedState().get(12L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(17L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(17L).batchState());
+        assertNotNull(sharePartition.cachedState().get(17L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(22L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(22L).batchState());
+        assertNull(sharePartition.cachedState().get(22L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(27L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(27L).batchState());
+        assertNull(sharePartition.cachedState().get(27L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(32L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(32L).batchState());
+        assertNotNull(sharePartition.cachedState().get(32L).batchAcquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingOffsets() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(4, 8, Collections.singletonList((byte) 1))));
+
+        // LSO at is 5.
+        sharePartition.updateCacheAndOffsets(5);
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(5, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+        assertNull(sharePartition.cachedState().get(7L).offsetState().get(7L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(7L).offsetState().get(8L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(7L).offsetState().get(9L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(7L).offsetState().get(10L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(7L).offsetState().get(11L).acquisitionLockTimeoutTask());
+
+        // Checked cached offset state map.
+        expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(2L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(3L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(4L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(5L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(6L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(2L).offsetState());
+        assertNotNull(sharePartition.cachedState().get(2L).offsetState().get(2L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(2L).offsetState().get(3L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(2L).offsetState().get(4L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(2L).offsetState().get(5L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(2L).offsetState().get(6L).acquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingOffsetsWithStartAndEndBatchesNotFullMatches() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 4.
+        sharePartition.updateCacheAndOffsets(4);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(4, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        // LSO is at 8.
+        sharePartition.updateCacheAndOffsets(8);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(8, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingOffsetsWithStartOffsetNotFullMatches() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 4.
+        sharePartition.updateCacheAndOffsets(4);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(4, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // LSO is at 7.
+        sharePartition.updateCacheAndOffsets(7);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingOffsetsWithStartOffsetNotFullMatchesPostAcceptAcknowledgement() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 4.
+        sharePartition.updateCacheAndOffsets(4);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(4, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Acknowledge with ACCEPT action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 1))));
+
+        // LSO is at 7.
+        sharePartition.updateCacheAndOffsets(7);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingOffsetsWithStartOffsetNotFullMatchesPostReleaseAcknowledgement() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // LSO is at 4.
+        sharePartition.updateCacheAndOffsets(4);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(4, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+
+        // LSO is at 7.
+        sharePartition.updateCacheAndOffsets(7);
+
+        assertEquals(7, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementToEndOffset() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+
+        // LSO is at 11.
+        sharePartition.updateCacheAndOffsets(11);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(11, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementToEndOffsetWhereEndOffsetIsAvailable() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(11, 11, Collections.singletonList((byte) 2))));
+
+        // LSO is at 11.
+        sharePartition.updateCacheAndOffsets(11);
+
+        assertEquals(11, sharePartition.nextFetchOffset());
+        assertEquals(11, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementAheadOfEndOffsetPostAcknowledgment() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+
+        // LSO is at 12.
+        sharePartition.updateCacheAndOffsets(12);
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(12, sharePartition.startOffset());
+        assertEquals(12, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(7L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementAheadOfEndOffset() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 7), Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // LSO is at 14.
+        sharePartition.updateCacheAndOffsets(14);
+
+        assertEquals(14, sharePartition.nextFetchOffset());
+        assertEquals(14, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
+    }
+
+    @Test
+    public void testLsoMovementWithGapsInCachedStateMap() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        // Gap of 7-9.
+        MemoryRecords records2 = memoryRecords(5, 10);
+        // Gap of 15-19.
+        MemoryRecords records3 = memoryRecords(5, 20);
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records3, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // LSO is at 18.
+        sharePartition.updateCacheAndOffsets(18);
+
+        assertEquals(25, sharePartition.nextFetchOffset());
+        assertEquals(18, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+        assertEquals(3, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(20L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
+    }
+
+    @Test
+    public void testLsoMovementWithGapsInCachedStateMapAndAcknowledgedBatch() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        // Gap of 7-9.
+        MemoryRecords records2 = memoryRecords(5, 10);
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+
+        // LSO is at 10.
+        sharePartition.updateCacheAndOffsets(10);
+
+        assertEquals(10, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
+    }
+
+    @Test
+    public void testLsoMovementPostGapsInAcknowledgments() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        MemoryRecords records1 = memoryRecords(2, 5);
+        // Untracked gap of 3 offsets from 7-9.
+        MemoryRecordsBuilder recordsBuilder = memoryRecordsBuilder(5, 10);
+        // Gap from 15-17 offsets.
+        recordsBuilder.appendWithOffset(18, 0L, TestUtils.randomString(10).getBytes(), TestUtils.randomString(10).getBytes());
+        MemoryRecords records2 = recordsBuilder.build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 30, 0, records1, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 30, 0, records2, Optional.empty(),
+                OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new ShareAcknowledgementBatch(5, 6, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(10, 18, Arrays.asList(
+                        (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 2
+                ))));
+
+        // LSO is at 18.
+        sharePartition.updateCacheAndOffsets(18);
+
+        assertEquals(18, sharePartition.nextFetchOffset());
+        assertEquals(18, sharePartition.startOffset());
+        assertEquals(18, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
+
+        // Check cached state.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(15L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(16L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(17L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(18L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+    }
+
+//    @Test
+//    public void testReleaseAcquiredRecordsBatchesPostStartOffsetMovement() {
+//        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+//
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire("member-2", new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 15),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 20),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 25),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 30),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 35),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//
+//        // Acknowledge records.
+//        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+//                new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
+//                new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
+//                new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
+//                new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
+//        ));
+//
+//        // LSO is at 24.
+//        sharePartition.updateCacheAndOffsets(24);
+//
+//        assertEquals(25, sharePartition.nextFetchOffset());
+//        assertEquals(24, sharePartition.startOffset());
+//        assertEquals(39, sharePartition.endOffset());
+//        assertEquals(7, sharePartition.cachedState().size());
+//
+//        // Release acquired records for MEMBER_ID.
+//        CompletableFuture<Optional<Throwable>> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
+//        assertFalse(releaseResult.isCompletedExceptionally());
+//        assertFalse(releaseResult.join().isPresent());
+//
+//        // Check cached state.
+//        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(5L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(6L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(5L).offsetState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
+//
+//        assertEquals("member-2", sharePartition.cachedState().get(15L).batchMemberId());
+//        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(15L).batchState());
+//
+//        expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(20L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(21L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(22L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(23L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(24L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(20L).offsetState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(25L).batchMemberId());
+//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(25L).batchState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(30L).batchMemberId());
+//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(30L).batchState());
+//
+//        expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(35L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(36L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(37L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(38L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(39L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(35L).offsetState());
+//    }
+//
+//    @Test
+//    public void testReleaseAcquiredRecordsBatchesPostStartOffsetMovementToStartOfBatch() {
+//        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+//        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+//
+//        MemoryRecords records1 = memoryRecords(5, 5);
+//        MemoryRecords records2 = memoryRecords(5, 10);
+//
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records1,
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records2,
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//
+//        // LSO is at 10.
+//        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+//                new Some<>(new FileRecords.TimestampAndOffset(
+//                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 10, Optional.of(0))));
+//        sharePartition.updateCacheAndOffsets();
+//
+//        assertEquals(15, sharePartition.nextFetchOffset());
+//        assertEquals(10, sharePartition.startOffset());
+//        assertEquals(14, sharePartition.endOffset());
+//        assertEquals(2, sharePartition.cachedState().size());
+//
+//        // Release acquired records.
+//        CompletableFuture<Optional<Throwable>> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
+//        assertFalse(releaseResult.isCompletedExceptionally());
+//        assertFalse(releaseResult.join().isPresent());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
+//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
+//    }
+//
+//    @Test
+//    public void testReleaseAcquiredRecordsBatchesPostStartOffsetMovementToMiddleOfBatch() {
+//        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+//        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+//
+//        MemoryRecords records1 = memoryRecords(5, 5);
+//        MemoryRecords records2 = memoryRecords(5, 10);
+//
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records1,
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, records2,
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//
+//        // LSO is at 11.
+//        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+//                new Some<>(new FileRecords.TimestampAndOffset(
+//                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 11, Optional.of(0))));
+//        sharePartition.updateCacheAndOffsets();
+//
+//        assertEquals(15, sharePartition.nextFetchOffset());
+//        assertEquals(11, sharePartition.startOffset());
+//        assertEquals(14, sharePartition.endOffset());
+//        assertEquals(2, sharePartition.cachedState().size());
+//
+//        // Release acquired records.
+//        CompletableFuture<Optional<Throwable>> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
+//        assertFalse(releaseResult.isCompletedExceptionally());
+//        assertFalse(releaseResult.join().isPresent());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
+//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
+//
+//        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+//    }
+
+//    @Test
+//    public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovement() throws InterruptedException {
+//        SharePartition sharePartition = SharePartitionBuilder.builder()
+//                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+//
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire("member-2", new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 15),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 20),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 25),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 30),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 35),
+//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+//                OptionalInt.empty(), false));
+//
+//        // Acknowledge records.
+//        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
+//                MEMBER_ID, Arrays.asList(
+//                        new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
+//                        new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
+//                        new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
+//                        new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
+//                ));
+//
+//        // LSO is at 24.
+//        sharePartition.updateCacheAndOffsets(24);
+//
+//        assertEquals(25, sharePartition.nextFetchOffset());
+//        assertEquals(24, sharePartition.startOffset());
+//        assertEquals(39, sharePartition.endOffset());
+//        assertEquals(7, sharePartition.cachedState().size());
+//
+//        // Allowing acquisition lock to expire.
+//        Thread.sleep(200);
+//
+//        // Check cached state.
+//        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(5L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(6L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(5L).offsetState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(15L).batchMemberId());
+//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(15L).batchState());
+//
+//        expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(20L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(21L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(22L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(23L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(24L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(20L).offsetState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(25L).batchMemberId());
+//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(25L).batchState());
+//
+//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(30L).batchMemberId());
+//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(30L).batchState());
+//
+//        expectedOffsetStateMap = new HashMap<>();
+//        expectedOffsetStateMap.put(35L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(36L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(37L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(38L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//        expectedOffsetStateMap.put(39L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+//
+//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(35L).offsetState());
+//    }
+
+    @Test
+    public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovementToStartOfBatch() throws InterruptedException {
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 10.
+        sharePartition.updateCacheAndOffsets(10);
+
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Allowing acquisition lock to expire.
+        TestUtils.waitForCondition(
+                () -> sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                        sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED &&
+                        sharePartition.cachedState().get(10L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                        sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
+                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+                () -> "Acquisition lock never got released.");
+    }
+
+    @Test
+    public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovementToMiddleOfBatch() throws InterruptedException {
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 11.
+        sharePartition.updateCacheAndOffsets(11);
+
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(11, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Allowing acquisition lock to expire.
+        TestUtils.waitForCondition(
+                () -> {
+                    Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+                    expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                    expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                    expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                    expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                    expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                    return sharePartition.cachedState().get(10L).offsetState().equals(expectedOffsetStateMap) &&
+                            sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                            sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED;
+                },
+                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+                () -> "Acquisition lock never got released.");
+    }
+
+    @Test
+    public void testAcknowledgeBatchAndOffsetPostLsoMovement() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 12.
+        sharePartition.updateCacheAndOffsets(12);
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(12, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Checked cached state map.
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
+
+        // Acknowledge with RELEASE action.
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new ShareAcknowledgementBatch(2, 6, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(12, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).batchAcquisitionLockTimeoutTask());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState>  expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(10L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(11L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(12L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(13L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(14L).acquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testAcknowledgeBatchPostLsoMovement() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 20),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 14.
+        sharePartition.updateCacheAndOffsets(14);
+        assertEquals(25, sharePartition.nextFetchOffset());
+        assertEquals(14, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+        assertEquals(3, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(20L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
+
+        // Acknowledge with ACCEPT action.
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(2, 14, Collections.singletonList((byte) 1))));
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(25, sharePartition.nextFetchOffset());
+        // For cached state corresponding to entry 2, the offset states will be ARCHIVED, ARCHIVED, ARCHIVED, ARCHIVED and ACKNOWLEDGED.
+        // Hence, it will get removed when calling maybeUpdateCachedStateAndOffsets() internally.
+        assertEquals(14, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+        assertEquals(3, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(20L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
+
+        // Check cached state offset map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+    }
+
+    @Test
+    public void testLsoMovementThenAcquisitionLockTimeoutThenAcknowledge() throws InterruptedException {
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 2),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 7.
+        sharePartition.updateCacheAndOffsets(7);
+        assertEquals(7, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(7, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        // Checked cached state map.
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).batchAcquisitionLockTimeoutTask());
+
+        // Allowing acquisition lock to expire.
+        TestUtils.waitForCondition(
+                () -> sharePartition.nextFetchOffset() == 7 && sharePartition.cachedState().isEmpty() &&
+                            sharePartition.startOffset() == 7 && sharePartition.endOffset() == 7,
+                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+                () -> "Acquisition lock never got released.");
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(2, 14, Collections.singletonList((byte) 2))));
+
+        assertEquals(10, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
+        assertNull(sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testLsoMovementThenAcquisitionLockTimeoutThenAcknowledgeBatchLastOffsetAheadOfStartOffsetBatch() throws InterruptedException {
+        SharePartition sharePartition = SharePartitionBuilder.builder().withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(2, 1),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // LSO is at 3.
+        sharePartition.updateCacheAndOffsets(3);
+        assertEquals(3, sharePartition.nextFetchOffset());
+        assertEquals(3, sharePartition.startOffset());
+        assertEquals(3, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        // Checked cached state map.
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(1L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(1L).batchState());
+        assertNotNull(sharePartition.cachedState().get(1L).batchAcquisitionLockTimeoutTask());
+
+        // Allowing acquisition lock to expire.
+        TestUtils.waitForCondition(
+                () -> sharePartition.nextFetchOffset() == 3 && sharePartition.cachedState().isEmpty() &&
+                        sharePartition.startOffset() == 3 && sharePartition.endOffset() == 3,
+                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+                () -> "Acquisition lock never got released.");
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(2, 3),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(3, 5),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        assertEquals(8, sharePartition.nextFetchOffset());
+        assertEquals(3, sharePartition.startOffset());
+        assertEquals(7, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new ShareAcknowledgementBatch(1, 7, Collections.singletonList((byte) 2))));
+
+        assertEquals(3, sharePartition.nextFetchOffset());
+        assertEquals(3, sharePartition.startOffset());
+        assertEquals(7, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(3L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(3L).batchState());
+        assertNull(sharePartition.cachedState().get(3L).batchAcquisitionLockTimeoutTask());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
+        assertNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
+    }
+
     private MemoryRecords memoryRecords(int numOfRecords) {
         return memoryRecords(numOfRecords, 0);
     }

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -3600,25 +3600,6 @@ public class SharePartitionTest {
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
     }
 
-//    private void acquireRecords(SharePartition sharePartition, String memberId, int totalRecords, long startOffset) {
-//        sharePartition.acquire(memberId, new FetchPartitionData(Errors.NONE, 20, 0,
-//                memoryRecords(totalRecords, startOffset), Optional.empty(), OptionalLong.empty(),
-//                Optional.empty(), OptionalInt.empty(), false));
-//    }
-//
-//    private void assertInFlightBatch(SharePartition sharePartition, long batchStartOffset, RecordState state, String memberId) {
-//        SharePartition.InFlightBatch inFlightBatch = sharePartition.cachedState().get(batchStartOffset);
-//        assertEquals(state, inFlightBatch.batchState());
-//        assertEquals(memberId, inFlightBatch.batchMemberId());
-//    }
-//
-//    private void assertInFlightBatch(SharePartition sharePartition, long batchStartOffset, RecordState state, String memberId, int deliveryCount) {
-//        SharePartition.InFlightBatch inFlightBatch = sharePartition.cachedState().get(batchStartOffset);
-//        assertEquals(state, inFlightBatch.batchState());
-//        assertEquals(memberId, inFlightBatch.batchMemberId());
-//        assertEquals(deliveryCount, inFlightBatch.batchDeliveryCount());
-//    }
-
     private static class SharePartitionBuilder {
 
         private int acquisitionLockTimeoutMs = 30000;

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -3194,93 +3194,88 @@ public class SharePartitionTest {
 //        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
 //    }
 
-//    @Test
-//    public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovement() throws InterruptedException {
-//        SharePartition sharePartition = SharePartitionBuilder.builder()
-//                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
-//
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire("member-2", new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 15),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 20),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 25),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 30),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 35),
-//                Optional.empty(), OptionalLong.empty(), Optional.empty(),
-//                OptionalInt.empty(), false));
-//
-//        // Acknowledge records.
-//        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
-//                MEMBER_ID, Arrays.asList(
-//                        new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
-//                        new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
-//                        new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
-//                        new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
-//                ));
-//
-//        // LSO is at 24.
-//        sharePartition.updateCacheAndOffsets(24);
-//
-//        assertEquals(25, sharePartition.nextFetchOffset());
-//        assertEquals(24, sharePartition.startOffset());
-//        assertEquals(39, sharePartition.endOffset());
-//        assertEquals(7, sharePartition.cachedState().size());
-//
-//        // Allowing acquisition lock to expire.
-//        Thread.sleep(200);
-//
-//        // Check cached state.
-//        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
-//        expectedOffsetStateMap.put(5L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(6L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(9L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//
-//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(5L).offsetState());
-//
-//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
-//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
-//
-//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(15L).batchMemberId());
-//        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(15L).batchState());
-//
-//        expectedOffsetStateMap = new HashMap<>();
-//        expectedOffsetStateMap.put(20L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(21L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(22L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(23L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(24L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//
-//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(20L).offsetState());
-//
-//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(25L).batchMemberId());
-//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(25L).batchState());
-//
-//        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(30L).batchMemberId());
-//        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(30L).batchState());
-//
-//        expectedOffsetStateMap = new HashMap<>();
-//        expectedOffsetStateMap.put(35L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(36L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(37L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(38L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//        expectedOffsetStateMap.put(39L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-//
-//        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(35L).offsetState());
-//    }
+    @Test
+    public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovement() throws InterruptedException {
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 5),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 10),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire("member-2", new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 15),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 20),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 25),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 30),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID, new FetchPartitionData(Errors.NONE, 20, 0, memoryRecords(5, 35),
+                Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false));
+
+        // Acknowledge records.
+        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
+                new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
+                new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
+        ));
+
+        // LSO is at 24.
+        sharePartition.updateCacheAndOffsets(24);
+
+        assertEquals(25, sharePartition.nextFetchOffset());
+        assertEquals(24, sharePartition.startOffset());
+        assertEquals(39, sharePartition.endOffset());
+        assertEquals(7, sharePartition.cachedState().size());
+
+        // Allowing acquisition lock to expire.
+        TestUtils.waitForCondition(
+            () -> {
+                Map<Long, InFlightState> expectedOffsetStateMap1 = new HashMap<>();
+                expectedOffsetStateMap1.put(5L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap1.put(6L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap1.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap1.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap1.put(9L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+
+                Map<Long, InFlightState> expectedOffsetStateMap2 = new HashMap<>();
+                expectedOffsetStateMap2.put(20L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap2.put(21L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap2.put(22L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap2.put(23L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap2.put(24L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+
+                Map<Long, InFlightState> expectedOffsetStateMap3 = new HashMap<>();
+                expectedOffsetStateMap3.put(35L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap3.put(36L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap3.put(37L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap3.put(38L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap3.put(39L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+
+                return sharePartition.cachedState().get(5L).offsetState().equals(expectedOffsetStateMap1) &&
+                        sharePartition.cachedState().get(20L).offsetState().equals(expectedOffsetStateMap2) &&
+                        sharePartition.cachedState().get(25L).batchState() == RecordState.AVAILABLE &&
+                        sharePartition.cachedState().get(30L).batchState() == RecordState.AVAILABLE &&
+                        sharePartition.cachedState().get(35L).offsetState().equals(expectedOffsetStateMap3);
+            },
+            DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+            () -> "Acquisition lock never got released.");
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(15L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(15L).batchState());
+    }
 
     @Test
     public void testAcquisitionLockTimeoutForBatchesPostStartOffsetMovementToStartOfBatch() throws InterruptedException {
@@ -3304,12 +3299,12 @@ public class SharePartitionTest {
 
         // Allowing acquisition lock to expire.
         TestUtils.waitForCondition(
-                () -> sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
-                        sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED &&
-                        sharePartition.cachedState().get(10L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
-                        sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
-                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> "Acquisition lock never got released.");
+            () -> sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                    sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED &&
+                    sharePartition.cachedState().get(10L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                    sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
+            DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+            () -> "Acquisition lock never got released.");
     }
 
     @Test
@@ -3334,19 +3329,19 @@ public class SharePartitionTest {
 
         // Allowing acquisition lock to expire.
         TestUtils.waitForCondition(
-                () -> {
-                    Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
-                    expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
-                    expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-                    expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-                    expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-                    expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
-                    return sharePartition.cachedState().get(10L).offsetState().equals(expectedOffsetStateMap) &&
-                            sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
-                            sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED;
-                },
-                DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> "Acquisition lock never got released.");
+            () -> {
+                Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+                expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+                return sharePartition.cachedState().get(10L).offsetState().equals(expectedOffsetStateMap) &&
+                        sharePartition.cachedState().get(5L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
+                        sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED;
+            },
+            DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+            () -> "Acquisition lock never got released.");
     }
 
     @Test

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -2525,7 +2525,7 @@ public class SharePartitionTest {
         assertEquals(20, sharePartition.startOffset());
         assertEquals(36, sharePartition.endOffset());
 
-        // For cached state corresponding to entry 2, the batch state will be ACKNOWLEDGED, hence it will be cleared as part of acknowledgment().
+        // For cached state corresponding to entry 2, the batch state will be ACKNOWLEDGED, hence it will be cleared as part of acknowledgment.
         assertEquals(6, sharePartition.cachedState().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
@@ -2574,7 +2574,7 @@ public class SharePartitionTest {
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
@@ -2589,7 +2589,7 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(7L).offsetState().get(10L).acquisitionLockTimeoutTask());
         assertNotNull(sharePartition.cachedState().get(7L).offsetState().get(11L).acquisitionLockTimeoutTask());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(2L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
         expectedOffsetStateMap.put(3L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
@@ -2725,7 +2725,7 @@ public class SharePartitionTest {
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
@@ -2773,7 +2773,7 @@ public class SharePartitionTest {
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
@@ -2807,7 +2807,7 @@ public class SharePartitionTest {
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
@@ -2842,7 +2842,7 @@ public class SharePartitionTest {
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
@@ -2876,7 +2876,7 @@ public class SharePartitionTest {
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(7L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(8L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
@@ -3362,7 +3362,7 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
 
-        // Checked cached state map.
+        // Check cached state map.
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
@@ -3386,7 +3386,7 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
         assertNotNull(sharePartition.cachedState().get(2L).batchAcquisitionLockTimeoutTask());
 
-        // Checked cached offset state map.
+        // Check cached offset state map.
         Map<Long, InFlightState>  expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
         expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
@@ -3478,7 +3478,7 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.endOffset());
         assertEquals(1, sharePartition.cachedState().size());
 
-        // Checked cached state map.
+        // Check cached state map.
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
         assertNotNull(sharePartition.cachedState().get(2L).batchAcquisitionLockTimeoutTask());
@@ -3528,7 +3528,7 @@ public class SharePartitionTest {
         assertEquals(3, sharePartition.endOffset());
         assertEquals(1, sharePartition.cachedState().size());
 
-        // Checked cached state map.
+        // Check cached state map.
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(1L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(1L).batchState());
         assertNotNull(sharePartition.cachedState().get(1L).batchAcquisitionLockTimeoutTask());


### PR DESCRIPTION
### About
Implemented the functionality which takes care of archiving the records when LSO moves past them. Implemented the following functions - 
1. `updateCacheAndOffsets` - Updates the cached state, start and end offsets of the share partition as per the new log start offset. The method is called when the log start offset is moved for the share partition.
2. `archiveAvailableRecordsOnLsoMovement` - This function archives all the available records when they are behind the LSO.
3. `archivePerOffsetBatchRecords` - It archives all the available records in the per offset tracked batch passed to this function.
4.  `archiveCompleteBatch` - It archives all the available records of the complete batch passed to this function.

### Testing
The added functionality has been tested with unit tests.

### Suppression
In order for build to pass, I had to add JavaNCSS suppression for `SharePartitionTest`. It takes into account the total lines of non-commented source code. Agreed, that we can optimize the current `SharePartitionTest` code at a few places, however, when we add new test cases, we will again breach this limit which is currently set at 1500. Hence, adding the suppression made sense to me.