### PR TITLE
KAFKA-17160: Determine mockitoArtifactName based on mockitoVersion instead of JavaVersion

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,10 +71,10 @@ else
 // Java versions.
 // We always use the `inline` strategy.
 String mockitoArtifactName
-if (mockitoVersion == "5.10.0")
-  mockitoArtifactName = "mockito-core"
-else
+if (mockitoVersion.startsWith("4."))
   mockitoArtifactName = "mockito-inline"
+else
+  mockitoArtifactName = "mockito-core"
 
 // When adding, removing or updating dependencies, please also update the LICENSE-binary file accordingly.
 // See https://issues.apache.org/jira/browse/KAFKA-12622 for steps to verify the LICENSE-binary file is correct.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ else
 // Java versions.
 // We always use the `inline` strategy.
 String mockitoArtifactName
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11))
+if (mockitoVersion == "5.10.0")
   mockitoArtifactName = "mockito-core"
 else
   mockitoArtifactName = "mockito-inline"


### PR DESCRIPTION
Based on the code comment, Kafka uses "mockito-core" for mockitoVersion 5.x and "mockito-inline" for mockitoVersion 4.x. Therefore, we should determine the Mockito artifact name based on the mockitoVersion rather than the JavaVersion.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
