### PR TITLE
KAFKA-16853: Split RemoteLogManagerScheduledThreadPool

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -40,6 +40,7 @@
               files="core[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="NPathComplexity" files="(ClusterTestExtensions|KafkaApisBuilder|SharePartition).java"/>
     <suppress checks="NPathComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling" files="(RemoteLogManager|RemoteLogManagerTest).java"/>
+    <suppress checks="MethodLength" files="RemoteLogManager.java"/>
     <suppress checks="ClassFanOutComplexity" files="RemoteLogManagerTest.java"/>
     <suppress checks="MethodLength"
               files="(KafkaClusterTestKit).java"/>

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -179,11 +179,15 @@ public class RemoteLogManager implements Closeable {
 
     private final RemoteIndexCache indexCache;
     private final RemoteStorageThreadPool remoteStorageReaderThreadPool;
-    private final RLMScheduledThreadPool rlmScheduledThreadPool;
+    private final RLMScheduledThreadPool rlmCopyThreadPool;
+    private final RLMScheduledThreadPool rlmExpirationThreadPool;
+    private final RLMScheduledThreadPool followerThreadPool;
 
     private final long delayInMs;
 
-    private final ConcurrentHashMap<TopicIdPartition, RLMTaskWithFuture> leaderOrFollowerTasks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TopicIdPartition, RLMTaskWithFuture> leaderCopyRLMTasks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TopicIdPartition, RLMTaskWithFuture> leaderExpirationRLMTasks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TopicIdPartition, RLMTaskWithFuture> followerRLMTasks = new ConcurrentHashMap<>();
 
     // topic ids that are received on leadership changes, this map is cleared on stop partitions
     private final ConcurrentMap<TopicPartition, Uuid> topicIdByPartitionMap = new ConcurrentHashMap<>();
@@ -241,12 +245,17 @@ public class RemoteLogManager implements Closeable {
 
         indexCache = new RemoteIndexCache(rlmConfig.remoteLogIndexFileCacheTotalSizeBytes(), remoteLogStorageManager, logDir);
         delayInMs = rlmConfig.remoteLogManagerTaskIntervalMs();
-        rlmScheduledThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerThreadPoolSize());
+        rlmCopyThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerCopierThreadPoolSize(),
+            "RLMCopyThreadPool", "kafka-rlm-copy-thread-pool-");
+        rlmExpirationThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerExpirationThreadPoolSize(),
+            "RLMExpirationThreadPool", "kafka-rlm-expiration-thread-pool-");
+        followerThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerThreadPoolSize(),
+            "RLMFollowerScheduledThreadPool", "kafka-rlm-follower-thread-pool-");
 
         metricsGroup.newGauge(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC, new Gauge<Double>() {
             @Override
             public Double value() {
-                return rlmScheduledThreadPool.getIdlePercent();
+                return rlmCopyThreadPool.getIdlePercent();
             }
         });
         remoteReadTimer = metricsGroup.newTimer(REMOTE_LOG_READER_FETCH_RATE_AND_TIME_METRIC,
@@ -433,11 +442,8 @@ public class RemoteLogManager implements Closeable {
             throw new KafkaException("RemoteLogManager is not configured when remote storage system is enabled");
         }
 
-        Map<TopicIdPartition, Integer> leaderPartitionsWithLeaderEpoch = filterPartitions(partitionsBecomeLeader)
-                .collect(Collectors.toMap(
-                        partition -> new TopicIdPartition(topicIds.get(partition.topic()), partition.topicPartition()),
-                        Partition::getLeaderEpoch));
-        Set<TopicIdPartition> leaderPartitions = leaderPartitionsWithLeaderEpoch.keySet();
+        Set<TopicIdPartition> leaderPartitions = filterPartitions(partitionsBecomeLeader)
+                .map(p -> new TopicIdPartition(topicIds.get(p.topic()), p.topicPartition())).collect(Collectors.toSet());
 
         Set<TopicIdPartition> followerPartitions = filterPartitions(partitionsBecomeFollower)
                 .map(p -> new TopicIdPartition(topicIds.get(p.topic()), p.topicPartition())).collect(Collectors.toSet());
@@ -450,16 +456,13 @@ public class RemoteLogManager implements Closeable {
             followerPartitions.forEach(this::cacheTopicPartitionIds);
 
             remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions, followerPartitions);
-            followerPartitions.forEach(topicIdPartition ->
-                    doHandleLeaderOrFollowerPartitions(topicIdPartition, RLMTask::convertToFollower));
+            followerPartitions.forEach(this::doHandleFollowerPartition);
 
             // If this node was the previous leader for the partition, then the RLMTask might be running in the
             // background thread and might emit metrics. So, removing the metrics after marking this node as follower.
             followerPartitions.forEach(this::removeRemoteTopicPartitionMetrics);
 
-            leaderPartitionsWithLeaderEpoch.forEach((topicIdPartition, leaderEpoch) ->
-                    doHandleLeaderOrFollowerPartitions(topicIdPartition,
-                            rlmTask -> rlmTask.convertToLeader(leaderEpoch)));
+            leaderPartitions.forEach(this::doHandleLeaderPartition);
         }
     }
 
@@ -479,11 +482,21 @@ public class RemoteLogManager implements Closeable {
             try {
                 if (topicIdByPartitionMap.containsKey(tp)) {
                     TopicIdPartition tpId = new TopicIdPartition(topicIdByPartitionMap.get(tp), tp);
-                    RLMTaskWithFuture task = leaderOrFollowerTasks.remove(tpId);
-                    if (task != null) {
-                        LOGGER.info("Cancelling the RLM task for tpId: {}", tpId);
+                    leaderCopyRLMTasks.computeIfPresent(tpId, (topicIdPartition, task) -> {
+                        LOGGER.info("Cancelling the copy RLM task for tpId: {}", tpId);
                         task.cancel();
-                    }
+                        return null;
+                    });
+                    leaderExpirationRLMTasks.computeIfPresent(tpId, (topicIdPartition, task) -> {
+                        LOGGER.info("Cancelling the expiration RLM task for tpId: {}", tpId);
+                        task.cancel();
+                        return null;
+                    });
+                    followerRLMTasks.computeIfPresent(tpId, (topicIdPartition, task) -> {
+                        LOGGER.info("Cancelling the follower RLM task for tpId: {}", tpId);
+                        task.cancel();
+                        return null;
+                    });
 
                     removeRemoteTopicPartitionMetrics(tpId);
 
@@ -686,62 +699,95 @@ public class RemoteLogManager implements Closeable {
     }
 
     // VisibleForTesting
-    RLMTask rlmTask(TopicIdPartition topicIdPartition) {
-        RLMTaskWithFuture task = leaderOrFollowerTasks.get(topicIdPartition);
+    RLMTask rlmCopyTask(TopicIdPartition topicIdPartition) {
+        RLMTaskWithFuture task = leaderCopyRLMTasks.get(topicIdPartition);
         if (task != null) {
             return task.rlmTask;
         }
         return null;
     }
 
-    class RLMTask extends CancellableRunnable {
+    abstract class RLMTask extends CancellableRunnable {
 
-        private final TopicIdPartition topicIdPartition;
+        protected final TopicIdPartition topicIdPartition;
+        private final Logger logger;
+
+        public RLMTask(TopicIdPartition topicIdPartition) {
+            this.topicIdPartition = topicIdPartition;
+            this.logger = getLogContext().logger(RLMTask.class);
+        }
+
+        protected LogContext getLogContext() {
+            return new LogContext("[RemoteLogManager=" + brokerId + " partition=" + topicIdPartition + "] ");
+        }
+
+        public void run() {
+            if (isCancelled())
+                return;
+
+            try {
+                Optional<UnifiedLog> unifiedLogOptional = fetchLog.apply(topicIdPartition.topicPartition());
+
+                if (!unifiedLogOptional.isPresent()) {
+                    return;
+                }
+
+                execute(unifiedLogOptional.get());
+            } catch (InterruptedException ex) {
+                if (!isCancelled()) {
+                    logger.warn("Current thread for topic-partition-id {} is interrupted", topicIdPartition, ex);
+                }
+            } catch (RetriableException ex) {
+                logger.debug("Encountered a retryable error while executing current task for topic-partition {}", topicIdPartition, ex);
+            } catch (Exception ex) {
+                if (!isCancelled()) {
+                    logger.warn("Current task for topic-partition {} received error but it will be scheduled", topicIdPartition, ex);
+                }
+            }
+        }
+
+        protected abstract void execute(UnifiedLog log) throws InterruptedException, RemoteStorageException, ExecutionException;
+
+        public String toString() {
+            return this.getClass() + "[" + topicIdPartition + "]";
+        }
+    }
+
+    class RLMCopyTask extends RLMTask {
         private final int customMetadataSizeLimit;
         private final Logger logger;
 
-        private volatile int leaderEpoch = -1;
-
-        public RLMTask(TopicIdPartition topicIdPartition, int customMetadataSizeLimit) {
-            this.topicIdPartition = topicIdPartition;
-            this.customMetadataSizeLimit = customMetadataSizeLimit;
-            LogContext logContext = new LogContext("[RemoteLogManager=" + brokerId + " partition=" + topicIdPartition + "] ");
-            logger = logContext.logger(RLMTask.class);
-        }
-
-        boolean isLeader() {
-            return leaderEpoch >= 0;
-        }
-
-        // The copied and log-start offset is empty initially for a new leader RLMTask, and needs to be fetched inside
+        // The copied and log-start offset is empty initially for a new RLMCopyTask, and needs to be fetched inside
         // the task's run() method.
         private volatile Optional<OffsetAndEpoch> copiedOffsetOption = Optional.empty();
-        private volatile boolean isLogStartOffsetUpdatedOnBecomingLeader = false;
+        private volatile boolean isLogStartOffsetUpdated = false;
         private volatile Optional<String> logDirectory = Optional.empty();
 
-        public void convertToLeader(int leaderEpochVal) {
-            if (leaderEpochVal < 0) {
-                throw new KafkaException("leaderEpoch value for topic partition " + topicIdPartition + " can not be negative");
-            }
-            if (this.leaderEpoch != leaderEpochVal) {
-                leaderEpoch = leaderEpochVal;
-            }
-            // Reset copied and log-start offset, so that it is set in next run of RLMTask
-            copiedOffsetOption = Optional.empty();
-            isLogStartOffsetUpdatedOnBecomingLeader = false;
+        public RLMCopyTask(TopicIdPartition topicIdPartition, int customMetadataSizeLimit) {
+            super(topicIdPartition);
+            this.customMetadataSizeLimit = customMetadataSizeLimit;
+            this.logger = getLogContext().logger(RLMCopyTask.class);
         }
 
-        public void convertToFollower() {
-            leaderEpoch = -1;
+        @Override
+        protected void execute(UnifiedLog log) throws InterruptedException {
+            // In the first run after completing altering logDir within broker, we should make sure the state is reset. (KAFKA-16711)
+            if (!log.parentDir().equals(logDirectory.orElse(null))) {
+                copiedOffsetOption = Optional.empty();
+                isLogStartOffsetUpdated = false;
+                logDirectory = Optional.of(log.parentDir());
+            }
+
+            copyLogSegmentsToRemote(log);
         }
 
         private void maybeUpdateLogStartOffsetOnBecomingLeader(UnifiedLog log) throws RemoteStorageException {
-            if (!isLogStartOffsetUpdatedOnBecomingLeader) {
+            if (!isLogStartOffsetUpdated) {
                 long logStartOffset = findLogStartOffset(topicIdPartition, log);
                 updateRemoteLogStartOffset.accept(topicIdPartition.topicPartition(), logStartOffset);
-                isLogStartOffsetUpdatedOnBecomingLeader = true;
-                logger.info("Found the logStartOffset: {} for partition: {} after becoming leader, leaderEpoch: {}",
-                        logStartOffset, topicIdPartition, leaderEpoch);
+                isLogStartOffsetUpdated = true;
+                logger.info("Found the logStartOffset: {} for partition: {} after becoming leader",
+                        logStartOffset, topicIdPartition);
             }
         }
 
@@ -752,8 +798,7 @@ public class RemoteLogManager implements Closeable {
                 // previous leader epoch till it finds an entry, If there are no entries till the earliest leader epoch in leader
                 // epoch cache then it starts copying the segments from the earliest epoch entry's offset.
                 copiedOffsetOption = Optional.of(findHighestRemoteOffset(topicIdPartition, log));
-                logger.info("Found the highest copiedRemoteOffset: {} for partition: {} after becoming leader, " +
-                                "leaderEpoch: {}", copiedOffsetOption, topicIdPartition, leaderEpoch);
+                logger.info("Found the highest copiedRemoteOffset: {} for partition: {} after becoming leader", copiedOffsetOption, topicIdPartition);
                 copiedOffsetOption.ifPresent(offsetAndEpoch ->  log.updateHighestOffsetInRemoteStorage(offsetAndEpoch.offset()));
             }
         }
@@ -810,9 +855,9 @@ public class RemoteLogManager implements Closeable {
                                 topicIdPartition, copiedOffset, log.activeSegment().baseOffset());
                     } else {
                         for (EnrichedLogSegment candidateLogSegment : candidateLogSegments) {
-                            if (isCancelled() || !isLeader()) {
-                                logger.info("Skipping copying log segments as the current task state is changed, cancelled: {} leader:{}",
-                                        isCancelled(), isLeader());
+                            if (isCancelled()) {
+                                logger.info("Skipping copying log segments as the current task state is changed, cancelled: {}",
+                                        isCancelled());
                                 return;
                             }
 
@@ -932,7 +977,7 @@ public class RemoteLogManager implements Closeable {
 
         // VisibleForTesting
         void recordLagStats(long bytesLag, long segmentsLag) {
-            if (isLeader()) {
+            if (!isCancelled()) {
                 String topic = topicIdPartition.topic();
                 int partition = topicIdPartition.partition();
                 brokerTopicStats.recordRemoteCopyLagBytes(topic, partition, bytesLag);
@@ -943,55 +988,25 @@ public class RemoteLogManager implements Closeable {
         private Path toPathIfExists(File file) {
             return file.exists() ? file.toPath() : null;
         }
+    }
 
-        public void run() {
-            if (isCancelled())
-                return;
+    class RLMExpirationTask extends RLMTask {
+        private final Logger logger;
 
-            try {
-                Optional<UnifiedLog> unifiedLogOptional = fetchLog.apply(topicIdPartition.topicPartition());
+        public RLMExpirationTask(TopicIdPartition topicIdPartition) {
+            super(topicIdPartition);
+            this.logger = getLogContext().logger(RLMExpirationTask.class);
+        }
 
-                if (!unifiedLogOptional.isPresent()) {
-                    return;
-                }
-
-                UnifiedLog log = unifiedLogOptional.get();
-                // In the first run after completing altering logDir within broker, we should make sure the state is reset. (KAFKA-16711)
-                if (!log.parentDir().equals(logDirectory.orElse(null))) {
-                    copiedOffsetOption = Optional.empty();
-                    isLogStartOffsetUpdatedOnBecomingLeader = false;
-                    logDirectory = Optional.of(log.parentDir());
-                }
-
-                if (isLeader()) {
-                    // Copy log segments to remote storage
-                    copyLogSegmentsToRemote(log);
-                    // Cleanup/delete expired remote log segments
-                    cleanupExpiredRemoteLogSegments();
-                } else {
-                    OffsetAndEpoch offsetAndEpoch = findHighestRemoteOffset(topicIdPartition, log);
-                    // Update the highest offset in remote storage for this partition's log so that the local log segments
-                    // are not deleted before they are copied to remote storage.
-                    log.updateHighestOffsetInRemoteStorage(offsetAndEpoch.offset());
-                }
-            } catch (InterruptedException ex) {
-                if (!isCancelled()) {
-                    logger.warn("Current thread for topic-partition-id {} is interrupted", topicIdPartition, ex);
-                }
-            } catch (RetriableException ex) {
-                logger.debug("Encountered a retryable error while executing current task for topic-partition {}", topicIdPartition, ex);
-            } catch (Exception ex) {
-                if (!isCancelled()) {
-                    logger.warn("Current task for topic-partition {} received error but it will be scheduled", topicIdPartition, ex);
-                }
-            }
+        @Override
+        protected void execute(UnifiedLog log) throws InterruptedException, RemoteStorageException, ExecutionException {
+            // Cleanup/delete expired remote log segments
+            cleanupExpiredRemoteLogSegments();
         }
 
         public void handleLogStartOffsetUpdate(TopicPartition topicPartition, long remoteLogStartOffset) {
-            if (isLeader()) {
-                logger.debug("Updating {} with remoteLogStartOffset: {}", topicPartition, remoteLogStartOffset);
-                updateRemoteLogStartOffset.accept(topicPartition, remoteLogStartOffset);
-            }
+            logger.debug("Updating {} with remoteLogStartOffset: {}", topicPartition, remoteLogStartOffset);
+            updateRemoteLogStartOffset.accept(topicPartition, remoteLogStartOffset);
         }
 
         class RemoteLogRetentionHandler {
@@ -1137,7 +1152,7 @@ public class RemoteLogManager implements Closeable {
         }
 
         void cleanupExpiredRemoteLogSegments() throws RemoteStorageException, ExecutionException, InterruptedException {
-            if (isCancelled() || !isLeader()) {
+            if (isCancelled()) {
                 logger.info("Returning from remote log segments cleanup as the task state is changed");
                 return;
             }
@@ -1200,7 +1215,7 @@ public class RemoteLogManager implements Closeable {
                 Integer epoch = epochIterator.next();
                 Iterator<RemoteLogSegmentMetadata> segmentsIterator = remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition, epoch);
                 while (canProcess && segmentsIterator.hasNext()) {
-                    if (isCancelled() || !isLeader()) {
+                    if (isCancelled()) {
                         logger.info("Returning from remote log segments cleanup for the remaining segments as the task state is changed.");
                         return;
                     }
@@ -1252,7 +1267,7 @@ public class RemoteLogManager implements Closeable {
             updateRemoteDeleteLagWith(segmentsLeftToDelete, sizeOfDeletableSegmentsBytes);
             List<String> undeletedSegments = new ArrayList<>();
             for (RemoteLogSegmentMetadata segmentMetadata : segmentsToDelete) {
-                if (!remoteLogRetentionHandler.deleteRemoteLogSegment(segmentMetadata, x -> !isCancelled() && isLeader())) {
+                if (!remoteLogRetentionHandler.deleteRemoteLogSegment(segmentMetadata, x -> !isCancelled())) {
                     undeletedSegments.add(segmentMetadata.remoteLogSegmentId().toString());
                 } else {
                     sizeOfDeletableSegmentsBytes -= segmentMetadata.segmentSizeInBytes();
@@ -1281,7 +1296,7 @@ public class RemoteLogManager implements Closeable {
                     int epoch = epochsToClean.next();
                     Iterator<RemoteLogSegmentMetadata> segmentsToBeCleaned = remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition, epoch);
                     while (segmentsToBeCleaned.hasNext()) {
-                        if (!isCancelled() && isLeader()) {
+                        if (!isCancelled()) {
                             RemoteLogSegmentMetadata nextSegmentMetadata = segmentsToBeCleaned.next();
                             sizeOfDeletableSegmentsBytes += nextSegmentMetadata.segmentSizeInBytes();
                             listOfSegmentsToBeCleaned.add(nextSegmentMetadata);
@@ -1292,7 +1307,7 @@ public class RemoteLogManager implements Closeable {
                 segmentsLeftToDelete += listOfSegmentsToBeCleaned.size();
                 updateRemoteDeleteLagWith(segmentsLeftToDelete, sizeOfDeletableSegmentsBytes);
                 for (RemoteLogSegmentMetadata segmentMetadata : listOfSegmentsToBeCleaned) {
-                    if (!isCancelled() && isLeader()) {
+                    if (!isCancelled()) {
                         // No need to update the log-start-offset even though the segment is deleted as these epochs/offsets are earlier to that value.
                         if (remoteLogRetentionHandler.deleteLogSegmentsDueToLeaderEpochCacheTruncation(earliestEpochEntry, segmentMetadata)) {
                             sizeOfDeletableSegmentsBytes -= segmentMetadata.segmentSizeInBytes();
@@ -1348,9 +1363,20 @@ public class RemoteLogManager implements Closeable {
 
             return Optional.empty();
         }
+    }
 
-        public String toString() {
-            return this.getClass() + "[" + topicIdPartition + "]";
+    class RLMFollowerTask extends RLMTask {
+
+        public RLMFollowerTask(TopicIdPartition topicIdPartition) {
+            super(topicIdPartition);
+        }
+
+        @Override
+        protected void execute(UnifiedLog log) throws InterruptedException, RemoteStorageException, ExecutionException {
+            OffsetAndEpoch offsetAndEpoch = findHighestRemoteOffset(topicIdPartition, log);
+            // Update the highest offset in remote storage for this partition's log so that the local log segments
+            // are not deleted before they are copied to remote storage.
+            log.updateHighestOffsetInRemoteStorage(offsetAndEpoch.offset());
         }
     }
 
@@ -1761,19 +1787,48 @@ public class RemoteLogManager implements Closeable {
                 new RemoteLogReader(fetchInfo, this, callback, brokerTopicStats, rlmFetchQuotaManager, remoteReadTimer));
     }
 
-    void doHandleLeaderOrFollowerPartitions(TopicIdPartition topicPartition,
-                                            Consumer<RLMTask> convertToLeaderOrFollower) {
-        RLMTaskWithFuture rlmTaskWithFuture = leaderOrFollowerTasks.computeIfAbsent(topicPartition,
-                topicIdPartition -> {
-                    RLMTask task = new RLMTask(topicIdPartition, rlmConfig.remoteLogMetadataCustomMetadataMaxBytes());
-                    // set this upfront when it is getting initialized instead of doing it after scheduling.
-                    convertToLeaderOrFollower.accept(task);
-                    LOGGER.info("Created a new task: {} and getting scheduled", task);
-                    ScheduledFuture<?> future = rlmScheduledThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS);
-                    return new RLMTaskWithFuture(task, future);
-                }
-        );
-        convertToLeaderOrFollower.accept(rlmTaskWithFuture.rlmTask);
+    void doHandleLeaderPartition(TopicIdPartition topicPartition) {
+        RLMTaskWithFuture followerRLMTaskWithFuture = followerRLMTasks.remove(topicPartition);
+        if (followerRLMTaskWithFuture != null) {
+            LOGGER.info("Cancelling the follower task: {}", followerRLMTaskWithFuture.rlmTask);
+            followerRLMTaskWithFuture.cancel();
+        }
+
+        leaderCopyRLMTasks.computeIfAbsent(topicPartition, topicIdPartition -> {
+            RLMCopyTask task = new RLMCopyTask(topicIdPartition, this.rlmConfig.remoteLogMetadataCustomMetadataMaxBytes());
+            // set this upfront when it is getting initialized instead of doing it after scheduling.
+            LOGGER.info("Created a new copy task: {} and getting scheduled", task);
+            ScheduledFuture<?> future = rlmCopyThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS);
+            return new RLMTaskWithFuture(task, future);
+        });
+
+        leaderExpirationRLMTasks.computeIfAbsent(topicPartition, topicIdPartition -> {
+            RLMExpirationTask task = new RLMExpirationTask(topicIdPartition);
+            LOGGER.info("Created a new expiration task: {} and getting scheduled", task);
+            ScheduledFuture<?> future = rlmExpirationThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS);
+            return new RLMTaskWithFuture(task, future);
+        });
+    }
+
+    void doHandleFollowerPartition(TopicIdPartition topicPartition) {
+        RLMTaskWithFuture copyRLMTaskWithFuture = leaderCopyRLMTasks.remove(topicPartition);
+        if (copyRLMTaskWithFuture != null) {
+            LOGGER.info("Cancelling the copy task: {}", copyRLMTaskWithFuture.rlmTask);
+            copyRLMTaskWithFuture.cancel();
+        }
+
+        RLMTaskWithFuture expirationRLMTaskWithFuture = leaderExpirationRLMTasks.remove(topicPartition);
+        if (expirationRLMTaskWithFuture != null) {
+            LOGGER.info("Cancelling the expiration task: {}", expirationRLMTaskWithFuture.rlmTask);
+            expirationRLMTaskWithFuture.cancel();
+        }
+
+        followerRLMTasks.computeIfAbsent(topicPartition, topicIdPartition -> {
+            RLMFollowerTask task = new RLMFollowerTask(topicIdPartition);
+            LOGGER.info("Created a new follower task: {} and getting scheduled", task);
+            ScheduledFuture<?> future = followerThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS);
+            return new RLMTaskWithFuture(task, future);
+        });
     }
 
     static class RLMTaskWithFuture {
@@ -1803,19 +1858,25 @@ public class RemoteLogManager implements Closeable {
     public void close() {
         synchronized (this) {
             if (!closed) {
-                leaderOrFollowerTasks.values().forEach(RLMTaskWithFuture::cancel);
+                leaderCopyRLMTasks.values().forEach(RLMTaskWithFuture::cancel);
+                leaderExpirationRLMTasks.values().forEach(RLMTaskWithFuture::cancel);
+                followerRLMTasks.values().forEach(RLMTaskWithFuture::cancel);
                 Utils.closeQuietly(remoteLogStorageManager, "RemoteLogStorageManager");
                 Utils.closeQuietly(remoteLogMetadataManager, "RemoteLogMetadataManager");
                 Utils.closeQuietly(indexCache, "RemoteIndexCache");
 
-                rlmScheduledThreadPool.close();
+                rlmCopyThreadPool.close();
+                rlmExpirationThreadPool.close();
+                followerThreadPool.close();
                 try {
                     shutdownAndAwaitTermination(remoteStorageReaderThreadPool, "RemoteStorageReaderThreadPool", 10, TimeUnit.SECONDS);
                 } finally {
                     removeMetrics();
                 }
 
-                leaderOrFollowerTasks.clear();
+                leaderCopyRLMTasks.clear();
+                leaderExpirationRLMTasks.clear();
+                followerRLMTasks.clear();
                 closed = true;
             }
         }
@@ -1883,18 +1944,28 @@ public class RemoteLogManager implements Closeable {
     }
 
     //Visible for testing
-    RLMTaskWithFuture task(TopicIdPartition partition) {
-        return leaderOrFollowerTasks.get(partition);
+    RLMTaskWithFuture leaderCopyTask(TopicIdPartition partition) {
+        return leaderCopyRLMTasks.get(partition);
+    }
+    RLMTaskWithFuture leaderExpirationTask(TopicIdPartition partition) {
+        return leaderExpirationRLMTasks.get(partition);
+    }
+    RLMTaskWithFuture followerTask(TopicIdPartition partition) {
+        return followerRLMTasks.get(partition);
     }
 
     static class RLMScheduledThreadPool {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(RLMScheduledThreadPool.class);
         private final int poolSize;
+        private final String threadPoolName;
+        private final String threadNamePrefix;
         private final ScheduledThreadPoolExecutor scheduledThreadPool;
 
-        public RLMScheduledThreadPool(int poolSize) {
+        public RLMScheduledThreadPool(int poolSize, String threadPoolName, String threadNamePrefix) {
             this.poolSize = poolSize;
+            this.threadPoolName = threadPoolName;
+            this.threadNamePrefix = threadNamePrefix;
             scheduledThreadPool = createPool();
         }
 
@@ -1907,7 +1978,7 @@ public class RemoteLogManager implements Closeable {
                 private final AtomicInteger sequence = new AtomicInteger();
 
                 public Thread newThread(Runnable r) {
-                    return KafkaThread.daemon("kafka-rlm-thread-pool-" + sequence.incrementAndGet(), r);
+                    return KafkaThread.daemon(threadNamePrefix + sequence.incrementAndGet(), r);
                 }
             });
 
@@ -1924,7 +1995,7 @@ public class RemoteLogManager implements Closeable {
         }
 
         public void close() {
-            shutdownAndAwaitTermination(scheduledThreadPool, "RLMScheduledThreadPool", 10, TimeUnit.SECONDS);
+            shutdownAndAwaitTermination(scheduledThreadPool, threadPoolName, 10, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
As part of [KIP-950](https://cwiki.apache.org/confluence/display/KAFKA/KIP-950%3A++Tiered+Storage+Disablement), we want to split the RemoteLogManagerScheduledThreadPool into separate thread pools (one for copy and another for expiration). In this PR, we are splitting it into three thread pools (one for copy, one for expiration, and another one for follower). We are reusing the same thread pool configuration for all three thread pools. We can introduce new user-facing configurations later.

Modified the existing unit tests to validate the functionality.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
