### PR TITLE
KAFKA-17051: ApiKeys#toHtml should exclude the APIs having unstable latest version

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -278,7 +278,7 @@ public enum ApiKeys {
         return messageType.listeners().contains(listener);
     }
 
-    private static String toHtml() {
+    static String toHtml() {
         final StringBuilder b = new StringBuilder();
         b.append("<table class=\"data-table\"><tbody>\n");
         b.append("<tr>");

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -285,16 +285,19 @@ public enum ApiKeys {
         b.append("<th>Name</th>\n");
         b.append("<th>Key</th>\n");
         b.append("</tr>");
-        for (ApiKeys key : clientApis()) {
-            b.append("<tr>\n");
-            b.append("<td>");
-            b.append("<a href=\"#The_Messages_" + key.name + "\">" + key.name + "</a>");
-            b.append("</td>");
-            b.append("<td>");
-            b.append(key.id);
-            b.append("</td>");
-            b.append("</tr>\n");
-        }
+        
+        clientApis().stream()
+            .filter(apiKey -> !apiKey.messageType.latestVersionUnstable())
+            .forEach(apiKey -> {
+                b.append("<tr>\n");
+                b.append("<td>");
+                b.append("<a href=\"#The_Messages_" + apiKey.name + "\">" + apiKey.name + "</a>");
+                b.append("</td>");
+                b.append("<td>");
+                b.append(apiKey.id);
+                b.append("</td>");
+                b.append("</tr>\n");
+            });
         b.append("</tbody></table>\n");
         return b.toString();
     }
@@ -332,7 +335,6 @@ public enum ApiKeys {
     public static EnumSet<ApiKeys> clientApis() {
         List<ApiKeys> apis = Arrays.stream(ApiKeys.values())
             .filter(apiKey -> apiKey.inScope(ApiMessageType.ListenerType.ZK_BROKER) || apiKey.inScope(ApiMessageType.ListenerType.BROKER))
-                .filter(apiKey -> !apiKey.messageType.latestVersionUnstable())
             .collect(Collectors.toList());
         return EnumSet.copyOf(apis);
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -285,7 +285,6 @@ public enum ApiKeys {
         b.append("<th>Name</th>\n");
         b.append("<th>Key</th>\n");
         b.append("</tr>");
-        
         clientApis().stream()
             .filter(apiKey -> !apiKey.messageType.latestVersionUnstable())
             .forEach(apiKey -> {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -332,6 +332,7 @@ public enum ApiKeys {
     public static EnumSet<ApiKeys> clientApis() {
         List<ApiKeys> apis = Arrays.stream(ApiKeys.values())
             .filter(apiKey -> apiKey.inScope(ApiMessageType.ListenerType.ZK_BROKER) || apiKey.inScope(ApiMessageType.ListenerType.BROKER))
+                .filter(apiKey -> !apiKey.messageType.latestVersionUnstable())
             .collect(Collectors.toList());
         return EnumSet.copyOf(apis);
     }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -91,13 +91,12 @@ public class ApiKeysTest {
     @Test
     public void testHtmlOnlyHaveStableApi() {
         String html = ApiKeys.toHtml();
-        ApiKeys.clientApis()
-            .stream()
-            .filter(apiKeys -> !apiKeys.messageType.latestVersionUnstable())
-            .forEach(apiKey -> assertTrue(html.contains(apiKey.name), "Html should contain " + apiKey.name));
-        ApiKeys.clientApis()
-            .stream()
-            .filter(apiKeys -> apiKeys.messageType.latestVersionUnstable())
-            .forEach(apiKey -> assertFalse(html.contains(apiKey.name), "Html should not contain " + apiKey.name));
+        for (ApiKeys apiKeys : ApiKeys.clientApis()) {
+            if (apiKeys.messageType.latestVersionUnstable()) {
+                assertFalse(html.contains(apiKeys.name), "Html should not contain unstable api: " + apiKeys.name);
+            } else {
+                assertTrue(html.contains(apiKeys.name), "Html should contain stable api: " + apiKeys.name);
+            }
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -87,4 +88,16 @@ public class ApiKeysTest {
             "Found some APIs missing scope definition");
     }
 
+    @Test
+    public void testHtmlOnlyHaveStableApi() {
+        String html = ApiKeys.toHtml();
+        ApiKeys.clientApis()
+            .stream()
+            .filter(apiKeys -> !apiKeys.messageType.latestVersionUnstable())
+            .forEach(apiKey -> assertTrue(html.contains(apiKey.name), "Html should contain " + apiKey.name));
+        ApiKeys.clientApis()
+            .stream()
+            .filter(apiKeys -> apiKeys.messageType.latestVersionUnstable())
+            .forEach(apiKey -> assertFalse(html.contains(apiKey.name), "Html should not contain " + apiKey.name));
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -93,9 +93,9 @@ public class ApiKeysTest {
         String html = ApiKeys.toHtml();
         for (ApiKeys apiKeys : ApiKeys.clientApis()) {
             if (apiKeys.messageType.latestVersionUnstable()) {
-                assertFalse(html.contains(apiKeys.name), "Html should not contain unstable api: " + apiKeys.name);
+                assertFalse(html.contains("The_Messages_" + apiKeys.name), "Html should not contain unstable api: " + apiKeys.name);
             } else {
-                assertTrue(html.contains(apiKeys.name), "Html should contain stable api: " + apiKeys.name);
+                assertTrue(html.contains("The_Messages_" + apiKeys.name), "Html should contain stable api: " + apiKeys.name);
             }
         }
     }

--- a/docs/protocol.html
+++ b/docs/protocol.html
@@ -200,7 +200,7 @@ Kafka request. SASL/GSSAPI authentication is performed starting with this packet
 <!--#include virtual="generated/protocol_errors.html" -->
 
 <h5 class="anchor-heading"><a id="protocol_api_keys" class="anchor-link"></a><a href="#protocol_api_keys">Api Keys</a></h5>
-<p>The following are the numeric codes that the stable ApiKey which in the request can take for each of the below request types.</p>
+<p>The following are the numeric codes that the stable ApiKey in the request can take for each of the below request types.</p>
 <!--#include virtual="generated/protocol_api_keys.html" -->
 
 <h4 class="anchor-heading"><a id="protocol_messages" class="anchor-link"></a><a href="#protocol_messages">The Messages</a></h4>

--- a/docs/protocol.html
+++ b/docs/protocol.html
@@ -200,7 +200,7 @@ Kafka request. SASL/GSSAPI authentication is performed starting with this packet
 <!--#include virtual="generated/protocol_errors.html" -->
 
 <h5 class="anchor-heading"><a id="protocol_api_keys" class="anchor-link"></a><a href="#protocol_api_keys">Api Keys</a></h5>
-<p>The following are the numeric codes that the ApiKey which last version is stable in the request can take for each of the below request types.</p>
+<p>The following are the numeric codes that the stable ApiKey which in the request can take for each of the below request types.</p>
 <!--#include virtual="generated/protocol_api_keys.html" -->
 
 <h4 class="anchor-heading"><a id="protocol_messages" class="anchor-link"></a><a href="#protocol_messages">The Messages</a></h4>

--- a/docs/protocol.html
+++ b/docs/protocol.html
@@ -200,7 +200,7 @@ Kafka request. SASL/GSSAPI authentication is performed starting with this packet
 <!--#include virtual="generated/protocol_errors.html" -->
 
 <h5 class="anchor-heading"><a id="protocol_api_keys" class="anchor-link"></a><a href="#protocol_api_keys">Api Keys</a></h5>
-<p>The following are the numeric codes that the ApiKey in the request can take for each of the below request types.</p>
+<p>The following are the numeric codes that the ApiKey which last version is stable in the request can take for each of the below request types.</p>
 <!--#include virtual="generated/protocol_api_keys.html" -->
 
 <h4 class="anchor-heading"><a id="protocol_messages" class="anchor-link"></a><a href="#protocol_messages">The Messages</a></h4>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17051 
we should exclude those APIs having make "latestVersionUnstable=true".

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
