### PR TITLE
KAFKA-17121: junit-platform.properties files in published artifacts pollute the test classpath of consumers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -588,8 +588,9 @@ subprojects {
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
       from sourceSets.test.output
-      // The junit-platform.properties is a junit file that should be excluded from testJar
-      // issue url: https://issues.apache.org/jira/browse/KAFKA-17121
+      // The junit-platform.properties file is used for configuring and customizing the behavior of the JUnit platform.
+      // It should only apply to Kafka's own JUnit tests, and should not exist in the test JAR.
+      // If we include it in the test JAR, it could lead to conflicts with user configurations.
       exclude 'junit-platform.properties'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -588,6 +588,7 @@ subprojects {
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
       from sourceSets.test.output
+      exclude 'junit-platform.properties'
     }
 
     task testSrcJar(type: Jar, dependsOn: testJar) {

--- a/build.gradle
+++ b/build.gradle
@@ -588,6 +588,8 @@ subprojects {
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
       from sourceSets.test.output
+      // The junit-platform.properties is a junit file that should be excluded from testJar
+      // issue url: https://issues.apache.org/jira/browse/KAFKA-17121
       exclude 'junit-platform.properties'
     }
 


### PR DESCRIPTION
Exclude the junit-platform.properties file from `testJar` task

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
