### PR TITLE
KAFKA-17133: add unit test to make sure `ConsumerRecords#recoreds` returns immutable object

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -150,25 +150,26 @@ public class ConsumerRecordsTest {
         int recordSize = 3;
         int partitionSize = 6;
         int emptyPartitionIndex = 2;
-        TopicPartition topicFilter = new TopicPartition(topic, 0);
-        TopicPartition newPartition = new TopicPartition(topic, 0);
+        TopicPartition topicPartition = new TopicPartition(topic, 0);
         ConsumerRecord<Integer, String> newRecord = new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
             0, 0, 0, "0", new RecordHeaders(), Optional.empty());
         ConsumerRecords<Integer, String> records = buildTopicTestRecords(recordSize, partitionSize, emptyPartitionIndex, Collections.singleton(topic));
         ConsumerRecords<Integer, String> emptyRecords = ConsumerRecords.empty();
 
-        // check records / partitions by add method
-        // check iterator by remove method
+        // check records(TopicPartition) / partitions by add method
+        // check iterator / records(String) by remove method
         // check data count after all operations
-        assertThrows(UnsupportedOperationException.class, () -> records.records(topicFilter).add(newRecord));
-        assertThrows(UnsupportedOperationException.class, () -> records.partitions().add(newPartition));
+        assertThrows(UnsupportedOperationException.class, () -> records.records(topicPartition).add(newRecord));
+        assertThrows(UnsupportedOperationException.class, () -> records.partitions().add(topicPartition));
         assertThrows(UnsupportedOperationException.class, () -> records.iterator().remove());
+        assertThrows(UnsupportedOperationException.class, () -> records.records(topic).iterator().remove());
         assertEquals(recordSize * (partitionSize - 1), records.count());
 
         // do the same unittest on the empty records
-        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topicFilter).add(newRecord));
-        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.partitions().add(newPartition));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topicPartition).add(newRecord));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.partitions().add(topicPartition));
         assertThrows(UnsupportedOperationException.class, () -> emptyRecords.iterator().remove());
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topic).iterator().remove());
         assertEquals(0, emptyRecords.count());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -151,15 +151,24 @@ public class ConsumerRecordsTest {
         int partitionSize = 6;
         int emptyPartitionIndex = 2;
         TopicPartition topicFilter = new TopicPartition(topic, 0);
+        TopicPartition newPartition = new TopicPartition(topic, 0);
         ConsumerRecord<Integer, String> newRecord = new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
             0, 0, 0, "0", new RecordHeaders(), Optional.empty());
-
         ConsumerRecords<Integer, String> records = buildTopicTestRecords(recordSize, partitionSize, emptyPartitionIndex, Collections.singleton(topic));
         ConsumerRecords<Integer, String> emptyRecords = ConsumerRecords.empty();
 
+        // check records / partitions by add method
+        // check iterator by remove method
+        // check data count after all operations
         assertThrows(UnsupportedOperationException.class, () -> records.records(topicFilter).add(newRecord));
-        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topicFilter).add(newRecord));
+        assertThrows(UnsupportedOperationException.class, () -> records.partitions().add(newPartition));
+        assertThrows(UnsupportedOperationException.class, () -> records.iterator().remove());
         assertEquals(recordSize * (partitionSize - 1), records.count());
+
+        // do the same unittest on the empty records
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topicFilter).add(newRecord));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.partitions().add(newPartition));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.iterator().remove());
         assertEquals(0, emptyRecords.count());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -107,7 +107,6 @@ public class ConsumerRecordsTest {
         assertEquals("Topic must be non-null.", exception.getMessage());
     }
 
-
     @Test
     public void testRecordsByTopic() {
         List<String> topics = Arrays.asList("topic1", "topic2", "topic3", "topic4");
@@ -143,6 +142,26 @@ public class ConsumerRecordsTest {
             assertEquals(partitionSize, partitionCount + 1);
             assertEquals(expectedTotalRecordSizeOfEachTopic, recordCount);
         }
+    }
+
+    @Test
+    public void testRecordsAreImmutable() {
+        String topic = "topic";
+        int recordSize = 3;
+        int partitionSize = 6;
+        int emptyPartitionIndex = 2;
+
+        ConsumerRecords<Integer, String> records = buildTopicTestRecords(recordSize, partitionSize, emptyPartitionIndex, Collections.singleton(topic));
+        ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        assertThrows(UnsupportedOperationException.class, () -> records.records(new TopicPartition(topic, 0))
+            .add(new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
+                0, 0, 0, String.valueOf(0), new RecordHeaders(), Optional.empty())));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(new TopicPartition(topic, 0))
+            .add(new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
+                0, 0, 0, String.valueOf(0), new RecordHeaders(), Optional.empty())));
+        assertEquals(recordSize * (partitionSize - 1), records.count());
+        assertEquals(0, emptyRecords.count());
     }
 
     private ConsumerRecords<Integer, String> buildTopicTestRecords(int recordSize,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -150,16 +150,15 @@ public class ConsumerRecordsTest {
         int recordSize = 3;
         int partitionSize = 6;
         int emptyPartitionIndex = 2;
+        TopicPartition topicFilter = new TopicPartition(topic, 0);
+        ConsumerRecord<Integer, String> newRecord = new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
+            0, 0, 0, "0", new RecordHeaders(), Optional.empty());
 
         ConsumerRecords<Integer, String> records = buildTopicTestRecords(recordSize, partitionSize, emptyPartitionIndex, Collections.singleton(topic));
-        ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+        ConsumerRecords<Integer, String> emptyRecords = ConsumerRecords.empty();
 
-        assertThrows(UnsupportedOperationException.class, () -> records.records(new TopicPartition(topic, 0))
-            .add(new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
-                0, 0, 0, String.valueOf(0), new RecordHeaders(), Optional.empty())));
-        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(new TopicPartition(topic, 0))
-            .add(new ConsumerRecord<>(topic, 0, 0, 0L, TimestampType.CREATE_TIME,
-                0, 0, 0, String.valueOf(0), new RecordHeaders(), Optional.empty())));
+        assertThrows(UnsupportedOperationException.class, () -> records.records(topicFilter).add(newRecord));
+        assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topicFilter).add(newRecord));
         assertEquals(recordSize * (partitionSize - 1), records.count());
         assertEquals(0, emptyRecords.count());
     }


### PR DESCRIPTION
### More detailed description of your change,
1. Use add method and it is expected to throw exception.
2. Confirm count is the same after add operation.

### Summary of testing strategy (including rationale)
1. Considering the existence and emptiness of records

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
