### PR TITLE
KAFKA-16666: Migrate OffsetMessageFormatter to tools module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2117,6 +2117,7 @@ project(':tools') {
     implementation project(':connect:runtime')
     implementation project(':tools:tools-api')
     implementation project(':transaction-coordinator')
+    implementation project(':group-coordinator')
     implementation libs.argparse4j
     implementation libs.jacksonDatabind
     implementation libs.jacksonDataformatCsv
@@ -2140,7 +2141,6 @@ project(':tools') {
     testImplementation project(':connect:runtime')
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':storage:storage-api').sourceSets.main.output
-    testImplementation project(':group-coordinator')
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -301,6 +301,7 @@
     <allow pkg="kafka.utils" />
     <allow pkg="scala.collection" />
     <allow pkg="org.apache.kafka.coordinator.transaction" />
+    <allow pkg="org.apache.kafka.coordinator.group" />
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.tools"/>

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -1243,6 +1243,7 @@ object GroupMetadataManager {
 
   // Formatter for use with tools such as console consumer: Consumer should also set exclude.internal.topics to false.
   // (specify --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" when consuming __consumer_offsets)
+  @Deprecated
   class OffsetsMessageFormatter extends MessageFormatter {
     def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
       Option(consumerRecord.key).map(key => GroupMetadataManager.readMessageKey(ByteBuffer.wrap(key))).foreach {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -368,6 +368,10 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                 System.err.println("WARNING: kafka.coordinator.transaction.TransactionLog$TransactionLogMessageFormatter is deprecated and will be removed in the next major release. " +
                         "Please use org.apache.kafka.tools.consumer.TransactionLogMessageFormatter instead");
                 return className;
+            case "kafka.coordinator.group.GroupMetadataManager$OffsetsMessageFormatter":
+                System.err.println("WARNING: kafka.coordinator.group.GroupMetadataManager$OffsetsMessageFormatter is deprecated and will be removed in the next major release. " +
+                        "Please use org.apache.kafka.tools.consumer.OffsetsMessageFormatter instead");
+                return className;
             default:
                 return className;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -75,7 +75,7 @@ public class OffsetsMessageFormatter implements MessageFormatter {
                     .put(VERSION, valueVersion)
                     .set(DATA, dataNode);
         } else {
-            json.set(KEY, NullNode.getInstance());
+            json.set(VALUE, NullNode.getInstance());
         }
 
         try {
@@ -104,7 +104,7 @@ public class OffsetsMessageFormatter implements MessageFormatter {
             value.setExpireTimestamp(value.expireTimestamp() == DEFAULT_TIMESTAMP ? 0L : value.expireTimestamp());
             return Optional.of(value);
         } else {
-            throw new IllegalStateException("Unknown offset message version: " + version);
+            return Optional.empty();
         }
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.tools.consumer;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -73,7 +89,7 @@ public class OffsetsMessageFormatter implements MessageFormatter {
         if (version >= OffsetCommitValue.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitValue.HIGHEST_SUPPORTED_VERSION) {
             OffsetCommitValue value = new OffsetCommitValue(new ByteBufferAccessor(byteBuffer), version);
-            value.setLeaderEpoch(value.leaderEpoch() == NO_PARTITION_LEADER_EPOCH ? 0: value.leaderEpoch());
+            value.setLeaderEpoch(value.leaderEpoch() == NO_PARTITION_LEADER_EPOCH ? 0 : value.leaderEpoch());
             value.setExpireTimestamp(value.expireTimestamp() == DEFAULT_TIMESTAMP ? 0L : value.expireTimestamp());
             return Optional.of(value);
         } else {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -1,0 +1,114 @@
+package org.apache.kafka.tools.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitKeyJsonConverter;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitValueJsonConverter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
+import static org.apache.kafka.common.requests.OffsetCommitRequest.DEFAULT_TIMESTAMP;
+
+public class OffsetsMessageFormatter implements MessageFormatter {
+
+    private static final String VERSION = "version";
+    private static final String DATA = "data";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    private static final String NULL = "NULL";
+
+    @Override
+    public void writeTo(ConsumerRecord<byte[], byte[]> consumerRecord, PrintStream output) {
+        ObjectNode json = new ObjectNode(JsonNodeFactory.instance);
+
+        byte[] key = consumerRecord.key();
+        if (Objects.nonNull(key)) {
+            short keyVersion = ByteBuffer.wrap(key).getShort();
+            Optional<OffsetCommitKey> offsetCommitKey = readToGroupMetadataKey(ByteBuffer.wrap(key));
+            settingKeyNode(json, offsetCommitKey, keyVersion);
+        } else {
+            json.put(KEY, NULL);
+        }
+
+        byte[] value = consumerRecord.value();
+        if (Objects.nonNull(value)) {
+            short valueVersion = ByteBuffer.wrap(value).getShort();
+            Optional<OffsetCommitValue> offsetCommitValue = readToOffsetCommitValue(ByteBuffer.wrap(value));
+            settingValueNode(json, offsetCommitValue, valueVersion);
+        } else {
+            json.put(VALUE, NULL);
+        }
+
+        try {
+            output.write(json.toString().getBytes(UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<OffsetCommitKey> readToGroupMetadataKey(ByteBuffer byteBuffer) {
+        short version = byteBuffer.getShort();
+        if (version >= OffsetCommitKey.LOWEST_SUPPORTED_VERSION
+                && version <= OffsetCommitKey.HIGHEST_SUPPORTED_VERSION) {
+            return Optional.of(new OffsetCommitKey(new ByteBufferAccessor(byteBuffer), version));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<OffsetCommitValue> readToOffsetCommitValue(ByteBuffer byteBuffer) {
+        short version = byteBuffer.getShort();
+        if (version >= OffsetCommitValue.LOWEST_SUPPORTED_VERSION
+                && version <= OffsetCommitValue.HIGHEST_SUPPORTED_VERSION) {
+            OffsetCommitValue value = new OffsetCommitValue(new ByteBufferAccessor(byteBuffer), version);
+            value.setLeaderEpoch(value.leaderEpoch() == NO_PARTITION_LEADER_EPOCH ? 0: value.leaderEpoch());
+            value.setExpireTimestamp(value.expireTimestamp() == DEFAULT_TIMESTAMP ? 0L : value.expireTimestamp());
+            return Optional.of(value);
+        } else {
+            throw new IllegalStateException("Unknown offset message version: " + version);
+        }
+    }
+
+    private void settingKeyNode(ObjectNode json, Optional<OffsetCommitKey> transactionLogKey, short keyVersion) {
+        if (transactionLogKey.isPresent()) {
+            addDataNode(json, KEY, keyVersion,
+                    OffsetCommitKeyJsonConverter.write(transactionLogKey.get(), keyVersion));
+        } else {
+            addUnknownNode(json, KEY, keyVersion);
+        }
+    }
+
+    private void settingValueNode(ObjectNode json, Optional<OffsetCommitValue> transactionLogValue, short valueVersion) {
+        if (transactionLogValue.isPresent()) {
+            addDataNode(json, VALUE, valueVersion,
+                    OffsetCommitValueJsonConverter.write(transactionLogValue.get(), valueVersion));
+        } else {
+            addUnknownNode(json, VALUE, valueVersion);
+        }
+    }
+
+    private void addUnknownNode(ObjectNode json, String nodeName, short keyVersion) {
+        json.putObject(nodeName)
+                .put(VERSION, Short.toString(keyVersion))
+                .put(DATA, "unknown");
+    }
+
+    private static void addDataNode(ObjectNode json, String value,
+                                    short valueVersion, JsonNode data) {
+        json.putObject(value)
+                .put(VERSION, Short.toString(valueVersion))
+                .set(DATA, data);
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -39,8 +39,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
-import static org.apache.kafka.common.requests.OffsetCommitRequest.DEFAULT_TIMESTAMP;
 
 /**
  * Formatter for use with tools such as console consumer: Consumer should also set exclude.internal.topics to false.
@@ -116,17 +114,11 @@ public class OffsetsMessageFormatter implements MessageFormatter {
         }
     }
 
-    /**
-     * We ignore the timestamp of the message because GroupMetadataMessage has its own timestamp.
-     */
     private Optional<OffsetCommitValue> readToOffsetCommitValue(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= OffsetCommitValue.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitValue.HIGHEST_SUPPORTED_VERSION) {
-            OffsetCommitValue value = new OffsetCommitValue(new ByteBufferAccessor(byteBuffer), version);
-            value.setLeaderEpoch(value.leaderEpoch() == NO_PARTITION_LEADER_EPOCH ? 0 : value.leaderEpoch());
-            value.setExpireTimestamp(value.expireTimestamp() == DEFAULT_TIMESTAMP ? 0L : value.expireTimestamp());
-            return Optional.of(value);
+            return Optional.of(new OffsetCommitValue(new ByteBufferAccessor(byteBuffer), version));
         } else {
             return Optional.empty();
         }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -649,50 +649,50 @@ public class ConsoleConsumerOptionsTest {
 
     @Test
     public void testParseDeprecatedFormatter() throws Exception {
-        String[] deprecatedDefaultMessageFormatter = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--topic", "test",
-            "--partition", "0",
-            "--formatter", "kafka.tools.DefaultMessageFormatter",
-        };
+        String[] deprecatedDefaultMessageFormatter = generateArgsForFormatter("kafka.tools.DefaultMessageFormatter");
         assertInstanceOf(DefaultMessageFormatter.class, new ConsoleConsumerOptions(deprecatedDefaultMessageFormatter).formatter());
 
-        String[] deprecatedLoggingMessageFormatter = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--topic", "test",
-            "--partition", "0",
-            "--formatter", "kafka.tools.LoggingMessageFormatter",
-        };
+        String[] deprecatedLoggingMessageFormatter = generateArgsForFormatter("kafka.tools.LoggingMessageFormatter");
         assertInstanceOf(LoggingMessageFormatter.class, new ConsoleConsumerOptions(deprecatedLoggingMessageFormatter).formatter());
 
-        String[] deprecatedNoOpMessageFormatter = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--topic", "test",
-            "--partition", "0",
-            "--formatter", "kafka.tools.NoOpMessageFormatter",
-        };
+        String[] deprecatedNoOpMessageFormatter = generateArgsForFormatter("kafka.tools.NoOpMessageFormatter");
         assertInstanceOf(NoOpMessageFormatter.class, new ConsoleConsumerOptions(deprecatedNoOpMessageFormatter).formatter());
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testNewAndDeprecateTransactionLogMessageFormatter() throws Exception {
-        String[] deprecatedTransactionLogMessageFormatter = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--topic", "test",
-            "--partition", "0",
-            "--formatter", "kafka.coordinator.transaction.TransactionLog$TransactionLogMessageFormatter",
-        };
+        String[] deprecatedTransactionLogMessageFormatter = 
+                generateArgsForFormatter("kafka.coordinator.transaction.TransactionLog$TransactionLogMessageFormatter");
         assertInstanceOf(kafka.coordinator.transaction.TransactionLog.TransactionLogMessageFormatter.class, 
                 new ConsoleConsumerOptions(deprecatedTransactionLogMessageFormatter).formatter());
 
-        String[] transactionLogMessageFormatter = new String[]{
+        String[] transactionLogMessageFormatter = 
+                generateArgsForFormatter("org.apache.kafka.tools.consumer.TransactionLogMessageFormatter");
+        assertInstanceOf(TransactionLogMessageFormatter.class, 
+                new ConsoleConsumerOptions(transactionLogMessageFormatter).formatter());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testNewAndDeprecateOffsetsMessageFormatter() throws Exception {
+        String[] deprecatedOffsetsMessageFormatter = 
+                generateArgsForFormatter("kafka.coordinator.group.GroupMetadataManager$OffsetsMessageFormatter");
+        assertInstanceOf(kafka.coordinator.group.GroupMetadataManager.OffsetsMessageFormatter.class,
+                new ConsoleConsumerOptions(deprecatedOffsetsMessageFormatter).formatter());
+
+        String[] offsetsMessageFormatter = 
+                generateArgsForFormatter("org.apache.kafka.tools.consumer.OffsetsMessageFormatter");
+        assertInstanceOf(OffsetsMessageFormatter.class,
+                new ConsoleConsumerOptions(offsetsMessageFormatter).formatter());
+    }
+    
+    private String[] generateArgsForFormatter(String formatter) {
+        return new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
             "--partition", "0",
-            "--formatter", "org.apache.kafka.tools.consumer.TransactionLogMessageFormatter",
+            "--formatter", formatter,
         };
-        assertInstanceOf(TransactionLogMessageFormatter.class, 
-                new ConsoleConsumerOptions(transactionLogMessageFormatter).formatter());
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
@@ -366,7 +366,7 @@ public class ConsoleConsumerTest {
                         OffsetCommitValueJsonConverter.read(valueNode.get("data"), OffsetCommitValue.HIGHEST_SUPPORTED_VERSION);
                 assertNotNull(offsetCommitValue);
                 assertEquals(0, offsetCommitValue.offset());
-                assertEquals(0, offsetCommitValue.leaderEpoch());
+                assertEquals(-1, offsetCommitValue.leaderEpoch());
                 assertNotNull(offsetCommitValue.metadata());
                 assertEquals(-1, offsetCommitValue.expireTimestamp());
             } finally {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OffsetMessageFormatterTest {
+
+    private static final OffsetCommitKey OFFSET_COMMIT_KEY = new OffsetCommitKey()
+            .setGroup("group-id")
+            .setTopic("foo")
+            .setPartition(1);
+    private static final OffsetCommitValue OFFSET_COMMIT_VALUE = new OffsetCommitValue()
+            .setOffset(100L)
+            .setLeaderEpoch(10)
+            .setMetadata("metadata")
+            .setCommitTimestamp(1234L)
+            .setExpireTimestamp(-1L);
+    private static final String TOPIC = "TOPIC";
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 10, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 10, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":10,\"data\":\"unknown\"},\"value\":{\"version\":10,\"data\":\"unknown\"}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":0,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
+                            "\"commitTimestamp\":1234}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 1, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":1,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
+                            "\"commitTimestamp\":1234,\"expireTimestamp\":0}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":2,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
+                            "\"commitTimestamp\":1234}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 3, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":3,\"data\":{\"offset\":100,\"leaderEpoch\":10," +
+                            "\"metadata\":\"metadata\",\"commitTimestamp\":1234}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 4, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":4,\"data\":{\"offset\":100,\"leaderEpoch\":10," +
+                            "\"metadata\":\"metadata\",\"commitTimestamp\":1234}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 5, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 4, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":5,\"data\":\"unknown\"},\"value\":{\"version\":4," +
+                            "\"data\":{\"offset\":100,\"leaderEpoch\":10,\"metadata\":\"metadata\"," +
+                            "\"commitTimestamp\":1234}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 5, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":{\"version\":5,\"data\":\"unknown\"}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        null,
+                        "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
+                            "\"value\":null}"),
+                Arguments.of(
+                        null,
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 1, OFFSET_COMMIT_VALUE).array(),
+                        "{\"key\":null,\"value\":{\"version\":1,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
+                            "\"commitTimestamp\":1234,\"expireTimestamp\":0}}}"),
+                Arguments.of(null, null, "{\"key\":null,\"value\":null}")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testTransactionLogMessageFormatter(byte[] keyBuffer, byte[] valueBuffer, String expectedOutput) {
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                TOPIC, 0, 0,
+                0L, TimestampType.CREATE_TIME, 0,
+                0, keyBuffer, valueBuffer,
+                new RecordHeaders(), Optional.empty());
+        
+        try (MessageFormatter formatter = new OffsetsMessageFormatter()) {
+            formatter.configure(emptyMap());
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            formatter.writeTo(record, new PrintStream(out));
+            assertEquals(expectedOutput, out.toString());
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.MessageFormatter;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 
@@ -30,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -48,6 +51,13 @@ public class OffsetMessageFormatterTest {
             .setMetadata("metadata")
             .setCommitTimestamp(1234L)
             .setExpireTimestamp(-1L);
+    private static final GroupMetadataKey GROUP_METADATA_KEY = new GroupMetadataKey().setGroup("group-id");
+    private static final GroupMetadataValue GROUP_METADATA_VALUE = new GroupMetadataValue()
+            .setProtocolType("consumer")
+            .setGeneration(1)
+            .setProtocol("range")
+            .setLeader("leader")
+            .setMembers(Collections.emptyList());
     private static final String TOPIC = "TOPIC";
 
     private static Stream<Arguments> parameters() {
@@ -69,7 +79,7 @@ public class OffsetMessageFormatterTest {
                         MessageUtil.toVersionPrefixedByteBuffer((short) 1, OFFSET_COMMIT_VALUE).array(),
                         "{\"key\":{\"version\":0,\"data\":{\"group\":\"group-id\",\"topic\":\"foo\",\"partition\":1}}," +
                             "\"value\":{\"version\":1,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
-                            "\"commitTimestamp\":1234,\"expireTimestamp\":0}}}"
+                            "\"commitTimestamp\":1234,\"expireTimestamp\":-1}}}"
                 ),
                 Arguments.of(
                         MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
@@ -114,8 +124,13 @@ public class OffsetMessageFormatterTest {
                         null,
                         MessageUtil.toVersionPrefixedByteBuffer((short) 1, OFFSET_COMMIT_VALUE).array(),
                         "{\"key\":null,\"value\":{\"version\":1,\"data\":{\"offset\":100,\"metadata\":\"metadata\"," +
-                            "\"commitTimestamp\":1234,\"expireTimestamp\":0}}}"),
-                Arguments.of(null, null, "{\"key\":null,\"value\":null}")
+                            "\"commitTimestamp\":1234,\"expireTimestamp\":-1}}}"),
+                Arguments.of(null, null, "{\"key\":null,\"value\":null}"),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_VALUE).array(),
+                        ""
+                )
         );
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/OffsetMessageFormatterTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-16666

transfer OffsetMessageFormatter form scala code to java code, and move to tool module

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
