### PR TITLE
MINOR: Fix retry logic in DedicatedMirrorIntegrationTest::awaitTaskConfigurations

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -354,10 +354,8 @@ public class DedicatedMirrorIntegrationTest {
                         .stream()
                         .map(TaskInfo::config)
                         .allMatch(predicate);
-            } catch (Exception ex) {
-                boolean retriable = (ex instanceof RebalanceNeededException)
-                        || ((ex instanceof ExecutionException) && (ex.getCause() instanceof RebalanceNeededException));
-                if (retriable) {
+            } catch (ExecutionException ex) {
+                if (ex.getCause() instanceof RebalanceNeededException) {
                     // RebalanceNeededException should be retriable
                     // This happens when a worker has read a new config from the config topic, but hasn't completed the
                     // subsequent rebalance yet

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -354,8 +355,10 @@ public class DedicatedMirrorIntegrationTest {
                         .map(TaskInfo::config)
                         .allMatch(predicate);
             } catch (Exception ex) {
-                if (ex instanceof RebalanceNeededException) {
-                    // RebalanceNeededException should be retry-able.
+                boolean retriable = (ex instanceof RebalanceNeededException)
+                        || ((ex instanceof ExecutionException) && (ex.getCause() instanceof RebalanceNeededException));
+                if (retriable) {
+                    // RebalanceNeededException should be retriable
                     // This happens when a worker has read a new config from the config topic, but hasn't completed the
                     // subsequent rebalance yet
                     throw ex;


### PR DESCRIPTION
This test is failing very frequently because our retry logic doesn't handle `RebalanceNeededException` instances that are wrapped in an `ExecutionException`; see [Gradle Enterprise](https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.startTimeMax=1720120130872&search.startTimeMin=1719460800000&search.timeZoneId=America%2FNew_York&tests.container=org.apache.kafka.connect.mirror.integration.DedicatedMirrorIntegrationTest&tests.test=testMultiNodeCluster()).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
