### PR TITLE
KAFKA-17132: Revisit testMissingOffsetNoResetPolicy for AsyncConsumer

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -931,7 +931,7 @@ public class KafkaConsumerTest {
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
 
         if (groupProtocol == GroupProtocol.CONSUMER) {
-            // New consumer poll(ZERO) needs to wait for the offset fetch event add by a call to poll, to be processed
+            // New consumer poll(ZERO) needs to wait for the offset fetch event added by a call to poll, to be processed
             // by the background thread, so it can realize there are no committed offsets and then
             // throw the NoOffsetForPartitionException
             TestUtils.waitForCondition(() -> {
@@ -943,7 +943,6 @@ public class KafkaConsumerTest {
                 }
             }, "Consumer was not able to update fetch positions on continuous calls with 0 timeout");
         } else {
-            // CLASSIC CONSUMER PROTOCOL
             assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ZERO));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -910,10 +910,8 @@ public class KafkaConsumerTest {
         mockClient.updateMetadata(initialMetadata);
     }
 
-    // TODO: this test triggers a bug with the CONSUMER group protocol implementation.
-    //       The bug will be investigated and fixed so this test can use both group protocols.
     @ParameterizedTest
-    @EnumSource(value = GroupProtocol.class, names = "CLASSIC")
+    @EnumSource(value = GroupProtocol.class)
     public void testMissingOffsetNoResetPolicy(GroupProtocol groupProtocol) {
         SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
         ConsumerMetadata metadata = createMetadata(subscription);
@@ -931,7 +929,7 @@ public class KafkaConsumerTest {
 
         // lookup committed offset and find nothing
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
-        assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ZERO));
+        assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ofMillis(1)));
     }
 
     // TODO: this test triggers a bug with the CONSUMER group protocol implementation.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -935,12 +935,11 @@ public class KafkaConsumerTest {
             // by the background thread, so it can realize there are no committed offsets and then
             // throw the NoOffsetForPartitionException
             TestUtils.waitForCondition(() -> {
-                while (true) {
-                    try {
-                        consumer.poll(Duration.ZERO);
-                    } catch (NoOffsetForPartitionException e) {
-                        return true;
-                    }
+                try {
+                    consumer.poll(Duration.ZERO);
+                    return false;
+                } catch (NoOffsetForPartitionException e) {
+                    return true;
                 }
             }, "Consumer was not able to update fetch positions on continuous calls with 0 timeout");
         } else {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -929,7 +929,7 @@ public class KafkaConsumerTest {
 
         // lookup committed offset and find nothing
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
-        assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ofMillis(1)));
+        assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ofSeconds(3)));
     }
 
     // TODO: this test triggers a bug with the CONSUMER group protocol implementation.


### PR DESCRIPTION
### More detailed description of your change
When we use AsyncConsumer.poll(0) it will return immediately and does not wait event to finish.
By contrast, LegcyConsumer.poll(0) will send request successfully at least.

The behavior difference between AsyncConsumer and LegacyConsumer make testMissingOffsetNoResetPolicy fail for  AsyncConsumer.

In the PR, we use `waitForCondition`  to check the result of AsyncConsumer.
This method can check the reuslt of AsyncConsumer periodically utils expectation return.

### Summary of testing strategy (including rationale)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
