### PR TITLE
Minor: Consumer group response should set error msg

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
@@ -76,6 +76,13 @@ public class ApiError {
     }
 
     /**
+     * The error code for the exception
+     */
+    public short code() {
+        return error.code();
+    }
+
+    /**
      * Return the optional error message or null. Consider using {@link #messageWithFallback()} instead.
      */
     public String message() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -90,13 +90,14 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
 
     public static List<ConsumerGroupDescribeResponseData.DescribedGroup> getErrorDescribedGroupList(
         List<String> groupIds,
-        Errors error
+        Errors error,
+        String errorMessage
     ) {
         return groupIds.stream()
             .map(groupId -> new ConsumerGroupDescribeResponseData.DescribedGroup()
                 .setGroupId(groupId)
                 .setErrorCode(error.code())
-                .setErrorMessage(error.message())
+                .setErrorMessage(errorMessage)
             ).collect(Collectors.toList());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -63,12 +63,14 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
     public ConsumerGroupDescribeResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
             .setThrottleTimeMs(throttleTimeMs);
+        ApiError apiError = ApiError.fromThrowable(e);
         // Set error for each group
         this.data.groupIds().forEach(
             groupId -> data.groups().add(
                 new ConsumerGroupDescribeResponseData.DescribedGroup()
                     .setGroupId(groupId)
-                    .setErrorCode(Errors.forException(e).code())
+                    .setErrorCode(apiError.code())
+                    .setErrorMessage(apiError.messageWithFallback())
             )
         );
         return new ConsumerGroupDescribeResponse(data);
@@ -94,6 +96,7 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
             .map(groupId -> new ConsumerGroupDescribeResponseData.DescribedGroup()
                 .setGroupId(groupId)
                 .setErrorCode(error.code())
+                .setErrorMessage(error.message())
             ).collect(Collectors.toList());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
-import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
 
@@ -68,11 +67,13 @@ public class ConsumerGroupHeartbeatRequest extends AbstractRequest {
     }
 
     @Override
-    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+    public ConsumerGroupHeartbeatResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        ApiError apiError = ApiError.fromThrowable(e);
         return new ConsumerGroupHeartbeatResponse(
             new ConsumerGroupHeartbeatResponseData()
                 .setThrottleTimeMs(throttleTimeMs)
-                .setErrorCode(Errors.forException(e).code())
+                .setErrorCode(apiError.code())
+                .setErrorMessage(apiError.messageWithFallback())
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequestTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
-import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.protocol.Errors;
 
 import org.junit.jupiter.api.Test;
@@ -29,21 +28,7 @@ import java.util.List;
 import static org.apache.kafka.common.requests.ConsumerGroupDescribeRequest.getErrorDescribedGroupList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConsumerGroupRequestTest {
-    private static final int THROTTLE_TIME_MS = 1000;
-
-    @Test
-    void testGetErrorConsumerGroupHeartbeatResponse() {
-        ConsumerGroupHeartbeatRequestData data = new ConsumerGroupHeartbeatRequestData();
-        ConsumerGroupHeartbeatRequest request = new ConsumerGroupHeartbeatRequest.Builder(data).build();
-        Throwable e = Errors.UNSUPPORTED_VERSION.exception();
-        ConsumerGroupHeartbeatResponse response = request.getErrorResponse(THROTTLE_TIME_MS, e);
-
-        assertEquals(THROTTLE_TIME_MS, response.throttleTimeMs());
-        ApiError apiError = ApiError.fromThrowable(e);
-        assertEquals(apiError.code(), response.data().errorCode());
-        assertEquals(e.getMessage(), response.data().errorMessage());
-    }
+public class ConsumerGroupDescribeRequestTest {
 
     @Test
     void testGetErrorConsumerGroupDescribeResponse() {
@@ -53,9 +38,10 @@ public class ConsumerGroupRequestTest {
         ConsumerGroupDescribeRequest request = new ConsumerGroupDescribeRequest.Builder(data, true)
             .build();
         Throwable e = Errors.GROUP_AUTHORIZATION_FAILED.exception();
-        ConsumerGroupDescribeResponse response = request.getErrorResponse(THROTTLE_TIME_MS, e);
+        int throttleTimeMs = 1000;
+        ConsumerGroupDescribeResponse response = request.getErrorResponse(throttleTimeMs, e);
 
-        assertEquals(THROTTLE_TIME_MS, response.throttleTimeMs());
+        assertEquals(throttleTimeMs, response.throttleTimeMs());
         ApiError apiError = ApiError.fromThrowable(e);
         for (int i = 0; i < groupIds.size(); i++) {
             ConsumerGroupDescribeResponseData.DescribedGroup group = response.data().groups().get(i);
@@ -84,7 +70,8 @@ public class ConsumerGroupRequestTest {
 
         List<ConsumerGroupDescribeResponseData.DescribedGroup> describedGroupList = getErrorDescribedGroupList(
             Arrays.asList("group-id-1", "group-id-2", "group-id-3"),
-            Errors.COORDINATOR_LOAD_IN_PROGRESS
+            Errors.COORDINATOR_LOAD_IN_PROGRESS,
+            Errors.COORDINATOR_LOAD_IN_PROGRESS.message()
         );
 
         assertEquals(expectedDescribedGroupList, describedGroupList);

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsumerGroupHeartbeatRequestTest {
+
+    @Test
+    void testGetErrorConsumerGroupHeartbeatResponse() {
+        ConsumerGroupHeartbeatRequestData data = new ConsumerGroupHeartbeatRequestData();
+        ConsumerGroupHeartbeatRequest request = new ConsumerGroupHeartbeatRequest.Builder(data).build();
+        Throwable e = Errors.UNSUPPORTED_VERSION.exception();
+        int throttleTimeMs = 1000;
+        ConsumerGroupHeartbeatResponse response = request.getErrorResponse(throttleTimeMs, e);
+
+        assertEquals(throttleTimeMs, response.throttleTimeMs());
+        ApiError apiError = ApiError.fromThrowable(e);
+        assertEquals(apiError.code(), response.data().errorCode());
+        assertEquals(e.getMessage(), response.data().errorMessage());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
@@ -19,12 +19,26 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.protocol.Errors;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsumerGroupHeartbeatRequestTest {
-    private void testGetError(Errors e) {
+    @ParameterizedTest
+    @EnumSource(value = Errors.class, names = {
+        "UNSUPPORTED_VERSION",
+        "GROUP_AUTHORIZATION_FAILED",
+        "NOT_COORDINATOR",
+        "COORDINATOR_NOT_AVAILABLE",
+        "COORDINATOR_LOAD_IN_PROGRESS",
+        "INVALID_REQUEST",
+        "UNKNOWN_MEMBER_ID",
+        "FENCED_MEMBER_EPOCH",
+        "UNSUPPORTED_ASSIGNOR",
+        "UNRELEASED_INSTANCE_ID",
+        "GROUP_MAX_SIZE_REACHED"})
+    void testGetErrorConsumerGroupHeartbeatResponse(Errors e) {
         ConsumerGroupHeartbeatRequestData data = new ConsumerGroupHeartbeatRequestData();
         ConsumerGroupHeartbeatRequest request = new ConsumerGroupHeartbeatRequest.Builder(data).build();
         int throttleTimeMs = 1000;
@@ -32,20 +46,5 @@ public class ConsumerGroupHeartbeatRequestTest {
         assertEquals(response.throttleTimeMs(), throttleTimeMs);
         assertEquals(response.data().errorCode(), e.code());
         assertEquals(response.data().errorMessage(), e.message());
-    }
-
-    @Test
-    void testGetErrorConsumerGroupHeartbeatResponse() {
-        testGetError(Errors.UNSUPPORTED_VERSION);
-        testGetError(Errors.GROUP_AUTHORIZATION_FAILED);
-        testGetError(Errors.NOT_COORDINATOR);
-        testGetError(Errors.COORDINATOR_NOT_AVAILABLE);
-        testGetError(Errors.COORDINATOR_LOAD_IN_PROGRESS);
-        testGetError(Errors.INVALID_REQUEST);
-        testGetError(Errors.UNKNOWN_MEMBER_ID);
-        testGetError(Errors.FENCED_MEMBER_EPOCH);
-        testGetError(Errors.UNSUPPORTED_ASSIGNOR);
-        testGetError(Errors.UNRELEASED_INSTANCE_ID);
-        testGetError(Errors.GROUP_MAX_SIZE_REACHED);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.protocol.Errors;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequestTest.java
@@ -24,18 +24,28 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsumerGroupHeartbeatRequestTest {
+    private void testGetError(Errors e) {
+        ConsumerGroupHeartbeatRequestData data = new ConsumerGroupHeartbeatRequestData();
+        ConsumerGroupHeartbeatRequest request = new ConsumerGroupHeartbeatRequest.Builder(data).build();
+        int throttleTimeMs = 1000;
+        ConsumerGroupHeartbeatResponse response = request.getErrorResponse(throttleTimeMs, e.exception());
+        assertEquals(response.throttleTimeMs(), throttleTimeMs);
+        assertEquals(response.data().errorCode(), e.code());
+        assertEquals(response.data().errorMessage(), e.message());
+    }
 
     @Test
     void testGetErrorConsumerGroupHeartbeatResponse() {
-        ConsumerGroupHeartbeatRequestData data = new ConsumerGroupHeartbeatRequestData();
-        ConsumerGroupHeartbeatRequest request = new ConsumerGroupHeartbeatRequest.Builder(data).build();
-        Throwable e = Errors.UNSUPPORTED_VERSION.exception();
-        int throttleTimeMs = 1000;
-        ConsumerGroupHeartbeatResponse response = request.getErrorResponse(throttleTimeMs, e);
-
-        assertEquals(throttleTimeMs, response.throttleTimeMs());
-        ApiError apiError = ApiError.fromThrowable(e);
-        assertEquals(apiError.code(), response.data().errorCode());
-        assertEquals(e.getMessage(), response.data().errorMessage());
+        testGetError(Errors.UNSUPPORTED_VERSION);
+        testGetError(Errors.GROUP_AUTHORIZATION_FAILED);
+        testGetError(Errors.NOT_COORDINATOR);
+        testGetError(Errors.COORDINATOR_NOT_AVAILABLE);
+        testGetError(Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        testGetError(Errors.INVALID_REQUEST);
+        testGetError(Errors.UNKNOWN_MEMBER_ID);
+        testGetError(Errors.FENCED_MEMBER_EPOCH);
+        testGetError(Errors.UNSUPPORTED_ASSIGNOR);
+        testGetError(Errors.UNRELEASED_INSTANCE_ID);
+        testGetError(Errors.GROUP_MAX_SIZE_REACHED);
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -564,7 +564,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
         if (!isActive.get()) {
             return CompletableFuture.completedFuture(ConsumerGroupDescribeRequest.getErrorDescribedGroupList(
                 groupIds,
-                Errors.COORDINATOR_NOT_AVAILABLE
+                Errors.COORDINATOR_NOT_AVAILABLE,
+                Errors.COORDINATOR_NOT_AVAILABLE.message()
             ));
         }
 
@@ -595,7 +596,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     "consumer-group-describe",
                     groupList,
                     exception,
-                    (error, __) -> ConsumerGroupDescribeRequest.getErrorDescribedGroupList(groupList, error)
+                    (error, message) -> ConsumerGroupDescribeRequest.getErrorDescribedGroupList(groupList, error, message)
                 ));
 
             futures.add(future);
@@ -1131,7 +1132,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             case UNKNOWN_SERVER_ERROR:
                 log.error("Operation {} with {} hit an unexpected exception: {}.",
                     operationName, operationInput, exception.getMessage(), exception);
-                return handler.apply(Errors.UNKNOWN_SERVER_ERROR, null);
+                return handler.apply(Errors.UNKNOWN_SERVER_ERROR, Errors.UNKNOWN_SERVER_ERROR.message());
 
             case NETWORK_EXCEPTION:
                 // When committing offsets transactionally, we now verify the transaction with the
@@ -1139,24 +1140,24 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 // retriable error which older clients may not expect and retry correctly. We
                 // translate the error to `COORDINATOR_LOAD_IN_PROGRESS` because it causes clients
                 // to retry the request without an unnecessary coordinator lookup.
-                return handler.apply(Errors.COORDINATOR_LOAD_IN_PROGRESS, null);
+                return handler.apply(Errors.COORDINATOR_LOAD_IN_PROGRESS, Errors.COORDINATOR_LOAD_IN_PROGRESS.message());
 
             case UNKNOWN_TOPIC_OR_PARTITION:
             case NOT_ENOUGH_REPLICAS:
             case REQUEST_TIMED_OUT:
-                return handler.apply(Errors.COORDINATOR_NOT_AVAILABLE, null);
+                return handler.apply(Errors.COORDINATOR_NOT_AVAILABLE, Errors.COORDINATOR_NOT_AVAILABLE.message());
 
             case NOT_LEADER_OR_FOLLOWER:
             case KAFKA_STORAGE_ERROR:
-                return handler.apply(Errors.NOT_COORDINATOR, null);
+                return handler.apply(Errors.NOT_COORDINATOR, Errors.NOT_COORDINATOR.message());
 
             case MESSAGE_TOO_LARGE:
             case RECORD_LIST_TOO_LARGE:
             case INVALID_FETCH_SIZE:
-                return handler.apply(Errors.UNKNOWN_SERVER_ERROR, null);
+                return handler.apply(Errors.UNKNOWN_SERVER_ERROR, Errors.UNKNOWN_SERVER_ERROR.message());
 
             default:
-                return handler.apply(apiError.error(), apiError.message());
+                return handler.apply(apiError.error(), apiError.messageWithFallback());
         }
     }
 }


### PR DESCRIPTION
When we use new group consumer protocol type to connect with old server, we would fail with such error msg. It seems we miss set the error msg.

Before:
```
[2024-07-01 16:54:11,466] ERROR [Consumer clientId=console-consumer, groupId=uly3] GroupHeartbeatRequest failed due to UNSUPPORTED_VERSION: null (org.apache.kafka.clients.consumer.internals.HeartbeatRequestManager)
```

After:
```
[2024-07-01 17:13:02,212] ERROR [Consumer clientId=console-consumer, groupId=uly3] GroupHeartbeatRequest failed due to UNSUPPORTED_VERSION: The version of API is not supported. (org.apache.kafka.clients.consumer.internals.HeartbeatRequestManager)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
