### PR TITLE
MINOR: docs(bootstrap.servers): updates the property description

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -45,11 +45,11 @@ public class CommonClientConfigs {
      */
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
-    public static final String BOOTSTRAP_SERVERS_DOC = "A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping&mdash;this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form "
-                                                       + "<code>host1:port1,host2:port2,...</code>. Since these servers are just used for the initial connection to "
-                                                       + "discover the full cluster membership (which may change dynamically), this list need not contain the full set of "
-                                                       + "servers (you may want more than one, though, in case a server is down).";
-
+    public static final String BOOTSTRAP_SERVERS_DOC = "A list of host/port pairs used to establish the initial connection to the Kafka cluster. "
+                                                        + "Clients use this list to bootstrap and discover the full set of Kafka brokers. "
+                                                        + "While the order of servers in the list does not matter—clients randomly select an entry to start with—include more than one server to ensure resilience if any servers are down. "
+                                                        + "This list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently. "
+                                                        + "This list must be in the form <code>host1:port1,host2:port2,...</code>.";
     public static final String CLIENT_DNS_LOOKUP_CONFIG = "client.dns.lookup";
     public static final String CLIENT_DNS_LOOKUP_DOC = "Controls how the client uses DNS lookups. "
                                                        + "If set to <code>use_all_dns_ips</code>, connect to each returned IP "

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -47,7 +47,7 @@ public class CommonClientConfigs {
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
     public static final String BOOTSTRAP_SERVERS_DOC = "A list of host/port pairs used to establish the initial connection to the Kafka cluster. "
                                                         + "Clients use this list to bootstrap and discover the full set of Kafka brokers. "
-                                                        + "While the order of servers in the list does not matter—clients randomly select an entry to start with—include more than one server to ensure resilience if any servers are down. "
+                                                        + "While the order of servers in the list does not matter, we recommend including more than one server to ensure resilience if any servers are down. "
                                                         + "This list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently. "
                                                         + "This list must be in the form <code>host1:port1,host2:port2,...</code>.";
     public static final String CLIENT_DNS_LOOKUP_CONFIG = "client.dns.lookup";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -61,7 +61,7 @@ public class WorkerConfig extends AbstractConfig {
     public static final String BOOTSTRAP_SERVERS_DOC = 
                 "A list of host/port pairs used to establish the initial connection to the Kafka cluster. "
                         + "Clients use this list to bootstrap and discover the full set of Kafka brokers. "
-                        + "While the order of servers in the list does not matter—clients randomly select an entry to start with—include more than one server to ensure resilience if any servers are down. "
+                        + "While the order of servers in the list does not matter, we recommend including more than one server to ensure resilience if any servers are down. "
                         + "This list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently. "
                         + "This list must be in the form <code>host1:port1,host2:port2,...</code>.";
     public static final String BOOTSTRAP_SERVERS_DEFAULT = "localhost:9092";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -58,15 +58,12 @@ public class WorkerConfig extends AbstractConfig {
     private static final Logger log = LoggerFactory.getLogger(WorkerConfig.class);
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
-    public static final String BOOTSTRAP_SERVERS_DOC
-            = "A list of host/port pairs to use for establishing the initial connection to the Kafka "
-            + "cluster. The client will make use of all servers irrespective of which servers are "
-            + "specified here for bootstrapping&mdash;this list only impacts the initial hosts used "
-            + "to discover the full set of servers. This list should be in the form "
-            + "<code>host1:port1,host2:port2,...</code>. Since these servers are just used for the "
-            + "initial connection to discover the full cluster membership (which may change "
-            + "dynamically), this list need not contain the full set of servers (you may want more "
-            + "than one, though, in case a server is down).";
+    public static final String BOOTSTRAP_SERVERS_DOC = 
+                "A list of host/port pairs used to establish the initial connection to the Kafka cluster. "
+                        + "Clients use this list to bootstrap and discover the full set of Kafka brokers. "
+                        + "While the order of servers in the list does not matter—clients randomly select an entry to start with—include more than one server to ensure resilience if any servers are down. "
+                        + "This list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently. "
+                        + "This list must be in the form <code>host1:port1,host2:port2,...</code>.";
     public static final String BOOTSTRAP_SERVERS_DEFAULT = "localhost:9092";
 
     public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG;


### PR DESCRIPTION
**Documentation**
Updates the `bootsrap.servers` property description for producer, consumer, connect, streams, and admin.

- Recommends listing more than one server
- States that the order does not matter as clients will first bootstrap using a random entry in the list and then automatically manage the connections as efficiently as possible

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
