### PR TITLE
Kafka-16355: Fix ConcurrentModificationException in evictWhile Method

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
@@ -386,6 +386,8 @@ public final class InMemoryTimeOrderedKeyValueChangeBuffer<K, V, T> implements T
         final List<Map.Entry<BufferKey, BufferValue>> entries = new ArrayList<>(sortedMap.entrySet());
         int evictions = 0;
 
+        final List<BufferKey> keysToDelete = new ArrayList<>();
+
         if (predicate.get()) {
             for (Iterator<Map.Entry<BufferKey, BufferValue>> entryIterator = entries.iterator(); entryIterator.hasNext(); ) {
                 final Map.Entry<BufferKey, BufferValue> next = entryIterator.next();
@@ -407,18 +409,20 @@ public final class InMemoryTimeOrderedKeyValueChangeBuffer<K, V, T> implements T
                     new Change<>(bufferValue.newValue(), bufferValue.oldValue())
                 );
                 callback.accept(new Eviction<K, Change<V>>(key, value, bufferValue.context()));
-
-                sortedMap.remove(next.getKey());
-                index.remove(next.getKey().key());
+                keysToDelete.add(next.getKey());
 
                 if (loggingEnabled) {
                     dirtyKeys.add(next.getKey().key());
                 }
-
                 memBufferSize -= computeRecordSize(next.getKey().key(), bufferValue);
                 minTimestamp = entries.isEmpty() ? Long.MAX_VALUE : entries.get(0).getKey().time();
                 evictions++;
             }
+            for (BufferKey keyToDelete : keysToDelete) {
+                sortedMap.remove(keyToDelete);
+                index.remove(keyToDelete.key());
+            }
+            minTimestamp = sortedMap.isEmpty() ? Long.MAX_VALUE : sortedMap.firstKey().time();
         }
         if (evictions > 0) {
             updateBufferMetrics();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
@@ -383,49 +383,45 @@ public final class InMemoryTimeOrderedKeyValueChangeBuffer<K, V, T> implements T
     @Override
     public void evictWhile(final Supplier<Boolean> predicate,
                            final Consumer<Eviction<K, Change<V>>> callback) {
-        final List<Map.Entry<BufferKey, BufferValue>> entries = new ArrayList<>(sortedMap.entrySet());
-        int evictions = 0;
+        final Iterator<Map.Entry<BufferKey, BufferValue>> iterator = sortedMap.entrySet().iterator();
+        final List<Eviction<K, Change<V>>> evictions = new ArrayList<>();
+        int evictionCount = 0;
 
-        final List<BufferKey> keysToDelete = new ArrayList<>();
+        while (iterator.hasNext()) {
+            if (!predicate.get()) {
+                break;
+            }
 
-        if (predicate.get()) {
-            for (Iterator<Map.Entry<BufferKey, BufferValue>> entryIterator = entries.iterator(); entryIterator.hasNext(); ) {
-                final Map.Entry<BufferKey, BufferValue> next = entryIterator.next();
+            final Map.Entry<BufferKey, BufferValue> next = iterator.next();
+            final BufferValue bufferValue = next.getValue();
 
-                if (!predicate.get()) {
-                    break;
-                }
-
-                if (next.getKey().time() != minTimestamp) {
-                    throw new IllegalStateException(
-                        "minTimestamp [" + minTimestamp + "] did not match the actual min timestamp [" +
-                            next.getKey().time() + "]"
-                    );
-                }
-                final K key = keySerde.deserializer().deserialize(changelogTopic, next.getKey().key().get());
-                final BufferValue bufferValue = next.getValue();
-                final Change<V> value = valueSerde.deserializeParts(
+            // Collect evictions to process them outside the iterator loop
+            final K key = keySerde.deserializer().deserialize(changelogTopic, next.getKey().key().get());
+            final Change<V> value = valueSerde.deserializeParts(
                     changelogTopic,
                     new Change<>(bufferValue.newValue(), bufferValue.oldValue())
-                );
-                callback.accept(new Eviction<K, Change<V>>(key, value, bufferValue.context()));
-                keysToDelete.add(next.getKey());
+            );
+            evictions.add(new Eviction<>(key, value, bufferValue.context()));
 
-                if (loggingEnabled) {
-                    dirtyKeys.add(next.getKey().key());
-                }
-                memBufferSize -= computeRecordSize(next.getKey().key(), bufferValue);
-                minTimestamp = entries.isEmpty() ? Long.MAX_VALUE : entries.get(0).getKey().time();
-                evictions++;
+            if (loggingEnabled) {
+                dirtyKeys.add(next.getKey().key());
             }
-            for (BufferKey keyToDelete : keysToDelete) {
-                sortedMap.remove(keyToDelete);
-                index.remove(keyToDelete.key());
-            }
-            minTimestamp = sortedMap.isEmpty() ? Long.MAX_VALUE : sortedMap.firstKey().time();
+
+            memBufferSize -= computeRecordSize(next.getKey().key(), bufferValue);
+
+            iterator.remove();
+            index.remove(next.getKey().key());
+
+            evictionCount++;
         }
-        if (evictions > 0) {
+
+        if (evictionCount > 0) {
+            minTimestamp = sortedMap.isEmpty() ? Long.MAX_VALUE : sortedMap.firstKey().time();
             updateBufferMetrics();
+        }
+
+        for (final Eviction<K, Change<V>> eviction : evictions) {
+            callback.accept(eviction);
         }
     }
 


### PR DESCRIPTION
This PR addresses an issue with the evictWhile method where a ConcurrentModificationException was being thrown due to modifications made to sortedMap during iteration. The following changes have been made:

- Safe Iteration: The method now iterates over a copied list of entries from sortedMap, ensuring that modifications to sortedMap do not interfere with the iteration process.
- Consistent Removal: Entries are safely removed from sortedMap during the iteration without causing a ConcurrentModificationException

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
