### PR TITLE
KAFKA-17204: KafkaStreamsCloseOptionsIntegrationTest.before leaks AdminClient

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
@@ -90,6 +90,10 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
 
     @AfterAll
     public static void closeCluster() {
+        if (adminClient != null) {
+            adminClient.close();
+        }
+
         CLUSTER.stop();
     }
 
@@ -146,6 +150,7 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
         if (streams != null) {
             streams.close(Duration.ofSeconds(30));
         }
+
         Utils.delete(testFolder);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
@@ -90,10 +90,7 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
 
     @AfterAll
     public static void closeCluster() {
-        if (adminClient != null) {
-            adminClient.close();
-        }
-
+        Utils.closeQuietly(adminClient, "admin");
         CLUSTER.stop();
     }
 
@@ -150,7 +147,6 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
         if (streams != null) {
             streams.close(Duration.ofSeconds(30));
         }
-
         Utils.delete(testFolder);
     }
 


### PR DESCRIPTION
To avoid resource leak, we should close `AdminClient` after test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
