### PR TITLE
MINOR: Fix flakiness in state updater unit tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -332,7 +332,7 @@ class DefaultStateUpdaterTest {
                 allChangelogCompleted.set(true);
                 return Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0);
             });
-        when(changelogReader.allChangelogsCompleted()).thenReturn(allChangelogCompleted.get());
+        when(changelogReader.allChangelogsCompleted()).thenAnswer(invocation -> allChangelogCompleted.get());
         stateUpdater.start();
 
         stateUpdater.add(task);
@@ -363,7 +363,7 @@ class DefaultStateUpdaterTest {
                 allChangelogCompleted.set(true);
                 return Set.of(TOPIC_PARTITION_C_0, TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0);
             });
-        when(changelogReader.allChangelogsCompleted()).thenReturn(allChangelogCompleted.get());
+        when(changelogReader.allChangelogsCompleted()).thenAnswer(invocation -> allChangelogCompleted.get());
         stateUpdater.start();
 
         stateUpdater.add(task1);


### PR DESCRIPTION
Unit test shouldRestoreSingleActiveStatefulTask() in DefaultStateUpdaterTest is flaky.

The flakiness comes from the fact that the state updater thread could call the first time `changelogReader.allChangelogsCompleted()` before it calls the first time `changelogReader.completedChangelogs()`. That happens, if `runOnce()` is run before the state updater thread reads a task from the input queue.

This commit fixes the flakiness, by making `changelogReader.allChangelogsCompleted()` depend on `changelogReader.completedChangelogs()`. 



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
