### PR TITLE
MINOR: Generate javadocs on all source files for streams:test-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2518,10 +2518,6 @@ project(':streams:test-utils') {
     testRuntimeOnly libs.junitPlatformLanucher
   }
 
-  javadoc {
-    include "**/org/apache/kafka/streams/test/**"
-  }
-
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-streams*')


### PR DESCRIPTION
When streams/test-utils was added, the javadocs were given an inclusion filter: https://github.com/apache/kafka/pull/4402/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R973

I spoke with the original author (@mjsax) about removing this filter so that the javadocs contain all the source files.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
