### PR TITLE
KAFKA-16211 Inconsistent config values in CreateTopicsResult and DescribeConfigsResult

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -206,6 +206,11 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
         config.setProperty(ServerLogConfigs.LOG_ROLL_TIME_JITTER_MILLIS_CONFIG, "123")
       })
     }
+    if (testInfo.getTestMethod.toString.contains("testConsistentReturnsConfigs")) {
+      configs.foreach(config => {
+        config.setProperty(ServerLogConfigs.LOG_SEGMENT_BYTES_CONFIG, "573741824")
+      })
+    }
     configs.foreach { config =>
       config.setProperty(ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, "true")
       config.setProperty(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0")

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2714,6 +2714,24 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       ConfigSource.DYNAMIC_TOPIC_CONFIG, false, false, Collections.emptyList(), null, null),
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
+
+  /**
+   * Test that createTopics returns the dynamic configurations of the topics that were created.
+   *
+   * Note: this test requires some custom static broker and controller configurations, which are set up in
+   * BaseAdminIntegrationTest.modifyConfigs.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testConsistentReturnsConfigs(quorum: String): Unit = {
+    client = createAdminClient
+    val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
+    val newTopics = Seq(new NewTopic(topic, 1, 1.toShort))
+    val create = client.createTopics(newTopics.asJava).config(topic).get().get("segment.bytes")
+    val describe = client.describeConfigs(Collections.singletonList(resource)).values().get(resource).get().get("segment.bytes")
+//    println(s"create $create \ndescribe: $describe")
+    assertEquals(create, describe)
+  }
 }
 
 object PlaintextAdminIntegrationTest {


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
