### PR TITLE
KAFKA-17102: FetchRequest#forgottenTopics would return incorrect data

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
@@ -244,9 +244,10 @@ public class FetchRequestTest {
             new FetchRequest.PartitionData(Uuid.randomUuid(), 300, 0L, 300, Optional.of(300)));
     }
 
-    @Test
-    public void testFetchRequestNoCacheData() {
-        short version = 13;
+    @ParameterizedTest
+    @MethodSource("fetchVersions")
+    public void testFetchRequestNoCacheData(short version) {
+        boolean fetchRequestUsesTopicIds = version >= 13;
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
         TopicIdPartition tp = new TopicIdPartition(topicId, partition, "topic");
@@ -263,8 +264,9 @@ public class FetchRequestTest {
 
         Map<Uuid, String> topicNames = Collections.singletonMap(topicId, tp.topic());
 
+        int expectedSize = fetchRequestUsesTopicIds ? topicNames.size() : 0;
         List<TopicIdPartition> requestsWithTopicsName = fetchRequest.forgottenTopics(topicNames);
-        assertEquals(1, requestsWithTopicsName.size());
+        assertEquals(expectedSize, requestsWithTopicsName.size());
         requestsWithTopicsName.forEach(request -> {
             assertEquals(tp.topic(), request.topic());
             assertEquals(topicId, request.topicId());
@@ -273,7 +275,7 @@ public class FetchRequestTest {
         });
 
         List<TopicIdPartition> requestData = fetchRequest.forgottenTopics(Collections.emptyMap());
-        assertEquals(1, requestData.size());
+        assertEquals(expectedSize, requestData.size());
         requestData.forEach(request -> {
             assertNull(request.topic());
             assertEquals(topicId, request.topicId());

--- a/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FetchRequestTest {
@@ -248,7 +249,8 @@ public class FetchRequestTest {
     public void testFetchRequestNoCacheData() {
         short version = 13;
         Uuid topicId = Uuid.randomUuid();
-        TopicIdPartition tp = new TopicIdPartition(topicId, 0, "topic");
+        int partition = 0;
+        TopicIdPartition tp = new TopicIdPartition(topicId, partition, "topic");
 
         Map<TopicPartition, FetchRequest.PartitionData> partitionData = Collections.singletonMap(tp.topicPartition(),
                 new FetchRequest.PartitionData(topicId, 0, 0, 0, Optional.empty()));
@@ -262,18 +264,23 @@ public class FetchRequestTest {
         
         HashMap<Uuid, String> topicNames = new HashMap<>();
         topicNames.put(topicId, tp.topic());
+        
         List<TopicIdPartition> requestsWithTopicsName = fetchRequest.forgottenTopics(topicNames);
         assertEquals(1, requestsWithTopicsName.size());
         requestsWithTopicsName.forEach(request -> {
             assertEquals(tp.topic(), request.topic());
             assertEquals(topicId, request.topicId());
+            assertEquals(tp.partition(), request.partition());
+            assertEquals(tp.topicPartition(), request.topicPartition());
         });
 
         List<TopicIdPartition> requestData = fetchRequest.forgottenTopics(Collections.emptyMap());
         assertEquals(1, requestData.size());
         requestData.forEach(request -> {
-            assertEquals(tp.topic(), request.topic());
+            assertNull(request.topic());
             assertEquals(topicId, request.topicId());
+            assertEquals(tp.partition(), request.partition());
+            assertEquals(new TopicPartition(null, partition), request.topicPartition());
         });
         
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
@@ -246,7 +246,6 @@ public class FetchRequestTest {
     @ParameterizedTest
     @MethodSource("fetchVersions")
     public void testFetchRequestNoCacheData(short version) {
-        boolean fetchRequestUsesTopicIds = version >= 13;
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
         TopicIdPartition tp = new TopicIdPartition(topicId, partition, "topic");
@@ -263,7 +262,7 @@ public class FetchRequestTest {
             assertEquals(tp.topicPartition(), request.topicPartition());
         });
 
-        String expectedTopic = fetchRequestUsesTopicIds ? null : tp.topic();
+        String expectedTopic = version >= 13 ? null : tp.topic();
         List<TopicIdPartition> requestData = fetchRequest.forgottenTopics(Collections.emptyMap());
         assertEquals(1, requestData.size());
         requestData.forEach(request -> {
@@ -276,10 +275,9 @@ public class FetchRequestTest {
     }
 
     private FetchRequest createFetchRequestByVersion(short version, Uuid topicId, TopicIdPartition tp) {
-        boolean fetchRequestUsesTopicIds = version >= 13;
         Map<TopicPartition, FetchRequest.PartitionData> partitionData = Collections.singletonMap(tp.topicPartition(),
                 new FetchRequest.PartitionData(topicId, 0, 0, 0, Optional.empty()));
-        if (fetchRequestUsesTopicIds) {
+        if (version >= 13) {
             return FetchRequest.Builder
                     .forReplica(version, 0, 1, 1, 1, partitionData)
                     .replaced(Collections.singletonList(tp))

--- a/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/FetchRequestTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -261,10 +260,9 @@ public class FetchRequestTest {
                 .removed(Collections.emptyList())
                 .replaced(toReplace)
                 .metadata(FetchMetadata.newIncremental(123)).build(version);
-        
-        HashMap<Uuid, String> topicNames = new HashMap<>();
-        topicNames.put(topicId, tp.topic());
-        
+
+        Map<Uuid, String> topicNames = Collections.singletonMap(topicId, tp.topic());
+
         List<TopicIdPartition> requestsWithTopicsName = fetchRequest.forgottenTopics(topicNames);
         assertEquals(1, requestsWithTopicsName.size());
         requestsWithTopicsName.forEach(request -> {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17102
The Cache data will return incorrect data, hence we should remove the cache 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
