### PR TITLE
KAFKA-17118: Remove StorageTool#buildMetadataProperties

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -482,37 +482,6 @@ object StorageTool extends Logging {
     BootstrapMetadata.fromRecords(metadataRecords, source)
   }
 
-
-  def buildMetadataProperties(
-    clusterIdStr: String,
-    config: KafkaConfig
-  ): MetaProperties = {
-    val effectiveClusterId = try {
-      Uuid.fromString(clusterIdStr)
-    } catch {
-      case e: Throwable => throw new TerseFailure(s"Cluster ID string $clusterIdStr " +
-        s"does not appear to be a valid UUID: ${e.getMessage}")
-    }
-    if (config.nodeId < 0) {
-      throw new TerseFailure(s"The node.id must be set to a non-negative integer. We saw ${config.nodeId}")
-    }
-    new MetaProperties.Builder().
-      setClusterId(effectiveClusterId.toString).
-      setNodeId(config.nodeId).
-      build()
-  }
-
-  def formatCommand(
-    stream: PrintStream,
-    directories: Seq[String],
-    metaProperties: MetaProperties,
-    metadataVersion: MetadataVersion,
-    ignoreFormatted: Boolean
-  ): Int = {
-    val bootstrapMetadata = buildBootstrapMetadata(metadataVersion, None, "format command")
-    formatCommand(stream, directories, metaProperties, bootstrapMetadata, metadataVersion, ignoreFormatted)
-  }
-
   def formatCommand(
     stream: PrintStream,
     directories: Seq[String],

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -256,15 +256,6 @@ Found problem:
   }
 
   @Test
-  def testFormatWithInvalidClusterId(): Unit = {
-    val config = new KafkaConfig(newSelfManagedProperties())
-    assertEquals("Cluster ID string invalid does not appear to be a valid UUID: " +
-      "Input string `invalid` decoded as 5 bytes, which is not equal to the expected " +
-        "16 bytes of a base64-encoded UUID", assertThrows(classOf[TerseFailure],
-          () => StorageTool.buildMetadataProperties("invalid", config)).getMessage)
-  }
-
-  @Test
   def testDefaultMetadataVersion(): Unit = {
     val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
     val mv = StorageTool.getMetadataVersion(namespace, Map.empty, defaultVersionString = None)


### PR DESCRIPTION
Remove StorageTool#buildMetadataProperties
It is useless in production after https://github.com/apache/kafka/commit/7060c08d6f9b0408e7f40a90499caf2e636fac61

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
