### PR TITLE
DO NOT MERGE: Isolate MirrorMaker 2 tests, run multiple times per CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,68 +30,11 @@ def isChangeRequest(env) {
 }
 
 def doTest(env, target = "test") {
-  sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
+  sh """./gradlew -PscalaVersion=$SCALA_VERSION cleanTest ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
 }
-
-def runTestOnDevBranch(env) {
-  if (!isChangeRequest(env)) {
-    doTest(env)
-  }
-}
-
-def doStreamsArchetype() {
-  echo 'Verify that Kafka Streams archetype compiles'
-
-  sh '''
-    ./gradlew streams:publishToMavenLocal clients:publishToMavenLocal connect:json:publishToMavenLocal connect:api:publishToMavenLocal \
-         || { echo 'Could not publish kafka-streams.jar (and dependencies) locally to Maven'; exit 1; }
-  '''
-
-  VERSION = sh(script: 'grep "^version=" gradle.properties | cut -d= -f 2', returnStdout: true).trim()
-
-  dir('streams/quickstart') {
-    sh '''
-      mvn clean install -Dgpg.skip  \
-          || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
-    '''
-
-    dir('test-streams-archetype') {
-      // Note the double quotes for variable interpolation
-      sh """ 
-        echo "Y" | mvn archetype:generate \
-            -DarchetypeCatalog=local \
-            -DarchetypeGroupId=org.apache.kafka \
-            -DarchetypeArtifactId=streams-quickstart-java \
-            -DarchetypeVersion=${VERSION} \
-            -DgroupId=streams.examples \
-            -DartifactId=streams.examples \
-            -Dversion=0.1 \
-            -Dpackage=myapps \
-            || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
-      """
-
-      dir('streams.examples') {
-        sh '''
-          mvn compile \
-              || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
-        '''
-      }
-    }
-  }
-}
-
-def tryStreamsArchetype() {
-  try {
-    doStreamsArchetype()
-  } catch(err) {
-    echo 'Failed to build Kafka Streams archetype, marking this build UNSTABLE'
-    currentBuild.result = 'UNSTABLE'
-  }
-}
-
 
 pipeline {
   agent none
@@ -119,46 +62,17 @@ pipeline {
           }
           steps {
             doValidation()
-            doTest(env)
-            tryStreamsArchetype()
-          }
-        }
 
-        stage('JDK 11 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_11_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            runTestOnDevBranch(env)
-            echo 'Skipping Kafka Streams archetype test for Java 11'
-          }
-        }
-
-        stage('JDK 17 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_17_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            runTestOnDevBranch(env)
-            echo 'Skipping Kafka Streams archetype test for Java 17'
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
           }
         }
 
@@ -176,8 +90,17 @@ pipeline {
           }
           steps {
             doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 21'
+
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
+            doTest(env, target = ':connect:mirror:test')
           }
         }
       }

--- a/connect/mirror/src/test/resources/log4j.properties
+++ b/connect/mirror/src/test/resources/log4j.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-log4j.rootLogger=ERROR, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -28,7 +28,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 # The following line includes no MDC context parameters:
 #log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n (%t)
 
-log4j.logger.org.reflections=OFF
-log4j.logger.kafka=OFF
-log4j.logger.state.change.logger=OFF
-log4j.logger.org.apache.kafka.connect.mirror=INFO
+log4j.logger.org.reflections=ERROR
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka.connect=DEBUG

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2424,10 +2424,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.info("Connector {} config removed", connector);
 
             synchronized (DistributedHerder.this) {
-                // rebalance after connector removal to ensure that existing tasks are balanced among workers
-                if (configState.contains(connector))
+                if (configState.contains(connector)) {
+                    // rebalance after connector removal to ensure that existing tasks are balanced among workers
                     needsReconfigRebalance = true;
-                connectorConfigUpdates.add(connector);
+                } else {
+                    connectorConfigUpdates.add(connector);
+                }
+
             }
             member.wakeup();
         }
@@ -2440,9 +2443,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             // to be bounced. However, this callback may also indicate a connector *addition*, which does require
             // a rebalance, so we need to be careful about what operation we request.
             synchronized (DistributedHerder.this) {
-                if (!configState.contains(connector))
+                if (!configState.contains(connector)) {
                     needsReconfigRebalance = true;
-                connectorConfigUpdates.add(connector);
+                } else {
+                    // Only need to restart the connector if it already existed
+                    connectorConfigUpdates.add(connector);
+                }
+
             }
             member.wakeup();
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -77,6 +77,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1576,6 +1578,55 @@ public class DistributedHerderTest {
         herder.tick(); // do rebalance
 
         verify(worker).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
+        verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {CONNECT_PROTOCOL_V0, CONNECT_PROTOCOL_V1, CONNECT_PROTOCOL_V2})
+    public void testConnectorConfigDetectedAfterLeaderAlreadyAssigned(short protocolVersion) {
+        connectProtocolVersion = protocolVersion;
+
+        // If a connector was added, we need to rebalance
+        when(worker.isSinkConnector(CONN1)).thenReturn(Boolean.TRUE);
+        when(member.memberId()).thenReturn("member");
+        when(member.currentProtocolVersion()).thenReturn(protocolVersion);
+
+        // join, no configs so no need to catch up on config topic
+        expectRebalance(-1, Collections.emptyList(), Collections.emptyList());
+        expectMemberPoll();
+
+        herder.tick(); // join
+
+        // Checks for config updates and starts rebalance
+        configUpdateListener.onConnectorConfigUpdate(CONN1); // read updated config
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        // Rebalance will be triggered when the new config is detected
+        // TODO: This is still buggy; we're requesting a rebalance for a connector
+        //       that's already been assigned to us, which is clearly unnecessary.
+        //       We might consider tracking the offsets of records we've read from the
+        //       config topic and only triggering rebalances if we see something that's
+        //       greater than the offset included by the leader in the latest assignment
+        doNothing().when(member).requestRejoin();
+
+        // Rebalance will be triggered when the new config is detected
+        // Performs rebalance and gets new assignment
+        // Important--we're simulating a scenario where the leader has already detected the new
+        // connector, and assigns it to our herder at the top of its tick thread
+        expectRebalance(Collections.emptyList(), Collections.emptyList(),
+                ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList());
+
+        ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            onStart.getValue().onCompletion(null, TargetState.STARTED);
+            return true;
+        }).when(worker).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
+        expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
+
+        herder.tick(); // assigned connector
+
+        // We should only start the connector once; if we start it several times, that's probably a bug
+        verify(worker, times(1)).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 


### PR DESCRIPTION
This is an attempt to gather better logs for the flaky MirrorMaker 2 integration tests we've been seeing lately, including `testReplicateSourceDefault` and `testSyncTopicConfigs`.

The fixes for KAFKA-17105 and KAFKA-17115 are included under the assumption that they will be merged soon in order to address other flaky tests affecting the Kafka Connect runtime, since they may also have a positive impact on the flakiness of MirrorMaker 2 tests.