### PR TITLE
MINOR: add comment for correctness issue to LeaderEpochFileCache

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/LeaderEpochCheckpointFile.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/LeaderEpochCheckpointFile.java
@@ -56,7 +56,7 @@ public class LeaderEpochCheckpointFile {
         checkpoint.write(epochs);
     }
 
-    public void writeForTruncation(Collection<EpochEntry> epochs) {
+    public void writeIfDirExists(Collection<EpochEntry> epochs) {
         // Writing epoch entries after truncation is done asynchronously for performance reasons.
         // This could cause NoSuchFileException when the directory is renamed concurrently for topic deletion,
         // so we use writeIfDirExists here.


### PR DESCRIPTION
Follow up: https://github.com/apache/kafka/pull/16641

* Add comment for the correctness issue.
* Change `LeaderEpochCheckpointFile#writeForTruncation` to `LeaderEpochCheckpointFile#writeIfDirExists`.
* Change `LeaderEpochFileCache#writeToFileForTruncation` to `LeaderEpochFileCache#writeIfDirExists`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
