### PR TITLE
Fix DOAP syntax

### DIFF
--- a/doap_Kafka.rdf
+++ b/doap_Kafka.rdf
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
          xmlns="http://usefulinc.com/ns/doap#"
-         xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:asfext="https://projects.apache.org/ns/asfext#"
-         xmlns:foaf="https://xmlns.com/foaf/0.1/">
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
xmlns strings need to match exactly, and these vocabularies are defined with `http` namespace strings, so we need to follow that.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
