### PR TITLE
KAFKA-17090: Add reminder to CreateTopicsResult#config for null values of type and documentation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -64,6 +64,7 @@ public class CreateTopicsResult {
      * If broker returned an error for topic configs, throw appropriate exception. For example,
      * {@link org.apache.kafka.common.errors.TopicAuthorizationException} is thrown if user does not
      * have permission to describe topic configs.
+     * Note that it is possible to obtain type and documentation with null values even if they are not defined
      */
     public KafkaFuture<Config> config(String topic) {
         return futures.get(topic).thenApply(TopicMetadataAndConfig::config);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -64,7 +64,7 @@ public class CreateTopicsResult {
      * If broker returned an error for topic configs, throw appropriate exception. For example,
      * {@link org.apache.kafka.common.errors.TopicAuthorizationException} is thrown if user does not
      * have permission to describe topic configs.
-     * Note that it is possible to obtain type and documentation with null values even if they are not defined
+     * Note that type and documentation must be null since the protocol doesn't specify these fields.
      */
     public KafkaFuture<Config> config(String topic) {
         return futures.get(topic).thenApply(TopicMetadataAndConfig::config);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -64,7 +64,7 @@ public class CreateTopicsResult {
      * If broker returned an error for topic configs, throw appropriate exception. For example,
      * {@link org.apache.kafka.common.errors.TopicAuthorizationException} is thrown if user does not
      * have permission to describe topic configs.
-     * Note that type and documentation must be null since the protocol doesn't specify these fields.
+     * Note that the values for the type and documentation fields will be null.
      */
     public KafkaFuture<Config> config(String topic) {
         return futures.get(topic).thenApply(TopicMetadataAndConfig::config);


### PR DESCRIPTION
Add reminder to the documentation of CreateTopicsResult#config to let users know that it is possible to obtain `type` and `documentation` with `null` values even if they are not defined


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
