### PR TITLE
KAFKA-2526: command line --producer-property wins

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -386,21 +386,13 @@ public class ConsoleProducer {
         Properties producerProps() throws IOException {
             Properties props = new Properties();
 
-            if (options.has(commandConfigOpt)) {
-                props.putAll(loadProps(options.valueOf(commandConfigOpt)));
-            }
-
-            props.putAll(parseKeyValueArgs(options.valuesOf(commandPropertyOpt)));
+            // default properties
             props.put(BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOpt));
             props.put(COMPRESSION_TYPE_CONFIG, compressionCodec());
-
-            if (props.getProperty(CLIENT_ID_CONFIG) == null) {
-                props.put(CLIENT_ID_CONFIG, "console-producer");
-            }
-
             props.put(KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
             props.put(VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
 
+            // optional properties
             CommandLineUtils.maybeMergeOptions(props, LINGER_MS_CONFIG, options, sendTimeoutOpt);
             CommandLineUtils.maybeMergeOptions(props, ACKS_CONFIG, options, requestRequiredAcksOpt);
             CommandLineUtils.maybeMergeOptions(props, REQUEST_TIMEOUT_MS_CONFIG, options, requestTimeoutMsOpt);
@@ -412,6 +404,17 @@ public class ConsoleProducer {
             CommandLineUtils.maybeMergeOptions(props, BATCH_SIZE_CONFIG, options, maxPartitionMemoryBytesOpt);
             CommandLineUtils.maybeMergeOptions(props, METADATA_MAX_AGE_CONFIG, options, metadataExpiryMsOpt);
             CommandLineUtils.maybeMergeOptions(props, MAX_BLOCK_MS_CONFIG, options, maxBlockMsOpt);
+
+            // command line properties
+            if (options.has(commandConfigOpt)) {
+                props.putAll(loadProps(options.valueOf(commandConfigOpt)));
+            }
+            props.putAll(parseKeyValueArgs(options.valuesOf(commandPropertyOpt)));
+
+            // required properties
+            if (props.getProperty(CLIENT_ID_CONFIG) == null) {
+                props.put(CLIENT_ID_CONFIG, "console-producer");
+            }
 
             return props;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -388,6 +388,7 @@ public class ConsoleProducer {
 
             // default properties
             props.put(BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOpt));
+            props.put(CLIENT_ID_CONFIG, "console-producer");
             props.put(COMPRESSION_TYPE_CONFIG, compressionCodec());
             props.put(KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
             props.put(VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
@@ -410,11 +411,6 @@ public class ConsoleProducer {
                 props.putAll(loadProps(options.valueOf(commandConfigOpt)));
             }
             props.putAll(parseKeyValueArgs(options.valuesOf(commandPropertyOpt)));
-
-            // required properties
-            if (props.getProperty(CLIENT_ID_CONFIG) == null) {
-                props.put(CLIENT_ID_CONFIG, "console-producer");
-            }
 
             return props;
         }


### PR DESCRIPTION
apply --producer-property settings last to override any, including default, values.

tested manually with value.serializer.  the extant [test for client.id ](https://github.com/apache/kafka/blob/trunk/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala#L69-L76)is unaffected.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
