### PR TITLE
KAFKA-14460: Skip removed entries from in-memory KeyValueIterator

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -430,8 +430,7 @@ public class CachingKeyValueStore
     @Override
     public KeyValueIterator<Bytes, byte[]> all() {
         validateStoreOpen();
-        final KeyValueIterator<Bytes, byte[]> storeIterator =
-            new DelegatingPeekingKeyValueIterator<>(this.name(), wrapped().all());
+        final KeyValueIterator<Bytes, byte[]> storeIterator = wrapped().all();
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = context.cache().all(cacheName);
         return new MergedSortedCacheKeyValueBytesStoreIterator(cacheIterator, storeIterator, true);
     }
@@ -449,8 +448,7 @@ public class CachingKeyValueStore
     @Override
     public KeyValueIterator<Bytes, byte[]> reverseAll() {
         validateStoreOpen();
-        final KeyValueIterator<Bytes, byte[]> storeIterator =
-            new DelegatingPeekingKeyValueIterator<>(this.name(), wrapped().reverseAll());
+        final KeyValueIterator<Bytes, byte[]> storeIterator = wrapped().reverseAll();
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = context.cache().reverseAll(cacheName);
         return new MergedSortedCacheKeyValueBytesStoreIterator(cacheIterator, storeIterator, false);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import java.util.NoSuchElementException;
@@ -54,7 +53,7 @@ public class DelegatingPeekingKeyValueIterator<K, V> implements KeyValueIterator
     @Override
     public synchronized boolean hasNext() {
         if (!open) {
-            throw new InvalidStateStoreException(String.format("Store %s has closed", storeName));
+            throw new IllegalStateException("Iterator has already been closed.");
         }
         if (next != null) {
             return true;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
@@ -53,7 +53,7 @@ public class DelegatingPeekingKeyValueIterator<K, V> implements KeyValueIterator
     @Override
     public synchronized boolean hasNext() {
         if (!open) {
-            throw new IllegalStateException("Iterator has already been closed.");
+            throw new IllegalStateException(String.format("Iterator for store %s has already been closed.", storeName));
         }
         if (next != null) {
             return true;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -264,7 +264,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         @Override
         public boolean hasNext() {
             if (!iteratorOpen) {
-                throw new IllegalStateException("Iterator has already been closed.");
+                throw new IllegalStateException(String.format("Iterator for store %s has already been closed.", name));
             }
             if (currentKey != null) {
                 if (map.containsKey(currentKey)) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -252,7 +251,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private class InMemoryKeyValueIterator implements KeyValueIterator<Bytes, byte[]> {
         private final Iterator<Bytes> iter;
         private Bytes currentKey;
-        private volatile Boolean open = true;
+        private Boolean iteratorOpen = true;
 
         private InMemoryKeyValueIterator(final Set<Bytes> keySet, final boolean forward) {
             if (forward) {
@@ -264,8 +263,8 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
         @Override
         public boolean hasNext() {
-            if (!open) {
-                throw new InvalidStateStoreException(String.format("Store %s has closed", name));
+            if (!iteratorOpen) {
+                throw new IllegalStateException("Iterator has already been closed.");
             }
             if (currentKey != null) {
                 if (map.containsKey(currentKey)) {
@@ -294,7 +293,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
         @Override
         public void close() {
-            open = false;
+            iteratorOpen = false;
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+
 import org.rocksdb.RocksIterator;
 
 import java.util.NoSuchElementException;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
-
 import org.rocksdb.RocksIterator;
 
 import java.util.NoSuchElementException;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -424,6 +424,17 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
         assertEquals(bytesKey("key2"), iter.peekNextKey());
     }
 
+    @Test
+    public void iteratorShouldThrowIllegalStateExceptionIfAlreadyClosed() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        iter.close();
+        assertThrows(IllegalStateException.class, iter::hasNext);
+        assertThrows(IllegalStateException.class, iter::next);
+        assertThrows(IllegalStateException.class, iter::peekNextKey);
+    }
+
     private byte[] bytesValue(final String value) {
         return value.getBytes();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -45,8 +46,11 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
@@ -264,6 +268,160 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
         final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
         final Position actual = inMemoryKeyValueStore.getPosition();
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void iteratorHasNextOnEmptyStoreShouldReturnFalse() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void iteratorHasNextOnDeletedEntryShouldReturnFalse() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        assertTrue(iter.hasNext());
+        inMemoryKeyValueStore.delete(bytesKey("key"));
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void iteratorHasNextShouldNotAdvanceIterator() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        assertTrue(iter.hasNext());
+        assertTrue(iter.hasNext()); // should still point to the first element
+    }
+
+    @Test
+    public void iteratorHasNextShouldReturnTrueIfElementsRemaining() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key1"), bytesValue("value1"));
+        inMemoryKeyValueStore.put(bytesKey("key2"), bytesValue("value2"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        inMemoryKeyValueStore.delete(bytesKey("key1"));
+        assertTrue(iter.hasNext());
+    }
+
+    @Test
+    public void iteratorNextShouldReturnNextElement() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        final KeyValue<Bytes, byte[]> next = iter.next();
+        assertEquals(bytesKey("key"), next.key);
+        assertArrayEquals(bytesValue("value"), next.value);
+    }
+
+    @Test
+    public void iteratorNextAfterHasNextShouldReturnNextElement() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        assertTrue(iter.hasNext());
+        final KeyValue<Bytes, byte[]> next = iter.next();
+        assertEquals(bytesKey("key"), next.key);
+        assertArrayEquals(bytesValue("value"), next.value);
+    }
+
+    @Test
+    public void iteratorNextOnEmptyStoreShouldThrowException() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+        assertThrows(NoSuchElementException.class, iter::next);
+    }
+
+    @Test
+    public void iteratorNextShouldThrowExceptionIfRemainingElementsDeleted() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key1"), bytesValue("value1"));
+        inMemoryKeyValueStore.put(bytesKey("key2"), bytesValue("value2"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        final KeyValue<Bytes, byte[]> next = iter.next();
+        assertEquals(bytesKey("key1"), next.key);
+        assertArrayEquals(bytesValue("value1"), next.value);
+
+        inMemoryKeyValueStore.delete(bytesKey("key2"));
+        assertThrows(NoSuchElementException.class, iter::next);
+    }
+
+    @Test
+    public void iteratorNextShouldSkipDeletedElements() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key1"), bytesValue("value1"));
+        inMemoryKeyValueStore.put(bytesKey("key2"), bytesValue("value2"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        inMemoryKeyValueStore.delete(bytesKey("key1"));
+        final KeyValue<Bytes, byte[]> next = iter.next();
+        assertEquals(bytesKey("key2"), next.key);
+        assertArrayEquals(bytesValue("value2"), next.value);
+    }
+
+    @Test
+    public void iteratorNextShouldIterateOverAllElements() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key1"), bytesValue("value1"));
+        inMemoryKeyValueStore.put(bytesKey("key2"), bytesValue("value2"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        final KeyValue<Bytes, byte[]> next1 = iter.next();
+        assertEquals(bytesKey("key1"), next1.key);
+        assertArrayEquals(bytesValue("value1"), next1.value);
+
+        final KeyValue<Bytes, byte[]> next2 = iter.next();
+        assertEquals(bytesKey("key2"), next2.key);
+        assertArrayEquals(bytesValue("value2"), next2.value);
+
+        assertThrows(NoSuchElementException.class, iter::next);
+    }
+
+    @Test
+    public void iteratorPeekNextKeyOnEmptyStoreShouldThrowException() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+        assertThrows(NoSuchElementException.class, iter::peekNextKey);
+    }
+
+    @Test
+    public void iteratorPeekNextKeyOnDeletedEntryShouldThrowException() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        assertEquals(bytesKey("key"), iter.peekNextKey());
+        inMemoryKeyValueStore.delete(bytesKey("key"));
+        assertThrows(NoSuchElementException.class, iter::peekNextKey);
+    }
+
+    @Test
+    public void iteratorPeekNextKeyShouldNotAdvanceIterator() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key"), bytesValue("value"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        assertEquals(bytesKey("key"), iter.peekNextKey());
+        assertEquals(bytesKey("key"), iter.peekNextKey());
+    }
+
+    @Test
+    public void iteratorPeekNextKeyShouldSkipDeletedElements() {
+        inMemoryKeyValueStore.init((StateStoreContext) context, inMemoryKeyValueStore);
+        inMemoryKeyValueStore.put(bytesKey("key1"), bytesValue("value1"));
+        inMemoryKeyValueStore.put(bytesKey("key2"), bytesValue("value2"));
+        final KeyValueIterator<Bytes, byte[]> iter = inMemoryKeyValueStore.all();
+
+        inMemoryKeyValueStore.delete(bytesKey("key1"));
+        assertEquals(bytesKey("key2"), iter.peekNextKey());
     }
 
     private byte[] bytesValue(final String value) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
@@ -201,6 +201,10 @@ public class ListValueStoreTest {
         it.close();
 
         // A new all() iterator after a previous all() iterator was closed should not return deleted records.
-        assertThrows(InvalidStateStoreException.class, it::next);
+        if (storeType == StoreType.InMemory) {
+            assertThrows(IllegalStateException.class, it::next);
+        } else {
+            assertThrows(InvalidStateStoreException.class, it::next);
+        }
     }
 }


### PR DESCRIPTION
As described in KAFKA-14460, one of the functional requirements of [KeyValueStore](https://kafka.apache.org/37/javadoc/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html) is that "The returned iterator must not return null values" on methods which return iterator.

This is not completely the case today for InMemoryKeyValueStore. To iterate over the store, we copy the keySet in order not to block access for other threads. However, entries that are removed from the store after initializing the iterator will be returned with null values by the iterator.
