### PR TITLE
KAFKA-16731: Added share group metrics class.

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -806,6 +806,7 @@ public class SharePartitionManager implements AutoCloseable {
         }
 
         void recordAcknowledgement(byte ackType) {
+            // unknown ack types (such as gaps for control records) are intentionally ignored
             if (recordAcksSensorMap.containsKey(ackType)) {
                 recordAcksSensorMap.get(ackType).record();
             }

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -20,12 +20,18 @@ import kafka.server.FetchSession;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
 
+import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData.PartitionData;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset;
 import org.apache.kafka.common.requests.FetchRequest;
@@ -133,6 +139,11 @@ public class SharePartitionManager implements AutoCloseable {
      */
     private final Persister persister;
 
+    /**
+     * Class with methods to record share group metrics.
+     */
+    private final ShareGroupMetrics shareGroupMetrics;
+
     public SharePartitionManager(
         ReplicaManager replicaManager,
         Time time,
@@ -140,7 +151,8 @@ public class SharePartitionManager implements AutoCloseable {
         int recordLockDurationMs,
         int maxDeliveryCount,
         int maxInFlightMessages,
-        Persister persister
+        Persister persister,
+        Metrics metrics
     ) {
         this(
             replicaManager,
@@ -150,7 +162,8 @@ public class SharePartitionManager implements AutoCloseable {
             recordLockDurationMs,
             maxDeliveryCount,
             maxInFlightMessages,
-            persister
+            persister,
+            metrics
         );
     }
 
@@ -162,7 +175,8 @@ public class SharePartitionManager implements AutoCloseable {
         int recordLockDurationMs,
         int maxDeliveryCount,
         int maxInFlightMessages,
-        Persister persister
+        Persister persister,
+        Metrics metrics
     ) {
         this.replicaManager = replicaManager;
         this.time = time;
@@ -176,6 +190,7 @@ public class SharePartitionManager implements AutoCloseable {
         this.maxDeliveryCount = maxDeliveryCount;
         this.maxInFlightMessages = maxInFlightMessages;
         this.persister = persister;
+        this.shareGroupMetrics = new ShareGroupMetrics(Objects.requireNonNull(metrics), time);
     }
 
     // Visible for testing.
@@ -188,7 +203,8 @@ public class SharePartitionManager implements AutoCloseable {
             Timer timer,
             int maxDeliveryCount,
             int maxInFlightMessages,
-            Persister persister
+            Persister persister,
+            Metrics metrics
     ) {
         this.replicaManager = replicaManager;
         this.time = time;
@@ -201,6 +217,7 @@ public class SharePartitionManager implements AutoCloseable {
         this.maxDeliveryCount = maxDeliveryCount;
         this.maxInFlightMessages = maxInFlightMessages;
         this.persister = persister;
+        this.shareGroupMetrics = new ShareGroupMetrics(Objects.requireNonNull(metrics), time);
     }
 
     /**
@@ -251,6 +268,7 @@ public class SharePartitionManager implements AutoCloseable {
     ) {
         log.trace("Acknowledge request for topicIdPartitions: {} with groupId: {}",
             acknowledgeTopics.keySet(), groupId);
+        this.shareGroupMetrics.shareAcknowledgement();
         Map<TopicIdPartition, CompletableFuture<Errors>> futures = new HashMap<>();
         acknowledgeTopics.forEach((topicIdPartition, acknowledgePartitionBatches) -> {
             SharePartition sharePartition = partitionCacheMap.get(sharePartitionKey(groupId, topicIdPartition));
@@ -259,6 +277,9 @@ public class SharePartitionManager implements AutoCloseable {
                     if (throwable.isPresent()) {
                         return Errors.forException(throwable.get());
                     }
+                    acknowledgePartitionBatches.forEach(batch -> {
+                        batch.acknowledgeTypes().forEach(this.shareGroupMetrics::recordAcknowledgement);
+                    });
                     return Errors.NONE;
                 });
                 futures.put(topicIdPartition, future);
@@ -468,8 +489,13 @@ public class SharePartitionManager implements AutoCloseable {
                     topicIdPartition
                 );
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey,
-                    k -> new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,
-                        recordLockDurationMs, timer, time, persister));
+                    k -> {
+                        long start = time.hiResClockMs();
+                        SharePartition partition = new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,
+                            recordLockDurationMs, timer, time, persister);
+                        this.shareGroupMetrics.partitionLoadTime(start);
+                        return partition;
+                    });
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.
@@ -694,6 +720,101 @@ public class SharePartitionManager implements AutoCloseable {
             this.topicIdPartitions = topicIdPartitions;
             this.future = future;
             this.partitionMaxBytes = partitionMaxBytes;
+        }
+    }
+
+    static class ShareGroupMetrics {
+        /**
+         * share-acknowledgement (share-acknowledgement-rate and share-acknowledgement-count) - The total number of offsets acknowledged for share groups (requests to be ack).
+         * record-acknowledgement (record-acknowledgement-rate and record-acknowledgement-count) - The number of records acknowledged per acknowledgement type.
+         * partition-load-time (partition-load-time-avg and partition-load-time-max) - The time taken to load the share partitions.
+         */
+
+        public static final String METRICS_GROUP_NAME = "share-group-metrics";
+
+        public static final String SHARE_ACK_SENSOR = "share-acknowledgement-sensor";
+        public static final String SHARE_ACK_RATE = "share-acknowledgement-rate";
+        public static final String SHARE_ACK_COUNT = "share-acknowledgement-count";
+
+        public static final String RECORD_ACK_SENSOR_PREFIX = "record-acknowledgement";
+        public static final String RECORD_ACK_RATE = "record-acknowledgement-rate";
+        public static final String RECORD_ACK_COUNT = "record-acknowledgement-count";
+        public static final String ACK_TYPE = "ack-type";
+
+        public static final String PARTITION_LOAD_TIME_SENSOR = "partition-load-time-sensor";
+        public static final String PARTITION_LOAD_TIME_AVG = "partition-load-time-avg";
+        public static final String PARTITION_LOAD_TIME_MAX = "partition-load-time-max";
+
+        public static final Map<Byte, String> RECORD_ACKS_MAP = new HashMap<>();
+        
+        private final Time time;
+        private final Sensor shareAcknowledgementSensor;
+        private final Map<Byte, Sensor> recordAcksSensorMap = new HashMap<>();
+        private final Sensor partitionLoadTimeSensor;
+
+        static {
+            RECORD_ACKS_MAP.put((byte) 1, AcknowledgeType.ACCEPT.toString());
+            RECORD_ACKS_MAP.put((byte) 2, AcknowledgeType.RELEASE.toString());
+            RECORD_ACKS_MAP.put((byte) 3, AcknowledgeType.REJECT.toString());
+        }
+
+        public ShareGroupMetrics(Metrics metrics, Time time) {
+            this.time = time;
+
+            shareAcknowledgementSensor = metrics.sensor(SHARE_ACK_SENSOR);
+            shareAcknowledgementSensor.add(new Meter(
+                metrics.metricName(
+                    SHARE_ACK_RATE,
+                    METRICS_GROUP_NAME,
+                    "The rate of number of acknowledge requests."),
+                metrics.metricName(
+                    SHARE_ACK_COUNT,
+                    METRICS_GROUP_NAME,
+                    "The number of acknowledge requests.")));
+
+            for (Map.Entry<Byte, String> entry : RECORD_ACKS_MAP.entrySet()) {
+                recordAcksSensorMap.put(entry.getKey(), metrics.sensor(String.format("%s-%s-sensor", RECORD_ACK_SENSOR_PREFIX, entry.getValue())));
+                recordAcksSensorMap.get(entry.getKey())
+                    .add(new Meter(
+                        metrics.metricName(
+                            RECORD_ACK_RATE,
+                            METRICS_GROUP_NAME,
+                            "The number of records acknowledged per acknowledgement type per second.",
+                            ACK_TYPE, entry.getValue()),
+                        metrics.metricName(
+                            RECORD_ACK_COUNT,
+                            METRICS_GROUP_NAME,
+                            "The number of records acknowledged per acknowledgement type.",
+                            ACK_TYPE, entry.getValue())));
+            }
+
+            partitionLoadTimeSensor = metrics.sensor(PARTITION_LOAD_TIME_SENSOR);
+            partitionLoadTimeSensor.add(metrics.metricName(
+                    PARTITION_LOAD_TIME_AVG,
+                    METRICS_GROUP_NAME,
+                    "The average time in milliseconds to load the share partitions."),
+                new Avg());
+            partitionLoadTimeSensor.add(metrics.metricName(
+                    PARTITION_LOAD_TIME_MAX,
+                    METRICS_GROUP_NAME,
+                    "The maximum time in milliseconds to load the share partitions."),
+                new Max());
+        }
+
+        void shareAcknowledgement() {
+            shareAcknowledgementSensor.record();
+        }
+
+        void recordAcknowledgement(byte ackType) {
+            if (recordAcksSensorMap.containsKey(ackType)) {
+                recordAcksSensorMap.get(ackType).record();
+            } else {
+                log.error("Unknown ack type {}", ackType);
+            }
+        }
+
+        void partitionLoadTime(long start) {
+            partitionLoadTimeSensor.record(time.hiResClockMs() - start);
         }
     }
 }

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -766,7 +766,7 @@ public class SharePartitionManager implements AutoCloseable {
                 metrics.metricName(
                     SHARE_ACK_RATE,
                     METRICS_GROUP_NAME,
-                    "The rate of number of acknowledge requests."),
+                    "Rate of acknowledge requests."),
                 metrics.metricName(
                     SHARE_ACK_COUNT,
                     METRICS_GROUP_NAME,
@@ -779,7 +779,7 @@ public class SharePartitionManager implements AutoCloseable {
                         metrics.metricName(
                             RECORD_ACK_RATE,
                             METRICS_GROUP_NAME,
-                            "The rate of number of records acknowledged per acknowledgement type.",
+                            "Rate of records acknowledged per acknowledgement type.",
                             ACK_TYPE, entry.getValue()),
                         metrics.metricName(
                             RECORD_ACK_COUNT,

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -779,7 +779,7 @@ public class SharePartitionManager implements AutoCloseable {
                         metrics.metricName(
                             RECORD_ACK_RATE,
                             METRICS_GROUP_NAME,
-                            "The number of records acknowledged per acknowledgement type per second.",
+                            "The rate of number of records acknowledged per acknowledgement type.",
                             ACK_TYPE, entry.getValue()),
                         metrics.metricName(
                             RECORD_ACK_COUNT,

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -808,8 +808,6 @@ public class SharePartitionManager implements AutoCloseable {
         void recordAcknowledgement(byte ackType) {
             if (recordAcksSensorMap.containsKey(ackType)) {
                 recordAcksSensorMap.get(ackType).record();
-            } else {
-                log.error("Unknown ack type {}", ackType);
             }
         }
 

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -19,6 +19,8 @@ package kafka.server.share;
 import kafka.server.ReplicaManager;
 import kafka.server.ReplicaQuota;
 
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -30,6 +32,7 @@ import org.apache.kafka.common.errors.ShareSessionNotFoundException;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData.PartitionData;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
@@ -81,6 +84,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import scala.Tuple2;
 
@@ -101,6 +105,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @Timeout(120)
+@SuppressWarnings({ "ClassDataAbstractionCoupling"})
 public class SharePartitionManagerTest {
 
     private static final int RECORD_LOCK_DURATION_MS = 30000;
@@ -923,8 +928,13 @@ public class SharePartitionManagerTest {
         partitionMaxBytes.put(tp6, PARTITION_MAX_BYTES);
 
         ReplicaManager replicaManager = mock(ReplicaManager.class);
+        Time time = mock(Time.class);
+        when(time.hiResClockMs()).thenReturn(0L).thenReturn(100L);
+        Metrics metrics = new Metrics();
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withReplicaManager(replicaManager)
+            .withTime(time)
+            .withMetrics(metrics)
             .build();
 
         doAnswer(invocation -> {
@@ -943,6 +953,20 @@ public class SharePartitionManagerTest {
         sharePartitionManager.fetchMessages(groupId, memberId1.toString(), fetchParams, Arrays.asList(tp5, tp6), partitionMaxBytes);
         Mockito.verify(replicaManager, times(3)).fetchMessages(
             any(), any(), any(ReplicaQuota.class), any());
+
+        Map<MetricName, Consumer<Double>> expectedMetrics = new HashMap<>();
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.PARTITION_LOAD_TIME_AVG, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME),
+                val -> assertEquals(val.intValue(), (int) 100.0 / 7, SharePartitionManager.ShareGroupMetrics.PARTITION_LOAD_TIME_AVG)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.PARTITION_LOAD_TIME_MAX, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME),
+                val -> assertEquals(val, 100.0, SharePartitionManager.ShareGroupMetrics.PARTITION_LOAD_TIME_MAX)
+        );
+        expectedMetrics.forEach((metric, test) -> {
+            assertTrue(metrics.metrics().containsKey(metric));
+            test.accept((Double) metrics.metrics().get(metric).metricValue());
+        });
     }
 
     @Test
@@ -1428,8 +1452,10 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp3), sp3);
+
+        Metrics metrics = new Metrics();
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
-                .withPartitionCacheMap(partitionCacheMap).build();
+                .withPartitionCacheMap(partitionCacheMap).withMetrics(metrics).build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
         acknowledgeTopics.put(tp1, Arrays.asList(
@@ -1457,6 +1483,50 @@ public class SharePartitionManagerTest {
         assertEquals(Errors.NONE.code(), result.get(tp2).errorCode());
         assertEquals(0, result.get(tp3).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp3).errorCode());
+
+        Map<MetricName, Consumer<Double>> expectedMetrics = new HashMap<>();
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.SHARE_ACK_COUNT, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME),
+                val -> assertEquals(val, 1.0)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.SHARE_ACK_RATE, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME),
+                val -> assertTrue(val > 0)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_COUNT, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.ACCEPT.toString())),
+                val -> assertEquals(2.0, val)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_COUNT, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.RELEASE.toString())),
+                val -> assertEquals(2.0, val)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_COUNT, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.REJECT.toString())),
+                val -> assertEquals(2.0, val)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_RATE, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.ACCEPT.toString())),
+                val -> assertTrue(val > 0)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_RATE, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.RELEASE.toString())),
+                val -> assertTrue(val > 0)
+        );
+        expectedMetrics.put(
+                metrics.metricName(SharePartitionManager.ShareGroupMetrics.RECORD_ACK_RATE, SharePartitionManager.ShareGroupMetrics.METRICS_GROUP_NAME,
+                        Collections.singletonMap(SharePartitionManager.ShareGroupMetrics.ACK_TYPE, AcknowledgeType.REJECT.toString())),
+                val -> assertTrue(val > 0)
+        );
+        expectedMetrics.forEach((metric, test) -> {
+            assertTrue(metrics.metrics().containsKey(metric));
+            test.accept((Double) metrics.metrics().get(metric).metricValue());
+        });
     }
 
     @Test
@@ -1717,6 +1787,7 @@ public class SharePartitionManagerTest {
         private Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
         private Persister persister = NoOpShareStatePersister.getInstance();
         private Timer timer = new MockTimer();
+        private Metrics metrics = new Metrics();
 
         private SharePartitionManagerBuilder withReplicaManager(ReplicaManager replicaManager) {
             this.replicaManager = replicaManager;
@@ -1748,12 +1819,17 @@ public class SharePartitionManagerTest {
             return this;
         }
 
+        private SharePartitionManagerBuilder withMetrics(Metrics metrics) {
+            this.metrics = metrics;
+            return this;
+        }
+
         public static SharePartitionManagerBuilder builder() {
             return new SharePartitionManagerBuilder();
         }
 
         public SharePartitionManager build() {
-            return new SharePartitionManager(replicaManager, time, cache, partitionCacheMap, RECORD_LOCK_DURATION_MS, timer, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, persister);
+            return new SharePartitionManager(replicaManager, time, cache, partitionCacheMap, RECORD_LOCK_DURATION_MS, timer, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, persister, metrics);
         }
     }
 }

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -105,7 +105,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @Timeout(120)
-@SuppressWarnings({ "ClassDataAbstractionCoupling"})
+@SuppressWarnings({"ClassDataAbstractionCoupling"})
 public class SharePartitionManagerTest {
 
     private static final int RECORD_LOCK_DURATION_MS = 30000;


### PR DESCRIPTION
### What
* Added ShareGroupMetrics inner class to SharePartitionManager.
* Added code to record metrics at various checkpoints in code.

### Why
* We want to record the shareAcknowledgement rate and count, partition load time max and average and record ack rate and count.

### Testing
* Updated tests to verify partition load metrics, record ack and share ack requests