### PR TITLE
MINOR: Update collaborators list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,14 +27,14 @@ jenkins:
   github_whitelist:
     - FrankYang0529
     - kamalcph
+    - apoorvmittal10
     - lianetm
+    - brandboat
     - kirktrue
     - nizhikov
-    - brandboat
-    - AndrewJSchofield
+    - OmniaGM
     - dongnuo123
-    - philipnee
-    - jeffkbkim
+    - frankvicky
 
 # This list allows you to triage pull requests. It can have a maximum of 10 people.
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
@@ -42,11 +42,11 @@ github:
   collaborators:
     - FrankYang0529
     - kamalcph
+    - apoorvmittal10
     - lianetm
+    - brandboat
     - kirktrue
     - nizhikov
-    - brandboat
-    - AndrewJSchofield
+    - OmniaGM
     - dongnuo123
-    - philipnee
-    - jeffkbkim
+    - frankvicky

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,28 +25,28 @@ notifications:
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-JenkinsPRwhitelisting
 jenkins:
   github_whitelist:
-    - vcrfxia
-    - clolov
-    - fvaleri
-    - philipnee
-    - vamossagar12
+    - FrankYang0529
     - kamalcph
-    - hudeqi
-    - lihaosky
+    - lianetm
+    - kirktrue
+    - nizhikov
+    - brandboat
+    - AndrewJSchofield
+    - dongnuo123
+    - philipnee
     - jeffkbkim
-    - tinaselenge
 
 # This list allows you to triage pull requests. It can have a maximum of 10 people.
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
 github:
   collaborators:
-    - vcrfxia
-    - clolov
-    - fvaleri
-    - philipnee
-    - vamossagar12
+    - FrankYang0529
     - kamalcph
-    - hudeqi
-    - lihaosky
+    - lianetm
+    - kirktrue
+    - nizhikov
+    - brandboat
+    - AndrewJSchofield
+    - dongnuo123
+    - philipnee
     - jeffkbkim
-    - tinaselenge


### PR DESCRIPTION
I did the following:

> git shortlog --email --numbered --summary --since=2023-07-24 > /tmp/contributors.txt

Then I excluded all committers from the list.

Cut the list to the top 10 and for each member I found their GitHub user name. List is in order of commits.

Note I used the `--email` flag as stated in https://issues.apache.org/jira/browse/KAFKA-14995

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
