### PR TITLE
KAFKA-17181: Replace fileChannel.write with Utils.writeFully to prevent partial write (ProducerStateManager)

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -684,7 +684,7 @@ public class ProducerStateManager {
         ByteUtils.writeUnsignedInt(buffer, CRC_OFFSET, crc);
 
         try (FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
-            fileChannel.write(buffer);
+            Utils.writeFully(fileChannel, buffer);
             if (sync) {
                 fileChannel.force(true);
             }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.Crc32C;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.metadata.storage.generated.ProducerSnapshot;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
There is no guarantee that the entire content of the buffer can be written to the fileChannel via method fileChannel.write. [1][2]
We should use Utils.writeFully to prevent partial writing.

[1] https://docs.oracle.com/javase/8/docs/api/java/nio/channels/WritableByteChannel.html#write-java.nio.ByteBuffer-
[2] https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#write-java.nio.ByteBuffer:A-

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
