### PR TITLE
KAKFA-16537; Implement remove voter RPC

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/VoterNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/VoterNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class VoterNotFoundException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public VoterNotFoundException(String message) {
+        super(message);
+    }
+
+    public VoterNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -145,6 +145,7 @@ import org.apache.kafka.common.errors.UnsupportedEndpointTypeException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.errors.VoterNotFoundException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -407,7 +408,8 @@ public enum Errors {
     INVALID_SHARE_SESSION_EPOCH(123, "The share session epoch is invalid.", InvalidShareSessionEpochException::new),
     FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match.", FencedStateEpochException::new),
     INVALID_VOTER_KEY(125, "The voter key doesn't match the receiving replica's key.", InvalidVoterKeyException::new),
-    DUPLICATE_VOTER(126, "The voter is already part of the set of voters.", DuplicateVoterException::new);
+    DUPLICATE_VOTER(126, "The voter is already part of the set of voters.", DuplicateVoterException::new),
+    VOTER_NOT_FOUND(127, "The voter is not part of the set of voters.", VoterNotFoundException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        public static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
 
         private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
             .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        public static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
 
         private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
             .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -1090,7 +1090,7 @@ class ControllerApis(
 
   def handleRemoveRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, ALTER)
-    throw new UnsupportedVersionException("handleRemoveRaftVoter is not supported yet.")
+    handleRaftRequest(request, response => new RemoveRaftVoterResponse(response.asInstanceOf[RemoveRaftVoterResponseData]))
   }
 
   def handleUpdateRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2909,7 +2909,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             // shutdown completes or an epoch bump forces another state transition
             return shutdown.remainingTimeMs();
         } else if (state.hasElectionTimeoutExpired(currentTimeMs)) {
-            // KAFKA-17067 is going to fix this. VotedState doesn't mean it that the replica is a voter
+            // KAFKA-17067 is going to fix this. VotedState doesn't mean that the replica is a voter
             // we need to treat VotedState similar to UnattachedState.
             transitionToCandidate(currentTimeMs);
             return 0L;

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2032,7 +2032,15 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         if (!hasValidClusterId(data.clusterId())) {
             return completedFuture(
-                new AddRaftVoterResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code())
+                new AddRaftVoterResponseData()
+                    .setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code())
+                    .setErrorMessage(
+                        String.format(
+                            "The given id \"%s\" doesn't match the cluster id \"%s\"",
+                            data.clusterId(),
+                            clusterId
+                        )
+                    )
             );
         }
 
@@ -2106,7 +2114,15 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         if (!hasValidClusterId(data.clusterId())) {
             return completedFuture(
-                new RemoveRaftVoterResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code())
+                new RemoveRaftVoterResponseData()
+                    .setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code())
+                    .setErrorMessage(
+                        String.format(
+                            "The given id \"%s\" doesn't match the cluster id \"%s\"",
+                            data.clusterId(),
+                            clusterId
+                        )
+                    )
             );
         }
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FetchSnapshotRequestData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
+import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.network.ListenerName;
@@ -527,6 +529,27 @@ public class RaftUtil {
             .setErrorMessage(errorMessage);
     }
 
+    public static RemoveRaftVoterRequestData removeVoterRequest(
+        String clusterId,
+        ReplicaKey voter
+    ) {
+        return new RemoveRaftVoterRequestData()
+            .setClusterId(clusterId)
+            .setVoterId(voter.id())
+            .setVoterDirectoryId(voter.directoryId().orElse(ReplicaKey.NO_DIRECTORY_ID));
+    }
+
+    public static RemoveRaftVoterResponseData removeVoterResponse(
+        Errors error,
+        String errorMessage
+    ) {
+        errorMessage = errorMessage == null ? error.message() : errorMessage;
+
+        return new RemoveRaftVoterResponseData()
+            .setErrorCode(error.code())
+            .setErrorMessage(errorMessage);
+    }
+
     public static Optional<ReplicaKey> voteRequestVoterKey(
         VoteRequestData request,
         VoteRequestData.PartitionData partition
@@ -550,6 +573,14 @@ public class RaftUtil {
     }
 
     public static Optional<ReplicaKey> addVoterRequestVoterKey(AddRaftVoterRequestData request) {
+        if (request.voterId() < 0) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ReplicaKey.of(request.voterId(), request.voterDirectoryId()));
+        }
+    }
+
+    public static Optional<ReplicaKey> removeVoterRequestVoterKey(RemoveRaftVoterRequestData request) {
         if (request.voterId() < 0) {
             return Optional.empty();
         } else {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -47,8 +47,6 @@ import java.util.concurrent.CompletableFuture;
  *    REQUEST_TIMED_OUT error if it doesn't commit in time.
  * 6. Send the RemoveVoter successful response to the client.
  * 7. Resign the leadership if the leader is not in the new voter set
- *
- * TODO: make sure that the user cannot shrink the voter set to zero voters
  */
 public final class RemoveVoterHandler {
     private final Optional<ReplicaKey> localReplicaKey;

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.raft.LeaderState;
+import org.apache.kafka.raft.LogOffsetMetadata;
+import org.apache.kafka.raft.RaftUtil;
+import org.apache.kafka.server.common.KRaftVersion;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This type implements the protocol for removing a voter from a KRaft partition.
+ *
+ * The general algorithm for removing voter to the voter set is:
+ *
+ * 1. Check that the leader has fenced the previous leader(s) by checking that the HWM is known,
+ *    otherwise return the REQUEST_TIMED_OUT error.
+ * 2. Check that the cluster supports kraft.version 1, otherwise return the UNSUPPORTED_VERSION error.
+ * 3. Check that there are no uncommitted voter changes, otherwise return the REQUEST_TIMED_OUT error.
+ * 4. Append the updated VotersRecord to the log. The KRaft internal listener will read this
+ *    uncommitted record from the log and add the new voter to the set of voters.
+ * 5. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a
+ *    REQUEST_TIMED_OUT error if it doesn't commit in time.
+ * 6. Send the RemoveVoter successful response to the client.
+ * 7. Resign the leadership if the leader is not in the new voter set
+ *
+ * TODO: make sure that the user cannot shrink the voter set to zero voters
+ */
+public final class RemoveVoterHandler {
+    private final Optional<ReplicaKey> localReplicaKey;
+    private final KRaftControlRecordStateMachine partitionState;
+    private final Time time;
+    private final long requestTimeoutMs;
+    private final Logger logger;
+
+    public RemoveVoterHandler(
+        OptionalInt nodeId,
+        Uuid nodeDirectoryId,
+        KRaftControlRecordStateMachine partitionState,
+        Time time,
+        long requestTimeoutMs,
+        LogContext logContext
+    ) {
+        this.localReplicaKey = nodeId.isPresent() ?
+            Optional.of(ReplicaKey.of(nodeId.getAsInt(), nodeDirectoryId)) :
+            Optional.empty();
+        this.partitionState = partitionState;
+        this.time = time;
+        this.requestTimeoutMs = requestTimeoutMs;
+        this.logger = logContext.logger(RemoveVoterHandler.class);
+    }
+
+    public CompletableFuture<RemoveRaftVoterResponseData> handleRemoveVoterRequest(
+        LeaderState<?> leaderState,
+        ReplicaKey voterKey,
+        long currentTimeMs
+    ) {
+        // Check if there are any pending add or remove voter requests
+        if (leaderState.isOperationPending(currentTimeMs)) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.removeVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to handle previous add or remove voter request"
+                )
+            );
+        }
+
+        // Check that the leader has established a HWM and committed the current epoch
+        Optional<Long> highWatermark = leaderState.highWatermark().map(LogOffsetMetadata::offset);
+        if (!highWatermark.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.removeVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    "Request timed out waiting for leader to establish HWM and fence previous voter changes"
+                )
+            );
+        }
+
+        // Check that the cluster supports kraft.version >= 1
+        KRaftVersion kraftVersion = partitionState.lastKraftVersion();
+        if (!kraftVersion.isReconfigSupported()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.removeVoterResponse(
+                    Errors.UNSUPPORTED_VERSION,
+                    String.format(
+                        "Cluster doesn't support removing voter because the %s feature is %s",
+                        kraftVersion.featureName(),
+                        kraftVersion.featureLevel()
+                    )
+                )
+            );
+        }
+
+        // Check that there are no uncommitted VotersRecord
+        Optional<LogHistory.Entry<VoterSet>> votersEntry = partitionState.lastVoterSetEntry();
+        if (!votersEntry.isPresent() || votersEntry.get().offset() >= highWatermark.get()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.removeVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    String.format(
+                        "Request timed out waiting for voters to commit the latest voter change at %s with HWM %d",
+                        votersEntry.map(LogHistory.Entry::offset),
+                        highWatermark.get()
+                    )
+                )
+            );
+        }
+
+        // Remove the voter from the set of voters
+        Optional<VoterSet> newVoters = votersEntry.get().value().removeVoter(voterKey);
+        if (!newVoters.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.removeVoterResponse(
+                    Errors.VOTER_NOT_FOUND,
+                    String.format(
+                        "Cannot remove voter %s from the set of voters %s",
+                        voterKey,
+                        votersEntry.get().value().voterKeys()
+                    )
+                )
+            );
+        }
+
+        // Append the record to the log
+        RemoveVoterHandlerState state = new RemoveVoterHandlerState(
+            leaderState.appendVotersRecord(newVoters.get(), currentTimeMs),
+            time.timer(requestTimeoutMs)
+        );
+        leaderState.resetRemoveVoterHandlerState(Errors.UNKNOWN_SERVER_ERROR, null, Optional.of(state));
+
+        return state.future();
+    }
+
+    public void highWatermarkUpdated(LeaderState<?> leaderState) {
+        leaderState.removeVoterHandlerState().ifPresent(current -> {
+            leaderState.highWatermark().ifPresent(highWatermark -> {
+                if (highWatermark.offset() > current.lastOffset()) {
+                    // VotersRecord with the removed voter was committed; complete the RPC
+                    leaderState.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.empty());
+
+                    // Resign if the leader is not part of the new committed voter set
+                    VoterSet voters = partitionState.lastVoterSet();
+                    ReplicaKey localKey = localReplicaKey.orElseThrow(
+                        () -> new IllegalStateException(
+                            String.format(
+                                "Leaders mush have an id and directory id %s",
+                                localReplicaKey
+                            )
+                        )
+                    );
+                    if (!voters.isVoter(localKey)) {
+                        logger.info(
+                            "Leader is not in the committed voter set {} resign from epoch {}",
+                            voters.voterKeys(),
+                            leaderState.epoch()
+                        );
+
+                        leaderState.requestResign();
+                    }
+                }
+            });
+        });
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandlerState.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.raft.RaftUtil;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class RemoveVoterHandlerState implements AutoCloseable {
+    private long lastOffset;
+    private final Timer timeout;
+    private final CompletableFuture<RemoveRaftVoterResponseData> future = new CompletableFuture<>();
+
+    RemoveVoterHandlerState(long lastOffset, Timer timeout) {
+        this.lastOffset = lastOffset;
+        this.timeout = timeout;
+    }
+
+    public long timeUntilOperationExpiration(long currentTimeMs) {
+        timeout.update(currentTimeMs);
+        return timeout.remainingMs();
+    }
+
+    public CompletableFuture<RemoveRaftVoterResponseData> future() {
+        return future;
+    }
+
+    public long lastOffset() {
+        return lastOffset;
+    }
+
+    @Override
+    public void close() {
+        future.complete(RaftUtil.removeVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER, null));
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandlerState.java
@@ -24,7 +24,7 @@ import org.apache.kafka.raft.RaftUtil;
 import java.util.concurrent.CompletableFuture;
 
 public final class RemoveVoterHandlerState implements AutoCloseable {
-    private long lastOffset;
+    private final long lastOffset;
     private final Timer timeout;
     private final CompletableFuture<RemoveRaftVoterResponseData> future = new CompletableFuture<>();
 

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -188,14 +188,18 @@ public final class VoterSet {
      *
      * This object is immutable. A new voter set is returned if the voter was removed.
      *
-     * A voter can be removed from the voter set if its id and directory id match.
+     * A voter can be removed from the voter set if its id and directory id match and there
+     * are more than one voter in the set of voters.
      *
      * @param voterKey the voter key
      * @return a new voter set if the voter was removed, otherwise {@code Optional.empty()}
      */
     public Optional<VoterSet> removeVoter(ReplicaKey voterKey) {
         VoterNode oldVoter = voters.get(voterKey.id());
-        if (oldVoter != null && Objects.equals(oldVoter.voterKey(), voterKey)) {
+        if (oldVoter != null &&
+            Objects.equals(oldVoter.voterKey(), voterKey) &&
+            voters.size() > 1
+        ) {
             HashMap<Integer, VoterNode> newVoters = new HashMap<>(voters);
             newVoters.remove(voterKey.id());
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -50,6 +50,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -446,6 +447,8 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.addVoterRequest("invalid-uuid", Integer.MAX_VALUE, newVoter, newListeners));
         context.pollUntilResponse();
         context.assertSentAddVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+
+        assertFalse(context.client.quorum().isVoter(newVoter));
     }
 
     @Test
@@ -1023,6 +1026,433 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.addVoterRequest(Integer.MAX_VALUE, newVoter, newListeners));
         context.pollUntilResponse();
         context.assertSentAddVoterResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    public void testRemoveVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        assertTrue(context.client.quorum().isVoter(follower2));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+
+        // Handle the remove voter request
+        context.client.poll();
+        // Append the VotersRecord to the log
+        context.client.poll();
+
+        // follower2 should not be a voter in the latest voter set
+        assertFalse(context.client.quorum().isVoter(follower2));
+
+        // Send a FETCH to increase the HWM and commit the new voter set
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Expect reply for RemoveVoter request
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.NONE);
+    }
+
+    @Test
+    public void testRemoveVoterIsLeader() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        assertTrue(context.client.quorum().isVoter(follower2));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove local leader
+        context.deliverRequest(context.removeVoterRequest(local));
+
+        // Handle the remove voter request
+        context.client.poll();
+        // Append the VotersRecord to the log
+        context.client.poll();
+
+        // local should not be a voter in the latest voter set
+        assertFalse(context.client.quorum().isVoter(local));
+
+        // Send a FETCH request for follower1
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Send a FETCH request for follower2 and increaes the HWM
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower2, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Expect reply for RemoveVoter request
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.NONE);
+
+        // Expect END_QUORUM_EPOCH requests
+        context.pollUntilRequest();
+        context.collectEndQuorumRequests(epoch, new HashSet<>(Arrays.asList(follower1.id(), follower2.id())), Optional.empty());
+
+        // Election timeout is randome numer in [electionTimeoutMs, 2 * electionTimeoutMs)
+        context.time.sleep(2 * context.electionTimeoutMs());
+        context.client.poll();
+
+        assertTrue(context.client.quorum().isObserver());
+        assertTrue(context.client.quorum().isUnattached());
+    }
+
+    @Test
+    public void testRemoveVoterInvalidClusterId() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        // empty cluster id is rejected
+        context.deliverRequest(context.removeVoterRequest("", follower1));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+
+        // invalid cluster id is rejected
+        context.deliverRequest(context.removeVoterRequest("invalid-uuid", follower1));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+
+        assertTrue(context.client.quorum().isVoter(follower1));
+    }
+
+    @Test
+    void testRemoveVoterToNotLeader() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        // Attempt to add new voter to the quorum
+        context.deliverRequest(context.removeVoterRequest(follower1));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+    }
+
+    @Test
+    void testRemoveVoterWithPendingRemoveVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+
+        // Handle the remove voter request
+        context.client.poll();
+        // Append the VotersRecord to the log
+        context.client.poll();
+
+        // Attempt to remove follower1
+        context.deliverRequest(context.removeVoterRequest(follower1));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testRemoveVoterWithoutFencedPreviousLeaders() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.REQUEST_TIMED_OUT);
+    }
+
+    @Test
+    void testRemoveVoterWithKraftVersion0() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withStaticVoters(voters)
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.UNSUPPORTED_VERSION);
+    }
+
+    @Test
+    void testRemoveVoterWithNoneVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove replica with same id as follower2
+        context.deliverRequest(context.removeVoterRequest(replicaKey(follower2.id(), true)));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.VOTER_NOT_FOUND);
+    }
+
+    @Test
+    void testRemoveVoterWithNoneVoterId() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(
+            context.removeVoterRequest(
+                ReplicaKey.of(follower2.id() + 1, follower2.directoryId().get())
+            )
+        );
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.VOTER_NOT_FOUND);
+    }
+
+    @Test
+    void testRemoveVoterToEmptyVoterSet() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .build();
+        assertEquals(OptionalInt.of(local.id()), context.currentLeader());
+
+        // Attempt to remove local leader to empty voter set
+        context.deliverRequest(context.removeVoterRequest(local));
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.VOTER_NOT_FOUND);
+    }
+
+    @Test
+    void testRemoveVoterTimedOut() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        assertTrue(context.client.quorum().isVoter(follower2));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+
+        // Handle the remove voter request
+        context.client.poll();
+        // Append the VotersRecord to the log
+        context.client.poll();
+
+        // Wait for request timeout without sending a FETCH request to timeout the remove voter RPC
+        context.time.sleep(context.requestTimeoutMs());
+
+        // Expect a timeout error
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.REQUEST_TIMED_OUT);
+
+        // Event though the voters record never committed and the RPC timeout show that the old
+        // voter is not part of the voter set
+        assertFalse(context.client.quorum().isVoter(follower2));
+    }
+
+    @Test
+    void testRemoveVoterFailsWhenLosingLeadership() throws Exception {
+        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey follower1 = replicaKey(local.id() + 1, true);
+        ReplicaKey follower2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower1, follower2));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withUnknownLeader(3)
+            .build();
+
+        context.becomeLeader();
+        int epoch = context.currentEpoch();
+
+        assertTrue(context.client.quorum().isVoter(follower2));
+
+        // Establish a HWM and fence previous leaders
+        context.deliverRequest(
+            context.fetchRequest(epoch, follower1, context.log.endOffset().offset(), epoch, 0)
+        );
+        context.pollUntilResponse();
+        context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
+
+        // Attempt to remove follower2
+        context.deliverRequest(context.removeVoterRequest(follower2));
+
+        // Handle the remove voter request
+        context.client.poll();
+        // Append the VotersRecord to the log
+        context.client.poll();
+
+        // Leader completes the RemoveVoter RPC when resigning
+        context.client.resign(epoch);
+        context.pollUntilResponse();
+        context.assertSentRemoveVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+
+        // Event though the voters record never committed, the old voter is not part of the voter
+        // set
+        assertFalse(context.client.quorum().isVoter(follower2));
     }
 
     private static void verifyVotersRecord(

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -596,21 +596,22 @@ public class KafkaRaftClientTest {
             .build();
 
         context.becomeLeader();
+        int epoch = context.currentEpoch();
         assertEquals(OptionalInt.of(localId), context.currentLeader());
 
         // begin epoch requests should be sent out every beginQuorumEpochTimeoutMs
         context.time.sleep(context.beginQuorumEpochTimeoutMs);
         context.client.poll();
-        context.assertSentBeginQuorumEpochRequest(context.currentEpoch(), Utils.mkSet(remoteId1, remoteId2));
+        context.assertSentBeginQuorumEpochRequest(epoch, Utils.mkSet(remoteId1, remoteId2));
 
         int partialDelay = context.beginQuorumEpochTimeoutMs / 2;
         context.time.sleep(partialDelay);
         context.client.poll();
-        context.assertSentBeginQuorumEpochRequest(context.currentEpoch(), Utils.mkSet());
+        context.assertSentBeginQuorumEpochRequest(epoch, Utils.mkSet());
 
         context.time.sleep(context.beginQuorumEpochTimeoutMs - partialDelay);
         context.client.poll();
-        context.assertSentBeginQuorumEpochRequest(context.currentEpoch(), Utils.mkSet(remoteId1, remoteId2));
+        context.assertSentBeginQuorumEpochRequest(epoch, Utils.mkSet(remoteId1, remoteId2));
     }
 
     @ParameterizedTest

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -37,6 +37,8 @@ import org.apache.kafka.common.message.FetchSnapshotRequestData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
+import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.metrics.Metrics;
@@ -577,8 +579,8 @@ public final class RaftClientTestContext {
         for (RaftRequest.Outbound request : collectBeginEpochRequests(epoch)) {
             BeginQuorumEpochResponseData beginEpochResponse = beginEpochResponse(epoch, localIdOrThrow());
             deliverResponse(request.correlationId(), request.destination(), beginEpochResponse);
+            client.poll();
         }
-        client.poll();
     }
 
     public void pollUntil(TestCondition condition) throws InterruptedException {
@@ -797,10 +799,12 @@ public final class RaftClientTestContext {
         channel.mockReceive(new RaftResponse.Inbound(correlationId, versionedResponse, source));
     }
 
-    void assertSentBeginQuorumEpochRequest(int epoch, Set<Integer> destinationIds) {
+    List<RaftRequest.Outbound> assertSentBeginQuorumEpochRequest(int epoch, Set<Integer> destinationIds) {
         List<RaftRequest.Outbound> requests = collectBeginEpochRequests(epoch);
         assertEquals(destinationIds.size(), requests.size());
         assertEquals(destinationIds, requests.stream().map(r -> r.destination().id()).collect(Collectors.toSet()));
+
+        return requests;
     }
 
     private List<RaftResponse.Outbound> drainSentResponses(
@@ -1108,6 +1112,20 @@ public final class RaftClientTestContext {
         return addVoterResponse;
     }
 
+    RemoveRaftVoterResponseData assertSentRemoveVoterResponse(Errors error) {
+        List<RaftResponse.Outbound> sentResponses = drainSentResponses(ApiKeys.REMOVE_RAFT_VOTER);
+        assertEquals(1, sentResponses.size());
+
+        RaftResponse.Outbound response = sentResponses.get(0);
+        assertInstanceOf(RemoveRaftVoterResponseData.class, response.data());
+
+        RemoveRaftVoterResponseData removeVoterResponse = (RemoveRaftVoterResponseData) response.data();
+        assertEquals(error, Errors.forCode(removeVoterResponse.errorCode()));
+
+        return removeVoterResponse;
+    }
+
+    // TODO: preferredSuccessors should be a list of replica keys
     List<RaftRequest.Outbound> collectEndQuorumRequests(
         int epoch,
         Set<Integer> destinationIdSet,
@@ -1251,7 +1269,7 @@ public final class RaftClientTestContext {
         );
     }
 
-    private BeginQuorumEpochResponseData beginEpochResponse(int epoch, int leaderId) {
+    BeginQuorumEpochResponseData beginEpochResponse(int epoch, int leaderId) {
         return RaftUtil.singletonBeginQuorumEpochResponse(
             channel.listenerName(),
             beginQuorumEpochRpcVersion(),
@@ -1574,7 +1592,7 @@ public final class RaftClientTestContext {
         Endpoints endpoints
     ) {
         return addVoterRequest(
-            clusterId.toString(),
+            clusterId,
             timeoutMs,
             voter,
             endpoints
@@ -1595,6 +1613,13 @@ public final class RaftClientTestContext {
         );
     }
 
+    RemoveRaftVoterRequestData removeVoterRequest(ReplicaKey voter) {
+        return removeVoterRequest(clusterId, voter);
+    }
+
+    RemoveRaftVoterRequestData removeVoterRequest(String cluster, ReplicaKey voter) {
+        return RaftUtil.removeVoterRequest(cluster, voter);
+    }
 
     private short fetchRpcVersion() {
         if (kip853Rpc) {
@@ -1652,6 +1677,14 @@ public final class RaftClientTestContext {
         }
     }
 
+    private short removeVoterRpcVersion() {
+        if (kip853Rpc) {
+            return 0;
+        } else {
+            throw new IllegalStateException("Reconfiguration must be enabled by calling withKip853Rpc(true)");
+        }
+    }
+
     private short raftRequestVersion(ApiMessage request) {
         if (request instanceof FetchRequestData) {
             return fetchRpcVersion();
@@ -1667,6 +1700,8 @@ public final class RaftClientTestContext {
             return describeQuorumRpcVersion();
         } else if (request instanceof AddRaftVoterRequestData) {
             return addVoterRpcVersion();
+        } else if (request instanceof RemoveRaftVoterRequestData) {
+            return removeVoterRpcVersion();
         } else {
             throw new IllegalArgumentException(String.format("Request %s is not a raft request", request));
         }
@@ -1687,6 +1722,8 @@ public final class RaftClientTestContext {
             return describeQuorumRpcVersion();
         } else if (response instanceof AddRaftVoterResponseData) {
             return addVoterRpcVersion();
+        } else if (response instanceof RemoveRaftVoterResponseData) {
+            return removeVoterRpcVersion();
         } else if (response instanceof ApiVersionsResponseData) {
             return 4;
         } else {

--- a/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
@@ -116,6 +116,16 @@ public final class VoterSetTest {
     }
 
     @Test
+    void testCannotRemoveToEmptyVoterSet() {
+        Map<Integer, VoterSet.VoterNode> aVoterMap = voterMap(IntStream.of(1), true);
+        VoterSet voterSet = new VoterSet(new HashMap<>(aVoterMap));
+
+        ReplicaKey voter1 = aVoterMap.get(1).voterKey();
+        assertTrue(voterSet.isVoter(voter1));
+        assertEquals(Optional.empty(), voterSet.removeVoter(voter1));
+    }
+
+    @Test
     void testIsVoterWithDirectoryId() {
         Map<Integer, VoterSet.VoterNode> aVoterMap = voterMap(IntStream.of(1, 2, 3), true);
         VoterSet voterSet = new VoterSet(new HashMap<>(aVoterMap));


### PR DESCRIPTION
Implement the RemoveVoter RPC. The general algorithm is as follow:

1. Check that the leader has fenced the previous leader(s) by checking that the HWM is known, otherwise return the REQUEST_TIMED_OUT error.
2. Check that the cluster supports kraft.version 1, otherwise return the UNSUPPORTED_VERSION error.
3. Check that there are no uncommitted voter changes, otherwise return the REQUEST_TIMED_OUT error.
4. Append the updated VotersRecord to the log. The KRaft internal listener will read this uncommitted record from the log and add the new voter to the set of voters.
5. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a REQUEST_TIMED_OUT error if it doesn't commit in time.
6. Send the RemoveVoter successful response to the client.
7. Resign the leadership if the leader is not in the new voter set

One thing to note is that now that KRaft supports both the remove voter and add voter RPC, only one change can be pending at once. This is achieved in the following ways. The AddVoter RPC checks if there are pending AddVoter or RemoveVoter RPC. The RemoveVoter RPC checks if there are any pending AddVoter or RemoveVoter RPC. Both RPCs check that there is no uncommitted VotersRecord.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
