### PR TITLE
KAFKA-17075: Use new health check endpoint in Connect system tests to verify worker readiness

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -468,7 +468,7 @@ class ConnectDistributedTest(Test):
 
         self.setup_services(num_workers=3)
         self.cc.set_configs(lambda node: self.render("connect-distributed.properties", node=node))
-        self.cc.start(mode=ConnectServiceBase.STARTUP_MODE_JOIN)
+        self.cc.start()
 
         worker = self.cc.nodes[0]
         initial_loggers = self.cc.get_all_loggers(worker)


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-17075)

Introduces a new startup mode, `STARTUP_MODE_HEALTH_CHECK`, and uses that as the new default value, for verifying worker readiness during system tests. This mode waits for a 200 response from the `GET /health` endpoint from the worker, and is resilient against temporary errors that may occur during startup (such as failure to start the REST server or initialize its resources yet).

I have not been able to run the full gamut of Connect system tests locally, but I have verified that this works with the [test_dynamic_logging](https://github.com/apache/kafka/blob/27220d146c5d043da4adc3d636036bd6e7b112d2/tests/kafkatest/tests/connect/connect_distributed_test.py#L464) case in [connect_distributed_test.py](https://github.com/apache/kafka/blob/27220d146c5d043da4adc3d636036bd6e7b112d2/tests/kafkatest/tests/connect/connect_distributed_test.py) and all tests in [connect_test.py](https://github.com/apache/kafka/blob/27220d146c5d043da4adc3d636036bd6e7b112d2/tests/kafkatest/tests/connect/connect_test.py).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
