### PR TITLE
MINOR: Add logs when metadata update is not successful

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1201,11 +1201,24 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             metadata.maybeThrowExceptionForTopic(topic);
             remainingWaitMs = maxWaitMs - elapsed;
             partitionsCount = cluster.partitionCountForTopic(topic);
-        } while (partitionsCount == null || (partition != null && partition >= partitionsCount));
+
+            if (!topicPartitionMetadataFound(partitionsCount, partition)) {
+                String expectedMetadataNotFoundMessage = partitionsCount == null ?
+                    String.format("Topic %s not present in metadata after %d ms. Retrying until %d ms elapses",
+                        topic, elapsed, maxWaitMs) :
+                    String.format("Partition %d of topic %s with partition count %d is not present in metadata after %d ms. Retrying until %d ms elapses",
+                        partition, topic, partitionsCount, elapsed, maxWaitMs);
+                log.info(expectedMetadataNotFoundMessage);
+            }
+        } while (!topicPartitionMetadataFound(partitionsCount, partition));
 
         producerMetrics.recordMetadataWait(time.nanoseconds() - nowNanos);
 
         return new ClusterAndWaitTime(cluster, elapsed);
+    }
+
+    private boolean topicPartitionMetadataFound(Integer partitionsCount, Integer expectedPartition) {
+        return partitionsCount != null && (expectedPartition == null || expectedPartition < partitionsCount);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1208,7 +1208,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         topic, elapsed, maxWaitMs) :
                     String.format("Partition %d of topic %s with partition count %d is not present in metadata after %d ms. Retrying until %d ms elapses",
                         partition, topic, partitionsCount, elapsed, maxWaitMs);
-                log.info(expectedMetadataNotFoundMessage);
+                log.debug(expectedMetadataNotFoundMessage);
             }
         } while (!topicPartitionMetadataFound(partitionsCount, partition));
 


### PR DESCRIPTION
### Problem
When a metadata update fails and is in retry loop, there is no log to suggest that metadata update is being retried. 
This info is not evident until a TimeoutException is thrown when `max.block.ms` elapses. 
In connect framework, `max.block.ms` is set to infinite and thus there is no way to know that the producer is stuck in an infinite loop trying to get metadata. 
Few cases where this problem can be expected are:
- Topic does not exist
- Topic exists, but the partition that we are trying to send does not exist

### Change
Adding some logs here, which can help capture the current status of connector.

### Testing
Leveraging existing test suite to validate the change


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
