### PR TITLE
KAFKA-17095: Fix the typo from "CreateableTopicConfig" to "CreatableTopicConfig"

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -19,7 +19,7 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
-import org.apache.kafka.common.message.CreateTopicsRequestData.CreateableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 
 import java.util.Collection;
@@ -137,7 +137,7 @@ public class NewTopic {
         if (configs != null) {
             for (Entry<String, String> entry : configs.entrySet()) {
                 creatableTopic.configs().add(
-                    new CreateableTopicConfig().
+                    new CreatableTopicConfig().
                         setName(entry.getKey()).
                         setValue(entry.getValue()));
             }

--- a/clients/src/main/resources/common/message/CreateTopicsRequest.json
+++ b/clients/src/main/resources/common/message/CreateTopicsRequest.json
@@ -48,7 +48,7 @@
         { "name": "BrokerIds", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
           "about": "The brokers to place the partition on." }
       ]},
-      { "name": "Configs", "type": "[]CreateableTopicConfig", "versions": "0+",
+      { "name": "Configs", "type": "[]CreatableTopicConfig", "versions": "0+",
         "about": "The custom topic configurations to set.", "fields": [
         { "name": "Name", "type": "string", "versions": "0+" , "mapKey": true,
           "about": "The configuration name." },

--- a/clients/src/test/java/org/apache/kafka/clients/admin/NewTopicTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/NewTopicTest.java
@@ -142,7 +142,7 @@ public class NewTopicTest {
         assertNotNull(creatableTopic.configs());
         assertEquals(1, creatableTopic.configs().size());
 
-        CreateTopicsRequestData.CreateableTopicConfig config = creatableTopic.configs().find(CLEANUP_POLICY_CONFIG_KEY);
+        CreateTopicsRequestData.CreatableTopicConfig config = creatableTopic.configs().find(CLEANUP_POLICY_CONFIG_KEY);
         assertEquals(CLEANUP_POLICY_CONFIG_KEY, config.name());
         assertEquals(CLEANUP_POLICY_CONFIG_VALUE, config.value());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -98,7 +98,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCollection;
-import org.apache.kafka.common.message.CreateTopicsRequestData.CreateableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicConfigs;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
@@ -2875,7 +2875,7 @@ public class RequestResponseTest {
         topic2.assignments().add(new CreatableReplicaAssignment()
             .setPartitionIndex(1)
             .setBrokerIds(asList(2, 3, 4)));
-        topic2.configs().add(new CreateableTopicConfig()
+        topic2.configs().add(new CreatableTopicConfig()
             .setName("config1").setValue("value1"));
 
         return new CreateTopicsRequest.Builder(data).build(version);

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.errors.InvalidTopicException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
 import org.apache.kafka.common.message.CreateTopicsRequestData
-import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreateableTopicConfig, CreateableTopicConfigCollection}
+import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreatableTopicConfig, CreatableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest, RequestContext, RequestHeader}
@@ -252,11 +252,11 @@ class DefaultAutoTopicCreationManager(
     }
   }
 
-  private def convertToTopicConfigCollections(config: Properties): CreateableTopicConfigCollection = {
-    val topicConfigs = new CreateableTopicConfigCollection()
+  private def convertToTopicConfigCollections(config: Properties): CreatableTopicConfigCollection = {
+    val topicConfigs = new CreatableTopicConfigCollection()
     config.forEach {
       case (name, value) =>
-        topicConfigs.add(new CreateableTopicConfig()
+        topicConfigs.add(new CreatableTopicConfig()
           .setName(name.toString)
           .setValue(value.toString))
     }

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -68,10 +68,10 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
       topic.setReplicationFactor(1.toShort)
     }
     if (config != null) {
-      val effectiveConfigs = new CreateableTopicConfigCollection()
+      val effectiveConfigs = new CreatableTopicConfigCollection()
       config.foreach {
         case (name, value) =>
-          effectiveConfigs.add(new CreateableTopicConfig().setName(name).setValue(value))
+          effectiveConfigs.add(new CreatableTopicConfig().setName(name).setValue(value))
       }
       topic.setConfigs(effectiveConfigs)
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -56,7 +56,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCollection;
-import org.apache.kafka.common.message.CreateTopicsRequestData.CreateableTopicConfigCollection;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
@@ -288,9 +288,9 @@ public class ReplicationControlManager {
     }
 
     /**
-     * Translate a CreateableTopicConfigCollection to a map from string to string.
+     * Translate a CreatableTopicConfigCollection to a map from string to string.
      */
-    static Map<String, String> translateCreationConfigs(CreateableTopicConfigCollection collection) {
+    static Map<String, String> translateCreationConfigs(CreatableTopicConfigCollection collection) {
         HashMap<String, String> result = new HashMap<>();
         collection.forEach(config -> result.put(config.name(), config.value()));
         return Collections.unmodifiableMap(result);
@@ -885,7 +885,7 @@ public class ReplicationControlManager {
             if (topicErrors.containsKey(topic.name())) continue;
             Map<String, Entry<OpType, String>> topicConfigs = new HashMap<>();
             List<String> nullConfigs = new ArrayList<>();
-            for (CreateTopicsRequestData.CreateableTopicConfig config : topic.configs()) {
+            for (CreateTopicsRequestData.CreatableTopicConfig config : topic.configs()) {
                 if (config.value() == null) {
                     nullConfigs.add(config.name());
                 } else {

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -306,7 +306,7 @@ public class ReplicationControlManagerTest {
                     setPartitionIndex(i).setBrokerIds(Replicas.toList(replicas[i])));
             }
             configs.forEach((key, value) -> topic.configs().add(
-                    new CreateTopicsRequestData.CreateableTopicConfig()
+                    new CreateTopicsRequestData.CreatableTopicConfig()
                             .setName(key)
                             .setValue(value)
                     )
@@ -689,10 +689,10 @@ public class ReplicationControlManagerTest {
         ctx.registerBrokers(0, 1, 2);
         ctx.unfenceBrokers(0, 1, 2);
 
-        CreateTopicsRequestData.CreateableTopicConfigCollection validConfigs =
-            new CreateTopicsRequestData.CreateableTopicConfigCollection();
+        CreateTopicsRequestData.CreatableTopicConfigCollection validConfigs =
+            new CreateTopicsRequestData.CreatableTopicConfigCollection();
         validConfigs.add(
-            new CreateTopicsRequestData.CreateableTopicConfig()
+            new CreateTopicsRequestData.CreatableTopicConfig()
                 .setName("foo")
                 .setValue("notNull")
         );
@@ -723,10 +723,10 @@ public class ReplicationControlManagerTest {
             ctx.configurationControl.getConfigs(new ConfigResource(ConfigResource.Type.TOPIC, "foo")).get("foo")
         );
 
-        CreateTopicsRequestData.CreateableTopicConfigCollection invalidConfigs =
-            new CreateTopicsRequestData.CreateableTopicConfigCollection();
+        CreateTopicsRequestData.CreatableTopicConfigCollection invalidConfigs =
+            new CreateTopicsRequestData.CreatableTopicConfigCollection();
         invalidConfigs.add(
-            new CreateTopicsRequestData.CreateableTopicConfig()
+            new CreateTopicsRequestData.CreatableTopicConfig()
                 .setName("foo")
                 .setValue(null)
         );
@@ -1335,12 +1335,12 @@ public class ReplicationControlManagerTest {
     private void assertCreatedTopicConfigs(
         ReplicationControlTestContext ctx,
         String topic,
-        CreateTopicsRequestData.CreateableTopicConfigCollection requestConfigs
+        CreateTopicsRequestData.CreatableTopicConfigCollection requestConfigs
     ) {
         Map<String, String> configs = ctx.configurationControl.getConfigs(
             new ConfigResource(ConfigResource.Type.TOPIC, topic));
         assertEquals(requestConfigs.size(), configs.size());
-        for (CreateTopicsRequestData.CreateableTopicConfig requestConfig : requestConfigs) {
+        for (CreateTopicsRequestData.CreatableTopicConfig requestConfig : requestConfigs) {
             String value = configs.get(requestConfig.name());
             assertEquals(requestConfig.value(), value);
         }
@@ -1360,11 +1360,11 @@ public class ReplicationControlManagerTest {
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
         CreateTopicsRequestData request = new CreateTopicsRequestData();
-        CreateTopicsRequestData.CreateableTopicConfigCollection requestConfigs =
-            new CreateTopicsRequestData.CreateableTopicConfigCollection();
-        requestConfigs.add(new CreateTopicsRequestData.CreateableTopicConfig().
+        CreateTopicsRequestData.CreatableTopicConfigCollection requestConfigs =
+            new CreateTopicsRequestData.CreatableTopicConfigCollection();
+        requestConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig().
             setName("cleanup.policy").setValue("compact"));
-        requestConfigs.add(new CreateTopicsRequestData.CreateableTopicConfig().
+        requestConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig().
             setName("min.cleanable.dirty.ratio").setValue("0.1"));
         request.topics().add(new CreatableTopic().setName("foo").
             setNumPartitions(3).setReplicationFactor((short) 2).


### PR DESCRIPTION
As title, fix the typo from "CreateableTopicConfig" to "CreatableTopicConfig" including all the code that reference the config.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
