### PR TITLE
KAFKA-16855 : Based on tiered state of topic, check for tasks

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -469,7 +469,7 @@ public class RemoteLogManager implements Closeable {
             leaderPartitions.forEach(this::doHandleLeaderPartition);
 
             // Based on tiered state of a topic, cancel or create "copy" and "expire" tasks
-            if(validateTasksForTieredStateOfTopic) {
+            if (validateTasksForTieredStateOfTopic) {
                 leaderPartitions.forEach(leaderPartition -> validateCopyAndExpireTasks(leaderPartition, tieredStateOfTopic));
             }
         }
@@ -1809,7 +1809,7 @@ public class RemoteLogManager implements Closeable {
     }
 
     void validateCopyAndExpireTasks(TopicIdPartition topicPartition, boolean tieredStateOfTopic) {
-        if(tieredStateOfTopic) {
+        if (tieredStateOfTopic) {
             // make sure a copy task is available
             leaderCopyRLMTasks.computeIfAbsent(topicPartition, topicIdPartition -> {
                 RLMCopyTask task = new RLMCopyTask(topicIdPartition, this.rlmConfig.remoteLogMetadataCustomMetadataMaxBytes());

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1808,6 +1808,13 @@ public class RemoteLogManager implements Closeable {
                 new RemoteLogReader(fetchInfo, this, callback, brokerTopicStats, rlmFetchQuotaManager, remoteReadTimer));
     }
 
+    /**
+     * this method validates the copy and expiry tasks based on tiered state of a topic.
+     * If tieredState of the topic is enabled, make sure copy task exists and expiration task
+     * If tieredState of the topic is disabled, make sure copy task doesn't exist and and expiration task exists
+     * @param topicPartition leader topic id partition
+     * @param tieredStateOfTopic tiered state of a topic
+     */
     void validateCopyAndExpireTasks(TopicIdPartition topicPartition, boolean tieredStateOfTopic) {
         if (tieredStateOfTopic) {
             // make sure a copy task is available
@@ -1821,7 +1828,7 @@ public class RemoteLogManager implements Closeable {
         } else {
             // make sure no copy task exists
             leaderCopyRLMTasks.computeIfPresent(topicPartition, (topicIdPartition, task) -> {
-                LOGGER.info("Cancelling the copy RLM task for tpId: {}", topicPartition);
+                LOGGER.info("Cancelling the copy RLM task for tpId: {}", topicIdPartition);
                 task.cancel();
                 return null;
             });

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -84,7 +84,7 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
         logs.flatMap(log => replicaManager.onlinePartition(log.topicPartition)).partition(_.isLeader)
       val topicIds = Collections.singletonMap(topic, replicaManager.metadataCache.getTopicId(topic))
       replicaManager.remoteLogManager.foreach(rlm =>
-        rlm.onLeadershipChange(leaderPartitions.toSet.asJava, followerPartitions.toSet.asJava, topicIds))
+        rlm.onLeadershipChange(leaderPartitions.toSet.asJava, followerPartitions.toSet.asJava, topicIds, false, false))
     } else if (wasRemoteLogEnabledBeforeUpdate && !isRemoteLogEnabled) {
       warn(s"Disabling remote log on the topic: $topic is not supported.")
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2064,7 +2064,7 @@ class ReplicaManager(val config: KafkaConfig,
           replicaFetcherManager.shutdownIdleFetcherThreads()
           replicaAlterLogDirsManager.shutdownIdleFetcherThreads()
 
-          remoteLogManager.foreach(rlm => rlm.onLeadershipChange(partitionsBecomeLeader.asJava, partitionsBecomeFollower.asJava, topicIds))
+          remoteLogManager.foreach(rlm => rlm.onLeadershipChange(partitionsBecomeLeader.asJava, partitionsBecomeFollower.asJava, topicIds, false, false))
 
           onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
 
@@ -2765,10 +2765,7 @@ class ReplicaManager(val config: KafkaConfig,
 
         val isTieredStateEnabled = getLogConfig(localChanges.deletes.asScala.head).get.getBoolean(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG)
 
-        remoteLogManager.foreach(rlm => {
-          rlm.validateCopyAndExpireTasks(isTieredStateEnabled, leaderChangedPartitions.asJava, localChanges.topicIds())
-          rlm.onLeadershipChange(leaderChangedPartitions.asJava, followerChangedPartitions.asJava, localChanges.topicIds())
-        })
+        remoteLogManager.foreach(rlm => rlm.onLeadershipChange(leaderChangedPartitions.asJava, followerChangedPartitions.asJava, localChanges.topicIds(), true, isTieredStateEnabled))
       }
 
       if (metadataVersion.isDirectoryAssignmentSupported) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1886,6 +1886,25 @@ public class RemoteLogManagerTest {
         verify(remoteLogMetadataManager, times(16)).updateRemoteLogSegmentMetadata(any());
     }
 
+    @Test
+    public void testLeaderPartitionsWithTieredStateEnabledOnTopic() {
+        remoteLogManager.startup();
+        remoteLogManager.onLeadershipChange(Collections.singleton(mockPartition(leaderTopicIdPartition)),
+            Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds, true, true);
+        assertNotNull(remoteLogManager.leaderCopyTask(leaderTopicIdPartition));
+        assertNotNull(remoteLogManager.leaderExpirationTask(leaderTopicIdPartition));
+    }
+
+    @Test
+    public void testLeaderPartitionsWithTieredStateDisabledOnTopic() {
+        remoteLogManager.startup();
+        remoteLogManager.onLeadershipChange(Collections.singleton(mockPartition(leaderTopicIdPartition)),
+            Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds, true, false);
+
+        assertNull(remoteLogManager.leaderCopyTask(leaderTopicIdPartition));
+        assertNotNull(remoteLogManager.leaderExpirationTask(leaderTopicIdPartition));
+    }
+
     /**
      * This test asserts that the newly elected leader for a partition is able to find the log-start-offset.
      * Note that the case tested here is that the previous leader deleted the log segments up-to offset 500. And, the

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -670,7 +670,7 @@ class DynamicConfigChangeUnitTest {
 
     val leaderPartitionsArg: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
     val followerPartitionsArg: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
-    doNothing().when(rlm).onLeadershipChange(leaderPartitionsArg.capture(), followerPartitionsArg.capture(), any())
+    doNothing().when(rlm).onLeadershipChange(leaderPartitionsArg.capture(), followerPartitionsArg.capture(), any(), any(), any())
 
     val isRemoteLogEnabledBeforeUpdate = false
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, None)
@@ -688,11 +688,11 @@ class DynamicConfigChangeUnitTest {
 
     val log0: UnifiedLog = mock(classOf[UnifiedLog])
     when(log0.remoteLogEnabled()).thenReturn(true)
-    doNothing().when(rlm).onLeadershipChange(any(), any(), any())
+    doNothing().when(rlm).onLeadershipChange(any(), any(), any(), any(), any())
 
     val isRemoteLogEnabledBeforeUpdate = true
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, None)
     configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log0), isRemoteLogEnabledBeforeUpdate)
-    verify(rlm, never()).onLeadershipChange(any(), any(), any())
+    verify(rlm, never()).onLeadershipChange(any(), any(), any(), any(), any())
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5076,7 +5076,7 @@ class ReplicaManagerTest {
     val leaderCapture: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
     val followerCapture: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
     val topicIdsCapture: ArgumentCaptor[util.Map[String, Uuid]] = ArgumentCaptor.forClass(classOf[util.Map[String, Uuid]])
-    verify(mockRemoteLogManager).onLeadershipChange(leaderCapture.capture(), followerCapture.capture(), topicIdsCapture.capture())
+    verify(mockRemoteLogManager).onLeadershipChange(leaderCapture.capture(), followerCapture.capture(), topicIdsCapture.capture(), false, false)
 
     val actualLeaderPartitions = leaderCapture.getValue
     val actualFollowerPartitions = followerCapture.getValue
@@ -5431,7 +5431,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(notReplicaTopicsDelta, notReplicaMetadataImage)
 
       if (enableRemoteStorage) {
-        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap())
+        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), false, false)
         verify(mockRemoteLogManager, times(1))
           .stopPartitions(ArgumentMatchers.eq(Collections.singleton(StopPartition(topicPartition, deleteLocalLog = true))), any())
       }
@@ -5479,7 +5479,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(removeTopicsDelta, removeMetadataImage)
 
       if (enableRemoteStorage) {
-        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap())
+        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), anyBoolean(), anyBoolean())
         verify(mockRemoteLogManager, times(1))
           .stopPartitions(ArgumentMatchers.eq(Collections.singleton(StopPartition(topicPartition, deleteLocalLog = true))), any())
       }
@@ -5526,7 +5526,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(notReplicaTopicsDelta, notReplicaMetadataImage)
 
       if (enableRemoteStorage) {
-        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap())
+        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), anyBoolean(), anyBoolean())
         verify(mockRemoteLogManager, times(1))
           .stopPartitions(ArgumentMatchers.eq(Collections.singleton(StopPartition(topicPartition, deleteLocalLog = true))), any())
       }
@@ -5573,7 +5573,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(removeTopicsDelta, removeMetadataImage)
 
       if (enableRemoteStorage) {
-        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap())
+        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), anyBoolean(), anyBoolean())
         verify(mockRemoteLogManager, times(1))
           .stopPartitions(ArgumentMatchers.eq(Collections.singleton(StopPartition(topicPartition, deleteLocalLog = true, deleteRemoteLog = true))), any())
       }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5076,7 +5076,7 @@ class ReplicaManagerTest {
     val leaderCapture: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
     val followerCapture: ArgumentCaptor[util.Set[Partition]] = ArgumentCaptor.forClass(classOf[util.Set[Partition]])
     val topicIdsCapture: ArgumentCaptor[util.Map[String, Uuid]] = ArgumentCaptor.forClass(classOf[util.Map[String, Uuid]])
-    verify(mockRemoteLogManager).onLeadershipChange(leaderCapture.capture(), followerCapture.capture(), topicIdsCapture.capture(), false, false)
+    verify(mockRemoteLogManager).onLeadershipChange(leaderCapture.capture(), followerCapture.capture(), topicIdsCapture.capture(), anyBoolean(), anyBoolean())
 
     val actualLeaderPartitions = leaderCapture.getValue
     val actualFollowerPartitions = followerCapture.getValue
@@ -5431,7 +5431,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(notReplicaTopicsDelta, notReplicaMetadataImage)
 
       if (enableRemoteStorage) {
-        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), false, false)
+        verify(mockRemoteLogManager, never()).onLeadershipChange(anySet(), anySet(), anyMap(), anyBoolean(), anyBoolean())
         verify(mockRemoteLogManager, times(1))
           .stopPartitions(ArgumentMatchers.eq(Collections.singleton(StopPartition(topicPartition, deleteLocalLog = true))), any())
       }


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/KAFKA-16855

Based on the comments from jira : 
Replaying a TopicRecord
- If a topic has tiering enabled then it should have both copy and expire tasks
- If a topic doesn't have tiering enabled then it should have only expire tasks

Records are replayed in ReplicaManager#applyDelta


### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
