### PR TITLE
MINOR: Clarify ACL requirements for Connect workers when exactly.once.source.support is set to preparing

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -442,7 +442,7 @@ errors.tolerance=all</code></pre>
 
     <h6>ACL requirements</h6>
 
-    <p>With exactly-once source support enabled, the principal for each Connect worker will require the following ACLs:</p>
+    <p>With exactly-once source support enabled, or with <code>exactly.once.source.support</code> set to <code>preparing</code>, the principal for each Connect worker will require the following ACLs:</p>
 
     <table class="data-table">
         <thead>
@@ -475,7 +475,7 @@ errors.tolerance=all</code></pre>
         </tbody>
     </table>
 
-    <p>And the principal for each individual connector will require the following ACLs:</p>
+    <p>And with exactly-once source enabled (but not if <code>exactly.once.source.support</code> is set to <code>preparing</code>), the principal for each individual connector will require the following ACLs:</p>
 
     <table class="data-table">
         <thead>


### PR DESCRIPTION
I noticed that we don't explicitly call out worker ACL requirements when `exactly.once.source.support` is set to `preparing`. We should include this information in our docs so that cluster administrators can anticipate whether rolling their Connect clusters to use that new value will be safe in ACL-secured environments.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
