### PR TITLE
KAFKA-17135 Add unit test for `ProducerStateManager#readSnapshot` and `ProducerStateManager#writeSnapshot`

### DIFF
--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -1192,7 +1192,7 @@ class ProducerStateManagerTest {
       }
     }
 
-    def assertProducerStateEntry(actual: ProducerStateEntry, expected: ProducerStateEntry): Unit = {
+    def assertProducerStateEntry(expected: ProducerStateEntry, actual: ProducerStateEntry): Unit = {
       assertEquals(expected.producerId(), actual.producerId())
       assertEquals(expected.producerEpoch(), actual.producerEpoch())
       assertEquals(expected.coordinatorEpoch(), actual.coordinatorEpoch())

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -685,7 +685,8 @@ public class ProducerStateManager {
         }
     }
 
-    private static void writeSnapshot(File file, Map<Long, ProducerStateEntry> entries, boolean sync) throws IOException {
+    // visible for testing
+    public static void writeSnapshot(File file, Map<Long, ProducerStateEntry> entries, boolean sync) throws IOException {
         Struct struct = new Struct(PID_SNAPSHOT_MAP_SCHEMA);
         struct.set(VERSION_FIELD, PRODUCER_SNAPSHOT_VERSION);
         struct.set(CRC_FIELD, 0L); // we'll fill this after writing the entries


### PR DESCRIPTION
related to https://issues.apache.org/jira/browse/KAFKA-17135,

as title, Add unit test for `ProducerStateManager#readSnapshot` and `ProducerStateManager#writeSnapshot`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
