### PR TITLE
KAFKA-17159: Make sure kafka-cluster-test-kit-executor get down when closing KafkaClusterTestKit

### DIFF
--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -295,8 +295,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 }
             } catch (Exception e) {
                 if (executorService != null) {
-                    executorService.shutdownNow();
-                    executorService.awaitTermination(5, TimeUnit.MINUTES);
+                    ThreadUtils.shutdownExecutorServiceQuietly(executorService, 5, TimeUnit.MINUTES);
                 }
                 for (BrokerServer brokerServer : brokers.values()) {
                     brokerServer.shutdown();
@@ -638,8 +637,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
             }
             throw e;
         } finally {
-            executorService.shutdownNow();
-            executorService.awaitTermination(5, TimeUnit.MINUTES);
+            ThreadUtils.shutdownExecutorServiceQuietly(executorService, 5, TimeUnit.MINUTES);
         }
         faultHandlerFactory.fatalFaultHandler().maybeRethrowFirstException();
         faultHandlerFactory.nonFatalFaultHandler().maybeRethrowFirstException();


### PR DESCRIPTION
When trying to remove `TestUtils.waitForCondition` in https://github.com/apache/kafka/pull/16499, kraft may have thread leak.

We can use [ThreadUtils#shutdownExecutorServiceQuietly](https://github.com/apache/kafka/blob/f595802cc752ed01dc74e9ab932209fe25a9d10b/clients/src/main/java/org/apache/kafka/common/utils/ThreadUtils.java#L71-L92) to replace the block in [KafkaClusterTestKit#close](https://github.com/apache/kafka/blob/f595802cc752ed01dc74e9ab932209fe25a9d10b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java#L640-L643).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
