### PR TITLE
KAFKA-3737: Adjusted the log level from INFO to WARN 

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -704,7 +704,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           val exceptionsSummary = mergedResponseStatus.map { case (topicPartition, status) =>
             topicPartition -> status.error.exceptionName
           }.mkString(", ")
-          info(
+          warn(
             s"Closing connection due to error during produce request with correlation id ${request.header.correlationId} " +
               s"from client id ${request.header.clientId} with ack=0\n" +
               s"Topic and partition to exceptions: $exceptionsSummary"


### PR DESCRIPTION
Changed the log level from INFO to WARN for errors occurring during produce requests to enhance visibility of critical issues. This adjustment helps in better anomaly detection and monitoring by highlighting significant errors like MessageSizeTooLargeException. The rest of the produce request errors continue to be logged at WARN level to ensure consistency and improve traceability.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
