### PR TITLE
KAFKA-8366: Avoid false positives on offline partition count

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -111,7 +111,11 @@ class KafkaController(val config: KafkaConfig,
                       tokenManager: DelegationTokenManager,
                       brokerFeatures: BrokerFeatures,
                       featureCache: ZkFinalizedFeatureCache,
-                      threadNamePrefix: Option[String] = None)
+                      threadNamePrefix: Option[String] = None,
+                      // KafkaYammerMetrics uses a static singleton that is shared across the JVM
+                      // Therefore, these are populated in tests with brokerId to disambiguate between metrics for
+                      // different nodes
+                      metricTags: Map[String, String] = Map())
   extends ControllerEventProcessor with Logging {
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
@@ -175,20 +179,20 @@ class KafkaController(val config: KafkaConfig,
   /* single-thread scheduler to clean expired tokens */
   private val tokenCleanScheduler = new KafkaScheduler(1, true, "delegation-token-cleaner")
 
-  metricsGroup.newGauge(ZkMigrationStateMetricName, () => ZkMigrationState.ZK.value().intValue())
-  metricsGroup.newGauge(ActiveControllerCountMetricName, () => if (isActive) 1 else 0)
-  metricsGroup.newGauge(OfflinePartitionsCountMetricName, () => offlinePartitionCount)
-  metricsGroup.newGauge(PreferredReplicaImbalanceCountMetricName, () => preferredReplicaImbalanceCount)
-  metricsGroup.newGauge(ControllerStateMetricName, () => state.value)
-  metricsGroup.newGauge(GlobalTopicCountMetricName, () => globalTopicCount)
-  metricsGroup.newGauge(GlobalPartitionCountMetricName, () => globalPartitionCount)
-  metricsGroup.newGauge(TopicsToDeleteCountMetricName, () => topicsToDeleteCount)
-  metricsGroup.newGauge(ReplicasToDeleteCountMetricName, () => replicasToDeleteCount)
-  metricsGroup.newGauge(TopicsIneligibleToDeleteCountMetricName, () => ineligibleTopicsToDeleteCount)
-  metricsGroup.newGauge(ReplicasIneligibleToDeleteCountMetricName, () => ineligibleReplicasToDeleteCount)
-  metricsGroup.newGauge(ActiveBrokerCountMetricName, () => activeBrokerCount)
+  metricsGroup.newGauge(ZkMigrationStateMetricName, () => ZkMigrationState.ZK.value().intValue(), metricTags.asJava)
+  metricsGroup.newGauge(ActiveControllerCountMetricName, () => if (isActive) 1 else 0, metricTags.asJava)
+  metricsGroup.newGauge(OfflinePartitionsCountMetricName, () => offlinePartitionCount, metricTags.asJava)
+  metricsGroup.newGauge(PreferredReplicaImbalanceCountMetricName, () => preferredReplicaImbalanceCount, metricTags.asJava)
+  metricsGroup.newGauge(ControllerStateMetricName, () => state.value, metricTags.asJava)
+  metricsGroup.newGauge(GlobalTopicCountMetricName, () => globalTopicCount, metricTags.asJava)
+  metricsGroup.newGauge(GlobalPartitionCountMetricName, () => globalPartitionCount, metricTags.asJava)
+  metricsGroup.newGauge(TopicsToDeleteCountMetricName, () => topicsToDeleteCount, metricTags.asJava)
+  metricsGroup.newGauge(ReplicasToDeleteCountMetricName, () => replicasToDeleteCount, metricTags.asJava)
+  metricsGroup.newGauge(TopicsIneligibleToDeleteCountMetricName, () => ineligibleTopicsToDeleteCount, metricTags.asJava)
+  metricsGroup.newGauge(ReplicasIneligibleToDeleteCountMetricName, () => ineligibleReplicasToDeleteCount, metricTags.asJava)
+  metricsGroup.newGauge(ActiveBrokerCountMetricName, () => activeBrokerCount, metricTags.asJava)
   // FencedBrokerCount metric is always 0 in the ZK controller.
-  metricsGroup.newGauge(FencedBrokerCountMetricName, () => 0)
+  metricsGroup.newGauge(FencedBrokerCountMetricName, () => 0, metricTags.asJava)
 
   /**
    * Returns true if this broker is the current controller.
@@ -539,7 +543,7 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def removeMetrics(): Unit = {
-    KafkaController.MetricNames.foreach(metricsGroup.removeMetric)
+    KafkaController.MetricNames.foreach(metricsGroup.removeMetric(_, metricTags.asJava))
   }
 
   /*

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -112,9 +112,11 @@ class KafkaController(val config: KafkaConfig,
                       brokerFeatures: BrokerFeatures,
                       featureCache: ZkFinalizedFeatureCache,
                       threadNamePrefix: Option[String] = None,
-                      // KafkaYammerMetrics uses a static singleton that is shared across the JVM
-                      // Therefore, these are populated in tests with brokerId to disambiguate between metrics for
-                      // different nodes
+                      // KafkaController objects are instantiated by all ZK brokers, including the inactive controllers.
+                      // It registers metrics on instantiation using KafkaYammerMetrics which uses a static singleton
+                      // that is shared across the JVM. These tags are populated with brokerId in tests to
+                      // disambiguate between metrics for different brokers and avoid removing KafkaController metrics
+                      // altogether on a broker shutdown.
                       metricTags: Map[String, String] = Map())
   extends ControllerEventProcessor with Logging {
 

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -98,7 +98,7 @@ class TopicDeletionManager(config: KafkaConfig,
     if (isDeleteTopicEnabled) {
       controllerContext.queueTopicDeletion(initialTopicsToBeDeleted)
       // We must populate topicsWithDeletionStarted with topics ineligible for deletion because that Set is used
-      // to check if OfflinePartitionCount metric must be changed or not.
+      // in updatePartitionStateMetrics to gate changes to OfflinePartitionCount via isTopicDeletionInProgress.
       controllerContext.topicsWithDeletionStarted ++= initialTopicsIneligibleForDeletion & controllerContext.topicsToBeDeleted
       controllerContext.topicsIneligibleForDeletion ++= initialTopicsIneligibleForDeletion & controllerContext.topicsToBeDeleted
     } else {

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -97,6 +97,9 @@ class TopicDeletionManager(config: KafkaConfig,
 
     if (isDeleteTopicEnabled) {
       controllerContext.queueTopicDeletion(initialTopicsToBeDeleted)
+      // We must populate topicsWithDeletionStarted with topics ineligible for deletion because that Set is used
+      // to check if OfflinePartitionCount metric must be changed or not.
+      controllerContext.topicsWithDeletionStarted ++= initialTopicsIneligibleForDeletion & controllerContext.topicsToBeDeleted
       controllerContext.topicsIneligibleForDeletion ++= initialTopicsIneligibleForDeletion & controllerContext.topicsToBeDeleted
     } else {
       // if delete topic is disabled clean the topic entries under /admin/delete_topics

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -113,7 +113,8 @@ class KafkaServer(
   val config: KafkaConfig,
   time: Time = Time.SYSTEM,
   threadNamePrefix: Option[String] = None,
-  enableForwarding: Boolean = false
+  enableForwarding: Boolean = false,
+  controllerMetricTags: Map[String, String] = Map()
 ) extends KafkaBroker with Server {
 
   private val startupComplete = new AtomicBoolean(false)
@@ -414,7 +415,7 @@ class KafkaServer(
         tokenManager.startup()
 
         /* start kafka controller */
-        _kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, brokerFeatures, metadataCache, threadNamePrefix)
+        _kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, brokerFeatures, metadataCache, threadNamePrefix, controllerMetricTags)
         kafkaController.startup()
 
         if (config.migrationEnabled) {

--- a/core/src/test/scala/integration/kafka/controller/OfflinePartitionsFromDeletedTopicTest.scala
+++ b/core/src/test/scala/integration/kafka/controller/OfflinePartitionsFromDeletedTopicTest.scala
@@ -32,7 +32,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.Duration
 import java.util.concurrent.TimeUnit
-import scala.jdk.CollectionConverters.{MapHasAsScala, SeqHasAsJava}
+import scala.jdk.CollectionConverters._
 
 
 class OfflinePartitionsFromDeletedTopicTest extends IntegrationTestHarness {
@@ -111,7 +111,7 @@ class OfflinePartitionsFromDeletedTopicTest extends IntegrationTestHarness {
       tries -= 1
     }
     assertNotEquals(oldController, newController, "Failed to elect a different controller")
-    log.info(s"Controller changed from ${oldController} to ${newController}")
+    log.info(s"Controller changed from $oldController to $newController")
     newController.get
   }
 

--- a/core/src/test/scala/integration/kafka/controller/OfflinePartitionsFromDeletedTopicTest.scala
+++ b/core/src/test/scala/integration/kafka/controller/OfflinePartitionsFromDeletedTopicTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.kafka.controller
+
+import com.yammer.metrics.core.Gauge
+import kafka.api.IntegrationTestHarness
+import kafka.server.IntegrationTestUtils
+import kafka.utils.TestUtils
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters.{MapHasAsScala, SeqHasAsJava}
+
+
+class OfflinePartitionsFromDeletedTopicTest extends IntegrationTestHarness {
+  val log: Logger = LoggerFactory.getLogger(classOf[OfflinePartitionsFromDeletedTopicTest])
+
+  override protected def brokerCount: Int = 3
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    doSetup(testInfo, createOffsetsTopic = false)
+  }
+
+  @Test
+  def testPartitionsOfTopicsToBeDeletedNotMarkedOfflineOnControllerElection(): Unit = {
+    var producer: KafkaProducer[String, String] = null
+    var admin: Admin = null
+
+    try {
+      // Create a topic with one partition per broker
+      admin = TestUtils.createAdminClient(brokers, listenerName, adminClientConfig)
+      val topic = "test-topic"
+      val replicaAssignment = Map(0 -> List(0), 1 -> List(1), 2 -> List(2))
+      IntegrationTestUtils.createTopic(admin, topic, replicaAssignment)
+
+      // Produce some data
+      val numRecords = 10
+      val numPartitions = replicaAssignment.size
+      producer = createProducer(new StringSerializer(), new StringSerializer())
+      (0 until numRecords)
+        .map { i =>
+          val partition = i % numPartitions
+          producer.send(new ProducerRecord(topic, partition, i.toString, i.toString))
+        }.map(_.get)
+
+      // There should be no offline partitions at this point
+      var controllerId = zkClient.getControllerId.get
+      assertEquals(0, offlinePartitionsCount(controllerId), "Non zero offline partitions")
+
+      // Shut down one of the brokers that is not a controller
+      killBroker(if (controllerId == 2) 1 else 2)
+      TestUtils.waitUntilTrue(() => offlinePartitionsCount(controllerId) == 1, "Expected one partition to be offline after broker shutdown")
+
+      // Now elect a new controller
+      controllerId = electNewController(zkClient)
+
+      // Delete the topic now
+      admin.deleteTopics(List(topic).asJava).all().get(30, TimeUnit.SECONDS)
+      TestUtils.waitUntilTrue(() => offlinePartitionsCount(controllerId) == 0, "Non zero offline partitions after topic deletion")
+
+      // Elect a controller again, this must be the original controller that the test started with
+      controllerId = electNewController(zkClient)
+      TestUtils.waitUntilTrue(() => offlinePartitionsCount(controllerId) == 0, "Non zero offline partitions after topic deletion and old controller re-elected")
+    } finally {
+      if (producer != null) {
+        producer.close(Duration.ofSeconds(30))
+      }
+      if (admin != null) {
+        admin.close(Duration.ofSeconds(30))
+      }
+    }
+  }
+
+  private def electNewController(zkClient: KafkaZkClient): Int = {
+    val oldController = zkClient.getControllerId
+    var newController = oldController
+    var tries = 10
+    while (tries > 0 && oldController == newController) {
+      zkClient.deletePath("/controller")
+      newController = Some(TestUtils.waitUntilControllerElected(zkClient))
+      tries -= 1
+    }
+    assertNotEquals(oldController, newController, "Failed to elect a different controller")
+    log.info(s"Controller changed from ${oldController} to ${newController}")
+    newController.get
+  }
+
+  private def offlinePartitionsCount(controllerId: Int): Int = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (k, _) => k.getName.endsWith("OfflinePartitionsCount") && k.getScope == s"brokerId.$controllerId" }.get._2
+      .asInstanceOf[Gauge[Int]].value()
+  }
+}

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -58,6 +58,7 @@ class TopicDeletionManagerTest {
 
     assertEquals(Set("foo", "bar"), controllerContext.topicsToBeDeleted.toSet)
     assertEquals(Set("bar"), controllerContext.topicsIneligibleForDeletion.toSet)
+    assertEquals(Set("bar"), controllerContext.topicsWithDeletionStarted.toSet)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -183,7 +183,7 @@ object TestUtils extends Logging {
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String],
                    startup: Boolean, enableZkApiForwarding: Boolean) = {
-    val server = new KafkaServer(config, time, threadNamePrefix, enableForwarding = enableZkApiForwarding)
+    val server = new KafkaServer(config, time, threadNamePrefix, enableForwarding = enableZkApiForwarding, controllerMetricTags = Map("brokerId" -> s"${config.brokerId}"))
     if (startup) server.startup()
     server
   }


### PR DESCRIPTION
In Zookeeper mode, the controller maintains an in-memory state of `topicsWithDeletionStarted` to decide if `OfflinePartitionsCount` metric must be incremented/decremented for a TopicPartition on its state transition.

This in-memory state is however not maintained when a controller election happens in the midst of a topic deletion leading to false positives on the `OfflinePartitionsCount` metric.

This change modifies `TopicDeletionManager::init` to populate `ControllerContext.topicsWithDeletionStarted` with `topicsIneligibleForDeletion` so that the new controller doesn't emit false positive metric.