### PR TITLE
KAFKA-17097: Add replace.null.with.default configuration to ValueToKey and ReplaceField (KIP-1040)

### DIFF
--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
@@ -25,9 +25,14 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -35,6 +40,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ValueToKeyTest {
     private final ValueToKey<SinkRecord> xform = new ValueToKey<>();
+
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of(false, null),
+                Arguments.of(true, 42)
+        );
+    }
 
     @AfterEach
     public void teardown() {
@@ -112,5 +124,24 @@ public class ValueToKeyTest {
     @Test
     public void testValueToKeyVersionRetrievedFromAppInfoParser() {
         assertEquals(AppInfoParser.getVersion(), xform.version());
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReplaceNullWithDefaultConfig(boolean replaceNullWithDefault, Object expectedValue) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("fields", "optional_with_default");
+        config.put("replace.null.with.default", replaceNullWithDefault);
+        xform.configure(config);
+
+        final Schema valueSchema = SchemaBuilder.struct()
+                .field("optional_with_default", SchemaBuilder.int32().optional().defaultValue(42).build())
+                .build();
+        final Struct value = new Struct(valueSchema).put("optional_with_default", null);
+
+        final SinkRecord record = new SinkRecord("", 0, null, null, valueSchema, value, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        assertEquals(expectedValue, ((Struct) transformedRecord.key()).getWithoutDefault("optional_with_default"));
     }
 }


### PR DESCRIPTION
[KIP-1040](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=303794677) mentioned adding new configuration to InsertField, ExtractField, HeaderFrom, Cast, SetSchemaMetadata, TimestampConverter, MaskField, ValueToKey and ReplaceField.

This PR is to finish final remaining transformations: ValueToKey and ReplaceField.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
