### PR TITLE
KAFKA-16448: Fix raw record not being cached in store

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -204,13 +204,16 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
             // Rethrow exceptions that should not be handled here
             throw e;
         } catch (final Exception e) {
+            final byte[] sourceRawKey = internalProcessorContext.recordContext().rawRecord() != null ? internalProcessorContext.recordContext().rawRecord().key() : null;
+            final byte[] sourceRawValue = internalProcessorContext.recordContext().rawRecord() != null ? internalProcessorContext.recordContext().rawRecord().value() : null;
+
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 internalProcessorContext.topic(),
                 internalProcessorContext.partition(),
                 internalProcessorContext.offset(),
                 internalProcessorContext.headers(),
-                internalProcessorContext.recordContext().rawRecord().key(),
-                internalProcessorContext.recordContext().rawRecord().value(),
+                sourceRawKey,
+                sourceRawValue,
                 internalProcessorContext.currentNode().name(),
                 internalProcessorContext.taskId());
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -189,7 +189,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             headers = new RecordHeaders(headerArr);
         }
 
-        return new ProcessorRecordContext(timestamp, offset, partition, topic, headers, null);
+        return new ProcessorRecordContext(timestamp, offset, partition, topic, headers);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -295,7 +295,9 @@ public class CachingKeyValueStore
                     context.offset(),
                     context.timestamp(),
                     context.partition(),
-                    context.topic()));
+                    context.topic(),
+                    context.recordContext().rawRecord())
+            );
 
             StoreQueryUtils.updatePosition(position, context);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -153,7 +153,9 @@ class CachingSessionStore
                 context.offset(),
                 context.timestamp(),
                 context.partition(),
-                context.topic());
+                context.topic(),
+                context.recordContext().rawRecord()
+            );
         context.cache().put(cacheName, cacheFunction.cacheKey(binaryKey), entry);
 
         maxObservedTimestamp = Math.max(keySchema.segmentTimestamp(binaryKey), maxObservedTimestamp);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -170,7 +170,9 @@ class CachingWindowStore
                 context.offset(),
                 context.timestamp(),
                 context.partition(),
-                context.topic());
+                context.topic(),
+                context.recordContext().rawRecord()
+            );
         context.cache().put(cacheName, cacheFunction.cacheKey(keyBytes), entry);
 
         maxObservedTimestamp.set(Math.max(keySchema.segmentTimestamp(keyBytes), maxObservedTimestamp.get()));

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
@@ -32,7 +33,7 @@ class LRUCacheEntry {
 
 
     LRUCacheEntry(final byte[] value) {
-        this(value, new RecordHeaders(), false, -1, -1, -1, "");
+        this(value, new RecordHeaders(), false, -1, -1, -1, "", null);
     }
 
     LRUCacheEntry(final byte[] value,
@@ -41,8 +42,16 @@ class LRUCacheEntry {
                   final long offset,
                   final long timestamp,
                   final int partition,
-                  final String topic) {
-        final ProcessorRecordContext context = new ProcessorRecordContext(timestamp, offset, partition, topic, headers);
+                  final String topic,
+                  final ConsumerRecord<byte[], byte[]> rawRecord) {
+        final ProcessorRecordContext context = new ProcessorRecordContext(
+            timestamp,
+            offset,
+            partition,
+            topic,
+            headers,
+            rawRecord
+        );
 
         this.record = new ContextualRecord(
             value,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -274,7 +274,9 @@ class TimeOrderedCachingWindowStore
                 context.offset(),
                 context.timestamp(),
                 context.partition(),
-                context.topic());
+                context.topic(),
+                context.recordContext().rawRecord()
+            );
 
         // Put to index first so that base can be evicted later
         if (hasIndex) {
@@ -291,7 +293,9 @@ class TimeOrderedCachingWindowStore
                     context.offset(),
                     context.timestamp(),
                     context.partition(),
-                    "");
+                    "",
+                    context.recordContext().rawRecord()
+                );
             final Bytes indexKey = KeyFirstWindowKeySchema.toStoreKeyBinary(key, windowStartTimestamp, 0);
             context.cache().put(cacheName, indexKeyCacheFunction.cacheKey(indexKey), emptyEntry);
         } else {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
@@ -89,7 +90,14 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         store.setFlushListener(cacheFlushListener, false);
         cache = new ThreadCache(new LogContext("testCache "), maxCacheSizeBytes, new MockStreamsMetrics(new Metrics()));
         context = new InternalMockProcessorContext<>(null, null, null, null, cache);
-        context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, new RecordHeaders()));
+        context.setRecordContext(new ProcessorRecordContext(
+            10,
+            0,
+            0,
+            TOPIC,
+            new RecordHeaders(),
+            new ConsumerRecord<>(TOPIC, 0, 0, new byte[0], new byte[0])
+        ));
         store.init((StateStoreContext) context, null);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
@@ -48,6 +49,7 @@ public class ThreadCacheTest {
     final String namespace2 = "0.2-namespace";
     private final LogContext logContext = new LogContext("testCache ");
     private final byte[][] bytes = new byte[][]{{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}};
+    private final ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>("topic", 0, 0, new byte[0], new byte[0]);
 
     @Test
     public void basicPutGet() {
@@ -65,7 +67,7 @@ public class ThreadCacheTest {
         for (final KeyValue<String, String> kvToInsert : toInsert) {
             final Bytes key = Bytes.wrap(kvToInsert.key.getBytes());
             final byte[] value = kvToInsert.value.getBytes();
-            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1L, 1L, 1, ""));
+            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1L, 1L, 1, "", consumerRecord));
         }
 
         for (final KeyValue<String, String> kvToInsert : toInsert) {
@@ -98,7 +100,7 @@ public class ThreadCacheTest {
             final String keyStr = "K" + i;
             final Bytes key = Bytes.wrap(keyStr.getBytes());
             final byte[] value = new byte[valueSizeBytes];
-            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1L, 1L, 1, ""));
+            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1L, 1L, 1, "", consumerRecord));
         }
 
 
@@ -176,7 +178,7 @@ public class ThreadCacheTest {
         for (final KeyValue<String, String> kvToInsert : toInsert) {
             final Bytes key = Bytes.wrap(kvToInsert.key.getBytes());
             final byte[] value = kvToInsert.value.getBytes();
-            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1, 1, 1, ""));
+            cache.put(namespace, key, new LRUCacheEntry(value, new RecordHeaders(), true, 1, 1, 1, "", consumerRecord));
         }
 
         for (int i = 0; i < expected.size(); i++) {
@@ -617,7 +619,7 @@ public class ThreadCacheTest {
     }
 
     private LRUCacheEntry dirtyEntry(final byte[] key) {
-        return new LRUCacheEntry(key, new RecordHeaders(), true, -1, -1, -1, "");
+        return new LRUCacheEntry(key, new RecordHeaders(), true, -1, -1, -1, "", consumerRecord);
     }
 
     private LRUCacheEntry cleanEntry(final byte[] key) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
@@ -120,7 +121,14 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
         cachingStore.setFlushListener(cacheListener, false);
         cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
         context = new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
-        context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, TOPIC, new RecordHeaders()));
+        context.setRecordContext(new ProcessorRecordContext(
+                DEFAULT_TIMESTAMP,
+                0,
+                0,
+                TOPIC,
+                new RecordHeaders(),
+                new ConsumerRecord<>(TOPIC, 0, 0, new byte[0], new byte[0])
+        ));
         cachingStore.init((StateStoreContext) context, cachingStore);
     }
 
@@ -948,7 +956,8 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
                 context.offset(),
                 context.timestamp(),
                 context.partition(),
-                "")
+                "",
+                context.recordContext().rawRecord())
         );
 
         underlyingStore.put(key, value, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
@@ -120,7 +121,14 @@ public class TimeOrderedWindowStoreTest {
         cachingStore.setFlushListener(cacheListener, false);
         cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
         context = new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
-        context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, TOPIC, new RecordHeaders()));
+        context.setRecordContext(new ProcessorRecordContext(
+                DEFAULT_TIMESTAMP,
+                0,
+                0,
+                TOPIC,
+                new RecordHeaders(),
+                new ConsumerRecord<>(TOPIC, 0, 0, new byte[0], new byte[0])
+        ));
         cachingStore.init((StateStoreContext) context, cachingStore);
     }
 
@@ -956,7 +964,8 @@ public class TimeOrderedWindowStoreTest {
                 context.offset(),
                 context.timestamp(),
                 context.partition(),
-                "")
+                "",
+                context.recordContext().rawRecord())
         );
 
         underlyingStore.put(key, value, 1);

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -239,6 +239,14 @@ public class InternalMockProcessorContext<KOut, VOut>
                 appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false);
+        this.recordContext = new ProcessorRecordContext(
+            0,
+            0,
+            0,
+            "",
+            new RecordHeaders(),
+            new ConsumerRecord<>("topic", 0, 0L, new byte[0], new byte[0])
+        );
     }
 
     @Override


### PR DESCRIPTION
@cadonna @mjsax 

After https://github.com/apache/kafka/pull/16093 has been merged, there is a scenario where processing exception handling ends with `NullPointerException`:

```java
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.kafka.clients.consumer.ConsumerRecord.key()" because the return value of "org.apache.kafka.streams.processor.internals.ProcessorRecordContext.rawRecord()" is null
	at org.apache.kafka.streams.processor.internals.ProcessorNode.process(ProcessorNode.java:212) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forwardInternal(ProcessorContextImpl.java:292) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:271) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:229) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.kstream.internals.TimestampedCacheFlushListener.apply(TimestampedCacheFlushListener.java:45) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.MeteredWindowStore.lambda$setFlushListener$6(MeteredWindowStore.java:190) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.CachingWindowStore.putAndMaybeForward(CachingWindowStore.java:125) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.CachingWindowStore.lambda$initInternal$0(CachingWindowStore.java:100) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.NamedCache.flush(NamedCache.java:159) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.NamedCache.flush(NamedCache.java:117) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.ThreadCache.flush(ThreadCache.java:148) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.CachingWindowStore.flushCache(CachingWindowStore.java:426) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.state.internals.WrappedStateStore.flushCache(WrappedStateStore.java:87) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
	at org.apache.kafka.streams.processor.internals.ProcessorStateManager.flushCache(ProcessorStateManager.java:537) ~[kafka-streams-3.9.0-SNAPSHOT.jar:na]
```

This happened with the following topology:

```java
builder
  .stream()
  .groupByKey()
  .windowedBy(...) // Does not really matter. NPE thrown windowing or not
  .aggregate(...)
  .mapValues(value -> throw new RuntimeException(...))
```

Raw record, that has been added to `ProcessorRecordContext`, is lost when caching store. This PR fixes it. Looking forward to provide unit tests