### PR TITLE
KAFKA-17042: The migration docs should remind users to set "broker.id.generation.enable" when adding broker.id

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3946,6 +3946,7 @@ inter.broker.listener.name=PLAINTEXT
   </p>
 
   <ul>
+    <li><a href="#brokerconfigs_broker.id">broker.id</a>: In zk mode, if <code>broker.id.generation.enable</code> is enabled (default is enabled), during migration, if <code>broker.id</code> is not set, the migration will fail because <code>node.id</code> will be -1. Both <code>broker.id</code> and <code>node.id</code> must be non-negative integers.</li>
     <li><a href="#brokerconfigs_controller.quorum.voters">controller.quorum.voters</a></li>
     <li><a href="#brokerconfigs_controller.listener.names">controller.listener.names</a></li>
     <li>The controller.listener.name should also be added to <a href="#brokerconfigs_listener.security.protocol.map">listener.security.property.map</a></li>
@@ -3972,12 +3973,6 @@ zookeeper.connect=localhost:2181
 # KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093
 controller.listener.names=CONTROLLER</code></pre>
-
-  <p>
-    <em>Note: If the broker ID already exists due to the migration, it can be accepted without enabling broker ID generation.
-    In such cases, set <code>broker.id.generation.enable=false</code>. If broker ID generation cannot be disabled for some reason, it is recommended to adjust
-    the <code>reserved.broker.max.id</code> to a known maximum node ID in the cluster to avoid conflicts.</em>
-  </p>
 
   <p>
     <em>Note: Once the final ZK broker has been restarted with the necessary configuration, the migration will automatically begin.</em>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3971,11 +3971,13 @@ zookeeper.connect=localhost:2181
 
 # KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093
-controller.listener.names=CONTROLLER
+controller.listener.names=CONTROLLER</code></pre>
 
-# This setting requires the broker ID to be specified, but since the ID already exists due to the migration, it can be accepted.
-# If broker.id.generation cannot be disabled for some reason, it is recommended to adjust the reserved.broker.max.id to a known maximum node ID in the cluster.
-broker.id.generation.enable=false</code></pre>
+  <p>
+    <em>Note: If the broker ID already exists due to the migration, it can be accepted without enabling broker ID generation.
+    In such cases, set <code>broker.id.generation.enable=false</code>. If broker ID generation cannot be disabled for some reason, it is recommended to adjust
+    the <code>reserved.broker.max.id</code> to a known maximum node ID in the cluster to avoid conflicts.</em>
+  </p>
 
   <p>
     <em>Note: Once the final ZK broker has been restarted with the necessary configuration, the migration will automatically begin.</em>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3946,7 +3946,7 @@ inter.broker.listener.name=PLAINTEXT
   </p>
 
   <ul>
-    <li><a href="#brokerconfigs_broker.id">broker.id</a>: Ensure <code>broker.id</code> is set to a non-negative integer even if <code>broker.id.generation.enable</code> is enabled (default is enabled).</li>
+    <li><a href="#brokerconfigs_broker.id">broker.id</a>: Ensure <code>broker.id</code> is set to a non-negative integer even if <code>broker.id.generation.enable</code> is enabled (default is enabled). Additionally, ensure <code>broker.id</code> does not exceed <code>reserved.broker.max.id</code> to avoid failure.</li>
     <li><a href="#brokerconfigs_controller.quorum.voters">controller.quorum.voters</a></li>
     <li><a href="#brokerconfigs_controller.listener.names">controller.listener.names</a></li>
     <li>The controller.listener.name should also be added to <a href="#brokerconfigs_listener.security.protocol.map">listener.security.property.map</a></li>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3973,7 +3973,8 @@ zookeeper.connect=localhost:2181
 controller.quorum.voters=3000@localhost:9093
 controller.listener.names=CONTROLLER
 
-# If the ZK broker is using a generated broker ID, disable broker ID generation
+# This setting requires the broker ID to be specified, but since the ID already exists due to the migration, it can be accepted.
+# If broker.id.generation cannot be disabled for some reason, it is recommended to adjust the reserved.broker.max.id to a known maximum node ID in the cluster.
 broker.id.generation.enable=false</code></pre>
 
   <p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3946,7 +3946,7 @@ inter.broker.listener.name=PLAINTEXT
   </p>
 
   <ul>
-    <li><a href="#brokerconfigs_broker.id">broker.id</a>: If <code>broker.id.generation.enable</code> is enabled (default is enabled) and <code>broker.id</code> is not set during migration, it will fail. Ensure <code>broker.id</code> is set to a non-negative integer.</li>
+    <li><a href="#brokerconfigs_broker.id">broker.id</a>: Ensure <code>broker.id</code> is set to a non-negative integer even if <code>broker.id.generation.enable</code> is enabled (default is enabled).</li>
     <li><a href="#brokerconfigs_controller.quorum.voters">controller.quorum.voters</a></li>
     <li><a href="#brokerconfigs_controller.listener.names">controller.listener.names</a></li>
     <li>The controller.listener.name should also be added to <a href="#brokerconfigs_listener.security.protocol.map">listener.security.property.map</a></li>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3971,7 +3971,10 @@ zookeeper.connect=localhost:2181
 
 # KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093
-controller.listener.names=CONTROLLER</code></pre>
+controller.listener.names=CONTROLLER
+
+# If the ZK broker is using a generated broker ID, disable broker ID generation
+broker.id.generation.enable=false</code></pre>
 
   <p>
     <em>Note: Once the final ZK broker has been restarted with the necessary configuration, the migration will automatically begin.</em>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3946,7 +3946,7 @@ inter.broker.listener.name=PLAINTEXT
   </p>
 
   <ul>
-    <li><a href="#brokerconfigs_broker.id">broker.id</a>: In zk mode, if <code>broker.id.generation.enable</code> is enabled (default is enabled), during migration, if <code>broker.id</code> is not set, the migration will fail because <code>node.id</code> will be -1. Both <code>broker.id</code> and <code>node.id</code> must be non-negative integers.</li>
+    <li><a href="#brokerconfigs_broker.id">broker.id</a>: If <code>broker.id.generation.enable</code> is enabled (default is enabled) and <code>broker.id</code> is not set during migration, it will fail. Ensure <code>broker.id</code> is set to a non-negative integer.</li>
     <li><a href="#brokerconfigs_controller.quorum.voters">controller.quorum.voters</a></li>
     <li><a href="#brokerconfigs_controller.listener.names">controller.listener.names</a></li>
     <li>The controller.listener.name should also be added to <a href="#brokerconfigs_listener.security.protocol.map">listener.security.property.map</a></li>


### PR DESCRIPTION
In the section: Enter Migration Mode on the Brokers

It requires users to add `broker.id`, but this can produce an error: "broker.id must be greater than or equal to -1 and not greater than reserved.broker.max.id". This error is caused by the ZooKeeper broker using a generated broker ID.

As this phase is temporary, a simple solution is to remind users to add `broker.id.generation.enable=false` if the ZooKeeper broker is using a generated broker ID.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
