### PR TITLE
KAFKA-17105: Prevent redundant restarts for newly-created connectors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2424,10 +2424,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.info("Connector {} config removed", connector);
 
             synchronized (DistributedHerder.this) {
-                // rebalance after connector removal to ensure that existing tasks are balanced among workers
-                if (configState.contains(connector))
+                if (configState.contains(connector)) {
+                    // rebalance after connector removal to ensure that existing tasks are balanced among workers
                     needsReconfigRebalance = true;
-                connectorConfigUpdates.add(connector);
+                } else {
+                    connectorConfigUpdates.add(connector);
+                }
+
             }
             member.wakeup();
         }
@@ -2440,9 +2443,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             // to be bounced. However, this callback may also indicate a connector *addition*, which does require
             // a rebalance, so we need to be careful about what operation we request.
             synchronized (DistributedHerder.this) {
-                if (!configState.contains(connector))
+                if (!configState.contains(connector)) {
                     needsReconfigRebalance = true;
-                connectorConfigUpdates.add(connector);
+                } else {
+                    // Only need to restart the connector if it already existed
+                    connectorConfigUpdates.add(connector);
+                }
+
             }
             member.wakeup();
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1602,11 +1602,8 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         // Rebalance will be triggered when the new config is detected
-        // TODO: This is still buggy; we're requesting a rebalance for a connector
-        //       that's already been assigned to us, which is clearly unnecessary.
-        //       We might consider tracking the offsets of records we've read from the
-        //       config topic and only triggering rebalances if we see something that's
-        //       greater than the offset included by the leader in the latest assignment
+        // This rebalance is unnecessary and only the result of a mostly-benign bug;
+        // see https://issues.apache.org/jira/browse/KAFKA-17155
         doNothing().when(member).requestRejoin();
 
         // Rebalance will be triggered when the new config is detected

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -77,6 +77,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1576,6 +1578,55 @@ public class DistributedHerderTest {
         herder.tick(); // do rebalance
 
         verify(worker).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
+        verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {CONNECT_PROTOCOL_V0, CONNECT_PROTOCOL_V1, CONNECT_PROTOCOL_V2})
+    public void testConnectorConfigDetectedAfterLeaderAlreadyAssigned(short protocolVersion) {
+        connectProtocolVersion = protocolVersion;
+
+        // If a connector was added, we need to rebalance
+        when(worker.isSinkConnector(CONN1)).thenReturn(Boolean.TRUE);
+        when(member.memberId()).thenReturn("member");
+        when(member.currentProtocolVersion()).thenReturn(protocolVersion);
+
+        // join, no configs so no need to catch up on config topic
+        expectRebalance(-1, Collections.emptyList(), Collections.emptyList());
+        expectMemberPoll();
+
+        herder.tick(); // join
+
+        // Checks for config updates and starts rebalance
+        configUpdateListener.onConnectorConfigUpdate(CONN1); // read updated config
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        // Rebalance will be triggered when the new config is detected
+        // TODO: This is still buggy; we're requesting a rebalance for a connector
+        //       that's already been assigned to us, which is clearly unnecessary.
+        //       We might consider tracking the offsets of records we've read from the
+        //       config topic and only triggering rebalances if we see something that's
+        //       greater than the offset included by the leader in the latest assignment
+        doNothing().when(member).requestRejoin();
+
+        // Rebalance will be triggered when the new config is detected
+        // Performs rebalance and gets new assignment
+        // Important--we're simulating a scenario where the leader has already detected the new
+        // connector, and assigns it to our herder at the top of its tick thread
+        expectRebalance(Collections.emptyList(), Collections.emptyList(),
+                ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList());
+
+        ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            onStart.getValue().onCompletion(null, TargetState.STARTED);
+            return true;
+        }).when(worker).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
+        expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
+
+        herder.tick(); // assigned connector
+
+        // We should only start the connector once; if we start it several times, that's probably a bug
+        verify(worker, times(1)).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-17105)

Currently, when a connector config is read from the config topic, the name of the connector is added to the `DistributedHerder.connectorConfigUpdates` field. Then, if assigned that connector after the most recent rebalance, the worker (re)-starts that connector in `DistributedHerder::processConnectorConfigUpdates`. However, this is redundant if the connector has just been created. The worker will already have started that connector after being assigned it during rebalance in `DistributedHerder::handleRebalanceCompleted` and `DistributedHerder::startWork`.

This can cause duplicate task configurations to be written to the config topic, since the worker may have already written task configs for the connector after starting it the first time in `startWork`, but not have updated its config snapshot (tracked in the `DistributedHerder.configState` field) before restarting the connector in `processConnectorConfigUpdates`. If the restarted connector then generates task configs before the `configState` snapshot is updated, the herder will write a second set of identical task configs to the config topic.

This leads to flakiness in the `OffsetsApiIntegrationTest` suite for cases related to zombie sink tasks because the second set of task configs leads to the shutdown of all previously-running tasks for the sink connector, and because the connector is configured to block its tasks indefinitely in their `stop` method, the runtime never has a chance to close their consumers. In turn, this causes a hung rebalance when the second generation of sink tasks starts up and their consumers try to join the group for the first time, but the first generation of sink tasks have consumers that are still sending heartbeats, but not being polled.

It's likely that if [KAFKA-15826](https://issues.apache.org/jira/browse/KAFKA-15826) were addressed, the affected integration tests would not be flaky, and this would probably be a better overall fix for the health of Kafka Connect. However, it would also be more involved, and this fix does provide benefits outside of reducing test flakiness, so it still seems worth pursuing for now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
