### PR TITLE
KAFKA-17073: Deprecate ReplicaVerificationTool in 3.9

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -112,6 +112,8 @@ public class ReplicaVerificationTool {
 
     public static void main(String[] args) {
         try {
+            LOG.warn("This tool is deprecated and may be removed in a future major release.");
+
             ReplicaVerificationToolOptions options = new ReplicaVerificationToolOptions(args);
             // getting topic metadata
             LOG.info("Getting topic metadata...");


### PR DESCRIPTION
### Summary

If the user runs `ReplicaVerificationTool`, it shows a deprecation warning.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
