### PR TITLE
KAFKA-17036: KIP-919 supports for createAcls, deleteAcls, describeAcls

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2573,7 +2573,7 @@ public class KafkaAdminClient extends AdminClient {
         final long now = time.milliseconds();
         final KafkaFutureImpl<Collection<AclBinding>> future = new KafkaFutureImpl<>();
         runnable.call(new Call("describeAcls", calcDeadlineMs(now, options.timeoutMs()),
-            new LeastLoadedNodeProvider()) {
+            new LeastLoadedBrokerOrActiveKController()) {
 
             @Override
             DescribeAclsRequest.Builder createRequest(int timeoutMs) {
@@ -2620,7 +2620,7 @@ public class KafkaAdminClient extends AdminClient {
         }
         final CreateAclsRequestData data = new CreateAclsRequestData().setCreations(aclCreations);
         runnable.call(new Call("createAcls", calcDeadlineMs(now, options.timeoutMs()),
-            new LeastLoadedNodeProvider()) {
+            new LeastLoadedBrokerOrActiveKController()) {
 
             @Override
             CreateAclsRequest.Builder createRequest(int timeoutMs) {
@@ -2672,7 +2672,7 @@ public class KafkaAdminClient extends AdminClient {
         }
         final DeleteAclsRequestData data = new DeleteAclsRequestData().setFilters(deleteAclsFilters);
         runnable.call(new Call("deleteAcls", calcDeadlineMs(now, options.timeoutMs()),
-            new LeastLoadedNodeProvider()) {
+            new LeastLoadedBrokerOrActiveKController()) {
 
             @Override
             DeleteAclsRequest.Builder createRequest(int timeoutMs) {

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -43,7 +43,7 @@ object AclCommand extends Logging {
 
   private val AuthorizerDeprecationMessage: String = "Warning: support for ACL configuration directly " +
     "through the authorizer is deprecated and will be removed in a future release. Please use " +
-    "--bootstrap-server instead to set ACLs through the admin client."
+    "--bootstrap-server or --bootstrap-controller instead to set ACLs through the admin client."
   private val ClusterResourceFilter = new ResourcePatternFilter(JResourceType.CLUSTER, JResource.CLUSTER_NAME, PatternType.LITERAL)
 
   private val Newline = scala.util.Properties.lineSeparator
@@ -57,7 +57,7 @@ object AclCommand extends Logging {
     opts.checkArgs()
 
     val aclCommandService = {
-      if (opts.options.has(opts.bootstrapServerOpt)) {
+      if (opts.options.has(opts.bootstrapServerOpt) || opts.options.has(opts.bootstrapControllerOpt)) {
         new AdminClientService(opts)
       } else {
         val authorizerClassName = if (opts.options.has(opts.authorizerOpt))
@@ -97,7 +97,12 @@ object AclCommand extends Logging {
         Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt))
       else
         new Properties()
-      props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
+
+      if (opts.options.has(opts.bootstrapServerOpt)) {
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
+      } else {
+        props.put(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, opts.options.valueOf(opts.bootstrapControllerOpt))
+      }
       val adminClient = Admin.create(props)
 
       try {
@@ -493,6 +498,12 @@ object AclCommand extends Logging {
       .describedAs("server to connect to")
       .ofType(classOf[String])
 
+    val bootstrapControllerOpt: OptionSpec[String] = parser.accepts("bootstrap-controller", "A list of host/port pairs to use for establishing the connection to the Kafka cluster." +
+        " This list should be in the form host1:port1,host2:port2,... This config is required for acl management using admin client API.")
+      .withRequiredArg
+      .describedAs("controller to connect to")
+      .ofType(classOf[String])
+
     val commandConfigOpt: OptionSpec[String] = parser.accepts("command-config", CommandConfigDoc)
       .withOptionalArg()
       .describedAs("command-config")
@@ -626,18 +637,22 @@ object AclCommand extends Logging {
     options = parser.parse(args: _*)
 
     def checkArgs(): Unit = {
-      if (options.has(bootstrapServerOpt) && options.has(authorizerOpt))
-        CommandLineUtils.printUsageAndExit(parser, "Only one of --bootstrap-server or --authorizer must be specified")
+      if (options.has(bootstrapServerOpt) && options.has(bootstrapControllerOpt))
+        CommandLineUtils.printUsageAndExit(parser, "Only one of --bootstrap-server or --bootstrap-controller must be specified")
 
-      if (!options.has(bootstrapServerOpt)) {
+      val hasServerOrController = options.has(bootstrapServerOpt) || options.has(bootstrapControllerOpt)
+      if (hasServerOrController && options.has(authorizerOpt))
+        CommandLineUtils.printUsageAndExit(parser, "The --authorizer option can only be used without --bootstrap-server or --bootstrap-controller")
+
+      if (!hasServerOrController) {
         CommandLineUtils.checkRequiredArgs(parser, options, authorizerPropertiesOpt)
         System.err.println(AclCommand.AuthorizerDeprecationMessage)
       }
 
-      if (options.has(commandConfigOpt) && !options.has(bootstrapServerOpt))
-        CommandLineUtils.printUsageAndExit(parser, "The --command-config option can only be used with --bootstrap-server option")
+      if (options.has(commandConfigOpt) && (!hasServerOrController))
+        CommandLineUtils.printUsageAndExit(parser, "The --command-config option can only be used with --bootstrap-server or --bootstrap-controller option")
 
-      if (options.has(authorizerPropertiesOpt) && options.has(bootstrapServerOpt))
+      if (options.has(authorizerPropertiesOpt) && hasServerOrController)
         CommandLineUtils.printUsageAndExit(parser, "The --authorizer-properties option can only be used with --authorizer option")
 
       val actions = Seq(addOpt, removeOpt, listOpt).count(options.has)

--- a/core/src/test/java/kafka/admin/AclCommandTest.java
+++ b/core/src/test/java/kafka/admin/AclCommandTest.java
@@ -26,9 +26,9 @@ import kafka.test.annotation.ClusterTests;
 import kafka.test.annotation.Type;
 import kafka.test.junit.ClusterTestExtensions;
 import kafka.test.junit.ZkClusterInvocationContext;
-import kafka.utils.TestUtils;
 
 import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.resource.PatternType;
@@ -41,7 +41,7 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
-import org.apache.kafka.server.authorizer.Authorizer;
+import org.apache.kafka.test.TestUtils;
 
 import org.apache.log4j.Level;
 import org.junit.jupiter.api.Test;
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -61,7 +62,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.management.InstanceAlreadyExistsException;
@@ -111,6 +111,7 @@ public class AclCommandTest {
     private static final String AUTHORIZER_PROPERTIES = AUTHORIZER + "-properties";
     private static final String ADD = "--add";
     private static final String BOOTSTRAP_SERVER = "--bootstrap-server";
+    private static final String BOOTSTRAP_CONTROLLER = "--bootstrap-controller";
     private static final String COMMAND_CONFIG = "--command-config";
     private static final String CONSUMER = "--consumer";
     private static final String IDEMPOTENT = "--idempotent";
@@ -221,7 +222,7 @@ public class AclCommandTest {
             }};
 
     @ClusterTest(types = {Type.ZK})
-    public void testAclCliWithAuthorizer(ClusterInstance cluster) {
+    public void testAclCliWithAuthorizer(ClusterInstance cluster) throws InterruptedException {
         testAclCli(cluster, zkArgs(cluster));
     }
 
@@ -231,12 +232,40 @@ public class AclCommandTest {
                     @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
             })
     })
-    public void testAclCliWithAdminAPI(ClusterInstance cluster) {
+    public void testAclCliWithAdminAPI(ClusterInstance cluster) throws InterruptedException {
         testAclCli(cluster, adminArgs(cluster.bootstrapServers(), Optional.empty()));
     }
 
+
+    @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+            @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+    })
+    public void testAclCliWithAdminAPIAndBootstrapController(ClusterInstance cluster) throws InterruptedException {
+        testAclCli(cluster, adminArgsWithBootstrapController(cluster.bootstrapControllers(), Optional.empty()));
+    }
+
+    @ClusterTests({
+            @ClusterTest(types = {Type.ZK}),
+            @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+                    @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+            })
+    })
+    public void testAclCliWithMisusingBootstrapServerToController(ClusterInstance cluster) {
+        assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgsWithBootstrapController(cluster.bootstrapServers(), Optional.empty())));
+    }
+
+    @ClusterTests({
+            @ClusterTest(types = {Type.ZK}),
+            @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+                    @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+            })
+    })
+    public void testAclCliWithMisusingBootstrapControllerToServer(ClusterInstance cluster) {
+        assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgs(cluster.bootstrapControllers(), Optional.empty())));
+    }
+
     @ClusterTest(types = {Type.ZK})
-    public void testProducerConsumerCliWithAuthorizer(ClusterInstance cluster) {
+    public void testProducerConsumerCliWithAuthorizer(ClusterInstance cluster) throws InterruptedException {
         testProducerConsumerCli(cluster, zkArgs(cluster));
     }
 
@@ -246,8 +275,15 @@ public class AclCommandTest {
                     @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
             })
     })
-    public void testProducerConsumerCliWithAdminAPI(ClusterInstance cluster) {
+    public void testProducerConsumerCliWithAdminAPI(ClusterInstance cluster) throws InterruptedException {
         testProducerConsumerCli(cluster, adminArgs(cluster.bootstrapServers(), Optional.empty()));
+    }
+
+    @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+            @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+    })
+    public void testProducerConsumerCliWithAdminAPIAndBootstrapController(ClusterInstance cluster) throws InterruptedException {
+        testProducerConsumerCli(cluster, adminArgsWithBootstrapController(cluster.bootstrapControllers(), Optional.empty()));
     }
 
     @ClusterTests({
@@ -256,22 +292,33 @@ public class AclCommandTest {
                     @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
             })
     })
-    public void testAclCliWithClientId(ClusterInstance cluster) {
-        LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        appender.setClassLogger(AppInfoParser.class, Level.WARN);
-        try {
+    public void testAclCliWithClientId(ClusterInstance cluster) throws IOException, InterruptedException {
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
+            appender.setClassLogger(AppInfoParser.class, Level.WARN);
             testAclCli(cluster, adminArgs(cluster.bootstrapServers(), Optional.of(TestUtils.tempFile("client.id=my-client"))));
-        } finally {
-            appender.close();
+            assertEquals(0, appender.getEvents().stream()
+                    .filter(e -> e.getLevel().equals(Level.WARN.toString()))
+                    .filter(e -> e.getThrowableClassName().filter(name -> name.equals(InstanceAlreadyExistsException.class.getName())).isPresent())
+                    .count(), "There should be no warnings about multiple registration of mbeans");
         }
-        assertEquals(0, appender.getEvents().stream()
-                .filter(e -> e.getLevel().equals(Level.WARN.toString()))
-                .filter(e -> e.getThrowableClassName().filter(name -> name.equals(InstanceAlreadyExistsException.class.getName())).isPresent())
-                .count(), "There should be no warnings about multiple registration of mbeans");
+    }
+
+    @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+            @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+    })
+    public void testAclCliWithClientIdAndBootstrapController(ClusterInstance cluster) throws IOException, InterruptedException {
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
+            appender.setClassLogger(AppInfoParser.class, Level.WARN);
+            testAclCli(cluster, adminArgsWithBootstrapController(cluster.bootstrapControllers(), Optional.of(TestUtils.tempFile("client.id=my-client"))));
+            assertEquals(0, appender.getEvents().stream()
+                    .filter(e -> e.getLevel().equals(Level.WARN.toString()))
+                    .filter(e -> e.getThrowableClassName().filter(name -> name.equals(InstanceAlreadyExistsException.class.getName())).isPresent())
+                    .count(), "There should be no warnings about multiple registration of mbeans");
+        }
     }
 
     @ClusterTest(types = {Type.ZK})
-    public void testAclsOnPrefixedResourcesWithAuthorizer(ClusterInstance cluster) {
+    public void testAclsOnPrefixedResourcesWithAuthorizer(ClusterInstance cluster) throws InterruptedException {
         testAclsOnPrefixedResources(cluster, zkArgs(cluster));
     }
 
@@ -281,8 +328,15 @@ public class AclCommandTest {
                     @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
             })
     })
-    public void testAclsOnPrefixedResourcesWithAdminAPI(ClusterInstance cluster) {
+    public void testAclsOnPrefixedResourcesWithAdminAPI(ClusterInstance cluster) throws InterruptedException {
         testAclsOnPrefixedResources(cluster, adminArgs(cluster.bootstrapServers(), Optional.empty()));
+    }
+
+    @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+            @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+    })
+    public void testAclsOnPrefixedResourcesWithAdminAPIAndBootstrapController(ClusterInstance cluster) throws InterruptedException {
+        testAclsOnPrefixedResources(cluster, adminArgsWithBootstrapController(cluster.bootstrapControllers(), Optional.empty()));
     }
 
     @ClusterTest(types = {Type.ZK})
@@ -309,11 +363,36 @@ public class AclCommandTest {
         testPatternTypes(adminArgs(cluster.bootstrapServers(), Optional.empty()));
     }
 
+    @ClusterTests({
+            @ClusterTest(types = {Type.KRAFT}, serverProperties = {
+                    @ClusterConfigProperty(key = AUTHORIZER_CLASS_NAME_CONFIG, value = STANDARD_AUTHORIZER)
+            })
+    })
+    public void testPatternTypesWithAdminAPIAndBootstrapController(ClusterInstance cluster) {
+        testPatternTypes(adminArgsWithBootstrapController(cluster.bootstrapControllers(), Optional.empty()));
+    }
+
+    @Test
+    public void testUseBootstrapServerOptWithBootstrapControllerOpt() {
+        assertInitializeInvalidOptionsExitCodeAndMsg(
+                Arrays.asList(BOOTSTRAP_SERVER, LOCALHOST, BOOTSTRAP_CONTROLLER, LOCALHOST),
+                "Only one of --bootstrap-server or --bootstrap-controller must be specified"
+        );
+    }
+
     @Test
     public void testUseBootstrapServerOptWithAuthorizerOpt() {
         assertInitializeInvalidOptionsExitCodeAndMsg(
                 Arrays.asList(BOOTSTRAP_SERVER, LOCALHOST, AUTHORIZER, ACL_AUTHORIZER),
-                "Only one of --bootstrap-server or --authorizer must be specified"
+                "The --authorizer option can only be used without --bootstrap-server or --bootstrap-controller"
+        );
+    }
+
+    @Test
+    public void testUseBootstrapControllerOptWithAuthorizerOpt() {
+        assertInitializeInvalidOptionsExitCodeAndMsg(
+                Arrays.asList(BOOTSTRAP_CONTROLLER, LOCALHOST, AUTHORIZER, ACL_AUTHORIZER),
+                "The --authorizer option can only be used without --bootstrap-server or --bootstrap-controller"
         );
     }
 
@@ -330,7 +409,7 @@ public class AclCommandTest {
     public void testUseCommandConfigOptWithoutBootstrapServerOpt() {
         assertInitializeInvalidOptionsExitCodeAndMsg(
                 Arrays.asList(COMMAND_CONFIG, "cfg.properties", AUTHORIZER, ACL_AUTHORIZER, AUTHORIZER_PROPERTIES, ZOOKEEPER_CONNECT),
-                "The --command-config option can only be used with --bootstrap-server option"
+                "The --command-config option can only be used with --bootstrap-server or --bootstrap-controller option"
         );
     }
 
@@ -398,7 +477,7 @@ public class AclCommandTest {
         );
     }
 
-    private void testProducerConsumerCli(ClusterInstance cluster, List<String> cmdArgs) {
+    private void testProducerConsumerCli(ClusterInstance cluster, List<String> cmdArgs) throws InterruptedException {
         for (Map.Entry<List<String>, Map<Set<ResourcePattern>, Set<AccessControlEntry>>> entry : CMD_TO_RESOURCES_TO_ACL.entrySet()) {
             List<String> cmd = entry.getKey();
             Map<Set<ResourcePattern>, Set<AccessControlEntry>> resourcesToAcls = entry.getValue();
@@ -418,8 +497,7 @@ public class AclCommandTest {
 
             for (Map.Entry<Set<ResourcePattern>, Set<AccessControlEntry>> resourcesToAclsEntry : resourcesToAcls.entrySet()) {
                 for (ResourcePattern resource : resourcesToAclsEntry.getKey()) {
-                    withAuthorizer(cluster, authorizer ->
-                            TestUtils.waitAndVerifyAcls(asScalaSet(resourcesToAclsEntry.getValue()), authorizer, resource, ANY));
+                    cluster.waitAcls(new AclBindingFilter(resource.toFilter(), ANY), resourcesToAclsEntry.getValue());
                 }
             }
             List<String> resourceCmd = new ArrayList<>(resourceCommand);
@@ -428,7 +506,7 @@ public class AclCommandTest {
         }
     }
 
-    private void testAclsOnPrefixedResources(ClusterInstance cluster, List<String> cmdArgs) {
+    private void testAclsOnPrefixedResources(ClusterInstance cluster, List<String> cmdArgs) throws InterruptedException {
         List<String> cmd = Arrays.asList("--allow-principal", PRINCIPAL.toString(), PRODUCER, TOPIC, "Test-",
                 RESOURCE_PATTERN_TYPE, "Prefixed");
 
@@ -437,17 +515,11 @@ public class AclCommandTest {
         args.add(ADD);
         callMain(args);
 
-        withAuthorizer(cluster, authorizer -> {
-            AccessControlEntry writeAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, WRITE, ALLOW);
-            AccessControlEntry describeAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, DESCRIBE, ALLOW);
-            AccessControlEntry createAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, CREATE, ALLOW);
-            TestUtils.waitAndVerifyAcls(
-                    asScalaSet(new HashSet<>(Arrays.asList(writeAcl, describeAcl, createAcl))),
-                    authorizer,
-                    new ResourcePattern(ResourceType.TOPIC, "Test-", PREFIXED),
-                    ANY
-            );
-        });
+        AccessControlEntry writeAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, WRITE, ALLOW);
+        AccessControlEntry describeAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, DESCRIBE, ALLOW);
+        AccessControlEntry createAcl = new AccessControlEntry(PRINCIPAL.toString(), WILDCARD_HOST, CREATE, ALLOW);
+        cluster.waitAcls(new AclBindingFilter(new ResourcePattern(ResourceType.TOPIC, "Test-", PREFIXED).toFilter(), ANY),
+                Arrays.asList(writeAcl, describeAcl, createAcl));
 
         args = new ArrayList<>(cmdArgs);
         args.addAll(cmd);
@@ -455,20 +527,10 @@ public class AclCommandTest {
         args.add("--force");
         callMain(args);
 
-        withAuthorizer(cluster, authorizer -> {
-            TestUtils.waitAndVerifyAcls(
-                    asScalaSet(Collections.emptySet()),
-                    authorizer,
-                    new ResourcePattern(CLUSTER, "kafka-cluster", LITERAL),
-                    ANY
-            );
-            TestUtils.waitAndVerifyAcls(
-                    asScalaSet(Collections.emptySet()),
-                    authorizer,
-                    new ResourcePattern(ResourceType.TOPIC, "Test-", PREFIXED),
-                    ANY
-            );
-        });
+        cluster.waitAcls(new AclBindingFilter(new ResourcePattern(ResourceType.CLUSTER, "kafka-cluster", PREFIXED).toFilter(), ANY),
+                Collections.emptySet());
+        cluster.waitAcls(new AclBindingFilter(new ResourcePattern(ResourceType.TOPIC, "Test-", PREFIXED).toFilter(), ANY),
+                Collections.emptySet());
     }
 
     private static Map<Set<ResourcePattern>, Set<AccessControlEntry>> producerResourceToAcls(boolean enableIdempotence) {
@@ -490,11 +552,17 @@ public class AclCommandTest {
         return adminArgs;
     }
 
+    private List<String> adminArgsWithBootstrapController(String bootstrapController, Optional<File> commandConfig) {
+        List<String> adminArgs = new ArrayList<>(Arrays.asList(BOOTSTRAP_CONTROLLER, bootstrapController));
+        commandConfig.ifPresent(file -> adminArgs.addAll(Arrays.asList(COMMAND_CONFIG, file.getAbsolutePath())));
+        return adminArgs;
+    }
+
     private Map.Entry<String, String> callMain(List<String> args) {
         return grabConsoleOutputAndError(() -> AclCommand.main(args.toArray(new String[0])));
     }
 
-    private void testAclCli(ClusterInstance cluster, List<String> cmdArgs) {
+    private void testAclCli(ClusterInstance cluster, List<String> cmdArgs) throws InterruptedException {
         for (Map.Entry<Set<ResourcePattern>, List<String>> entry : RESOURCE_TO_COMMAND.entrySet()) {
             Set<ResourcePattern> resources = entry.getKey();
             List<String> resourceCmd = entry.getValue();
@@ -514,8 +582,7 @@ public class AclCommandTest {
                 assertEquals("", out.getValue());
 
                 for (ResourcePattern resource : resources) {
-                    withAuthorizer(cluster, authorizer ->
-                            TestUtils.waitAndVerifyAcls(asScalaSet(aclToCommand.getKey()), authorizer, resource, ANY));
+                    cluster.waitAcls(new AclBindingFilter(resource.toFilter(), ANY), aclToCommand.getKey());
                 }
 
                 resultArgs = new ArrayList<>(cmdArgs);
@@ -592,7 +659,7 @@ public class AclCommandTest {
             List<String> cmdArgs,
             Set<ResourcePattern> resources,
             List<String> resourceCmd
-    ) {
+    ) throws InterruptedException {
         List<String> args = new ArrayList<>(cmdArgs);
         args.addAll(resourceCmd);
         args.add(REMOVE);
@@ -600,8 +667,7 @@ public class AclCommandTest {
         Map.Entry<String, String> out = callMain(args);
         assertEquals("", out.getValue());
         for (ResourcePattern resource : resources) {
-            withAuthorizer(cluster, authorizer ->
-                    TestUtils.waitAndVerifyAcls(asScalaSet(Collections.emptySet()), authorizer, resource, ANY));
+            cluster.waitAcls(new AclBindingFilter(resource.toFilter(), ANY), Collections.emptySet());
         }
     }
 
@@ -626,23 +692,6 @@ public class AclCommandTest {
         }
 
         return fullCmd;
-    }
-
-    private void withAuthorizer(ClusterInstance cluster, Consumer<Authorizer> consumer) {
-        if (cluster.isKRaftTest()) {
-            List<Authorizer> allAuthorizers = new ArrayList<>();
-            allAuthorizers.addAll(cluster.brokers().values().stream()
-                    .map(server -> server.authorizer().get()).collect(Collectors.toList()));
-            allAuthorizers.addAll(cluster.controllers().values().stream()
-                    .map(server -> server.authorizer().get()).collect(Collectors.toList()));
-            allAuthorizers.forEach(consumer);
-        } else {
-            consumer.accept(cluster.brokers().values().stream()
-                    .findFirst()
-                    .orElseThrow(() -> new RuntimeException("No broker found"))
-                    .authorizer().get()
-            );
-        }
     }
 
     /**

--- a/docs/security.html
+++ b/docs/security.html
@@ -1374,7 +1374,13 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
         </tr>
         <tr>
             <td>--bootstrap-server</td>
-            <td>A list of host/port pairs to use for establishing the connection to the Kafka cluster. Only one of --bootstrap-server or --authorizer option must be specified.</td>
+            <td>A list of host/port pairs to use for establishing the connection to the Kafka cluster broker. Only one of --bootstrap-server, --bootstrap-controller, or --authorizer option must be specified.</td>
+            <td></td>
+            <td>Configuration</td>
+        </tr>
+        <tr>
+            <td>--bootstrap-controller</td>
+            <td>A list of host/port pairs to use for establishing the connection to the Kafka cluster controller. Only one of --bootstrap-server, --bootstrap-controller, or --authorizer option must be specified.</td>
             <td></td>
             <td>Configuration</td>
         </tr>


### PR DESCRIPTION
* Use `LeastLoadedBrokerOrActiveKController` for `describeAcls`, `createAcls`, and `deleteAcls` APIs.
* Add `--bootstrap-controller` to `AclCommand`.
* Add related integration tests to `AclCommandTest`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
