### PR TITLE
KAFKA-17195: transaction-coordinator and group-coordinator remove wrong test path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1439,6 +1439,9 @@ project(':transaction-coordinator') {
   dependencies {
     implementation libs.jacksonDatabind
     implementation project(':clients')
+    testImplementation libs.junitJupiter
+    
+    testRuntimeOnly libs.junitPlatformLanucher
     generator project(':generator')
   }
   

--- a/build.gradle
+++ b/build.gradle
@@ -1439,7 +1439,6 @@ project(':transaction-coordinator') {
   dependencies {
     implementation libs.jacksonDatabind
     implementation project(':clients')
-    
     generator project(':generator')
   }
   

--- a/build.gradle
+++ b/build.gradle
@@ -1395,7 +1395,7 @@ project(':group-coordinator') {
     }
     test {
       java {
-        srcDirs = ["src/generated/java", "src/test/java"]
+        srcDirs = ["src/test/java"]
       }
     }
   }
@@ -1439,9 +1439,7 @@ project(':transaction-coordinator') {
   dependencies {
     implementation libs.jacksonDatabind
     implementation project(':clients')
-    testImplementation libs.junitJupiter
     
-    testRuntimeOnly libs.junitPlatformLanucher
     generator project(':generator')
   }
   
@@ -1453,7 +1451,7 @@ project(':transaction-coordinator') {
     }
     test {
       java {
-        srcDirs = ["src/generated/java", "src/test/java"]
+        srcDirs = ["src/test/java"]
       }
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17195
There is a quick fix to transaction-coordinator and group-coordinator modules test sets contains generated package, but generated packages don't contains any test, thus we should remove that path  

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
