### PR TITLE
KAFKA-17168: Remove the logPrefix to print the thread name

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogReader.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogReader.java
@@ -20,7 +20,6 @@ import kafka.log.remote.quota.RLMQuotaManager;
 import kafka.server.BrokerTopicStats;
 
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
-import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 import org.apache.kafka.storage.internals.log.RemoteLogReadResult;
 import org.apache.kafka.storage.internals.log.RemoteStorageFetchInfo;
@@ -28,13 +27,14 @@ import org.apache.kafka.storage.internals.log.RemoteStorageFetchInfo;
 import com.yammer.metrics.core.Timer;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 public class RemoteLogReader implements Callable<Void> {
-    private final Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(RemoteLogReader.class);
     private final RemoteStorageFetchInfo fetchInfo;
     private final RemoteLogManager rlm;
     private final BrokerTopicStats brokerTopicStats;
@@ -56,7 +56,6 @@ public class RemoteLogReader implements Callable<Void> {
         this.brokerTopicStats.allTopicsStats().remoteFetchRequestRate().mark();
         this.quotaManager = quotaManager;
         this.remoteReadTimer = remoteReadTimer;
-        logger = new LogContext("[" + Thread.currentThread().getName() + "]").logger(RemoteLogReader.class);
     }
 
     @Override

--- a/core/src/main/java/kafka/log/remote/RemoteLogReader.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogReader.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 public class RemoteLogReader implements Callable<Void> {
-    private static final Logger logger = LoggerFactory.getLogger(RemoteLogReader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteLogReader.class);
     private final RemoteStorageFetchInfo fetchInfo;
     private final RemoteLogManager rlm;
     private final BrokerTopicStats brokerTopicStats;
@@ -62,7 +62,7 @@ public class RemoteLogReader implements Callable<Void> {
     public Void call() {
         RemoteLogReadResult result;
         try {
-            logger.debug("Reading records from remote storage for topic partition {}", fetchInfo.topicPartition);
+            LOGGER.debug("Reading records from remote storage for topic partition {}", fetchInfo.topicPartition);
             FetchDataInfo fetchDataInfo = remoteReadTimer.time(() -> rlm.read(fetchInfo));
             brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
             brokerTopicStats.allTopicsStats().remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
@@ -72,10 +72,10 @@ public class RemoteLogReader implements Callable<Void> {
         } catch (Exception e) {
             brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).failedRemoteFetchRequestRate().mark();
             brokerTopicStats.allTopicsStats().failedRemoteFetchRequestRate().mark();
-            logger.error("Error occurred while reading the remote data for {}", fetchInfo.topicPartition, e);
+            LOGGER.error("Error occurred while reading the remote data for {}", fetchInfo.topicPartition, e);
             result = new RemoteLogReadResult(Optional.empty(), Optional.of(e));
         }
-        logger.debug("Finished reading records from remote storage for topic partition {}", fetchInfo.topicPartition);
+        LOGGER.debug("Finished reading records from remote storage for topic partition {}", fetchInfo.topicPartition);
         quotaManager.record(result.fetchDataInfo.map(fetchDataInfo -> fetchDataInfo.records.sizeInBytes()).orElse(0));
         callback.accept(result);
         return null;

--- a/core/src/main/java/kafka/log/remote/RemoteLogReader.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogReader.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 public class RemoteLogReader implements Callable<Void> {
-    private final Logger logger = LoggerFactory.getLogger(RemoteLogReader.class);
+    private static final Logger logger = LoggerFactory.getLogger(RemoteLogReader.class);
     private final RemoteStorageFetchInfo fetchInfo;
     private final RemoteLogManager rlm;
     private final BrokerTopicStats brokerTopicStats;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -34,7 +34,7 @@ import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.RE
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.REMOTE_STORAGE_THREAD_POOL_METRICS;
 
 public class RemoteStorageThreadPool extends ThreadPoolExecutor {
-    private static final Logger logger = LoggerFactory.getLogger(RemoteStorageThreadPool.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteStorageThreadPool.class);
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
 
     @SuppressWarnings("this-escape")
@@ -53,11 +53,11 @@ public class RemoteStorageThreadPool extends ThreadPoolExecutor {
     protected void afterExecute(Runnable runnable, Throwable th) {
         if (th != null) {
             if (th instanceof FatalExitError) {
-                logger.error("Stopping the server as it encountered a fatal error.");
+                LOGGER.error("Stopping the server as it encountered a fatal error.");
                 Exit.exit(((FatalExitError) th).statusCode());
             } else {
                 if (!isShutdown())
-                    logger.error("Error occurred while executing task: {}", runnable, th);
+                    LOGGER.error("Error occurred while executing task: {}", runnable, th);
             }
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -18,10 +18,10 @@ package org.apache.kafka.storage.internals.log;
 
 import org.apache.kafka.common.internals.FatalExitError;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -34,7 +34,7 @@ import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.RE
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.REMOTE_STORAGE_THREAD_POOL_METRICS;
 
 public class RemoteStorageThreadPool extends ThreadPoolExecutor {
-    private final Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(RemoteStorageThreadPool.class);
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
 
     @SuppressWarnings("this-escape")
@@ -43,8 +43,6 @@ public class RemoteStorageThreadPool extends ThreadPoolExecutor {
                                    int maxPendingTasks) {
         super(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(maxPendingTasks),
                 new RemoteStorageThreadFactory(threadNamePrefix));
-        logger = new LogContext("[" + Thread.currentThread().getName() + "]").logger(RemoteStorageThreadPool.class);
-
         metricsGroup.newGauge(REMOTE_LOG_READER_TASK_QUEUE_SIZE_METRIC.getName(),
                 () -> getQueue().size());
         metricsGroup.newGauge(REMOTE_LOG_READER_AVG_IDLE_PERCENT_METRIC.getName(),

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -34,7 +34,7 @@ import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.RE
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.REMOTE_STORAGE_THREAD_POOL_METRICS;
 
 public class RemoteStorageThreadPool extends ThreadPoolExecutor {
-    private final Logger logger = LoggerFactory.getLogger(RemoteStorageThreadPool.class);
+    private static final Logger logger = LoggerFactory.getLogger(RemoteStorageThreadPool.class);
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
 
     @SuppressWarnings("this-escape")


### PR DESCRIPTION
Users can configure the log4j conversion-pattern to print the thread name if required. It is a followup of the [comment](https://github.com/apache/kafka/pull/13535#discussion_r1686742439).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
