### PR TITLE
MINOR: Add more debug logging to EOSUncleanShutdownIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
@@ -147,7 +147,7 @@ public class EOSUncleanShutdownIntegrationTest {
 
             TestUtils.waitForCondition(() -> recordCount.get() == RECORD_TOTAL,
                 "Expected " + RECORD_TOTAL + " records processed but only got " + recordCount.get());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace();
         } finally {
             TestUtils.waitForCondition(() -> driver.state().equals(State.ERROR),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
@@ -127,6 +127,9 @@ public class EOSUncleanShutdownIntegrationTest {
         driver.cleanUp();
         driver.start();
 
+        TestUtils.waitForCondition(() -> driver.state().equals(State.RUNNING),
+            "Expected RUNNING state but driver is on " + driver.state());
+
         // Task's StateDir
         final File taskStateDir = new File(String.join("/", TEST_FOLDER.getPath(), appId, "0_0"));
         final File taskCheckpointFile = new File(taskStateDir, ".checkpoint");
@@ -144,6 +147,8 @@ public class EOSUncleanShutdownIntegrationTest {
 
             TestUtils.waitForCondition(() -> recordCount.get() == RECORD_TOTAL,
                 "Expected " + RECORD_TOTAL + " records processed but only got " + recordCount.get());
+        } catch (Exception e) {
+            e.printStackTrace();
         } finally {
             TestUtils.waitForCondition(() -> driver.state().equals(State.ERROR),
                 "Expected ERROR state but driver is on " + driver.state());


### PR DESCRIPTION
I could not find a root cause, but the test times out waiting KS to go into ERROR state inside the finally block.

So it seem we might swallow some error? Trying to add some more logging. The logs I have access too, do not contain any errors...