### PR TITLE
KAFKA-17152: Make sure zk session tracker gets down when closing embedded zk.

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -53,10 +53,12 @@ class EmbeddedZookeeper extends Closeable with Logging {
     // Also shuts down ZooKeeperServer
     CoreUtils.swallow(factory.shutdown(), this)
 
-    val sessionTracker: SessionTrackerImpl = zookeeper.getSessionTracker.asInstanceOf[SessionTrackerImpl]
-    while (sessionTracker.isAlive) {
-      // wait sessionTracker close.
-      Thread.sleep(100)
+    zookeeper.getSessionTracker match {
+      case tracker: SessionTrackerImpl =>
+        while (tracker.isAlive) {
+          Thread.sleep(100)
+        }
+      case _ =>
     }
 
     def isDown(): Boolean = {

--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -17,8 +17,7 @@
 
 package kafka.zk
 
-import org.apache.zookeeper.server.ZooKeeperServer
-import org.apache.zookeeper.server.NIOServerCnxnFactory
+import org.apache.zookeeper.server.{NIOServerCnxnFactory, SessionTrackerImpl, ZooKeeperServer}
 import kafka.utils.{CoreUtils, Logging, TestUtils}
 
 import java.net.InetSocketAddress
@@ -53,6 +52,12 @@ class EmbeddedZookeeper extends Closeable with Logging {
   def shutdown(): Unit = {
     // Also shuts down ZooKeeperServer
     CoreUtils.swallow(factory.shutdown(), this)
+
+    val sessionTracker: SessionTrackerImpl = zookeeper.getSessionTracker.asInstanceOf[SessionTrackerImpl]
+    while (sessionTracker.isAlive) {
+      // wait sessionTracker close.
+      Thread.sleep(100)
+    }
 
     def isDown(): Boolean = {
       try {


### PR DESCRIPTION
When `SessionTrackerImpl` exits the loop in the background, it can remain active for a while after Zookeeper shuts down. Therefore, we should include a short wait time when closing `EmbeddedZookeeper` to ensure it shuts down completely.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
