### PR TITLE
[Minor] Fill remaining elements with null when provided array is longer

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -100,7 +100,9 @@ class RangeSet implements Set<Integer> {
             a[i] = (T) Integer.valueOf(from + i);
         }
         if (a.length > size) {
-            a[size] = null;
+            for (int i = size; i < a.length; i++) {
+                a[i] = null;
+            }
         }
         return a;
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -87,8 +87,8 @@ public class RangeSetTest {
     @Test
     void testToArrayWithArrayParameter() {
         RangeSet rangeSet = new RangeSet(5, 10);
-        Integer[] inputArray = new Integer[5];
-        Integer[] expectedArray = {5, 6, 7, 8, 9};
+        Integer[] inputArray = new Integer[7];
+        Integer[] expectedArray = {5, 6, 7, 8, 9, null, null};
         assertArrayEquals(expectedArray, rangeSet.toArray(inputArray));
     }
 


### PR DESCRIPTION
In commit 42f267a853734effc7aff24e30ec812aba84f834, `RangeSet#toArray()` doesn't follow Java's practice of filling extra elements with null.
A sample program demonstrating Java's behavior can be found in the first comment.

This PR modifies `toArray` so that it follows Java's practice.

The `testToArrayWithArrayParameter` is modified to reflect the new behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
