### PR TITLE
KAFKA-17111: Explicitly Register Afterburner Module in JsonSerializer and JsonDeserializer

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -242,15 +242,15 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
     /**
      * Creates a JsonConvert initializing serializer and deserializer.
      *
-     * @param enableModules permits to enable/disable the registration of additional Jackson modules.
+     * @param enableAfterburner permits to enable/disable the registration of Jackson Afterburner module.
      * <p>
      * NOTE: This is visible only for testing
      */
-    public JsonConverter(boolean enableModules) {
+    public JsonConverter(boolean enableAfterburner) {
         serializer = new JsonSerializer(
             mkSet(),
             JSON_NODE_FACTORY,
-            enableModules
+            enableAfterburner
         );
 
         deserializer = new JsonDeserializer(
@@ -260,7 +260,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
                 DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS
             ),
             JSON_NODE_FACTORY,
-            enableModules
+            enableAfterburner
         );
     }
 

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonDeserializer.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 import java.util.Collections;
 import java.util.Set;
@@ -52,13 +53,13 @@ public class JsonDeserializer implements Deserializer<JsonNode> {
     JsonDeserializer(
         final Set<DeserializationFeature> deserializationFeatures,
         final JsonNodeFactory jsonNodeFactory,
-        final boolean enableModules
+        final boolean enableAfterburner
     ) {
         objectMapper.enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS.mappedFeature());
         deserializationFeatures.forEach(objectMapper::enable);
         objectMapper.setNodeFactory(jsonNodeFactory);
-        if (enableModules) {
-            objectMapper.findAndRegisterModules();
+        if (enableAfterburner) {
+            objectMapper.registerModule(new AfterburnerModule());
         }
     }
 

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonSerializer.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonSerializer.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 import java.util.Collections;
 import java.util.Set;
@@ -51,12 +52,12 @@ public class JsonSerializer implements Serializer<JsonNode> {
     JsonSerializer(
         final Set<SerializationFeature> serializationFeatures,
         final JsonNodeFactory jsonNodeFactory,
-        final boolean enableModules
+        final boolean enableAfterburner
     ) {
         serializationFeatures.forEach(objectMapper::enable);
         objectMapper.setNodeFactory(jsonNodeFactory);
-        if (enableModules) {
-            objectMapper.findAndRegisterModules();
+        if (enableAfterburner) {
+            objectMapper.registerModule(new AfterburnerModule());
         }
     }
 


### PR DESCRIPTION
## Problem:
Currently, `JsonSerializer` and `JsonDeserializer` use `objectMapper.findAndRegisterModules()` to automatically discover and register Jackson modules. This approach attempts to register all modules that implement `com.fasterxml.jackson.databind.Module`, which can lead to a `ServiceConfigurationError` when incompatible modules are present in the classpath.

Specifically, errors occur with messages like:
`com.fasterxml.jackson.databind.Module: <module-name> not a subtype`

Where <module-name> can be one of:
- com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
- com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
- com.fasterxml.jackson.datatype.guava.GuavaModule
- com.fasterxml.jackson.datatype.joda.JodaModule

## Solution:
This PR addresses the issue by explicitly registering the Afterburner module instead of using the broad `findAndRegisterModules()` method. This approach:

1. Retains the performance benefits of the Afterburner module, as intended by PR #14992.
2. Avoids errors caused by attempting to register incompatible Jackson modules.
3. Provides more control over which modules are registered, reducing unexpected behavior.

## Implementation:
- Remove `objectMapper.findAndRegisterModules()`
- Add explicit registration of the Afterburner module

This change ensures that we maintain the desired performance improvements while eliminating errors related to incompatible Jackson library versions.

## Testing
### Manual Testing
- Used connector plugins previously causing ServiceConfigurationError
- Verified that no ServiceConfigurationError is thrown during plugin discovery

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
