### PR TITLE
KAFKA-16765: NioEchoServer leaks accepted SocketChannel instances due to race condition

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
@@ -89,6 +89,7 @@ class EchoServer extends Thread {
                 }
                 synchronized (sockets) {
                     if (closing) {
+                        socket.close();
                         break;
                     }
                     sockets.add(socket);

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -362,12 +362,20 @@ public class NioEchoServer extends Thread {
         socketChannels.clear();
     }
 
+    public void closeNewChannels() throws IOException {
+        for (SocketChannel channel : newChannels) {
+            channel.close();
+        }
+        newChannels.clear();
+    }
+
     public void close() throws IOException, InterruptedException {
         this.serverSocketChannel.close();
         closeSocketChannels();
         Utils.closeQuietly(selector, "selector");
         acceptorThread.interrupt();
         acceptorThread.join();
+        closeNewChannels();
         interrupt();
         join();
     }

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -272,7 +272,9 @@ class ServerShutdownTest extends KafkaServerTestHarness {
       val receiveFuture = executor.submit(new Runnable {
         override def run(): Unit = {
           val socket = serverSocket.accept()
-          new DataInputStream(socket.getInputStream).readByte()
+          val inputStream = new DataInputStream(socket.getInputStream)
+          inputStream.readByte()
+          inputStream.close()
         }
       })
 


### PR DESCRIPTION
As described from [KAFKA-16765](https://issues.apache.org/jira/browse/KAFKA-16765):
There may be channel in `newChannels` that are not closed in time (NioEchoServer#run can handle it, but the process has ended), and a new method is introduced to clear the remaining channels.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
