### PR TITLE
MINOR: Align coordinator loader metrics data type

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
@@ -99,8 +99,8 @@ class CoordinatorLoaderImpl[T](
           var readAtLeastOneRecord = true
 
           var previousHighWatermark = -1L
-          var numRecords = 0
-          var numBytes = 0
+          var numRecords = 0L
+          var numBytes = 0L
           while (currentOffset < logEndOffset && readAtLeastOneRecord && isRunning.get) {
             val fetchDataInfo = log.read(
               startOffset = currentOffset,


### PR DESCRIPTION
The data types of `numRecords` and `numBytes` in `LoadSummary` are long, so change the definition to long in case overflow issue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
