### PR TITLE
KAFKA-15259: pass TxnSendOption to Producer send()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -867,12 +867,21 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     }
 
     /**
-     * Asynchronously send a record to a topic. Equivalent to <code>send(record, null)</code>.
-     * See {@link #send(ProducerRecord, Callback)} for details.
+     * Asynchronously send a record to a topic. Equivalent to <code>send(record, null, TxnSendOption.NONE)</code>.
+     * See {@link #send(ProducerRecord, Callback, TxnSendOption)} for details.
      */
     @Override
     public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
-        return send(record, null);
+        return send(record, null, TxnSendOption.NONE);
+    }
+
+    /**
+     * Asynchronously send a record to a topic. Equivalent to <code>send(record, callback, TxnSendOption.NONE)</code>.
+     * See {@link #send(ProducerRecord, Callback, TxnSendOption)} for details.
+     */
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+        return send(record, callback, TxnSendOption.NONE);
     }
 
     /**
@@ -971,10 +980,16 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * they will delay the sending of messages from other threads. If you want to execute blocking or computationally
      * expensive callbacks it is recommended to use your own {@link java.util.concurrent.Executor} in the callback body
      * to parallelize processing.
+     *</p>
+     * <p>
+     * To manage ApiExceptions in transactions, the user can configure the TnxSendOption to IGNORE_SEND_ERRORS. This setting
+     * excludes "poison pill" records from the batch, ensuring they do not disrupt the commit process. By default, TnxSendOption
+     * is set to NONE, which is the required setting for non-transactional sends.
      *
      * @param record The record to send
      * @param callback A user-supplied callback to execute when the record has been acknowledged by the server (null
      *        indicates no callback)
+     * @param txnSendOption Determines ignoring errors in transactions
      *
      * @throws AuthenticationException if authentication fails. See the exception for more details
      * @throws AuthorizationException fatal error indicating that the producer is not allowed to write
@@ -987,17 +1002,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * @throws KafkaException If a Kafka related error occurs that does not belong to the public API exceptions.
      */
     @Override
-    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, TxnSendOption txnSendOption) {
         // intercept the record, which can be potentially modified; this method does not throw exceptions
         ProducerRecord<K, V> interceptedRecord = this.interceptors.onSend(record);
-        return doSend(interceptedRecord, callback, TxnSendOption.NONE);
-    }
-
-    @Override
-    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, TxnSendOption option) {
-        // intercept the record, which can be potentially modified; this method does not throw exceptions
-        ProducerRecord<K, V> interceptedRecord = this.interceptors.onSend(record);
-        return doSend(interceptedRecord, callback, option);
+        return doSend(interceptedRecord, callback, txnSendOption);
     }
 
     // Verify that this producer instance has not been closed. This method throws IllegalStateException if the producer
@@ -1019,8 +1027,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     /**
      * Implementation of asynchronously send a record to a topic.
      */
-    private Future<RecordMetadata> doSend(ProducerRecord<K, V> record, Callback callback, TxnSendOption option) {
-        if (option == TxnSendOption.IGNORE_SEND_ERRORS) {
+    private Future<RecordMetadata> doSend(ProducerRecord<K, V> record, Callback callback, TxnSendOption txnSendOption) {
+        if (txnSendOption == TxnSendOption.IGNORE_SEND_ERRORS) {
             throwIfNoTransactionManager();
         }
         // Append callback takes care of the following:
@@ -1119,7 +1127,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             this.errors.record();
             this.interceptors.onSendError(record, appendCallbacks.topicPartition(), e);
-            if (transactionManager != null && option == TxnSendOption.NONE) {
+            if (transactionManager != null && txnSendOption == TxnSendOption.NONE) {
                 transactionManager.maybeTransitionToErrorState(e);
             }
             return new FutureFailure(e);
@@ -1613,7 +1621,14 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     }
 
     public enum TxnSendOption {
+        /**
+         * The irrecoverable {@link #send(ProducerRecord)} errors lead the transaction to the error state, which ends up an unsuccessful commit.
+         */
         NONE,
-        IGNORE_SEND_ERRORS;
+        /**
+         * The records causing irrecoverable errors are excluded from the batch and do not disrupt committing the transaction.
+         * Note to use this, only in transactions. Otherwise {@link #send(ProducerRecord, Callback, TxnSendOption)} throws exception.
+         */
+        IGNORE_SEND_ERRORS
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -81,6 +81,9 @@ public interface Producer<K, V> extends Closeable {
      */
     Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback);
 
+    default Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, KafkaProducer.TxnSendOption option) {
+        return send(record, callback);
+    }
     /**
      * See {@link KafkaProducer#flush()}
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -85,7 +85,7 @@ public interface Producer<K, V> extends Closeable {
      * See {@link KafkaProducer#send(ProducerRecord, Callback, KafkaProducer.TxnSendOption)}
      */
     default Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, KafkaProducer.TxnSendOption txnSendOption) {
-        return send(record, callback);
+        throw new UnsupportedOperationException();
     }
     /**
      * See {@link KafkaProducer#flush()}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -81,7 +81,10 @@ public interface Producer<K, V> extends Closeable {
      */
     Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback);
 
-    default Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, KafkaProducer.TxnSendOption option) {
+    /**
+     * See {@link KafkaProducer#send(ProducerRecord, Callback, KafkaProducer.TxnSendOption)}
+     */
+    default Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback, KafkaProducer.TxnSendOption txnSendOption) {
         return send(record, callback);
     }
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1515,6 +1515,43 @@ public class KafkaProducerTest {
     }
 
     @Test
+    public void testCommitTransactionWithIgnoreSendErrorsAndMetadataTimeoutForMissingTopic() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 60000);
+
+        // Create a record for a not-yet-created topic
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
+        ProducerMetadata metadata = mock(ProducerMetadata.class);
+
+        MockTime mockTime = new MockTime();
+
+        MockClient client = new MockClient(mockTime, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        when(metadata.fetch()).then(invocation -> {
+            invocationCount.incrementAndGet();
+            if (invocationCount.get() > 5) {
+                mockTime.setCurrentTimeMs(mockTime.milliseconds() + 70000);
+            }
+
+            return emptyCluster;
+        });
+
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, mockTime)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record, null, KafkaProducer.TxnSendOption.IGNORE_SEND_ERRORS), TimeoutException.class);
+            assertDoesNotThrow(producer::commitTransaction);
+        }
+    }
+
+    @Test
     public void testCommitTransactionWithMetadataTimeoutForPartitionOutOfRange() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
@@ -1548,6 +1585,43 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
+        }
+    }
+
+    @Test
+    public void testCommitTransactionWithIgnoreSendErrorsAndMetadataTimeoutForPartitionOutOfRange() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 60000);
+
+        // Create a record with a partition higher than the initial (outdated) partition range
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, 2, null, "value");
+        ProducerMetadata metadata = mock(ProducerMetadata.class);
+
+        MockTime mockTime = new MockTime();
+
+        MockClient client = new MockClient(mockTime, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        when(metadata.fetch()).then(invocation -> {
+            invocationCount.incrementAndGet();
+            if (invocationCount.get() > 5) {
+                mockTime.setCurrentTimeMs(mockTime.milliseconds() + 70000);
+            }
+
+            return onePartitionCluster;
+        });
+
+        try (KafkaProducer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, mockTime)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record, null, KafkaProducer.TxnSendOption.IGNORE_SEND_ERRORS), TimeoutException.class);
+            assertDoesNotThrow(producer::commitTransaction);
         }
     }
 
@@ -1587,6 +1661,45 @@ public class KafkaProducerTest {
 
             TestUtils.assertFutureError(producer.send(record), InvalidTopicException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
+        }
+    }
+
+    @Test
+    public void testCommitTransactionWithIgnoerSendErrorsAndSendToInvalidTopic() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "15000");
+
+        Time time = new MockTime();
+        MetadataResponse initialUpdateResponse = RequestTestUtils.metadataUpdateWith(1, emptyMap());
+        ProducerMetadata metadata = newMetadata(0, 0, Long.MAX_VALUE);
+        metadata.updateWithCurrentRequestVersion(initialUpdateResponse, false, time.milliseconds());
+
+        MockClient client = new MockClient(time, metadata);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+
+        String invalidTopicName = "topic abc"; // Invalid topic name due to space
+        ProducerRecord<String, String> record = new ProducerRecord<>(invalidTopicName, "HelloKafka");
+
+        List<MetadataResponse.TopicMetadata> topicMetadata = new ArrayList<>();
+        topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.INVALID_TOPIC_EXCEPTION,
+                invalidTopicName, false, Collections.emptyList()));
+        MetadataResponse updateResponse =  RequestTestUtils.metadataResponse(
+                new ArrayList<>(initialUpdateResponse.brokers()),
+                initialUpdateResponse.clusterId(),
+                initialUpdateResponse.controller().id(),
+                topicMetadata);
+        client.prepareMetadataUpdate(updateResponse);
+
+        try (Producer<String, String> producer = kafkaProducer(configs, new StringSerializer(),
+                new StringSerializer(), metadata, client, null, time)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+
+            TestUtils.assertFutureError(producer.send(record, null, KafkaProducer.TxnSendOption.IGNORE_SEND_ERRORS), InvalidTopicException.class);
+            assertDoesNotThrow(producer::commitTransaction);
         }
     }
 


### PR DESCRIPTION
Implementation of [KIP-1059](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1059%3A+Enable+Producer+to+resolve+send%28%29+method+errors)