### PR TITLE
KAFKA-17083: Update LATEST_STABLE_METADATA_VERSION in system tests

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -245,6 +245,8 @@ public enum MetadataVersion {
      * IT CANNOT BE CHANGED.</strong>
      */
     public static final MetadataVersion LATEST_PRODUCTION = IBP_3_8_IV0;
+    // If you change the value above please also update
+    // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 
     /**
      * An array containing all of the MetadataVersion entries.

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -125,7 +125,7 @@ DEV_BRANCH = KafkaVersion("dev")
 DEV_VERSION = KafkaVersion("3.8.0-SNAPSHOT")
 
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "3.7"
+LATEST_STABLE_METADATA_VERSION = "3.8"
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
`LATEST_PRODUCTION` version in MetadataVersion.java was updated in both #16347 and #16400, but it was left unchanged in the system tests.
