### PR TITLE
KAFKA-17058; Extend CoordinatorRuntime to support non-atomic writes

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -586,7 +586,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             records.size(), time.milliseconds() - startMs);
         // Reschedule the next cycle.
         scheduleGroupMetadataExpiration();
-        return new CoordinatorResult<>(records);
+        return new CoordinatorResult<>(records, false);
     }
 
     /**
@@ -618,7 +618,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         log.info("Generated {} tombstone records in {} milliseconds while deleting offsets for partitions {}.",
             records.size(), time.milliseconds() - startTimeMs, topicPartitions);
 
-        return new CoordinatorResult<>(records);
+        return new CoordinatorResult<>(records, false);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -97,7 +97,7 @@ public class CoordinatorResult<T, U> {
      *
      * @param records       A non-null list of records.
      * @param appendFuture  The future to complete once the records are committed.
-     * @param replayRecords The replayRecords.
+     * @param replayRecords The records to replay.
      */
     public CoordinatorResult(
         List<U> records,
@@ -113,7 +113,7 @@ public class CoordinatorResult<T, U> {
      * @param records       A non-null list of records.
      * @param response      A response.
      * @param appendFuture  The future to complete once the records are committed.
-     * @param replayRecords The replayRecords.
+     * @param replayRecords The records to replay.
      */
     public CoordinatorResult(
         List<U> records,
@@ -130,7 +130,7 @@ public class CoordinatorResult<T, U> {
      * @param records       A non-null list of records.
      * @param response      A response.
      * @param appendFuture  The future to complete once the records are committed.
-     * @param replayRecords The replayRecords.
+     * @param replayRecords The records to replay.
      * @param isAtomic      A boolean indicating whether the result is atomic or not.
      */
     public CoordinatorResult(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -56,7 +56,7 @@ public class CoordinatorResult<T, U> {
     private final boolean isAtomic;
 
     /**
-     * Constructs a Result with records and a response.
+     * Constructs a Result with records.
      *
      * @param records   A non-null list of records.
      */
@@ -64,6 +64,19 @@ public class CoordinatorResult<T, U> {
         List<U> records
     ) {
         this(records, null, null, true, true);
+    }
+
+    /**
+     * Constructs a Result with records.
+     *
+     * @param records   A non-null list of records.
+     * @param isAtomic  A boolean indicating whether the result is atomic or not.
+     */
+    public CoordinatorResult(
+        List<U> records,
+        boolean isAtomic
+    ) {
+        this(records, null, null, true, isAtomic);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -50,6 +50,23 @@ public class CoordinatorResult<T, U> {
     private final boolean replayRecords;
 
     /**
+     * The boolean indicating whether the records must be persisted
+     * atomically.
+     */
+    private final boolean isAtomic;
+
+    /**
+     * Constructs a Result with records and a response.
+     *
+     * @param records   A non-null list of records.
+     */
+    public CoordinatorResult(
+        List<U> records
+    ) {
+        this(records, null, null, true, true);
+    }
+
+    /**
      * Constructs a Result with records and a response.
      *
      * @param records   A non-null list of records.
@@ -59,7 +76,7 @@ public class CoordinatorResult<T, U> {
         List<U> records,
         T response
     ) {
-        this(records, response, null, true);
+        this(records, response, null, true, true);
     }
 
     /**
@@ -74,7 +91,7 @@ public class CoordinatorResult<T, U> {
         CompletableFuture<Void> appendFuture,
         boolean replayRecords
     ) {
-        this(records, null, appendFuture, replayRecords);
+        this(records, null, appendFuture, replayRecords, true);
     }
 
     /**
@@ -91,21 +108,30 @@ public class CoordinatorResult<T, U> {
         CompletableFuture<Void> appendFuture,
         boolean replayRecords
     ) {
+        this(records, response, appendFuture, replayRecords, true);
+    }
+
+    /**
+     * Constructs a Result with records, a response, an append-future, and replayRecords.
+     *
+     * @param records       A non-null list of records.
+     * @param response      A response.
+     * @param appendFuture  The future to complete once the records are committed.
+     * @param replayRecords The replayRecords.
+     * @param isAtomic      A boolean indicating whether the result is atomic or not.
+     */
+    public CoordinatorResult(
+        List<U> records,
+        T response,
+        CompletableFuture<Void> appendFuture,
+        boolean replayRecords,
+        boolean isAtomic
+    ) {
         this.records = Objects.requireNonNull(records);
         this.response = response;
         this.appendFuture = appendFuture;
         this.replayRecords = replayRecords;
-    }
-
-    /**
-     * Constructs a Result with records and a response.
-     *
-     * @param records   A non-null list of records.
-     */
-    public CoordinatorResult(
-        List<U> records
-    ) {
-        this(records, null, null, true);
+        this.isAtomic = isAtomic;
     }
 
     /**
@@ -136,6 +162,13 @@ public class CoordinatorResult<T, U> {
         return replayRecords;
     }
 
+    /**
+     * @return Whether the result is atomic is not.
+     */
+    public boolean isAtomic() {
+        return isAtomic;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -146,6 +179,7 @@ public class CoordinatorResult<T, U> {
         if (!Objects.equals(records, that.records)) return false;
         if (!Objects.equals(response, that.response)) return false;
         if (!Objects.equals(replayRecords, that.replayRecords)) return false;
+        if (!Objects.equals(isAtomic, that.isAtomic)) return false;
         return Objects.equals(appendFuture, that.appendFuture);
     }
 
@@ -155,6 +189,7 @@ public class CoordinatorResult<T, U> {
         result = 31 * result + (response != null ? response.hashCode() : 0);
         result = 31 * result + (appendFuture != null ? appendFuture.hashCode() : 0);
         result = 31 * result + (replayRecords ? 1 : 0);
+        result = 31 * result + (isAtomic ? 1 : 0);
         return result;
     }
     @Override
@@ -163,6 +198,7 @@ public class CoordinatorResult<T, U> {
             ", response=" + response +
             ", appendFuture=" + appendFuture +
             ", replayRecords=" + replayRecords +
+            ", isAtomic=" + isAtomic +
             ")";
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -4031,7 +4031,6 @@ public class CoordinatorRuntimeTest {
         assertFalse(write1.isDone());
 
         // Verify the state.
-        //assertNull(ctx.currentBatch);
         assertEquals(3L, ctx.coordinator.lastWrittenOffset());
         assertEquals(0L, ctx.coordinator.lastCommittedOffset());
         assertEquals(Arrays.asList(0L, 3L), ctx.coordinator.snapshotRegistry().epochsList());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -3358,7 +3358,7 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleWriteOperationWithBatchingWhenWriteFails() {
         MockTimer timer = new MockTimer();
-        // The partition writer only accept no writes.
+        // The partition writer does not accept any writes
         MockPartitionWriter writer = new MockPartitionWriter(0);
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
@@ -4047,7 +4047,7 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleNonAtomicWriteOperationWhenWriteFails() {
         MockTimer timer = new MockTimer();
-        // The partition writer only accept no writes.
+        // The partition writer does not accept any writes.
         MockPartitionWriter writer = new MockPartitionWriter(0);
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =


### PR DESCRIPTION
The group coordinator has (internal) write operations that could generate a large number of records (e.g. expiring offsets and groups). At the moment, those operations are limited by the maximum message size. If they hit it, they are basically stuck forever. This patch extends the CoordinatorRuntime to support non-atomic writes and it changes those internal operations to be non-atomic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
