### PR TITLE
KAFKA-17205: Allow topic config validation in controller level in KRaft mode

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -89,14 +89,15 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
 
   override def validate(
     resource: ConfigResource,
-    config: util.Map[String, String]
+    newConfigs: util.Map[String, String],
+    oldConfigs: util.Map[String, String]
   ): Unit = {
     resource.`type`() match {
       case TOPIC =>
         validateTopicName(resource.name())
         val properties = new Properties()
         val nullTopicConfigs = new mutable.ArrayBuffer[String]()
-        config.forEach((key, value) => {
+        newConfigs.forEach((key, value) => {
           if (value == null) {
             nullTopicConfigs += key
           } else {
@@ -107,12 +108,12 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
           throw new InvalidConfigurationException("Null value not supported for topic configs: " +
             nullTopicConfigs.mkString(","))
         }
-        LogConfig.validate(properties, kafkaConfig.extractLogConfigMap,
+        LogConfig.validate(oldConfigs, properties, kafkaConfig.extractLogConfigMap,
           kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
       case BROKER => validateBrokerName(resource.name())
       case CLIENT_METRICS =>
         val properties = new Properties()
-        config.forEach((key, value) => properties.setProperty(key, value))
+        newConfigs.forEach((key, value) => properties.setProperty(key, value))
         ClientMetricsConfigs.validate(resource.name(), properties)
       case _ => throwExceptionForUnknownResourceType(resource)
     }

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -161,7 +161,7 @@ class AdminZkClient(zkClient: KafkaZkClient,
         partitionReplicaAssignment.keys.filter(_ >= 0).sum != sequenceSum)
         throw new InvalidReplicaAssignmentException("partitions should be a consecutive 0-based integer sequence")
 
-    LogConfig.validate(config,
+    LogConfig.validate(Collections.emptyMap(), config,
       kafkaConfig.map(_.extractLogConfigMap).getOrElse(Collections.emptyMap()),
       kafkaConfig.exists(_.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
   }
@@ -479,7 +479,7 @@ class AdminZkClient(zkClient: KafkaZkClient,
     if (!zkClient.topicExists(topic))
       throw new UnknownTopicOrPartitionException(s"Topic '$topic' does not exist.")
     // remove the topic overrides
-    LogConfig.validate(configs,
+    LogConfig.validate(Collections.emptyMap(), configs,
       kafkaConfig.map(_.extractLogConfigMap).getOrElse(Collections.emptyMap()),
       kafkaConfig.exists(_.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
   }

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -30,9 +30,10 @@ import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.security.authorizer.AclEntry
-import org.apache.kafka.server.config.{ServerConfigs, ReplicationConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach , TestInfo, Timeout}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -206,7 +207,12 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
         config.setProperty(ServerLogConfigs.LOG_ROLL_TIME_JITTER_MILLIS_CONFIG, "123")
       })
     }
+
     configs.foreach { config =>
+      // enable system-wide remote storage config for remote storage feature testing
+      config.setProperty(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+      config.setProperty(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteStorageManager].getName)
+      config.setProperty(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteLogMetadataManager].getName)
       config.setProperty(ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, "true")
       config.setProperty(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0")
       config.setProperty(ReplicationConfigs.AUTO_LEADER_REBALANCE_ENABLE_CONFIG, "false")

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs}
-import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
@@ -207,12 +206,7 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
         config.setProperty(ServerLogConfigs.LOG_ROLL_TIME_JITTER_MILLIS_CONFIG, "123")
       })
     }
-
     configs.foreach { config =>
-      // enable system-wide remote storage config for remote storage feature testing
-      config.setProperty(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
-      config.setProperty(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteStorageManager].getName)
-      config.setProperty(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteLogMetadataManager].getName)
       config.setProperty(ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, "true")
       config.setProperty(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0")
       config.setProperty(ReplicationConfigs.AUTO_LEADER_REBALANCE_ENABLE_CONFIG, "false")

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.security.authorizer.AclEntry
-import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{ServerConfigs, ReplicationConfigs, ServerLogConfigs}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.params.ParameterizedTest

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2152,34 +2152,6 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     }, "Expected to see the broker properties we just removed to be deleted", pause=25)
   }
 
-  // The remote storage config validation on controller level only works in KRaft
-  @ParameterizedTest
-  @ValueSource(strings = Array("kraft"))
-  def testDisablingRemoteStorageIncrementalAlterConfigs(quorum: String): Unit = {
-    client = createAdminClient
-
-    // Create a topic with remote storage enabled
-    val topic = "incremental-alter-configs-topic-1"
-    val topicCreateConfigs = new Properties
-    topicCreateConfigs.setProperty(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
-    val topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
-    createTopic(topic, numPartitions = 1, replicationFactor = 1, topicCreateConfigs)
-
-    // Try to disable remote storage
-    val topicAlterConfigs = Seq(
-      new AlterConfigOp(new ConfigEntry(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"), AlterConfigOp.OpType.SET),
-    ).asJavaCollection
-
-    val alterResult = client.incrementalAlterConfigs(Map(
-      topicResource -> topicAlterConfigs
-    ).asJava)
-    assertEquals(Set(topicResource).asJava, alterResult.values.keySet)
-
-    // InvalidConfigurationException exception thrown with expected message.
-    assertFutureExceptionTypeEquals(alterResult.values().get(topicResource), classOf[InvalidConfigurationException],
-      Some("Disabling remote storage feature on the topic level is not supported."))
-  }
-
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testInvalidIncrementalAlterConfigs(quorum: String): Unit = {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2152,6 +2152,34 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     }, "Expected to see the broker properties we just removed to be deleted", pause=25)
   }
 
+  // The remote storage config validation on controller level only works in KRaft
+  @ParameterizedTest
+  @ValueSource(strings = Array("kraft"))
+  def testDisablingRemoteStorageIncrementalAlterConfigs(quorum: String): Unit = {
+    client = createAdminClient
+
+    // Create a topic with remote storage enabled
+    val topic = "incremental-alter-configs-topic-1"
+    val topicCreateConfigs = new Properties
+    topicCreateConfigs.setProperty(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
+    val topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic)
+    createTopic(topic, numPartitions = 1, replicationFactor = 1, topicCreateConfigs)
+
+    // Try to disable remote storage
+    val topicAlterConfigs = Seq(
+      new AlterConfigOp(new ConfigEntry(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"), AlterConfigOp.OpType.SET),
+    ).asJavaCollection
+
+    val alterResult = client.incrementalAlterConfigs(Map(
+      topicResource -> topicAlterConfigs
+    ).asJava)
+    assertEquals(Set(topicResource).asJava, alterResult.values.keySet)
+
+    // InvalidConfigurationException exception thrown with expected message.
+    assertFutureExceptionTypeEquals(alterResult.values().get(topicResource), classOf[InvalidConfigurationException],
+      Some("Disabling remote storage feature on the topic level is not supported."))
+  }
+
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testInvalidIncrementalAlterConfigs(quorum: String): Unit = {

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.config.ConfigDef.Type.INT
 import org.apache.kafka.common.config.{ConfigException, SslConfigs, TopicConfig}
 import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.server.common.MetadataVersion
-import org.junit.jupiter.api.Assertions.{assertTrue, _}
+import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 import java.util.{Collections, Properties}

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -22,6 +22,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM
 import org.apache.kafka.common.config.ConfigDef.Type.INT
 import org.apache.kafka.common.config.{ConfigException, SslConfigs, TopicConfig}
+import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.{assertTrue, _}
 import org.junit.jupiter.api.Test
@@ -352,7 +353,7 @@ class LogConfigTest {
     val logProps = new Properties()
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")
     if (wasRemoteStorageEnabled) {
-      val message = assertThrows(classOf[ConfigException],
+      val message = assertThrows(classOf[InvalidConfigurationException],
         () => LogConfig.validate(Collections.singletonMap(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"),
           logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
       assertTrue(message.getMessage.contains("Disabling remote storage feature on the topic level is not supported."))

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -299,7 +299,7 @@ class LogConfigTest {
     props.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, localRetentionMs.toString)
     props.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, localRetentionBytes.toString)
     assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(props, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+      () => LogConfig.validate(Collections.emptyMap(), props, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
   }
 
   @Test
@@ -311,17 +311,17 @@ class LogConfigTest {
     val logProps = new Properties()
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
-    LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+    LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
 
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
     assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete,compact")
     assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "compact,delete")
     assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
   }
 
   @ParameterizedTest(name = "testEnableRemoteLogStorage with sysRemoteStorageEnabled: {0}")
@@ -334,10 +334,10 @@ class LogConfigTest {
     val logProps = new Properties()
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
     if (sysRemoteStorageEnabled) {
-      LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
     } else {
       val message = assertThrows(classOf[ConfigException],
-        () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+        () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
       assertTrue(message.getMessage.contains("Tiered Storage functionality is disabled in the broker"))
     }
   }
@@ -357,10 +357,10 @@ class LogConfigTest {
     logProps.put(TopicConfig.RETENTION_MS_CONFIG, "500")
     if (sysRemoteStorageEnabled) {
       val message = assertThrows(classOf[ConfigException],
-        () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+        () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
       assertTrue(message.getMessage.contains(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG))
     } else {
-      LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
     }
   }
 
@@ -379,10 +379,10 @@ class LogConfigTest {
     logProps.put(TopicConfig.RETENTION_BYTES_CONFIG, "128")
     if (sysRemoteStorageEnabled) {
       val message = assertThrows(classOf[ConfigException],
-        () => LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+        () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
       assertTrue(message.getMessage.contains(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG))
     } else {
-      LogConfig.validate(logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
@@ -37,7 +37,7 @@ class ControllerConfigurationValidatorTest {
   def testDefaultTopicResourceIsRejected(): Unit = {
     assertEquals("Default topic resources are not allowed.",
         assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(TOPIC, ""), emptyMap())). getMessage)
+        new ConfigResource(TOPIC, ""), emptyMap(), emptyMap())). getMessage)
   }
 
   @Test
@@ -45,14 +45,14 @@ class ControllerConfigurationValidatorTest {
     assertEquals("Topic name is invalid: '(<-invalid->)' contains " +
       "one or more characters other than ASCII alphanumerics, '.', '_' and '-'",
         assertThrows(classOf[InvalidTopicException], () => validator.validate(
-          new ConfigResource(TOPIC, "(<-invalid->)"), emptyMap())). getMessage)
+          new ConfigResource(TOPIC, "(<-invalid->)"), emptyMap(), emptyMap())). getMessage)
   }
 
   @Test
   def testUnknownResourceType(): Unit = {
     assertEquals("Unknown resource type BROKER_LOGGER",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(BROKER_LOGGER, "foo"), emptyMap())). getMessage)
+        new ConfigResource(BROKER_LOGGER, "foo"), emptyMap(), emptyMap())). getMessage)
   }
 
   @Test
@@ -63,7 +63,7 @@ class ControllerConfigurationValidatorTest {
     config.put(SEGMENT_MS_CONFIG, null)
     assertEquals("Null value not supported for topic configs: segment.bytes,segment.ms",
       assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
-        new ConfigResource(TOPIC, "foo"), config)). getMessage)
+        new ConfigResource(TOPIC, "foo"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -71,7 +71,7 @@ class ControllerConfigurationValidatorTest {
     val config = new util.TreeMap[String, String]()
     config.put(SEGMENT_JITTER_MS_CONFIG, "1000")
     config.put(SEGMENT_BYTES_CONFIG, "67108864")
-    validator.validate(new ConfigResource(TOPIC, "foo"), config)
+    validator.validate(new ConfigResource(TOPIC, "foo"), config, emptyMap())
   }
 
   @Test
@@ -82,7 +82,7 @@ class ControllerConfigurationValidatorTest {
     config.put("foobar", "abc")
     assertEquals("Unknown topic config name: foobar",
       assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
-        new ConfigResource(TOPIC, "foo"), config)). getMessage)
+        new ConfigResource(TOPIC, "foo"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -91,7 +91,7 @@ class ControllerConfigurationValidatorTest {
     config.put(SEGMENT_JITTER_MS_CONFIG, "1000")
     assertEquals("Unable to parse broker name as a base 10 number.",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(BROKER, "blah"), config)). getMessage)
+        new ConfigResource(BROKER, "blah"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -100,7 +100,7 @@ class ControllerConfigurationValidatorTest {
     config.put(SEGMENT_JITTER_MS_CONFIG, "1000")
     assertEquals("Invalid negative broker ID.",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(BROKER, "-1"), config)). getMessage)
+        new ConfigResource(BROKER, "-1"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -111,7 +111,7 @@ class ControllerConfigurationValidatorTest {
     config.put(ClientMetricsConfigs.CLIENT_MATCH_PATTERN, "client_instance_id=b69cc35a-7a54-4790-aa69-cc2bd4ee4538,client_id=1" +
       ",client_software_name=apache-kafka-java,client_software_version=2.8.0-SNAPSHOT,client_source_address=127.0.0.1," +
       "client_source_port=1234")
-    validator.validate(new ConfigResource(CLIENT_METRICS, "subscription-1"), config)
+    validator.validate(new ConfigResource(CLIENT_METRICS, "subscription-1"), config, emptyMap())
   }
 
   @Test
@@ -119,7 +119,7 @@ class ControllerConfigurationValidatorTest {
     val config = new util.TreeMap[String, String]()
     assertEquals("Subscription name can't be empty",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(CLIENT_METRICS, ""), config)). getMessage)
+        new ConfigResource(CLIENT_METRICS, ""), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -128,12 +128,12 @@ class ControllerConfigurationValidatorTest {
     config.put(ClientMetricsConfigs.PUSH_INTERVAL_MS, "10")
     assertEquals("Invalid value 10 for interval.ms, interval must be between 100 and 3600000 (1 hour)",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(CLIENT_METRICS, "subscription-1"), config)). getMessage)
+        new ConfigResource(CLIENT_METRICS, "subscription-1"), config, emptyMap())). getMessage)
 
     config.put(ClientMetricsConfigs.PUSH_INTERVAL_MS, "3600001")
     assertEquals("Invalid value 3600001 for interval.ms, interval must be between 100 and 3600000 (1 hour)",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(CLIENT_METRICS, "subscription-1"), config)). getMessage)
+        new ConfigResource(CLIENT_METRICS, "subscription-1"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -142,7 +142,7 @@ class ControllerConfigurationValidatorTest {
     config.put("random", "10")
     assertEquals("Unknown client metrics configuration: random",
       assertThrows(classOf[InvalidRequestException], () => validator.validate(
-        new ConfigResource(CLIENT_METRICS, "subscription-1"), config)). getMessage)
+        new ConfigResource(CLIENT_METRICS, "subscription-1"), config, emptyMap())). getMessage)
   }
 
   @Test
@@ -151,6 +151,6 @@ class ControllerConfigurationValidatorTest {
     config.put(ClientMetricsConfigs.CLIENT_MATCH_PATTERN, "10")
     assertEquals("Illegal client matching pattern: 10",
       assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
-        new ConfigResource(CLIENT_METRICS, "subscription-1"), config)). getMessage)
+        new ConfigResource(CLIENT_METRICS, "subscription-1"), config, emptyMap())). getMessage)
   }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -269,9 +269,13 @@ public class ConfigurationControlManager {
                                          List<ApiMessageAndVersion> recordsImplicitlyDeleted,
                                          boolean newlyCreatedResource) {
         Map<String, String> allConfigs = new HashMap<>();
+        Map<String, String> existingConfigsInMap = new HashMap<>();
         Map<String, String> alteredConfigsForAlterConfigPolicyCheck = new HashMap<>();
         TimelineHashMap<String, String> existingConfigs = configData.get(configResource);
-        if (existingConfigs != null) allConfigs.putAll(existingConfigs);
+        if (existingConfigs != null) {
+            existingConfigsInMap.putAll(existingConfigs);
+            allConfigs.putAll(existingConfigs);
+        }
         for (ApiMessageAndVersion newRecord : recordsExplicitlyAltered) {
             ConfigRecord configRecord = (ConfigRecord) newRecord.message();
             if (configRecord.value() == null) {
@@ -288,7 +292,7 @@ public class ConfigurationControlManager {
             // in the list passed to the policy in order to maintain backwards compatibility
         }
         try {
-            validator.validate(configResource, allConfigs);
+            validator.validate(configResource, allConfigs, existingConfigs);
             if (!newlyCreatedResource) {
                 existenceChecker.accept(configResource);
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -269,12 +269,12 @@ public class ConfigurationControlManager {
                                          List<ApiMessageAndVersion> recordsImplicitlyDeleted,
                                          boolean newlyCreatedResource) {
         Map<String, String> allConfigs = new HashMap<>();
-        Map<String, String> existingConfigsInMap = new HashMap<>();
+        Map<String, String> existingConfigsMap = new HashMap<>();
         Map<String, String> alteredConfigsForAlterConfigPolicyCheck = new HashMap<>();
-        TimelineHashMap<String, String> existingConfigs = configData.get(configResource);
-        if (existingConfigs != null) {
-            existingConfigsInMap.putAll(existingConfigs);
-            allConfigs.putAll(existingConfigs);
+        TimelineHashMap<String, String> existingConfigsSnapshot = configData.get(configResource);
+        if (existingConfigsSnapshot != null) {
+            allConfigs.putAll(existingConfigsSnapshot);
+            existingConfigsMap.putAll(existingConfigsSnapshot);
         }
         for (ApiMessageAndVersion newRecord : recordsExplicitlyAltered) {
             ConfigRecord configRecord = (ConfigRecord) newRecord.message();
@@ -292,7 +292,7 @@ public class ConfigurationControlManager {
             // in the list passed to the policy in order to maintain backwards compatibility
         }
         try {
-            validator.validate(configResource, allConfigs, existingConfigs);
+            validator.validate(configResource, allConfigs, existingConfigsMap);
             if (!newlyCreatedResource) {
                 existenceChecker.accept(configResource);
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationValidator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationValidator.java
@@ -28,7 +28,7 @@ public interface ConfigurationValidator {
         public void validate(ConfigResource resource) { }
 
         @Override
-        public void validate(ConfigResource resource, Map<String, String> config) { }
+        public void validate(ConfigResource resource, Map<String, String> newConfigs, Map<String, String> existingConfigs) { }
     };
 
     /**
@@ -41,8 +41,9 @@ public interface ConfigurationValidator {
     /**
      * Throws an ApiException if a configuration is invalid for the given resource.
      *
-     * @param resource      The configuration resource.
-     * @param config        The new configuration.
+     * @param resource               The configuration resource.
+     * @param newConfigs             The new configuration.
+     * @param existingConfigs        The existing configuration.
      */
-    void validate(ConfigResource resource, Map<String, String> config);
+    void validate(ConfigResource resource, Map<String, String> newConfigs, Map<String, String> existingConfigs);
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -608,9 +608,11 @@ public class LogConfig extends AbstractConfig {
 
     /**
      * Validates the values of the given properties. Should be called only by the broker.
-     * The `props` supplied contains the topic-level configs,
+     * The `newConfigs` supplied contains the topic-level configs,
      * The default values should be extracted from the KafkaConfig.
-     * @param props The properties to be validated
+     * @param existingConfigs                   The existing properties
+     * @param newConfigs                        The new properties to be validated
+     * @param isRemoteLogStorageSystemEnabled   true if system wise remote log storage is enabled
      */
     private static void validateTopicLogConfigValues(Map<String, String> existingConfigs,
                                                      Map<?, ?> newConfigs,

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -631,7 +631,7 @@ public class LogConfig extends AbstractConfig {
     public static void validateNotTurningOffRemoteStorage(Map<String, String> existingConfigs) {
         boolean wasRemoteLogEnabledBeforeUpdate = Boolean.parseBoolean(existingConfigs.getOrDefault(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"));
         if (wasRemoteLogEnabledBeforeUpdate) {
-            throw new ConfigException("Disabling remote storage feature on the topic level is not supported.");
+            throw new InvalidConfigurationException("Disabling remote storage feature on the topic level is not supported.");
         }
     }
 


### PR DESCRIPTION
Allow topic config validation in controller level in KRaft mode by passing existing configuration for validation. Adding tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
