### PR TITLE
KAFKA-16535; Implement KRaft add voter handling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/DuplicateVoterException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DuplicateVoterException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class DuplicateVoterException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DuplicateVoterException(String message) {
+        super(message);
+    }
+
+    public DuplicateVoterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors.DelegationTokenOwnerMismatchException;
 import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.DuplicateResourceException;
 import org.apache.kafka.common.errors.DuplicateSequenceException;
+import org.apache.kafka.common.errors.DuplicateVoterException;
 import org.apache.kafka.common.errors.ElectionNotNeededException;
 import org.apache.kafka.common.errors.EligibleLeadersNotAvailableException;
 import org.apache.kafka.common.errors.FeatureUpdateFailedException;
@@ -405,7 +406,8 @@ public enum Errors {
     SHARE_SESSION_NOT_FOUND(122, "The share session was not found.", ShareSessionNotFoundException::new),
     INVALID_SHARE_SESSION_EPOCH(123, "The share session epoch is invalid.", InvalidShareSessionEpochException::new),
     FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match.", FencedStateEpochException::new),
-    INVALID_VOTER_KEY(125, "The voter key doesn't match the receiving replica's key.", InvalidVoterKeyException::new);
+    INVALID_VOTER_KEY(125, "The voter key doesn't match the receiving replica's key.", InvalidVoterKeyException::new),
+    DUPLICATE_VOTER(126, "The voter is already part of the set of voters.", DuplicateVoterException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        public static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
 
         private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
             .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -1086,7 +1086,7 @@ class ControllerApis(
 
   def handleAddRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, ALTER)
-    throw new UnsupportedVersionException("handleAddRaftVoter is not supported yet.")
+    handleRaftRequest(request, response => new AddRaftVoterResponse(response.asInstanceOf[AddRaftVoterResponseData]))
   }
 
   def handleRemoveRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -24,6 +24,9 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.AddRaftVoterRequestData;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
@@ -57,10 +60,12 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.raft.errors.NotLeaderException;
+import org.apache.kafka.raft.internals.AddVoterHandler;
 import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.apache.kafka.raft.internals.BatchMemoryPool;
 import org.apache.kafka.raft.internals.BlockingMessageQueue;
 import org.apache.kafka.raft.internals.CloseListener;
+import org.apache.kafka.raft.internals.DefaultRequestSender;
 import org.apache.kafka.raft.internals.FuturePurgatory;
 import org.apache.kafka.raft.internals.KRaftControlRecordStateMachine;
 import org.apache.kafka.raft.internals.KafkaRaftMetrics;
@@ -195,6 +200,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private volatile KafkaRaftMetrics kafkaRaftMetrics;
     private volatile QuorumState quorum;
     private volatile RequestManager requestManager;
+
+    // Specialized handles
+    private volatile AddVoterHandler addVoterHandler;
 
     /**
      * Create a new instance.
@@ -333,6 +341,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             logger.debug("Leader high watermark updated to {}", highWatermark);
             log.updateHighWatermark(highWatermark);
 
+            // Notify the add voter handler that the HWM has been updated incase there are add
+            // voter request that need to be completed
+            addVoterHandler.highWatermarkUpdated(state);
+
             // After updating the high watermark, we first clear the append
             // purgatory so that we have an opportunity to route the pending
             // records still held in memory directly to the listener
@@ -351,8 +363,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 // Send snapshot to the listener, if the listener is at the beginning of the log and there is a snapshot,
                 // or the listener is trying to read an offset for which there isn't a segment in the log.
                 if (nextExpectedOffset < highWatermark &&
-                    ((nextExpectedOffset == 0 && latestSnapshot().isPresent()) ||
-                     nextExpectedOffset < log.startOffset())
+                    ((nextExpectedOffset == ListenerContext.STARTING_NEXT_OFFSET || nextExpectedOffset < log.startOffset())
+                     && latestSnapshot().isPresent())
                 ) {
                     SnapshotReader<T> snapshot = latestSnapshot().orElseThrow(() -> new IllegalStateException(
                         String.format(
@@ -364,6 +376,20 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                         )
                     ));
                     listenerContext.fireHandleSnapshot(snapshot);
+                } else if (nextExpectedOffset == ListenerContext.STARTING_NEXT_OFFSET) {
+                    // Reset the next offset to 0 since it is a new listener context and there is no
+                    // bootstraping checkpoint
+                    listenerContext.resetOffsetForEmptyPartition();
+                } else if (nextExpectedOffset < log.startOffset()) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "Snapshot expected since next offset of %s is %d, log start offset is %d and high-watermark is %d",
+                            listenerContext.listenerName(),
+                            nextExpectedOffset,
+                            log.startOffset(),
+                            highWatermark
+                        )
+                    );
                 }
             });
 
@@ -489,6 +515,19 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (quorum.isOnlyVoter() && !quorum.isCandidate()) {
             transitionToCandidate(currentTimeMs);
         }
+
+        // Specialized handlers
+        this.addVoterHandler = new AddVoterHandler(
+            partitionState,
+            new DefaultRequestSender(
+                requestManager,
+                channel,
+                messageQueue,
+                logContext
+            ),
+            time,
+            logContext
+        );
     }
 
     @Override
@@ -1970,6 +2009,80 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return true;
     }
 
+    private CompletableFuture<AddRaftVoterResponseData> handleAddVoterRequest(
+        RaftRequest.Inbound requestMetadata,
+        long currentTimeMs
+    ) {
+        AddRaftVoterRequestData data = (AddRaftVoterRequestData) requestMetadata.data();
+
+        if (!hasValidClusterId(data.clusterId())) {
+            return completedFuture(
+                new AddRaftVoterResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code())
+            );
+        }
+
+        Optional<Errors> leaderValidation = validateLeaderOnlyRequest(quorum.epoch());
+        if (leaderValidation.isPresent()) {
+            return completedFuture(
+                new AddRaftVoterResponseData().setErrorCode(leaderValidation.get().code())
+            );
+        }
+
+        Optional<ReplicaKey> newVoter = RaftUtil.addVoterRequestVoterKey(data);
+        if (!newVoter.isPresent()) {
+            return completedFuture(
+                new AddRaftVoterResponseData()
+                    .setErrorCode(Errors.INVALID_REQUEST.code())
+                    .setErrorMessage("Add voter request didn't include a valid voter")
+            );
+        }
+
+        Endpoints newVoterEndpoints = Endpoints.fromAddVoterRequest(data.listeners());
+        if (!newVoterEndpoints.address(channel.listenerName()).isPresent()) {
+            return completedFuture(
+                new AddRaftVoterResponseData()
+                    .setErrorCode(Errors.INVALID_REQUEST.code())
+                    .setErrorMessage(
+                        String.format(
+                            "Add voter request didn't include the default listener: %s",
+                            channel.listenerName()
+                        )
+                    )
+            );
+        }
+
+        return addVoterHandler.handleAddVoterRequest(
+            quorum.leaderStateOrThrow(),
+            newVoter.get(),
+            newVoterEndpoints,
+            currentTimeMs
+        );
+    }
+
+    private boolean handleApiVersionsResponse(
+        RaftResponse.Inbound responseMetadata,
+        long currentTimeMs
+    ) {
+        if (!quorum.isLeader()) {
+            // Not the leader anymore just ignore the API_VERSIONS response
+            return true;
+        }
+
+        ApiVersionsResponseData response = (ApiVersionsResponseData) responseMetadata.data();
+
+        Errors error = Errors.forCode(response.errorCode());
+        Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions =
+            Optional.ofNullable(response.supportedFeatures().find(KRaftVersion.FEATURE_NAME));
+
+        return addVoterHandler.handleApiVersionsResponse(
+            quorum.leaderStateOrThrow(),
+            responseMetadata.source(),
+            error,
+            supportedKraftVersions,
+            currentTimeMs
+        );
+    }
+
     private boolean hasConsistentLeader(int epoch, OptionalInt leaderId) {
         // Only elected leaders are sent in the request/response header, so if we have an elected
         // leaderId, it should be consistent with what is in the message.
@@ -2132,6 +2245,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 handledSuccessfully = handleFetchSnapshotResponse(response, currentTimeMs);
                 break;
 
+            case API_VERSIONS:
+                handledSuccessfully = handleApiVersionsResponse(response, currentTimeMs);
+                break;
+
             default:
                 throw new IllegalArgumentException("Received unexpected response type: " + apiKey);
         }
@@ -2222,6 +2339,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
             case FETCH_SNAPSHOT:
                 responseFuture = completedFuture(handleFetchSnapshotRequest(request, currentTimeMs));
+                break;
+
+            case ADD_RAFT_VOTER:
+                responseFuture = handleAddVoterRequest(request, currentTimeMs);
                 break;
 
             default:
@@ -2567,6 +2688,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return 0L;
         }
 
+        long timeUtilAddVoterExpires = addVoterHandler.maybeExpirePendingOperation(state, currentTimeMs);
+
         long timeUntilFlush = maybeAppendBatches(
             state,
             currentTimeMs
@@ -2577,7 +2700,16 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             currentTimeMs
         );
 
-        return Math.min(timeUntilFlush, Math.min(timeUntilNextBeginQuorumSend, timeUntilCheckQuorumExpires));
+        return Math.min(
+            timeUntilFlush,
+            Math.min(
+                timeUntilNextBeginQuorumSend,
+                Math.min(
+                    timeUntilCheckQuorumExpires,
+                    timeUtilAddVoterExpires
+                )
+            )
+        );
     }
 
     private long maybeSendVoteRequests(
@@ -3154,6 +3286,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private final class ListenerContext implements CloseListener<BatchReader<T>> {
+        private static final long STARTING_NEXT_OFFSET = -1;
         private final RaftClient.Listener<T> listener;
         // This field is used only by the Raft IO thread
         private LeaderAndEpoch lastFiredLeaderChange = LeaderAndEpoch.UNKNOWN;
@@ -3161,7 +3294,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         // These fields are visible to both the Raft IO thread and the listener
         // and are protected through synchronization on this ListenerContext instance
         private BatchReader<T> lastSent = null;
-        private long nextOffset = 0;
+        private long nextOffset = STARTING_NEXT_OFFSET;
 
         private ListenerContext(Listener<T> listener) {
             this.listener = listener;
@@ -3173,6 +3306,15 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
          */
         private synchronized long nextOffset() {
             return nextOffset;
+        }
+
+        /**
+         * Sets the nextOffset to zero.
+         *
+         * This is done when the partition is empty. No log and no bootstraping snapshot.
+         */
+        private synchronized void resetOffsetForEmptyPartition() {
+            nextOffset = 0;
         }
 
         /**

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -788,6 +788,8 @@ public class LeaderState<T> implements EpochState {
     @Override
     public void close() {
         addVoterHandlerState.ifPresent(AddVoterHandlerState::close);
+        addVoterHandlerState = Optional.empty();
+
         accumulator.close();
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.raft.internals.AddVoterHandlerState;
 import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
@@ -71,6 +72,7 @@ public class LeaderState<T> implements EpochState {
 
     private Optional<LogOffsetMetadata> highWatermark = Optional.empty();
     private Map<Integer, ReplicaState> voterStates = new HashMap<>();
+    private Optional<AddVoterHandlerState> addVoterHandlerState = Optional.empty();
     private final Map<ReplicaKey, ReplicaState> observerStates = new HashMap<>();
     private final Logger log;
     private final BatchAccumulator<T> accumulator;
@@ -198,7 +200,24 @@ public class LeaderState<T> implements EpochState {
     }
 
     public BatchAccumulator<T> accumulator() {
-        return this.accumulator;
+        return accumulator;
+    }
+
+    public Optional<AddVoterHandlerState> addVoterHandlerState() {
+        return addVoterHandlerState;
+    }
+
+    public void resetAddVoterHandlerState(
+        Errors error,
+        String message,
+        Optional<AddVoterHandlerState> state
+    ) {
+        addVoterHandlerState.ifPresent(
+            handlerState -> handlerState
+                .future()
+                .complete(RaftUtil.addVoterResponse(error, message))
+        );
+        addVoterHandlerState = state;
     }
 
     private static List<Voter> convertToVoters(Set<Integer> voterIds) {
@@ -273,8 +292,27 @@ public class LeaderState<T> implements EpochState {
         accumulator.forceDrain();
     }
 
+    public long appendVotersRecord(VoterSet voters, long currentTimeMs) {
+        return accumulator.appendVotersRecord(
+            voters.toVotersRecord(ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION),
+            currentTimeMs
+        );
+    }
+
     public boolean isResignRequested() {
         return resignRequested;
+    }
+
+    public boolean isReplicaCaughtUp(ReplicaKey replicaKey, long currentTimeMs) {
+        // In summary, let's consider a replica caughed up for add voter, if they
+        // have fetched within the last hour
+        return Optional.ofNullable(observerStates.get(replicaKey))
+            .map(state ->
+                state.lastCaughtUpTimestamp > 0 &&
+                state.lastFetchTimestamp > 0 &&
+                state.lastFetchTimestamp > currentTimeMs - 3600000
+            )
+            .orElse(false);
     }
 
     public void requestResign() {
@@ -510,7 +548,7 @@ public class LeaderState<T> implements EpochState {
         return state;
     }
 
-    private Optional<ReplicaState> getReplicaState(ReplicaKey replicaKey) {
+    public Optional<ReplicaState> getReplicaState(ReplicaKey replicaKey) {
         ReplicaState state = voterStates.get(replicaKey.id());
         if (state == null || !state.matchesKey(replicaKey)) {
             state = observerStates.get(replicaKey);
@@ -749,6 +787,7 @@ public class LeaderState<T> implements EpochState {
 
     @Override
     public void close() {
+        addVoterHandlerState.ifPresent(AddVoterHandlerState::close);
         accumulator.close();
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -558,6 +558,11 @@ public class QuorumState {
     }
 
     private void durableTransitionTo(EpochState newState) {
+        store.writeElectionState(newState.election(), partitionState.lastKraftVersion());
+        memoryTransitionTo(newState);
+    }
+
+    private void memoryTransitionTo(EpochState newState) {
         if (state != null) {
             try {
                 state.close();
@@ -567,11 +572,6 @@ public class QuorumState {
             }
         }
 
-        store.writeElectionState(newState.election(), partitionState.lastKraftVersion());
-        memoryTransitionTo(newState);
-    }
-
-    private void memoryTransitionTo(EpochState newState) {
         EpochState from = state;
         state = newState;
         log.info("Completed transition to {} from {}", newState, from);

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.raft.LeaderState;
+import org.apache.kafka.raft.LogOffsetMetadata;
+import org.apache.kafka.raft.RaftUtil;
+import org.apache.kafka.server.common.KRaftVersion;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This type implement the protocol for adding a voter to a KRaft partition.
+ *
+ * The general algorithm for adding a voter to the voter set is:
+ *
+ * 1. Wait until there are no uncommitted VotersRecord. Note that the implementation may just
+ *    return a REQUEST_TIMED_OUT error if there are pending operations.
+ * 2. Wait for the LeaderChangeMessage control record from the current epoch to get committed.
+ *    Note that the implementation may just return a REQUEST_TIMED_OUT error if there are pending
+ *    operations.
+ * 3. Send an ApiVersions RPC to the first listener to discover the supported kraft.version of the
+ *    new voter.
+ * 4. Check that the new voter supports the current kraft.version.
+ * 5. Wait for the fetch offset of the replica (ID, UUID) to catch up to the log end offset of
+ *    the leader.
+ * 6. Append the updated VotersRecord to the log.
+ * 7. The KRaft internal listener will read this record from the log and add the new voter to the
+ *    set of voters.
+ * 8. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a
+ *    REQUEST_TIMED_OUT error if it doesn't succeed in time.
+ * 9. Send the AddVoter response to the client.
+ *
+ * The algorithm above could be improved as part of KAFKA-17147. Instead of returning an error
+ * immediately for 1. and 2., KRaft can wait with a timeout until those invariants become true.
+ */
+public final class AddVoterHandler {
+    private final KRaftControlRecordStateMachine partitionState;
+    private final RequestSender requestSender;
+    private final Time time;
+    private final Logger logger;
+
+    public AddVoterHandler(
+        KRaftControlRecordStateMachine partitionState,
+        RequestSender requestSender,
+        Time time,
+        LogContext logContext
+    ) {
+        this.partitionState = partitionState;
+        this.requestSender = requestSender;
+        this.time = time;
+        this.logger = logContext.logger(AddVoterHandler.class);
+    }
+
+    public CompletableFuture<AddRaftVoterResponseData> handleAddVoterRequest(
+        LeaderState<?> leaderState,
+        ReplicaKey voterKey,
+        Endpoints voterEndpoints,
+        long currentTimeMs
+    ) {
+        // Check if there are any pending add voter requests
+        if (isOperationPending(leaderState, currentTimeMs)) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to handle previous add voter request"
+                )
+            );
+        }
+
+        Optional<LogHistory.Entry<VoterSet>> votersEntry = partitionState.lastVoterSetEntry();
+
+        // Check that the leader has established a HWM and committed the current epoch
+        Optional<Long> highWatermark = leaderState.highWatermark().map(LogOffsetMetadata::offset);
+        if (!highWatermark.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to establish HWM and fence previous voter changes"
+                )
+            );
+        }
+
+        // Check that the cluster supports kraft.version >= 1
+        KRaftVersion kraftVersion = partitionState.lastKraftVersion();
+        if (!kraftVersion.isReconfigSupported()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.UNSUPPORTED_VERSION,
+                    String.format(
+                        "Cluster doesn't support adding voter because the %s feature is %s",
+                        kraftVersion.featureName(),
+                        kraftVersion.featureLevel()
+                    )
+                )
+            );
+        }
+
+        // Check that there are no uncommitted VotersRecord
+        if (!votersEntry.isPresent() || votersEntry.get().offset() >= highWatermark.get()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    String.format(
+                        "Request timed out waiting for voters to commit the latest voter change at %s with HWM %d",
+                        votersEntry.map(LogHistory.Entry::offset),
+                        highWatermark.get()
+                    )
+                )
+            );
+        }
+
+        // Check that the new voter id is not part of the current voter set
+        VoterSet voters = votersEntry.get().value();
+        if (voters.voterIds().contains(voterKey.id())) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.DUPLICATE_VOTER,
+                    String.format(
+                        "The voter id for %s is already part of the set of voters %s.",
+                        voterKey,
+                        voters.voterKeys()
+                    )
+                )
+            );
+        }
+
+        // Send API_VERSIONS request to new voter to discover their supported kraft.version range
+        OptionalLong timeout = requestSender.send(
+            voterEndpoints
+                .address(requestSender.listenerName())
+                .map(address -> new Node(voterKey.id(), address.getHostName(), address.getPort()))
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format(
+                            "Provided listeners %s do not contain a listener for %s",
+                            voterEndpoints,
+                            requestSender.listenerName()
+                        )
+                    )
+                ),
+            this::buildApiVersionsRequest,
+            currentTimeMs
+        );
+        if (!timeout.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    String.format("New voter %s is not ready to receive requests", voterKey)
+                )
+            );
+        }
+
+        AddVoterHandlerState state = new AddVoterHandlerState(
+            voterKey,
+            voterEndpoints,
+            time.timer(timeout.getAsLong())
+        );
+        leaderState.resetAddVoterHandlerState(
+            Errors.UNKNOWN_SERVER_ERROR,
+            null,
+            Optional.of(state)
+        );
+
+        return state.future();
+    }
+
+    public boolean handleApiVersionsResponse(
+        LeaderState<?> leaderState,
+        Node source,
+        Errors error,
+        Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions,
+        long currentTimeMs
+    ) {
+        Optional<AddVoterHandlerState> handlerState = leaderState.addVoterHandlerState();
+        if (!handlerState.isPresent()) {
+            // There are no pending add operation just ignore the api response
+            return true;
+        }
+
+
+        // Check that the API_VERSIONS response matches the id of the voter getting added
+        AddVoterHandlerState current = handlerState.get();
+        if (!current.expectingApiResponse(source.id())) {
+            logger.info(
+                "API_VERSIONS response is not expected from {}: voterKey is {}, lastOffset is {}",
+                source,
+                current.voterKey(),
+                current.lastOffset()
+            );
+
+            return true;
+        }
+
+        // Abort operation if the API_VERSIONS returned an error
+        if (error != Errors.NONE) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since API_VERSIONS returned an error {}",
+                current.voterKey(),
+                current.voterEndpoints(),
+                error
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.REQUEST_TIMED_OUT,
+                String.format(
+                    "Aborted add voter operation for since API_VERSIONS returned an error %s",
+                    error
+                )
+            );
+
+            return false;
+        }
+
+        // Check that the new voter supports the kraft.verion for reconfiguration
+        if (!validVersionRange(supportedKraftVersions)) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since kraft.version range {} doesn't " +
+                "support reconfiguration",
+                current.voterKey(),
+                current.voterEndpoints(),
+                supportedKraftVersions
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.INVALID_REQUEST,
+                String.format(
+                    "Aborted add voter operation for %s since kraft.version range %s doesn't " +
+                    "support reconfiguration",
+                    current.voterKey(),
+                    supportedKraftVersions
+                        .map(
+                            range -> String.format(
+                                "(min: %s, max: %s",
+                                range.minVersion(),
+                                range.maxVersion()
+                            )
+                        )
+                        .orElse("(min: 0, max: 0)")
+                )
+            );
+
+            return true;
+        }
+
+        // Check that the new voter is caught up to the LEO to avoid delays in HWM increases
+        if (!leaderState.isReplicaCaughtUp(current.voterKey(), currentTimeMs)) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since it is lagging behind: {}",
+                current.voterKey(),
+                current.voterEndpoints(),
+                leaderState.getReplicaState(current.voterKey())
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.REQUEST_TIMED_OUT,
+                String.format(
+                    "Aborted add voter operation for %s since it is lagging behind",
+                    current.voterKey()
+                )
+            );
+
+            return true;
+        }
+
+        // Add the new voter to the set of voters and append the record to the log
+        VoterSet newVoters = partitionState
+            .lastVoterSet()
+            .addVoter(
+                VoterSet.VoterNode.of(
+                    current.voterKey(),
+                    current.voterEndpoints(),
+                    new SupportedVersionRange(
+                        supportedKraftVersions.get().minVersion(),
+                        supportedKraftVersions.get().maxVersion()
+                    )
+                )
+            )
+            .orElseThrow(() ->
+                new IllegalStateException(
+                    String.format(
+                        "Unable to add %s to the set of voters %s",
+                        current.voterKey(),
+                        partitionState.lastVoterSet()
+                    )
+                )
+            );
+        current.setLastOffset(leaderState.appendVotersRecord(newVoters, currentTimeMs));
+
+        return true;
+    }
+
+    public void highWatermarkUpdated(LeaderState<?> leaderState) {
+        leaderState.addVoterHandlerState().ifPresent(current -> {
+            leaderState.highWatermark().ifPresent(highWatermark -> {
+                current.lastOffset().ifPresent(lastOffset -> {
+                    if (highWatermark.offset() > lastOffset) {
+                        // VotersRecord with the added voter was committed; complete the RPC
+                        completeAddVoter(leaderState);
+                    }
+                });
+            });
+        });
+    }
+
+    public long maybeExpirePendingOperation(LeaderState<?> leaderState, long currentTimeMs) {
+        long timeUntilOperationExpiration = leaderState
+            .addVoterHandlerState()
+            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+            .orElse(Long.MAX_VALUE);
+
+        if (timeUntilOperationExpiration == 0) {
+            abortAddVoter(leaderState, Errors.REQUEST_TIMED_OUT, null);
+            return Long.MAX_VALUE;
+        } else {
+            return timeUntilOperationExpiration;
+        }
+
+    }
+
+    private ApiVersionsRequestData buildApiVersionsRequest() {
+        return new ApiVersionsRequestData()
+            .setClientSoftwareName(ApiVersionsRequest.Builder.DEFAULT_CLIENT_SOFTWARE_NAME)
+            .setClientSoftwareVersion(AppInfoParser.getVersion());
+    }
+
+    private boolean isOperationPending(LeaderState<?> leaderState, long currentTimeMs) {
+        maybeExpirePendingOperation(leaderState, currentTimeMs);
+        return leaderState.addVoterHandlerState().isPresent();
+    }
+
+    private boolean validVersionRange(
+        Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions
+    ) {
+        return supportedKraftVersions.isPresent() &&
+            (supportedKraftVersions.get().minVersion() <= 1 &&
+             supportedKraftVersions.get().maxVersion() >= 1);
+    }
+
+    private void completeAddVoter(LeaderState<?> leaderState) {
+        leaderState.resetAddVoterHandlerState(Errors.NONE, null, Optional.empty());
+    }
+
+    private void abortAddVoter(LeaderState<?> leaderState, Errors error, String message) {
+        leaderState.resetAddVoterHandlerState(error, message, Optional.empty());
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java.orig
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java.orig
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.raft.LeaderState;
+import org.apache.kafka.raft.LogOffsetMetadata;
+import org.apache.kafka.raft.RaftUtil;
+import org.apache.kafka.server.common.KRaftVersion;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This type implement the protocol for adding a voter to a KRaft partition.
+ *
+ * The general algorithm for adding a voter to the voter set is:
+ *
+ * 1. Wait until there are no uncommitted VotersRecord. Note that the implementation may just
+ *    return a REQUEST_TIMED_OUT error if there are pending operations.
+ * 2. Wait for the LeaderChangeMessage control record from the current epoch to get committed.
+ *    Note that the implementation may just return a REQUEST_TIMED_OUT error if there are pending
+ *    operations.
+ * 3. Send an ApiVersions RPC to the first listener to discover the supported kraft.version of the
+ *    new voter.
+ * 4. Check that the new voter supports the current kraft.version.
+ * 5. Wait for the fetch offset of the replica (ID, UUID) to catch up to the log end offset of
+ *    the leader.
+ * 6. Append the updated VotersRecord to the log.
+ * 7. The KRaft internal listener will read this record from the log and add the new voter to the
+ *    set of voters.
+ * 8. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a
+ *    REQUEST_TIMED_OUT error if it doesn't succeed in time.
+ * 9. Send the AddVoter response to the client.
+ *
+ * The algorithm above could be improved as part of KAFKA-17147. Instead of returning an error
+ * immediately for 1. and 2., KRaft can wait with a timeout until those invariants become true.
+ */
+public final class AddVoterHandler {
+    private final KRaftControlRecordStateMachine partitionState;
+    private final RequestSender requestSender;
+    private final Time time;
+    private final Logger logger;
+
+    public AddVoterHandler(
+        KRaftControlRecordStateMachine partitionState,
+        RequestSender requestSender,
+        Time time,
+        LogContext logContext
+    ) {
+        this.partitionState = partitionState;
+        this.requestSender = requestSender;
+        this.time = time;
+        this.logger = logContext.logger(AddVoterHandler.class);
+    }
+
+    public CompletableFuture<AddRaftVoterResponseData> handleAddVoterRequest(
+        LeaderState<?> leaderState,
+        ReplicaKey voterKey,
+        Endpoints voterEndpoints,
+        long currentTimeMs
+    ) {
+        // Check if there are any pending add voter requests
+        if (isOperationPending(leaderState, currentTimeMs)) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to handle previous add voter request"
+                )
+            );
+        }
+
+        Optional<LogHistory.Entry<VoterSet>> votersEntry = partitionState.lastVoterSetEntry();
+
+        // Check that the leader has established a HWM and committed the current epoch
+        Optional<Long> highWatermark = leaderState.highWatermark().map(LogOffsetMetadata::offset);
+        if (!highWatermark.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to establish HWM and fence previous voter changes"
+                )
+            );
+        }
+
+        // Check that the cluster supports kraft.version >= 1
+        KRaftVersion kraftVersion = partitionState.lastKraftVersion();
+        if (!kraftVersion.isReconfigSupported()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.UNSUPPORTED_VERSION,
+                    String.format(
+                        "Cluster doesn't support adding voter because the %s feature is %s",
+                        kraftVersion.featureName(),
+                        kraftVersion.featureLevel()
+                    )
+                )
+            );
+        }
+
+        // Check that there are no uncommitted VotersRecord
+        if (!votersEntry.isPresent() || votersEntry.get().offset() >= highWatermark.get()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    String.format(
+                        "Request timed out waiting for voters to commit the latest voter change at %s with HWM %d",
+                        votersEntry.map(LogHistory.Entry::offset),
+                        highWatermark.get()
+                    )
+                )
+            );
+        }
+
+        // Check that the new voter id is not part of the current voter set
+        VoterSet voters = votersEntry.get().value();
+        if (voters.voterIds().contains(voterKey.id())) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.DUPLICATE_VOTER,
+                    String.format(
+                        "The voter id for %s is already part of the set of voters %s.",
+                        voterKey,
+                        voters.voterKeys()
+                    )
+                )
+            );
+        }
+
+        // Send API_VERSIONS request to new voter to discover their supported kraft.version range
+        OptionalLong timeout = requestSender.send(
+            voterEndpoints
+                .address(requestSender.listenerName())
+                .map(address -> new Node(voterKey.id(), address.getHostName(), address.getPort()))
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format(
+                            "Provided listeners %s do not contain a listener for %s",
+                            voterEndpoints,
+                            requestSender.listenerName()
+                        )
+                    )
+                ),
+            this::buildApiVersionsRequest,
+            currentTimeMs
+        );
+        if (!timeout.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.addVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    String.format("New voter %s is not ready to receive requests", voterKey)
+                )
+            );
+        }
+
+        AddVoterHandlerState state = new AddVoterHandlerState(
+            voterKey,
+            voterEndpoints,
+            time.timer(timeout.getAsLong())
+        );
+        leaderState.resetAddVoterHandlerState(
+            Errors.UNKNOWN_SERVER_ERROR,
+            null,
+            Optional.of(state)
+        );
+
+        return state.future();
+    }
+
+    public boolean handleApiVersionsResponse(
+        LeaderState<?> leaderState,
+        Node source,
+        Errors error,
+        Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions,
+        long currentTimeMs
+    ) {
+        Optional<AddVoterHandlerState> handlerState = leaderState.addVoterHandlerState();
+        if (!handlerState.isPresent()) {
+            // There are no pending add operation just ignore the api response
+            return true;
+        }
+
+
+        // Check that the API_VERSIONS response matches the id of the voter getting added
+        AddVoterHandlerState current = handlerState.get();
+        if (!current.expectingApiResponse(source.id())) {
+            logger.info(
+                "API_VERSIONS response is not expected from {}: voterKey is {}, lastOffset is {}",
+                source,
+                current.voterKey(),
+                current.lastOffset()
+            );
+
+            return true;
+        }
+
+        // Abort operation if the API_VERSIONS returned an error
+        if (error != Errors.NONE) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since API_VERSIONS returned an error {}",
+                current.voterKey(),
+                current.voterEndpoints(),
+                error
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.REQUEST_TIMED_OUT,
+                String.format(
+                    "Aborted add voter operation for since API_VERSIONS returned an error %s",
+                    error
+                )
+            );
+
+            return false;
+        }
+
+        // Check that the new voter supports the kraft.verion for reconfiguration
+        if (!validVersionRange(supportedKraftVersions)) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since kraft.version range {} doesn't " +
+                "support reconfiguration",
+                current.voterKey(),
+                current.voterEndpoints(),
+                supportedKraftVersions
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.INVALID_REQUEST,
+                String.format(
+                    "Aborted add voter operation for %s since kraft.version range %s doesn't " +
+                    "support reconfiguration",
+                    current.voterKey(),
+                    supportedKraftVersions
+                        .map(
+                            range -> String.format(
+                                "(min: %s, max: %s",
+                                range.minVersion(),
+                                range.maxVersion()
+                            )
+                        )
+                        .orElse("(min: 0, max: 0)")
+                )
+            );
+
+            return true;
+        }
+
+        // Check that the new voter is caught up to the LEO to avoid delays in HWM increases
+        if (!leaderState.isReplicaCaughtUp(current.voterKey(), currentTimeMs)) {
+            logger.info(
+                "Aborting add voter operation for {} at {} since it is lagging behind: {}",
+                current.voterKey(),
+                current.voterEndpoints(),
+                leaderState.getReplicaState(current.voterKey())
+            );
+
+            abortAddVoter(
+                leaderState,
+                Errors.REQUEST_TIMED_OUT,
+                String.format(
+                    "Aborted add voter operation for %s since it is lagging behind",
+                    current.voterKey()
+                )
+            );
+
+            return true;
+        }
+
+        // Add the new voter to the set of voters and append the record to the log
+        VoterSet newVoters = partitionState
+            .lastVoterSet()
+            .addVoter(
+                VoterSet.VoterNode.of(
+                    current.voterKey(),
+                    current.voterEndpoints(),
+                    new SupportedVersionRange(
+                        supportedKraftVersions.get().minVersion(),
+                        supportedKraftVersions.get().maxVersion()
+                    )
+                )
+            )
+            .orElseThrow(() ->
+                new IllegalStateException(
+                    String.format(
+                        "Unable to add %s to the set of voters %s",
+                        current.voterKey(),
+                        partitionState.lastVoterSet()
+                    )
+                )
+            );
+        current.setLastOffset(leaderState.appendVotersRecord(newVoters, currentTimeMs));
+
+        return true;
+    }
+
+    public void highWatermarkUpdated(LeaderState<?> leaderState) {
+        leaderState.addVoterHandlerState().ifPresent(current -> {
+            leaderState.highWatermark().ifPresent(highWatermark -> {
+                current.lastOffset().ifPresent(lastOffset -> {
+                    if (highWatermark.offset() > lastOffset) {
+                        // VotersRecord with the added voter was committed; complete the RPC
+                        completeAddVoter(leaderState);
+                    }
+                });
+            });
+        });
+    }
+
+    public long maybeExpirePendingOperation(LeaderState<?> leaderState, long currentTimeMs) {
+        long timeUntilOperationExpiration = leaderState
+            .addVoterHandlerState()
+            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+            .orElse(Long.MAX_VALUE);
+
+        if (timeUntilOperationExpiration == 0) {
+            abortAddVoter(leaderState, Errors.REQUEST_TIMED_OUT, null);
+            return Long.MAX_VALUE;
+        } else {
+            return timeUntilOperationExpiration;
+        }
+
+    }
+
+    private ApiVersionsRequestData buildApiVersionsRequest() {
+        return new ApiVersionsRequestData()
+            .setClientSoftwareName(ApiVersionsRequest.Builder.DEFAULT_CLIENT_SOFTWARE_NAME)
+            .setClientSoftwareVersion(AppInfoParser.getVersion());
+    }
+
+    private boolean isOperationPending(LeaderState<?> leaderState, long currentTimeMs) {
+        maybeExpirePendingOperation(leaderState, currentTimeMs);
+        return leaderState.addVoterHandlerState().isPresent();
+    }
+
+    private boolean validVersionRange(
+        Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions
+    ) {
+        return supportedKraftVersions.isPresent() &&
+            (supportedKraftVersions.get().minVersion() <= 1 &&
+             supportedKraftVersions.get().maxVersion() >= 1);
+    }
+
+    private void completeAddVoter(LeaderState<?> leaderState) {
+        leaderState.resetAddVoterHandlerState(Errors.NONE, null, Optional.empty());
+    }
+
+    private void abortAddVoter(LeaderState<?> leaderState, Errors error, String message) {
+        leaderState.resetAddVoterHandlerState(error, message, Optional.empty());
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
@@ -56,14 +56,14 @@ public final class AddVoterHandlerState implements AutoCloseable {
     public void setLastOffset(long lastOffset) {
         if (this.lastOffset.isPresent()) {
             throw new IllegalStateException(
-                    String.format(
-                        "Cannot override last offset to %s for adding voter %s because it is " +
-                        "already set to %s",
-                        lastOffset,
-                        voterKey,
-                        this.lastOffset
-                        )
-                    );
+                String.format(
+                    "Cannot override last offset to %s for adding voter %s because it is " +
+                    "already set to %s",
+                    lastOffset,
+                    voterKey,
+                    this.lastOffset
+                )
+            );
         }
 
         this.lastOffset = OptionalLong.of(lastOffset);

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.raft.RaftUtil;
+
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+public final class AddVoterHandlerState implements AutoCloseable {
+    private final ReplicaKey voterKey;
+    private final Endpoints voterEndpoints;
+    private final Timer timeout;
+    private final CompletableFuture<AddRaftVoterResponseData> future = new CompletableFuture<>();
+
+    private OptionalLong lastOffset = OptionalLong.empty();
+
+    AddVoterHandlerState(
+        ReplicaKey voterKey,
+        Endpoints voterEndpoints,
+        Timer timeout
+    ) {
+        this.voterKey = voterKey;
+        this.voterEndpoints = voterEndpoints;
+        this.timeout = timeout;
+    }
+
+    public long timeUntilOperationExpiration(long currentTimeMs) {
+        timeout.update(currentTimeMs);
+        return timeout.remainingMs();
+    }
+
+    public boolean expectingApiResponse(int replicaId) {
+        return !lastOffset.isPresent() && replicaId == voterKey.id();
+    }
+
+    public void setLastOffset(long lastOffset) {
+        if (this.lastOffset.isPresent()) {
+            throw new IllegalStateException(
+                    String.format(
+                        "Cannot override last offset to %s for adding voter %s because it is " +
+                        "already set to %s",
+                        lastOffset,
+                        voterKey,
+                        this.lastOffset
+                        )
+                    );
+        }
+
+        this.lastOffset = OptionalLong.of(lastOffset);
+    }
+
+    public ReplicaKey voterKey() {
+        return voterKey;
+    }
+
+    public Endpoints voterEndpoints() {
+        return voterEndpoints;
+    }
+
+    public OptionalLong lastOffset() {
+        return lastOffset;
+    }
+
+    public CompletableFuture<AddRaftVoterResponseData> future() {
+        return future;
+    }
+
+    @Override
+    public void close() {
+        future.complete(RaftUtil.addVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER, null));
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.raft.NetworkChannel;
+import org.apache.kafka.raft.RaftMessageQueue;
+import org.apache.kafka.raft.RaftRequest;
+import org.apache.kafka.raft.RaftResponse;
+import org.apache.kafka.raft.RaftUtil;
+import org.apache.kafka.raft.RequestManager;
+
+import org.slf4j.Logger;
+
+import java.util.OptionalLong;
+import java.util.function.Supplier;
+
+public final class DefaultRequestSender  implements RequestSender {
+    private final RequestManager requestManager;
+    private final NetworkChannel channel;
+    private final RaftMessageQueue messageQueue;
+    private final Logger logger;
+
+    public DefaultRequestSender(
+        RequestManager requestManager,
+        NetworkChannel channel,
+        RaftMessageQueue messageQueue,
+        LogContext logContext
+    ) {
+        this.requestManager = requestManager;
+        this.channel = channel;
+        this.messageQueue = messageQueue;
+        this.logger = logContext.logger(DefaultRequestSender.class);
+    }
+
+    @Override
+    public ListenerName listenerName() {
+        return channel.listenerName();
+    }
+
+    @Override
+    public OptionalLong send(
+        Node destination,
+        Supplier<ApiMessage> requestSupplier,
+        long currentTimeMs
+    ) {
+        if (requestManager.isBackingOff(destination, currentTimeMs)) {
+            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs);
+            logger.debug("Connection for {} is backing off for {} ms", destination, remainingBackoffMs);
+            return OptionalLong.empty();
+        }
+
+        if (!requestManager.isReady(destination, currentTimeMs)) {
+            long remainingMs = requestManager.remainingRequestTimeMs(destination, currentTimeMs);
+            logger.debug("Connection for {} has a pending request for {} ms", destination, remainingMs);
+            return OptionalLong.empty();
+        }
+
+        int correlationId = channel.newCorrelationId();
+        ApiMessage request = requestSupplier.get();
+
+        RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
+            correlationId,
+            request,
+            destination,
+            currentTimeMs
+        );
+
+        requestMessage.completion.whenComplete((response, exception) -> {
+            if (exception != null) {
+                ApiKeys api = ApiKeys.forId(request.apiKey());
+                Errors error = Errors.forException(exception);
+                ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
+
+                response = new RaftResponse.Inbound(
+                    correlationId,
+                    errorResponse,
+                    destination
+                );
+            }
+
+            messageQueue.add(response);
+        });
+
+        requestManager.onRequestSent(destination, correlationId, currentTimeMs);
+        channel.send(requestMessage);
+        logger.trace("Sent outbound request: {}", requestMessage);
+
+        return OptionalLong.of(requestManager.remainingRequestTimeMs(destination, currentTimeMs));
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestSender.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import java.util.OptionalLong;
+import java.util.function.Supplier;
+
+/**
+ * Interface for sending KRaft requests.
+ *
+ * Responsible for managing the connection state and sending request when the connection is
+ * available.
+ */
+interface RequestSender {
+    /**
+     * The name of the listener used for sending request.
+     *
+     * This is generally the default (first) listener.
+     */
+    ListenerName listenerName();
+
+    /**
+     * Send a KRaft request to the destination.
+     *
+     * @param destination the destination for the request
+     * @param requestSupplier the default constructor for the request
+     * @param currentTimeMs the current time
+     * @return the request timeout if the request was sent; otherwise {@code Optional.empty()}
+     */
+    OptionalLong send(
+        Node destination,
+        Supplier<ApiMessage> requestSupplier,
+        long currentTimeMs
+    );
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -363,6 +363,14 @@ public final class VoterSet {
                 supportedKRaftVersion
             );
         }
+
+        public static VoterNode of(
+            ReplicaKey voterKey,
+            Endpoints listeners,
+            SupportedVersionRange supportedKRaftVersion
+        ) {
+            return new VoterNode(voterKey, listeners, supportedKRaftVersion);
+        }
     }
 
     /**

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSetHistory.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSetHistory.java
@@ -93,6 +93,13 @@ public final class VoterSetHistory {
     }
 
     /**
+     * Return the latest entry for the set of voters.
+     */
+    public Optional<LogHistory.Entry<VoterSet>> lastEntry() {
+        return votersHistory.lastEntry();
+    }
+
+    /**
      * Returns the offset of the last voter set stored in the partition history.
      *
      * Returns {@code OptionalLong.empty} if the last voter set is from the static voters

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -875,7 +875,7 @@ public class KafkaRaftClientReconfigTest {
             apiVersionRequest.destination()
         );
 
-        // Reply with API_VERSIONS response with supported kraft.version
+        // Reply with API_VERSIONS response that doesn't support kraft.version 1
         context.deliverResponse(
             apiVersionRequest.correlationId(),
             apiVersionRequest.destination(),

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.kafka.raft;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.KRaftVersionRecord;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
+import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.ControlRecordUtils;
@@ -35,18 +39,22 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
+import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.snapshot.RecordsSnapshotReader;
 import org.apache.kafka.snapshot.SnapshotReader;
 import org.apache.kafka.snapshot.SnapshotWriterReaderTest;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.raft.KafkaRaftClientTest.replicaKey;
@@ -55,12 +63,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+// KAFKA-16537 will add tests for testAddVoterWithPendingRemoveVoter
+// and testRemoveVoterWithPendingAddVoter
 public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testLeaderWritesBootstrapRecords() throws Exception {
-        ReplicaKey local = replicaKey(0, true);
-        ReplicaKey follower = replicaKey(1, true);
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
 
@@ -134,8 +144,8 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testBootstrapCheckpointIsNotReturnedOnFetch() throws Exception {
-        ReplicaKey local = replicaKey(0, true);
-        ReplicaKey follower = replicaKey(1, true);
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
 
@@ -164,13 +174,13 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testLeaderDoesNotBootstrapRecordsWithKraftVersion0() throws Exception {
-        ReplicaKey local = replicaKey(0, true);
-        ReplicaKey follower = replicaKey(1, true);
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
-            .withStaticVoters(voters.voterIds())
+            .withStaticVoters(voters)
             .withBootstrapSnapshot(Optional.empty())
             .withUnknownLeader(0)
             .build();
@@ -226,8 +236,8 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testFollowerDoesNotRequestLeaderBootstrapSnapshot() throws Exception {
-        ReplicaKey local = replicaKey(0, true);
-        ReplicaKey leader = replicaKey(1, true);
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey leader = replicaKey(local.id() + 1, true);
         int epoch = 1;
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, leader));
@@ -256,9 +266,9 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testFollowerReadsKRaftBootstrapRecords() throws Exception {
-        ReplicaKey local = replicaKey(0, true);
-        ReplicaKey leader = replicaKey(1, true);
-        ReplicaKey follower = replicaKey(2, true);
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey leader = replicaKey(local.id() + 1, true);
+        ReplicaKey follower = replicaKey(local.id() + 2, true);
         VoterSet voterSet = VoterSetTest.voterSet(Stream.of(local, leader));
         int epoch = 5;
 
@@ -324,6 +334,609 @@ public class KafkaRaftClientReconfigTest {
         assertTrue(context.client.quorum().isVoter(follower));
     }
 
+    @Test
+    public void testAddVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Show that the new voter is not currently a voter
+        assertFalse(context.client.quorum().isVoter(newVoter));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+
+        // Handle the the API_VERSIONS response
+        context.client.poll();
+        // Append new VotersRecord to log
+        context.client.poll();
+        // The new voter is now a voter after writing the VotersRecord to the log
+        assertTrue(context.client.quorum().isVoter(newVoter));
+
+        // Send a FETCH to increase the HWM and commit the new voter set
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Expect reply for AddVoter request
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.NONE);
+    }
+
+    @Test
+    void testAddVoterInvalidClusterId() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // empty cluster id is rejected
+        context.deliverRequest(context.addVoterRequest("", Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+
+        // invalid cluster id is rejected
+        context.deliverRequest(context.addVoterRequest("invalid-uuid", Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+    }
+
+    @Test
+    void testAddVoterToNotLeader() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+    }
+
+    @Test
+    void testAddVoterWithMissingDefaultListener() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(ListenerName.normalised("not_the_default_listener"), newAddress)
+        );
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    void testAddVoterWithPendingAddVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Attempting to add another voter should be an error
+        ReplicaKey anotherNewVoter = replicaKey(local.id() + 3, true);
+        InetSocketAddress anotherNewAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + anotherNewVoter.id()
+        );
+        Endpoints anotherNewListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), anotherNewAddress)
+        );
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, anotherNewVoter, anotherNewListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithoutFencedPreviousLeaders() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithKraftVersion0() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withStaticVoters(voters)
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.UNSUPPORTED_VERSION);
+    }
+
+    @Test
+    void testAddVoterWithExistingVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(follower.id(), true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter with the same id as an existing voter
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.DUPLICATE_VOTER);
+    }
+
+    @Test
+    void testAddVoterTimeout() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Show that the new voter is not currently a voter
+        assertFalse(context.client.quorum().isVoter(newVoter));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+
+        // Handle the the API_VERSIONS response
+        context.client.poll();
+        // Append new VotersRecord to log
+        context.client.poll();
+        // The new voter is now a voter after writing the VotersRecord to the log
+        assertTrue(context.client.quorum().isVoter(newVoter));
+
+        context.time.sleep(context.requestTimeoutMs());
+
+        // Expect the AddVoter RPC to timeout
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithApiVersionsFromIncorrectNode() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.INVALID_REQUEST)
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterInvalidFeatureVersion() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE, new SupportedVersionRange((short) 0))
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    void testAddVoterWithLaggingNewVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
     private static void verifyVotersRecord(
         VoterSet expectedVoterSet,
         ByteBuffer recordKey,
@@ -345,5 +958,31 @@ public class KafkaRaftClientReconfigTest {
         assertEquals(ControlRecordType.KRAFT_VERSION, ControlRecordType.parse(recordKey));
         KRaftVersionRecord kRaftVersionRecord = ControlRecordUtils.deserializeKRaftVersionRecord(recordValue);
         assertEquals(expectedKRaftVersion, kRaftVersionRecord.kRaftVersion());
+    }
+
+    private int randomeReplicaId() {
+        return ThreadLocalRandom.current().nextInt(1025);
+    }
+
+    private static ApiVersionsResponseData apiVersionsResponse(Errors error) {
+        return apiVersionsResponse(error, new SupportedVersionRange((short) 0, (short) 1));
+    }
+
+    private static ApiVersionsResponseData apiVersionsResponse(Errors error, SupportedVersionRange supportedVersions) {
+        ApiVersionsResponseData.SupportedFeatureKeyCollection supportedFeatures =
+            new ApiVersionsResponseData.SupportedFeatureKeyCollection(1);
+
+        if (supportedVersions.max() > 0) {
+            supportedFeatures.add(
+                new ApiVersionsResponseData.SupportedFeatureKey()
+                    .setName(KRaftVersion.FEATURE_NAME)
+                    .setMinVersion(supportedVersions.min())
+                    .setMaxVersion(supportedVersions.max())
+            );
+        }
+
+        return new ApiVersionsResponseData()
+            .setErrorCode(error.code())
+            .setSupportedFeatures(supportedFeatures);
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java.orig
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java.orig
@@ -1,0 +1,988 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.KRaftVersionRecord;
+import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.SnapshotFooterRecord;
+import org.apache.kafka.common.message.SnapshotHeaderRecord;
+import org.apache.kafka.common.message.VotersRecord;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.ControlRecordUtils;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.Records;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.raft.internals.ReplicaKey;
+import org.apache.kafka.raft.internals.VoterSet;
+import org.apache.kafka.raft.internals.VoterSetTest;
+import org.apache.kafka.server.common.KRaftVersion;
+import org.apache.kafka.snapshot.RecordsSnapshotReader;
+import org.apache.kafka.snapshot.SnapshotReader;
+import org.apache.kafka.snapshot.SnapshotWriterReaderTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+import static org.apache.kafka.raft.KafkaRaftClientTest.replicaKey;
+import static org.apache.kafka.snapshot.Snapshots.BOOTSTRAP_SNAPSHOT_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// KAFKA-16537 will add tests for testAddVoterWithPendingRemoveVoter
+// and testRemoveVoterWithPendingAddVoter
+public class KafkaRaftClientReconfigTest {
+
+    @Test
+    public void testLeaderWritesBootstrapRecords() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(0)
+            .build();
+
+        List<List<ControlRecord>> expectedBootstrapRecords = Arrays.asList(
+            Arrays.asList(
+                new ControlRecord(
+                    ControlRecordType.SNAPSHOT_HEADER,
+                    new SnapshotHeaderRecord()
+                        .setVersion((short) 0)
+                        .setLastContainedLogTimestamp(0)
+                ),
+                new ControlRecord(
+                    ControlRecordType.KRAFT_VERSION,
+                    new KRaftVersionRecord()
+                        .setVersion(ControlRecordUtils.KRAFT_VERSION_CURRENT_VERSION)
+                        .setKRaftVersion((short) 1)
+                ),
+                new ControlRecord(
+                    ControlRecordType.KRAFT_VOTERS,
+                    voters.toVotersRecord(ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION)
+                )
+            ),
+            Arrays.asList(
+                new ControlRecord(
+                    ControlRecordType.SNAPSHOT_FOOTER,
+                    new SnapshotFooterRecord()
+                        .setVersion((short) 0)
+                )
+            )
+        );
+
+        // check the bootstrap snapshot exists and contains the expected records
+        assertEquals(BOOTSTRAP_SNAPSHOT_ID, context.log.latestSnapshotId().get());
+        try (SnapshotReader<?> reader = RecordsSnapshotReader.of(
+                context.log.latestSnapshot().get(),
+                context.serde,
+                BufferSupplier.NO_CACHING,
+                KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+                false
+            )
+        ) {
+            SnapshotWriterReaderTest.assertControlSnapshot(expectedBootstrapRecords, reader);
+        }
+
+        context.becomeLeader();
+
+        // check if leader writes 3 bootstrap records to the log
+        Records records = context.log.read(0, Isolation.UNCOMMITTED).records;
+        RecordBatch batch = records.batches().iterator().next();
+        assertTrue(batch.isControlBatch());
+        Iterator<Record> recordIterator = batch.iterator();
+        Record record = recordIterator.next();
+        RaftClientTestContext.verifyLeaderChangeMessage(
+            local.id(),
+            Arrays.asList(local.id(), follower.id()),
+            Arrays.asList(local.id(), follower.id()),
+            record.key(),
+            record.value()
+        );
+        record = recordIterator.next();
+        verifyKRaftVersionRecord((short) 1, record.key(), record.value());
+        record = recordIterator.next();
+        verifyVotersRecord(voters, record.key(), record.value());
+    }
+
+    @Test
+    public void testBootstrapCheckpointIsNotReturnedOnFetch() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(0)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        // check that leader does not respond with bootstrap snapshot id when follower fetches offset 0
+        context.deliverRequest(
+            context.fetchRequest(
+                epoch,
+                follower,
+                0,
+                0,
+                0
+            )
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+    }
+
+    @Test
+    public void testLeaderDoesNotBootstrapRecordsWithKraftVersion0() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withStaticVoters(voters)
+            .withBootstrapSnapshot(Optional.empty())
+            .withUnknownLeader(0)
+            .build();
+
+        List<List<ControlRecord>> expectedBootstrapRecords = Arrays.asList(
+            Arrays.asList(
+                new ControlRecord(
+                    ControlRecordType.SNAPSHOT_HEADER,
+                    new SnapshotHeaderRecord()
+                        .setVersion((short) 0)
+                        .setLastContainedLogTimestamp(0)
+                )
+            ),
+            Arrays.asList(
+                new ControlRecord(
+                    ControlRecordType.SNAPSHOT_FOOTER,
+                    new SnapshotFooterRecord()
+                        .setVersion((short) 0)
+                )
+            )
+        );
+
+        // check the bootstrap snapshot exists but is empty
+        assertEquals(BOOTSTRAP_SNAPSHOT_ID, context.log.latestSnapshotId().get());
+        try (SnapshotReader<?> reader = RecordsSnapshotReader.of(
+                context.log.latestSnapshot().get(),
+                context.serde,
+                BufferSupplier.NO_CACHING,
+                KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+                false
+            )
+        ) {
+            SnapshotWriterReaderTest.assertControlSnapshot(expectedBootstrapRecords, reader);
+        }
+
+        // check leader does not write bootstrap records to log
+        context.becomeLeader();
+
+        Records records = context.log.read(0, Isolation.UNCOMMITTED).records;
+        RecordBatch batch = records.batches().iterator().next();
+        assertTrue(batch.isControlBatch());
+        Iterator<Record> recordIterator = batch.iterator();
+        Record record = recordIterator.next();
+        RaftClientTestContext.verifyLeaderChangeMessage(
+            local.id(),
+            Arrays.asList(local.id(), follower.id()),
+            Arrays.asList(local.id(), follower.id()),
+            record.key(),
+            record.value()
+        );
+        assertFalse(recordIterator.hasNext());
+    }
+
+    @Test
+    public void testFollowerDoesNotRequestLeaderBootstrapSnapshot() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey leader = replicaKey(local.id() + 1, true);
+        int epoch = 1;
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, leader));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withElectedLeader(epoch, leader.id())
+            .build();
+
+        // check that follower will send fetch request to leader
+        context.pollUntilRequest();
+        RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
+
+        // check if leader response were to contain bootstrap snapshot id, follower would not send fetch snapshot request
+        context.deliverResponse(
+            fetchRequest.correlationId(),
+            fetchRequest.destination(),
+            context.snapshotFetchResponse(epoch, leader.id(), BOOTSTRAP_SNAPSHOT_ID, 0)
+        );
+        context.pollUntilRequest();
+        fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
+    }
+
+    @Test
+    public void testFollowerReadsKRaftBootstrapRecords() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey leader = replicaKey(local.id() + 1, true);
+        ReplicaKey follower = replicaKey(local.id() + 2, true);
+        VoterSet voterSet = VoterSetTest.voterSet(Stream.of(local, leader));
+        int epoch = 5;
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voterSet))
+            .withElectedLeader(epoch, leader.id())
+            .build();
+
+        // check that follower will send fetch request to leader
+        context.pollUntilRequest();
+        RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
+
+        // check that before receiving bootstrap records from leader, follower is not in the voter set
+        assertFalse(context.client.quorum().isVoter(follower));
+
+        // leader sends batch with bootstrap records
+        VoterSet leadersVoterSet = VoterSetTest.voterSet(
+            Stream.concat(voterSet.voterKeys().stream(), Stream.of(follower))
+        );
+        ByteBuffer buffer = ByteBuffer.allocate(128);
+        try (MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+                buffer,
+                RecordBatch.CURRENT_MAGIC_VALUE,
+                Compression.NONE,
+                TimestampType.CREATE_TIME,
+                0, // baseOffset
+                0, // logAppendTime
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE,
+                false, // isTransactional
+                true, // isControlBatch
+                epoch,
+                buffer.capacity()
+            )
+        ) {
+            builder.appendLeaderChangeMessage(
+                0,
+                new LeaderChangeMessage()
+            );
+            builder.appendKRaftVersionMessage(
+                0, // timesteamp
+                new KRaftVersionRecord()
+                    .setVersion(ControlRecordUtils.KRAFT_VERSION_CURRENT_VERSION)
+                    .setKRaftVersion((short) 1)
+            );
+            builder.appendVotersMessage(
+                0, // timesteamp
+                leadersVoterSet.toVotersRecord(ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION)
+            );
+            MemoryRecords leaderRecords = builder.build();
+            context.deliverResponse(
+                fetchRequest.correlationId(),
+                fetchRequest.destination(),
+                context.fetchResponse(epoch, leader.id(), leaderRecords, 0, Errors.NONE)
+            );
+        }
+
+        // follower applies the bootstrap records, registering follower2 as a new voter
+        context.client.poll();
+        assertTrue(context.client.quorum().isVoter(follower));
+    }
+
+    @Test
+    public void testAddVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Show that the new voter is not currently a voter
+        assertFalse(context.client.quorum().isVoter(newVoter));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+
+        // Handle the the API_VERSIONS response
+        context.client.poll();
+        // Append new VotersRecord to log
+        context.client.poll();
+        // The new voter is now a voter after writing the VotersRecord to the log
+        assertTrue(context.client.quorum().isVoter(newVoter));
+
+        // Send a FETCH to increase the HWM and commit the new voter set
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Expect reply for AddVoter request
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.NONE);
+    }
+
+    @Test
+    void testAddVoterInvalidClusterId() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // empty cluster id is rejected
+        context.deliverRequest(context.addVoterRequest("", Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+
+        // invalid cluster id is rejected
+        context.deliverRequest(context.addVoterRequest("invalid-uuid", Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+    }
+
+    @Test
+    void testAddVoterToNotLeader() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+    }
+
+    @Test
+    void testAddVoterWithMissingDefaultListener() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(ListenerName.normalised("not_the_default_listener"), newAddress)
+        );
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    void testAddVoterWithPendingAddVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Attempting to add another voter should be an error
+        ReplicaKey anotherNewVoter = replicaKey(local.id() + 3, true);
+        InetSocketAddress anotherNewAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + anotherNewVoter.id()
+        );
+        Endpoints anotherNewListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), anotherNewAddress)
+        );
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, anotherNewVoter, anotherNewListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithoutFencedPreviousLeaders() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithKraftVersion0() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withStaticVoters(voters)
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.UNSUPPORTED_VERSION);
+    }
+
+    @Test
+    void testAddVoterWithExistingVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(follower.id(), true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter with the same id as an existing voter
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.DUPLICATE_VOTER);
+    }
+
+    @Test
+    void testAddVoterTimeout() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Show that the new voter is not currently a voter
+        assertFalse(context.client.quorum().isVoter(newVoter));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+
+        // Handle the the API_VERSIONS response
+        context.client.poll();
+        // Append new VotersRecord to log
+        context.client.poll();
+        // The new voter is now a voter after writing the VotersRecord to the log
+        assertTrue(context.client.quorum().isVoter(newVoter));
+
+        context.time.sleep(context.requestTimeoutMs());
+
+        // Expect the AddVoter RPC to timeout
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterWithApiVersionsFromIncorrectNode() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.INVALID_REQUEST)
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testAddVoterInvalidFeatureVersion() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Catch up the new voter to the leader's LEO
+        context.deliverRequest(
+            context.fetchRequest(epoch, newVoter, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE, new SupportedVersionRange((short) 0))
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    void testAddVoterWithLaggingNewVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower = replicaKey(local.id() + 1, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        ReplicaKey newVoter = replicaKey(local.id() + 2, true);
+        InetSocketAddress newAddress = InetSocketAddress.createUnresolved(
+            "localhost",
+            9990 + newVoter.id()
+        );
+        Endpoints newListeners = Endpoints.fromInetSocketAddresses(
+            Collections.singletonMap(context.channel.listenerName(), newAddress)
+        );
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
+
+        // Leader should send an API_VERSIONS request to the new voter's endpoint
+        context.pollUntilRequest();
+        RaftRequest.Outbound apiVersionRequest = context.assertSentApiVersionsRequest();
+        assertEquals(
+            new Node(newVoter.id(), newAddress.getHostString(), newAddress.getPort()),
+            apiVersionRequest.destination()
+        );
+
+        // Reply with API_VERSIONS response with supported kraft.version
+        context.deliverResponse(
+            apiVersionRequest.correlationId(),
+            apiVersionRequest.destination(),
+            apiVersionsResponse(Errors.NONE)
+        );
+        context.pollUntilResponse();
+        context.assertSentAddVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    private static void verifyVotersRecord(
+        VoterSet expectedVoterSet,
+        ByteBuffer recordKey,
+        ByteBuffer recordValue
+    ) {
+        assertEquals(ControlRecordType.KRAFT_VOTERS, ControlRecordType.parse(recordKey));
+        VotersRecord votersRecord = ControlRecordUtils.deserializeVotersRecord(recordValue);
+        assertEquals(
+            expectedVoterSet,
+            VoterSet.fromVotersRecord(votersRecord)
+        );
+    }
+
+    private static void verifyKRaftVersionRecord(
+        short expectedKRaftVersion,
+        ByteBuffer recordKey,
+        ByteBuffer recordValue
+    ) {
+        assertEquals(ControlRecordType.KRAFT_VERSION, ControlRecordType.parse(recordKey));
+        KRaftVersionRecord kRaftVersionRecord = ControlRecordUtils.deserializeKRaftVersionRecord(recordValue);
+        assertEquals(expectedKRaftVersion, kRaftVersionRecord.kRaftVersion());
+    }
+
+    private int randomeReplicaId() {
+        return ThreadLocalRandom.current().nextInt(1025);
+    }
+
+    private static ApiVersionsResponseData apiVersionsResponse(Errors error) {
+        return apiVersionsResponse(error, new SupportedVersionRange((short) 0, (short) 1));
+    }
+
+    private static ApiVersionsResponseData apiVersionsResponse(Errors error, SupportedVersionRange supportedVersions) {
+        ApiVersionsResponseData.SupportedFeatureKeyCollection supportedFeatures =
+            new ApiVersionsResponseData.SupportedFeatureKeyCollection(1);
+
+        if (supportedVersions.max() > 0) {
+            supportedFeatures.add(
+                new ApiVersionsResponseData.SupportedFeatureKey()
+                    .setName(KRaftVersion.FEATURE_NAME)
+                    .setMinVersion(supportedVersions.min())
+                    .setMaxVersion(supportedVersions.max())
+            );
+        }
+
+        return new ApiVersionsResponseData()
+            .setErrorCode(error.code())
+            .setSupportedFeatures(supportedFeatures);
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -21,6 +21,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.AddRaftVoterRequestData;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
@@ -300,12 +303,16 @@ public final class RaftClientTestContext {
                     Collectors.toMap(Function.identity(), RaftClientTestContext::mockAddress)
                 );
 
-            this.startingVoters = Optional.of(
+            return withStaticVoters(
                 VoterSet.fromInetSocketAddresses(
                     MockNetworkChannel.LISTENER_NAME,
                     staticVoterAddressMap
                 )
             );
+        }
+
+        Builder withStaticVoters(VoterSet staticVoters) {
+            this.startingVoters = Optional.of(staticVoters);
             this.isStartingVotersStatic = true;
 
             return this;
@@ -1081,6 +1088,26 @@ public final class RaftClientTestContext {
         return result;
     }
 
+    RaftRequest.Outbound assertSentApiVersionsRequest() {
+        List<RaftRequest.Outbound> sentRequests = channel.drainSentRequests(Optional.of(ApiKeys.API_VERSIONS));
+        assertEquals(1, sentRequests.size());
+
+        return sentRequests.get(0);
+    }
+
+    AddRaftVoterResponseData assertSentAddVoterResponse(Errors error) {
+        List<RaftResponse.Outbound> sentResponses = drainSentResponses(ApiKeys.ADD_RAFT_VOTER);
+        assertEquals(1, sentResponses.size());
+
+        RaftResponse.Outbound response = sentResponses.get(0);
+        assertInstanceOf(AddRaftVoterResponseData.class, response.data());
+
+        AddRaftVoterResponseData addVoterResponse = (AddRaftVoterResponseData) response.data();
+        assertEquals(error, Errors.forCode(addVoterResponse.errorCode()));
+
+        return addVoterResponse;
+    }
+
     List<RaftRequest.Outbound> collectEndQuorumRequests(
         int epoch,
         Set<Integer> destinationIdSet,
@@ -1339,12 +1366,8 @@ public final class RaftClientTestContext {
             voters
                 .stream()
                 .map(voterId -> new Voter().setVoterId(voterId))
-                .collect(Collectors.toList()),
-            leaderChangeMessage
-                    .voters()
-                    .stream()
-                    .sorted(Comparator.comparingInt(Voter::voterId))
-                    .collect(Collectors.toList())
+                .collect(Collectors.toSet()),
+            new HashSet<>(leaderChangeMessage.voters())
         );
         assertEquals(
             grantingVoters
@@ -1545,6 +1568,34 @@ public final class RaftClientTestContext {
         return RaftUtil.singletonDescribeQuorumRequest(metadataPartition);
     }
 
+    AddRaftVoterRequestData addVoterRequest(
+        int timeoutMs,
+        ReplicaKey voter,
+        Endpoints endpoints
+    ) {
+        return addVoterRequest(
+            clusterId.toString(),
+            timeoutMs,
+            voter,
+            endpoints
+        );
+    }
+
+    AddRaftVoterRequestData addVoterRequest(
+        String clusterId,
+        int timeoutMs,
+        ReplicaKey voter,
+        Endpoints endpoints
+    ) {
+        return RaftUtil.addVoterRequest(
+            clusterId,
+            timeoutMs,
+            voter,
+            endpoints
+        );
+    }
+
+
     private short fetchRpcVersion() {
         if (kip853Rpc) {
             return 17;
@@ -1593,6 +1644,15 @@ public final class RaftClientTestContext {
         }
     }
 
+    private short addVoterRpcVersion() {
+        if (kip853Rpc) {
+            return 0;
+        } else {
+            throw new IllegalStateException("Reconfiguration must be enabled by calling withKip853Rpc(true)");
+        }
+    }
+
+
     private short raftRequestVersion(ApiMessage request) {
         if (request instanceof FetchRequestData) {
             return fetchRpcVersion();
@@ -1606,6 +1666,8 @@ public final class RaftClientTestContext {
             return endQuorumEpochRpcVersion();
         } else if (request instanceof DescribeQuorumRequestData) {
             return describeQuorumRpcVersion();
+        } else if (request instanceof AddRaftVoterRequestData) {
+            return addVoterRpcVersion();
         } else {
             throw new IllegalArgumentException(String.format("Request %s is not a raft request", request));
         }
@@ -1624,6 +1686,10 @@ public final class RaftClientTestContext {
             return endQuorumEpochRpcVersion();
         } else if (response instanceof DescribeQuorumResponseData) {
             return describeQuorumRpcVersion();
+        } else if (response instanceof AddRaftVoterResponseData) {
+            return addVoterRpcVersion();
+        } else if (response instanceof ApiVersionsResponseData) {
+            return 4;
         } else {
             throw new IllegalArgumentException(String.format("Request %s is not a raft response", response));
         }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -1652,7 +1652,6 @@ public final class RaftClientTestContext {
         }
     }
 
-
     private short raftRequestVersion(ApiMessage request) {
         if (request instanceof FetchRequestData) {
             return fetchRpcVersion();


### PR DESCRIPTION
This change implements the AddVoter RPC. The high-level algorithm is as follow:

1. Check that the leader has fenced the previous leader(s) by checking that the HWM is known, otherwise return the REQUEST_TIMED_OUT error.
2. Check that the cluster supports kraft.version 1, otherwise return the UNSUPPORTED_VERSION error.
3. Check that there are no uncommitted voter changes, otherwise return the REQUEST_TIMED_OUT error.
4. Check that the new voter's id is not part of the existing voter set, otherwise return the DUPLICATE_VOTER error.
5. Send an API_VERSIONS RPC to the first (default) listener to discover the supported kraft.version of the new voter.
6. Check that the new voter supports the current kraft.version, otherwise return the INVALID_REQUEST error.
7. Check that the new voter is caught up to the log end offset of the leader, otherwise return a REQUEST_TIMED_OUT error.
8. Append the updated VotersRecord to the log.
The KRaft internal listener will read this uncommitted record from the log and add the new voter to the set of voters.
9. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a REQUEST_TIMED_OUT error if it doesn't commit in time.
10. Send the AddVoter successful response to the client.

The leader implements the above algorithm by tracking 3 events: the ADD_VOTER request is received, the API_VERSIONS response is received and finally the HWM is updated.

The state of the ADD_VOTER operation is tracked by LeaderState using the AddVoterHandlerState. The algorithm is implemented by the AddVoterHandler type.

This change also fixes a small issue introduced by the bootstrap checkpoint (0-0.checkpoint). The internal partition listener (KRaftControlRecordStateMachine) and the external partition listener (KafkaRaftClient.ListenerContext) were using "nextOffset = 0" as the initial state of the reading cursor. This was causing the bootstrap checkpoint to keep getting reloaded until the leader wrote a record to the log. Changing the initial offset (nextOffset) to -1 allows the listeners to distinguish between the initial state (nextOffset == -1) and the bootstrap checkpoint was loaded but the log segment is empty (nextOffset == 0).