### PR TITLE
KAFKA-16228: Add remote log metadata flag to the dump log tool

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -44,6 +44,7 @@ import org.apache.kafka.coordinator.group.runtime.CoordinatorLoader.UnknownRecor
 import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.metadata.bootstrap.BootstrapDirectory
 import org.apache.kafka.snapshot.Snapshots
+import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
 import org.apache.kafka.storage.internals.log.{CorruptSnapshotException, LogFileUtils, OffsetIndex, ProducerStateManager, TimeIndex, TransactionIndex}
 import org.apache.kafka.tools.api.{Decoder, DefaultDecoder, IntegerDecoder, LongDecoder, StringDecoder}
@@ -54,7 +55,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object DumpLogSegments {
-
   // visible for testing
   private[tools] val RecordIndent = "|"
 
@@ -584,10 +584,27 @@ object DumpLogSegments {
     }
   }
 
+  private class RemoteMetadataLogMessageParser extends MessageParser[String, String] {
+    private val metadataRecordSerde = new RemoteLogMetadataSerde
+    
+    override def parse(record: Record): (Option[String], Option[String]) = {
+      val output = try {
+        val data = new Array[Byte](record.value.remaining)
+        record.value.get(data)
+        metadataRecordSerde.deserialize(data).toString
+      } catch {
+        case e: Throwable =>
+          s"Error at offset ${record.offset}, skipping. ${e.getMessage}"
+      }
+      // No keys for metadata records
+      (None, Some(output))
+    }
+  }
+
   private class DumpLogSegmentsOptions(args: Array[String]) extends CommandDefaultOptions(args) {
-    private val printOpt = parser.accepts("print-data-log", "if set, printing the messages content when dumping data logs. Automatically set if any decoder option is specified.")
-    private val verifyOpt = parser.accepts("verify-index-only", "if set, just verify the index log without printing its content.")
-    private val indexSanityOpt = parser.accepts("index-sanity-check", "if set, just checks the index sanity without printing its content. " +
+    private val printOpt = parser.accepts("print-data-log", "If set, printing the messages content when dumping data logs. Automatically set if any decoder option is specified.")
+    private val verifyOpt = parser.accepts("verify-index-only", "If set, just verify the index log without printing its content.")
+    private val indexSanityOpt = parser.accepts("index-sanity-check", "If set, just checks the index sanity without printing its content. " +
       "This is the same check that is executed on broker startup to determine if an index needs rebuilding or not.")
     private val filesOpt = parser.accepts("files", "REQUIRED: The comma separated list of data and index log files to be dumped.")
       .withRequiredArg
@@ -603,21 +620,23 @@ object DumpLogSegments {
        .describedAs("size")
        .ofType(classOf[java.lang.Integer])
        .defaultsTo(Integer.MAX_VALUE)
-    private val deepIterationOpt = parser.accepts("deep-iteration", "if set, uses deep instead of shallow iteration. Automatically set if print-data-log is enabled.")
-    private val valueDecoderOpt = parser.accepts("value-decoder-class", "if set, used to deserialize the messages. This class should implement org.apache.kafka.tools.api.Decoder trait. Custom jar should be available in kafka/libs directory.")
+    private val deepIterationOpt = parser.accepts("deep-iteration", "If set, uses deep instead of shallow iteration. Automatically set if print-data-log is enabled.")
+    private val valueDecoderOpt = parser.accepts("value-decoder-class", "If set, used to deserialize the messages. This class should implement org.apache.kafka.tools.api.Decoder trait. Custom jar should be available in kafka/libs directory.")
       .withOptionalArg()
       .ofType(classOf[java.lang.String])
       .defaultsTo(classOf[StringDecoder].getName)
-    private val keyDecoderOpt = parser.accepts("key-decoder-class", "if set, used to deserialize the keys. This class should implement org.apache.kafka.tools.api.Decoder trait. Custom jar should be available in kafka/libs directory.")
+    private val keyDecoderOpt = parser.accepts("key-decoder-class", "If set, used to deserialize the keys. This class should implement org.apache.kafka.tools.api.Decoder trait. Custom jar should be available in kafka/libs directory.")
       .withOptionalArg()
       .ofType(classOf[java.lang.String])
       .defaultsTo(classOf[StringDecoder].getName)
-    private val offsetsOpt = parser.accepts("offsets-decoder", "if set, log data will be parsed as offset data from the " +
+    private val offsetsOpt = parser.accepts("offsets-decoder", "If set, log data will be parsed as offset data from the " +
       "__consumer_offsets topic.")
-    private val transactionLogOpt = parser.accepts("transaction-log-decoder", "if set, log data will be parsed as " +
+    private val transactionLogOpt = parser.accepts("transaction-log-decoder", "If set, log data will be parsed as " +
       "transaction metadata from the __transaction_state topic.")
-    private val clusterMetadataOpt = parser.accepts("cluster-metadata-decoder", "if set, log data will be parsed as cluster metadata records.")
-    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "whether to skip printing metadata for each record.")
+    private val clusterMetadataOpt = parser.accepts("cluster-metadata-decoder", "If set, log data will be parsed as cluster metadata records.")
+    private val remoteMetadataOpt = parser.accepts("remote-log-metadata-decoder", "If set, log data will be parsed as TopicBasedRemoteLogMetadataManager (RLMM) metadata records." + 
+      " Instead, the value-decoder-class option can be used if a custom RLMM implementation is configured.")
+    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing metadata for each record.")
     options = parser.parse(args : _*)
 
     def messageParser: MessageParser[_, _] =
@@ -627,6 +646,8 @@ object DumpLogSegments {
         new TransactionLogMessageParser
       } else if (options.has(clusterMetadataOpt)) {
         new ClusterMetadataLogMessageParser
+      } else if (options.has(remoteMetadataOpt)) {
+        new RemoteMetadataLogMessageParser  
       } else {
         val valueDecoder = newDecoder(options.valueOf(valueDecoderOpt))
         val keyDecoder = newDecoder(options.valueOf(keyDecoderOpt))
@@ -637,6 +658,7 @@ object DumpLogSegments {
       options.has(offsetsOpt) ||
       options.has(transactionLogOpt) ||
       options.has(clusterMetadataOpt) ||
+      options.has(remoteMetadataOpt) ||
       options.has(valueDecoderOpt) ||
       options.has(keyDecoderOpt)
 
@@ -649,7 +671,6 @@ object DumpLogSegments {
     lazy val maxBytes: Int = options.valueOf(maxBytesOpt).intValue()
 
     def checkArgs(): Unit = CommandLineUtils.checkRequiredArgs(parser, options, filesOpt)
-
   }
 
   /*

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -444,9 +444,12 @@ class DumpLogSegmentsTest {
   @Test
   def testDumpRemoteLogMetadataNoFilesFlag(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
-    val thrown = assertThrows(classOf[IllegalArgumentException], () => runDumpLogSegments(Array("--remote-log-metadata-decoder")))
-    Exit.resetExitProcedure()
-    assertTrue(thrown.getMessage.equals("Missing required argument \"[files]\""))
+    try {
+      val thrown = assertThrows(classOf[IllegalArgumentException], () => runDumpLogSegments(Array("--remote-log-metadata-decoder")))
+      assertTrue(thrown.getMessage.equals("Missing required argument \"[files]\""))
+    } finally {
+      Exit.resetExitProcedure()
+    }
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -246,12 +246,17 @@ class DumpLogSegmentsTest {
     assertEquals(Map.empty, errors.shallowOffsetNotFound)
   }
 
+  def countSubstring(str: String, sub: String): Int =
+    str.sliding(sub.length).count(_ == sub)
+
   @Test
   def testDumpRemoteLogMetadataEmpty(): Unit = {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 1024 * 1024)
     log = LogTestUtils.createLog(logDir, logConfig, new BrokerTopicStats, time.scheduler, time)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
+    assertTrue(countSubstring(output, "baseOffset:") == 0)
+    assertTrue(countSubstring(output, "payload:") == 0)
     assertTrue(output.contains("Log starting offset: 0"))
   }
 
@@ -276,6 +281,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
+    assertTrue(countSubstring(output, "baseOffset:") == 1)
+    assertTrue(countSubstring(output, "payload:") == 1)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains(expectedDeletePayload))
   }
@@ -309,6 +316,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
     
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
+    assertTrue(countSubstring(output, "baseOffset:") == 1)
+    assertTrue(countSubstring(output, "payload:") == 2)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains(expectedUpdatePayload))
     assertTrue(output.contains(expectedDeletePayload))
@@ -346,12 +355,11 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
+    assertTrue(countSubstring(output, "baseOffset:") == 2)
+    assertTrue(countSubstring(output, "payload:") == 4)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(countSubstring(output, expectedUpdatePayload) == 2)
     assertTrue(countSubstring(output, expectedDeletePayload) == 2)
-    
-    def countSubstring(str: String, sub: String): Int =
-      str.sliding(sub.length).count(_ == sub)
   }
 
   @Test
@@ -378,6 +386,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logPaths(1)))
+    assertTrue(countSubstring(output, "baseOffset:") == 1)
+    assertTrue(countSubstring(output, "payload:") == 1)
     assertTrue(output.contains("Log starting offset: 1"))
     assertTrue(output.contains(expectedDeletePayload))
   }
@@ -392,6 +402,8 @@ class DumpLogSegmentsTest {
     log.flush(false)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
+    assertTrue(countSubstring(output, "baseOffset:") == 1)
+    assertTrue(countSubstring(output, "payload:") == 1)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains("Could not deserialize metadata record"))
   }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -248,6 +248,16 @@ class DumpLogSegmentsTest {
 
   def countSubstring(str: String, sub: String): Int =
     str.sliding(sub.length).count(_ == sub)
+  
+  // the number of batches in the log dump is equal to 
+  // the number of occurrences of the "baseOffset:" substring
+  def batchCount(str: String): Int =
+    countSubstring(str, "baseOffset:")
+
+  // the number of records in the log dump is equal to 
+  // the number of occurrences of the "payload:" substring
+  def recordCount(str: String): Int =
+    countSubstring(str, "payload:")
 
   @Test
   def testDumpRemoteLogMetadataEmpty(): Unit = {
@@ -255,8 +265,8 @@ class DumpLogSegmentsTest {
     log = LogTestUtils.createLog(logDir, logConfig, new BrokerTopicStats, time.scheduler, time)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
-    assertTrue(countSubstring(output, "baseOffset:") == 0)
-    assertTrue(countSubstring(output, "payload:") == 0)
+    assertTrue(batchCount(output) == 0)
+    assertTrue(recordCount(output) == 0)
     assertTrue(output.contains("Log starting offset: 0"))
   }
 
@@ -281,8 +291,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
-    assertTrue(countSubstring(output, "baseOffset:") == 1)
-    assertTrue(countSubstring(output, "payload:") == 1)
+    assertTrue(batchCount(output) == 1)
+    assertTrue(recordCount(output) == 1)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains(expectedDeletePayload))
   }
@@ -316,8 +326,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
     
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
-    assertTrue(countSubstring(output, "baseOffset:") == 1)
-    assertTrue(countSubstring(output, "payload:") == 2)
+    assertTrue(batchCount(output) == 1)
+    assertTrue(recordCount(output) == 2)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains(expectedUpdatePayload))
     assertTrue(output.contains(expectedDeletePayload))
@@ -355,8 +365,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
-    assertTrue(countSubstring(output, "baseOffset:") == 2)
-    assertTrue(countSubstring(output, "payload:") == 4)
+    assertTrue(batchCount(output) == 2)
+    assertTrue(recordCount(output) == 4)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(countSubstring(output, expectedUpdatePayload) == 2)
     assertTrue(countSubstring(output, expectedDeletePayload) == 2)
@@ -386,8 +396,8 @@ class DumpLogSegmentsTest {
       "state=DELETE_PARTITION_MARKED, eventTimestampMs=0, brokerId=0}", topicId, topicName)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logPaths(1)))
-    assertTrue(countSubstring(output, "baseOffset:") == 1)
-    assertTrue(countSubstring(output, "payload:") == 1)
+    assertTrue(batchCount(output) == 1)
+    assertTrue(recordCount(output) == 1)
     assertTrue(output.contains("Log starting offset: 1"))
     assertTrue(output.contains(expectedDeletePayload))
   }
@@ -402,8 +412,8 @@ class DumpLogSegmentsTest {
     log.flush(false)
 
     val output = runDumpLogSegments(Array("--remote-log-metadata-decoder", "--files", logFilePath))
-    assertTrue(countSubstring(output, "baseOffset:") == 1)
-    assertTrue(countSubstring(output, "payload:") == 1)
+    assertTrue(batchCount(output) == 1)
+    assertTrue(recordCount(output) == 1)
     assertTrue(output.contains("Log starting offset: 0"))
     assertTrue(output.contains("Could not deserialize metadata record"))
   }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -389,7 +389,7 @@ class DumpLogSegmentsTest {
     log = LogTestUtils.createLog(logDir, logConfig, new BrokerTopicStats, time.scheduler, time)
     log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE, metadataRecords:_*), leaderEpoch = 0)
     log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE, metadataRecords:_*), leaderEpoch = 0)
-    log.flush(false)
+    log.flush(true)
 
     val logPaths = logDir.listFiles.filter(_.getName.endsWith(".log")).map(_.getAbsolutePath)
     val expectedDeletePayload = String.format("RemotePartitionDeleteMetadata{topicPartition=%s:%s-0, " +

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -433,21 +433,6 @@ class DumpLogSegmentsTest {
 
   @Test
   def testDumpRemoteLogMetadataNoFilesFlag(): Unit = {
-    val topicId = Uuid.randomUuid
-    val topicName = "foo"
-
-    val metadata = Seq(new RemotePartitionDeleteMetadata(new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
-      RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds, 0))
-
-    val records: Array[SimpleRecord] = metadata.map(message => {
-      new SimpleRecord(null, new RemoteLogMetadataSerde().serialize(message))
-    }).toArray
-
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = 1024 * 1024)
-    log = LogTestUtils.createLog(logDir, logConfig, new BrokerTopicStats, time.scheduler, time)
-    log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE, records:_*), leaderEpoch = 0)
-    log.flush(false)
-    
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
     val thrown = assertThrows(classOf[IllegalArgumentException], () => runDumpLogSegments(Array("--remote-log-metadata-decoder")))
     Exit.resetExitProcedure()

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -384,7 +384,7 @@ class DumpLogSegmentsTest {
 
   @Test
   def testDumpRemoteLogMetadataWithCorruption(): Unit = {
-    val metadataRecords = Array(new SimpleRecord(null, Array.fill(20)((scala.util.Random.nextInt(256) - 128).toByte)))
+    val metadataRecords = Array(new SimpleRecord(null, "corrupted".getBytes()))
 
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 1024 * 1024)
     log = LogTestUtils.createLog(logDir, logConfig, new BrokerTopicStats, time.scheduler, time)


### PR DESCRIPTION
This change adds the `--remote-log-metadata-decoder` flag to the `kafka-dump-log.sh` tool. This new flag can be used to decode the payload of the `__remote_log_metadata` records produced by the default `RemoteLogMetadataManager`.