### PR TITLE
Correct type in README.MD from "boolean" to "bool"

### DIFF
--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -69,7 +69,7 @@ Field Types
 -----------
 There are several primitive field types available.
 
-* "boolean": either true or false.
+* "bool": either true or false.
 
 * "int8": an 8-bit integer.
 


### PR DESCRIPTION
The actual type name in the JSON descriptor files is "bool" not "boolean"