### PR TITLE
MINOR: Clarify Spotless's instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,14 +232,14 @@ You can run checkstyle using:
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
-**Please note that `./gradlew spotlessCheck` currently has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
+**Please note that `./gradlew spotlessCheck` currently has an issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
 
 #### Spotless ####
 The import order is a part of static check. please call `spotlessApply` (require JDK 11+) to optimize the imports of Java codes before filing pull request.
 
     ./gradlew spotlessApply
 
-**Please note that `./gradlew spotlessApply` currently has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
+**Please note that `./gradlew spotlessApply` currently has an issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.

--- a/README.md
+++ b/README.md
@@ -232,10 +232,14 @@ You can run checkstyle using:
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
+**Please note that `./gradlew spotlessCheck` currently has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
+
 #### Spotless ####
 The import order is a part of static check. please call `spotlessApply` (require JDK 11+) to optimize the imports of Java codes before filing pull request.
 
     ./gradlew spotlessApply
+
+**Please note that `./gradlew spotlessApply` currently has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.


### PR DESCRIPTION
Spotless doesn't work with JDK 21 and the details is listed in `build.gradle` https://github.com/apache/kafka/blob/9b4f13efbc0674ec63835ceee728f5ec62e69171/build.gradle#L48
however the readme isn't clear as it just state that we need any JDK 11+ which isn't true as anyone run JDK 21 locally wouldn't catch this until they stumble on this comment in `build.gradle` like me. 

The PR updated the README to clarify that spotless tasks wouldn't work on JDK21 and it need either 11 or 17

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
