### PR TITLE
KAFKA-16448: Handle fatal user exception during processing error

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -213,9 +213,13 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                 internalProcessorContext.currentNode().name(),
                 internalProcessorContext.taskId());
 
-            final ProcessingExceptionHandler.ProcessingHandlerResponse response = processingExceptionHandler
-                .handle(errorHandlerContext, record, e);
+            final ProcessingExceptionHandler.ProcessingHandlerResponse response;
 
+            try {
+                response = processingExceptionHandler.handle(errorHandlerContext, record, e);
+            } catch (final Exception fatalUserException) {
+                throw new StreamsException("Fatal user code error in processing error callback", fatalUserException);
+            }
             if (response == ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL) {
                 log.error("Processing exception handler is set to fail upon" +
                      " a processing error. If you would rather have the streaming pipeline" +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -218,7 +218,7 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
             try {
                 response = processingExceptionHandler.handle(errorHandlerContext, record, e);
             } catch (final Exception fatalUserException) {
-                throw new StreamsException("Fatal user code error in processing error callback", fatalUserException);
+                throw new FailedProcessingException(fatalUserException);
             }
             if (response == ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL) {
                 log.error("Processing exception handler is set to fail upon" +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -31,13 +31,11 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.utils.Utils.getNullableSizePrefixedArray;
 
 public class ProcessorRecordContext implements RecordContext, RecordMetadata {
-
     private final long timestamp;
     private final long offset;
     private final String topic;
     private final int partition;
     private final Headers headers;
-
     public ProcessorRecordContext(final long timestamp,
                                   final long offset,
                                   final int partition,
@@ -49,32 +47,26 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         this.partition = partition;
         this.headers = Objects.requireNonNull(headers);
     }
-
     @Override
     public long offset() {
         return offset;
     }
-
     @Override
     public long timestamp() {
         return timestamp;
     }
-
     @Override
     public String topic() {
         return topic;
     }
-
     @Override
     public int partition() {
         return partition;
     }
-
     @Override
     public Headers headers() {
         return headers;
     }
-
     public long residentMemorySizeEstimate() {
         long size = 0;
         size += Long.BYTES; // value.context.timestamp
@@ -92,7 +84,6 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         }
         return size;
     }
-
     public byte[] serialize() {
         final byte[] topicBytes = topic.getBytes(UTF_8);
         final byte[][] headerKeysBytes;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -31,11 +31,13 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.utils.Utils.getNullableSizePrefixedArray;
 
 public class ProcessorRecordContext implements RecordContext, RecordMetadata {
+
     private final long timestamp;
     private final long offset;
     private final String topic;
     private final int partition;
     private final Headers headers;
+
     public ProcessorRecordContext(final long timestamp,
                                   final long offset,
                                   final int partition,
@@ -47,26 +49,32 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         this.partition = partition;
         this.headers = Objects.requireNonNull(headers);
     }
+
     @Override
     public long offset() {
         return offset;
     }
+
     @Override
     public long timestamp() {
         return timestamp;
     }
+
     @Override
     public String topic() {
         return topic;
     }
+
     @Override
     public int partition() {
         return partition;
     }
+
     @Override
     public Headers headers() {
         return headers;
     }
+
     public long residentMemorySizeEstimate() {
         long size = 0;
         size += Long.BYTES; // value.context.timestamp
@@ -84,6 +92,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         }
         return size;
     }
+    
     public byte[] serialize() {
         final byte[] topicBytes = topic.getBytes(UTF_8);
         final byte[][] headerKeysBytes;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -92,7 +92,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         }
         return size;
     }
-    
+
     public byte[] serialize() {
         final byte[] topicBytes = topic.getBytes(UTF_8);
         final byte[][] headerKeysBytes;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -100,7 +100,7 @@ public class ProcessorNodeTest {
             new ProcessorNode<>(NAME, new IgnoredInternalExceptionsProcessor(), Collections.emptySet());
 
         final InternalProcessorContext<Object, Object> internalProcessorContext = mockInternalProcessorContext();
-        node.init(internalProcessorContext, new ProcessingExceptionHandlerMock(ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL, internalProcessorContext));
+        node.init(internalProcessorContext, new ProcessingExceptionHandlerMock(ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL, internalProcessorContext, false));
 
         final FailedProcessingException failedProcessingException = assertThrows(FailedProcessingException.class,
             () -> node.process(new Record<>(KEY, VALUE, TIMESTAMP)));
@@ -116,7 +116,7 @@ public class ProcessorNodeTest {
             new ProcessorNode<>(NAME, new IgnoredInternalExceptionsProcessor(), Collections.emptySet());
 
         final InternalProcessorContext<Object, Object> internalProcessorContext = mockInternalProcessorContext();
-        node.init(internalProcessorContext, new ProcessingExceptionHandlerMock(ProcessingExceptionHandler.ProcessingHandlerResponse.CONTINUE, internalProcessorContext));
+        node.init(internalProcessorContext, new ProcessingExceptionHandlerMock(ProcessingExceptionHandler.ProcessingHandlerResponse.CONTINUE, internalProcessorContext, false));
 
         assertDoesNotThrow(() -> node.process(new Record<>(KEY, VALUE, TIMESTAMP)));
     }
@@ -144,6 +144,21 @@ public class ProcessorNodeTest {
         assertEquals(ignoredExceptionCause, runtimeException.getCause().getClass());
         assertEquals(ignoredExceptionCauseMessage, runtimeException.getCause().getMessage());
         verify(processingExceptionHandler, never()).handle(any(), any(), any());
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionWhenProcessingExceptionHandlerThrowsAnException() {
+        final ProcessorNode<Object, Object, Object, Object> node =
+                new ProcessorNode<>(NAME, new IgnoredInternalExceptionsProcessor(), Collections.emptySet());
+
+        final InternalProcessorContext<Object, Object> internalProcessorContext = mockInternalProcessorContext();
+        node.init(internalProcessorContext, new ProcessingExceptionHandlerMock(ProcessingExceptionHandler.ProcessingHandlerResponse.CONTINUE, internalProcessorContext, true));
+
+        final StreamsException streamsException = assertThrows(StreamsException.class,
+            () -> node.process(new Record<>(KEY, VALUE, TIMESTAMP)));
+
+        final String msg = streamsException.getMessage();
+        assertTrue(msg.contains("Fatal user code error in processing error callback"));
     }
 
     private static class ExceptionalProcessor implements Processor<Object, Object, Object, Object> {
@@ -323,10 +338,14 @@ public class ProcessorNodeTest {
         private final ProcessingExceptionHandler.ProcessingHandlerResponse response;
         private final InternalProcessorContext<Object, Object> internalProcessorContext;
 
+        private final boolean shouldThrowException;
+
         public ProcessingExceptionHandlerMock(final ProcessingExceptionHandler.ProcessingHandlerResponse response,
-                                              final InternalProcessorContext<Object, Object> internalProcessorContext) {
+                                              final InternalProcessorContext<Object, Object> internalProcessorContext,
+                                              final boolean shouldThrowException) {
             this.response = response;
             this.internalProcessorContext = internalProcessorContext;
+            this.shouldThrowException = shouldThrowException;
         }
 
         @Override
@@ -341,6 +360,9 @@ public class ProcessorNodeTest {
             assertTrue(exception instanceof RuntimeException);
             assertEquals("Processing exception should be caught and handled by the processing exception handler.", exception.getMessage());
 
+            if (shouldThrowException) {
+                throw new RuntimeException("KABOOM!");
+            }
             return response;
         }
 


### PR DESCRIPTION
This PR is part of [KAFKA-16448](https://issues.apache.org/jira/browse/KAFKA-16448) which aims to bring a ProcessingExceptionHandler to Kafka Streams in order to deal with exceptions that occur during processing.

This PR catch the exceptions thrown while handling a processing exception 

Jira: https://issues.apache.org/jira/browse/KAFKA-16448.

Contributors
@Dabz
@sebastienviale
@loicgreffier
