### PR TITLE
KAFKA-17144: Retract unimplemented ListGroups v6 added in error

### DIFF
--- a/clients/src/main/resources/common/message/ListGroupsRequest.json
+++ b/clients/src/main/resources/common/message/ListGroupsRequest.json
@@ -25,9 +25,7 @@
   // Version 4 adds the StatesFilter field (KIP-518).
   //
   // Version 5 adds the TypesFilter field (KIP-848).
-  //
-  // Version 6 adds support for share groups (KIP-932).
-  "validVersions": "0-6",
+  "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "StatesFilter", "type": "[]string", "versions": "4+",

--- a/clients/src/main/resources/common/message/ListGroupsResponse.json
+++ b/clients/src/main/resources/common/message/ListGroupsResponse.json
@@ -27,9 +27,7 @@
   // Version 4 adds the GroupState field (KIP-518).
   //
   // Version 5 adds the GroupType field (KIP-848).
-  //
-  // Version 6 adds support for share groups (KIP-932).
-  "validVersions": "0-6",
+  "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,


### PR DESCRIPTION
List Groups v6 was introduced in error as part of KIP-932. We agreed not to bump ListGroups during KIP discussion, but the RPC definitions were made in error. No code changes apart from the JSON RPC definitions were made, so this PR retracts the v6 definitions made in error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
