### PR TITLE
KAFKA-17198: Partition imbalance after alter due to inconsistent order of broker list

### DIFF
--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -187,7 +187,7 @@ class ZkAdminManager(val config: KafkaConfig,
 
         val assignments = if (topic.assignments.isEmpty) {
           CoreUtils.replicaToBrokerAssignmentAsScala(AdminUtils.assignReplicasToBrokers(
-            brokers.asJavaCollection, resolvedNumPartitions, resolvedReplicationFactor))
+            brokers.toList.sortBy(_.id).asJavaCollection, resolvedNumPartitions, resolvedReplicationFactor))
         } else {
           val assignments = new mutable.HashMap[Int, Seq[Int]]
           // Note: we don't check that replicaAssignment contains unknown brokers - unlike in add-partitions case,


### PR DESCRIPTION
*More detailed description of your change:
sort zk-based quorum's brokerList to keep consistent order when create and alter topics

*Summary of testing strategy (including rationale):
I set up an environment containing 3 Kafka brokers and based on [KAFKA-17198](https://issues.apache.org/jira/browse/KAFKA-17198) Conduct testing, the testing steps are as follows:
1. Create a topic with replica 1 and partition 2
2. Expand the topic to 3 partitions
The results meet expectations. All three possible distributions are: [1,2,0] [0,1,2] [2,0,1]

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
