### PR TITLE
KAFKA-17213: Change ControllerMovedException from ApiException to InvalidMetadataException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.errors;
 
-public class ControllerMovedException extends ApiException {
+public class ControllerMovedException extends InvalidMetadataException {
 
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
@@ -20,7 +20,7 @@ package org.apache.kafka.common.errors;
 /**
  * Thrown if a request cannot be completed because a partition reassignment is in progress.
  */
-public class ReassignmentInProgressException extends ApiException {
+public class ReassignmentInProgressException extends RetriableException {
 
     public ReassignmentInProgressException(String msg) {
         super(msg);


### PR DESCRIPTION
jira: https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-17213

##  More detailed description of your change


After the Kafka client fails to send, it will update the metadata. The InvalidMetadataException is retryable. I think the Controller information also belongs to Kafka's metadata, so ControllerMovedException should be InvalidMetadataException.

## Committer Checklist (excluded from commit message)
 Verify design and implementation
 Verify test coverage and CI build status
 Verify documentation (including upgrade notes)
