### PR TITLE
KAFKA-17091: Add @FunctionalInterface to Streams interfaces

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Aggregator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Aggregator.java
@@ -38,6 +38,7 @@ package org.apache.kafka.streams.kstream;
  * @see SessionWindowedKStream#aggregate(Initializer, Aggregator, Merger, Materialized)
  * @see Reducer
  */
+@FunctionalInterface
 public interface Aggregator<K, V, VAgg> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ForeachAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ForeachAction.java
@@ -30,6 +30,7 @@ package org.apache.kafka.streams.kstream;
  *
  * @see KStream#foreach(ForeachAction)
  */
+@FunctionalInterface
 public interface ForeachAction<K, V> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
@@ -65,6 +65,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  * @see KStream#join(GlobalKTable, KeyValueMapper, ValueJoiner)
  * @see KStream#leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
  */
+@FunctionalInterface
 public interface GlobalKTable<K, V> {
     /**
      * Get the name of the local state store that can be used to query this {@code GlobalKTable}.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Initializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Initializer.java
@@ -30,6 +30,7 @@ package org.apache.kafka.streams.kstream;
  * @see SessionWindowedKStream#aggregate(Initializer, Aggregator, Merger)
  * @see SessionWindowedKStream#aggregate(Initializer, Aggregator, Merger, Materialized)
  */
+@FunctionalInterface
 public interface Initializer<VAgg> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KeyValueMapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KeyValueMapper.java
@@ -44,6 +44,7 @@ import org.apache.kafka.streams.KeyValue;
  * @see KTable#groupBy(KeyValueMapper, Grouped)
  * @see KTable#toStream(KeyValueMapper)
  */
+@FunctionalInterface
 public interface KeyValueMapper<K, V, VR> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
@@ -23,6 +23,7 @@ package org.apache.kafka.streams.kstream;
  * @param <K>   key type
  * @param <V>   aggregate value type
  */
+@FunctionalInterface
 public interface Merger<K, V> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/NamedOperation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/NamedOperation.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream;
 /**
  * Default interface which can be used to customize the name of operations, internal topics or stores.
  */
+@FunctionalInterface
 interface NamedOperation<T extends NamedOperation<T>> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Predicate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Predicate.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.KeyValue;
  * @see KTable#filter(Predicate)
  * @see KTable#filterNot(Predicate)
  */
+@FunctionalInterface
 public interface Predicate<K, V> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Reducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Reducer.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.KeyValue;
  * @see SessionWindowedKStream#reduce(Reducer, Materialized)
  * @see Aggregator
  */
+@FunctionalInterface
 public interface Reducer<V> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TransformerSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TransformerSupplier.java
@@ -38,6 +38,7 @@ import java.util.function.Supplier;
  * @see ValueTransformerSupplier
  * @see KStream#transformValues(ValueTransformerSupplier, String...)
  */
+@FunctionalInterface
 public interface TransformerSupplier<K, V, R> extends ConnectedStoreProvider, Supplier<Transformer<K, V, R>> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoiner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoiner.java
@@ -40,6 +40,7 @@ package org.apache.kafka.streams.kstream;
  * @see KTable#leftJoin(KTable, ValueJoiner)
  * @see KTable#outerJoin(KTable, ValueJoiner)
  */
+@FunctionalInterface
 public interface ValueJoiner<V1, V2, VR> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -44,6 +44,7 @@ package org.apache.kafka.streams.kstream;
  * @see KStream#leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
  * @see KStream#leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey, Named)
  */
+@FunctionalInterface
 public interface ValueJoinerWithKey<K1, V1, V2, VR> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapper.java
@@ -37,6 +37,7 @@ package org.apache.kafka.streams.kstream;
  * @see KTable#mapValues(ValueMapper)
  * @see KTable#mapValues(ValueMapperWithKey)
  */
+@FunctionalInterface
 public interface ValueMapper<V, VR> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
@@ -38,7 +38,7 @@ package org.apache.kafka.streams.kstream;
  * @see KTable#mapValues(ValueMapper)
  * @see KTable#mapValues(ValueMapperWithKey)
  */
-
+@FunctionalInterface
 public interface ValueMapperWithKey<K, V, VR> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerSupplier.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.processor.ConnectedStoreProvider;
  * @see TransformerSupplier
  * @see KStream#transform(TransformerSupplier, String...)
  */
+@FunctionalInterface
 public interface ValueTransformerSupplier<V, VR> extends ConnectedStoreProvider {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -38,6 +38,7 @@ import java.util.function.Supplier;
  * @see TransformerSupplier
  * @see KStream#transform(TransformerSupplier, String...)
  */
+@FunctionalInterface
 public interface ValueTransformerWithKeySupplier<K, V, VR> extends ConnectedStoreProvider, Supplier<ValueTransformerWithKey<K, V, VR>> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/FixedKeyProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/FixedKeyProcessor.java
@@ -29,6 +29,7 @@ import java.time.Duration;
  * @param <VIn> the type of input values
  * @param <VOut> the type of output values
  */
+@FunctionalInterface
 public interface FixedKeyProcessor<KIn, VIn, VOut> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/Processor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/Processor.java
@@ -30,6 +30,7 @@ import java.time.Duration;
  * @param <KOut> the type of output keys
  * @param <VOut> the type of output values
  */
+@FunctionalInterface
 public interface Processor<KIn, VIn, KOut, VOut> {
 
     /**


### PR DESCRIPTION
### Goal

Add @FunctionalInterface to Streams interfaces to enable Clojure 1.12 (and any other JVM language) to have the correct hints for these SAM interfaces.

The Clojure issue is [here ](https://ask.clojure.org/index.php/13908/expand-fi-adapting-to-sam-types-not-marked-as-fi)

### Testing
Unit tests and system tests all pass locally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
