### PR TITLE
KAFKA-17077: The node.id is inconsistent to broker.id when "broker.id.generation.enable=true".

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -307,10 +307,10 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   /** ********* General Configuration ***********/
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
-  private[server] var _brokerIf: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
-  def brokerId: Int = _brokerIf
-  private[server] var _nodeIf: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
-  def nodeId: Int = _nodeIf
+  private[server] var _brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
+  def brokerId: Int = _brokerId
+  private[server] var _nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
+  def nodeId: Int = _nodeId
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)
   val brokerHeartbeatIntervalMs: Int = getInt(KRaftConfigs.BROKER_HEARTBEAT_INTERVAL_MS_CONFIG)
   val brokerSessionTimeoutMs: Int = getInt(KRaftConfigs.BROKER_SESSION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -307,7 +307,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   /** ********* General Configuration ***********/
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
-  var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
+  private[server] var _brokerIf: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
+  def brokerId: Int = _brokerIf
   private[server] var _nodeIf: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   def nodeId: Int = _nodeIf
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -308,7 +308,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
   var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
-  var nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   private[server] var _nodeIf: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   def nodeId: Int = _nodeIf
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -310,7 +310,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
   // Making `nodeId` mutable is a workaround to fix the issue of de-synchronization between the generated `brokerId` and `nodeId`.
   // It should be back to immutable after removing zk.
-  var nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
+  private[server] var _nodeIf: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
+  def nodeId: Int = _nodeIf
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)
   val brokerHeartbeatIntervalMs: Int = getInt(KRaftConfigs.BROKER_HEARTBEAT_INTERVAL_MS_CONFIG)
   val brokerSessionTimeoutMs: Int = getInt(KRaftConfigs.BROKER_SESSION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -308,7 +308,9 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
   var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
-  val nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
+  // Making `nodeId` mutable is a workaround to fix the issue of de-synchronization between the generated `brokerId` and `nodeId`.
+  // It should be back to immutable after removing zk.
+  var nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)
   val brokerHeartbeatIntervalMs: Int = getInt(KRaftConfigs.BROKER_HEARTBEAT_INTERVAL_MS_CONFIG)
   val brokerSessionTimeoutMs: Int = getInt(KRaftConfigs.BROKER_SESSION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -308,8 +308,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
   var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
-  // Making `nodeId` mutable is a workaround to fix the issue of de-synchronization between the generated `brokerId` and `nodeId`.
-  // It should be back to immutable after removing zk.
   var nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)
   val brokerHeartbeatIntervalMs: Int = getInt(KRaftConfigs.BROKER_HEARTBEAT_INTERVAL_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -259,6 +259,9 @@ class KafkaServer(
 
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
+        // Currently, we are migrating from ZooKeeper to KRaft. If broker.id.generation.enable is set to true,
+        // we must ensure that the nodeId synchronizes with the broker.id to prevent the nodeId from being -1,
+        // which would result in a failure during the migration.
         config.nodeId = config.brokerId
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -258,7 +258,7 @@ class KafkaServer(
         initialMetaPropsEnsemble.verify(Optional.of(_clusterId), verificationId, verificationFlags)
 
         /* generate brokerId */
-        config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
+        config._brokerIf = getOrGenerateBrokerId(initialMetaPropsEnsemble)
         // Currently, we are migrating from ZooKeeper to KRaft. If broker.id.generation.enable is set to true,
         // we must ensure that the nodeId synchronizes with the broker.id to prevent the nodeId from being -1,
         // which would result in a failure during the migration.

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -258,11 +258,11 @@ class KafkaServer(
         initialMetaPropsEnsemble.verify(Optional.of(_clusterId), verificationId, verificationFlags)
 
         /* generate brokerId */
-        config._brokerIf = getOrGenerateBrokerId(initialMetaPropsEnsemble)
+        config._brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
         // Currently, we are migrating from ZooKeeper to KRaft. If broker.id.generation.enable is set to true,
         // we must ensure that the nodeId synchronizes with the broker.id to prevent the nodeId from being -1,
         // which would result in a failure during the migration.
-        config._nodeIf = config.brokerId
+        config._nodeId = config.brokerId
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -262,7 +262,7 @@ class KafkaServer(
         // Currently, we are migrating from ZooKeeper to KRaft. If broker.id.generation.enable is set to true,
         // we must ensure that the nodeId synchronizes with the broker.id to prevent the nodeId from being -1,
         // which would result in a failure during the migration.
-        config.nodeId = config.brokerId
+        config._nodeIf = config.brokerId
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -259,6 +259,7 @@ class KafkaServer(
 
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
+        config.updateCurrentConfig(new KafkaConfig(config.props))
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -259,7 +259,7 @@ class KafkaServer(
 
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
-        config.updateCurrentConfig(new KafkaConfig(config.props))
+        config.nodeId = config.brokerId
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix
 

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -178,17 +178,14 @@ class KafkaServerTest extends QuorumTestHarness {
 
   @Test
   def testGeneratedBrokerIdSyncWithNodeId(): Unit = {
-    var kafkaServer: KafkaServer = null
+    val props = TestUtils.createBrokerConfig(-1, zkConnect)
+    props.put("reserved.broker.max.id", "2000")
+    val kafkaServer: KafkaServer = TestUtils.createServer(KafkaConfig.fromProps(props))
     try {
-      val props = TestUtils.createBrokerConfig(-1, zkConnect)
-      props.put("reserved.broker.max.id", "2000")
-      kafkaServer = TestUtils.createServer(KafkaConfig.fromProps(props))
       kafkaServer.startup()
       assertEquals(2001, kafkaServer.config.brokerId)
       assertEquals(2001, kafkaServer.config.nodeId)
-    } finally if (null != kafkaServer) {
-      kafkaServer.shutdown()
-    }
+    } finally kafkaServer.shutdown()
   }
 
   def createServer(nodeId: Int, hostName: String, port: Int): KafkaServer = {


### PR DESCRIPTION
We directly change the `broker.id` in `KafkaConfig` when `broker.id.generation.enable` is set to `true`. However, this update is NOT synchronized with the `node.id` in `KafkaConfig`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
