### PR TITLE
KAFKA-17168 The logPrefix of RemoteLogReader/RemoteStorageThreadPool is not propagated correctly

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogReader.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogReader.java
@@ -56,12 +56,7 @@ public class RemoteLogReader implements Callable<Void> {
         this.brokerTopicStats.allTopicsStats().remoteFetchRequestRate().mark();
         this.quotaManager = quotaManager;
         this.remoteReadTimer = remoteReadTimer;
-        logger = new LogContext() {
-            @Override
-            public String logPrefix() {
-                return "[" + Thread.currentThread().getName() + "]";
-            }
-        }.logger(RemoteLogReader.class);
+        logger = new LogContext("[" + Thread.currentThread().getName() + "]").logger(RemoteLogReader.class);
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -44,12 +44,7 @@ public class RemoteStorageThreadPool extends ThreadPoolExecutor {
                                    int maxPendingTasks) {
         super(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(maxPendingTasks),
                 new RemoteStorageThreadFactory(threadNamePrefix));
-        logger = new LogContext() {
-            @Override
-            public String logPrefix() {
-                return "[" + Thread.currentThread().getName() + "]";
-            }
-        }.logger(RemoteStorageThreadPool.class);
+        logger = new LogContext("[" + Thread.currentThread().getName() + "]").logger(RemoteStorageThreadPool.class);
 
         metricsGroup.newGauge(REMOTE_LOG_READER_TASK_QUEUE_SIZE_METRIC.getName(), new Gauge<Integer>() {
             @Override


### PR DESCRIPTION
related to https://issues.apache.org/jira/browse/KAFKA-17168

RemoteLogReader [0] and RemoteStorageThreadPool [1] override the method `logPrefix` instead of passing to constructor. However, `LogContext` does not use the method `logPrefix` to set the prefix inner. That means the override method is no-op and the expected prefix is never propagated.
[0] https://github.com/apache/kafka/blob/66655ab49a9401a62e1e99e637e0c5bd5a1ba550/core/src/main/java/kafka/log/remote/RemoteLogReader.java#L59
[1] https://github.com/apache/kafka/blob/66655ab49a9401a62e1e99e637e0c5bd5a1ba550/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java#L49

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
