### PR TITLE
KAFKA-16057 : Change the configuration for adminclient connections.max.idle.ms to 9 minutes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -212,7 +212,7 @@ public class AdminClientConfig extends AbstractConfig {
                                         CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                                         Type.LONG,
-                                        5 * 60 * 1000,
+                                        9 * 60 * 1000,
                                         Importance.MEDIUM,
                                         CONNECTIONS_MAX_IDLE_MS_DOC)
                                 .define(RETRIES_CONFIG,


### PR DESCRIPTION
Defined connection.max.idle.ms property explicitly to 9 minutes in adminClient configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
