### PR TITLE
KAFKA-16390 add `group.coordinator.rebalance.protocols=classic,consumer` to broker configs when system tests need the new coordinator

### DIFF
--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -70,6 +70,7 @@ DELEGATION_TOKEN_SECRET_KEY="delegation.token.secret.key"
 SASL_ENABLED_MECHANISMS="sasl.enabled.mechanisms"
 
 NEW_GROUP_COORDINATOR_ENABLE="group.coordinator.new.enable"
+GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG="group.coordinator.rebalance.protocols"
 
 """
 From KafkaConfig.scala

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -70,7 +70,7 @@ DELEGATION_TOKEN_SECRET_KEY="delegation.token.secret.key"
 SASL_ENABLED_MECHANISMS="sasl.enabled.mechanisms"
 
 NEW_GROUP_COORDINATOR_ENABLE="group.coordinator.new.enable"
-GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG="group.coordinator.rebalance.protocols"
+GROUP_COORDINATOR_REBALANCE_PROTOCOLS="group.coordinator.rebalance.protocols"
 
 """
 From KafkaConfig.scala

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -782,7 +782,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         if self.use_new_coordinator:
             override_configs[config_property.NEW_GROUP_COORDINATOR_ENABLE] = 'true'
-    
+            override_configs[config_property.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG] = 'classic,consumer'
+
         for prop in self.server_prop_overrides:
             override_configs[prop[0]] = prop[1]
 

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -409,6 +409,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.interbroker_sasl_mechanism = interbroker_sasl_mechanism
         self._security_config = None
 
+        # When the new group coordinator is enabled, the new consumer rebalance
+        # protocol is enabled too.
+        rebalance_protocols = "classic"
+        if self.use_new_coordinator:
+            rebalance_protocols = "classic,consumer"
+
         for node in self.nodes:
             node_quorum_info = quorum.NodeQuorumInfo(self.quorum_info, node)
 
@@ -422,7 +428,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             kraft_broker_configs = {
                 config_property.PORT: config_property.FIRST_BROKER_PORT,
                 config_property.NODE_ID: self.idx(node),
-                config_property.NEW_GROUP_COORDINATOR_ENABLE: use_new_coordinator
+                config_property.NEW_GROUP_COORDINATOR_ENABLE: use_new_coordinator,
+                config_property.GROUP_COORDINATOR_REBALANCE_PROTOCOLS: rebalance_protocols
             }
             kraft_broker_plus_zk_configs = kraft_broker_configs.copy()
             kraft_broker_plus_zk_configs.update(zk_broker_configs)
@@ -782,7 +789,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         if self.use_new_coordinator:
             override_configs[config_property.NEW_GROUP_COORDINATOR_ENABLE] = 'true'
-            override_configs[config_property.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG] = 'classic,consumer'
+            override_configs[config_property.GROUP_COORDINATOR_REBALANCE_PROTOCOLS] = 'classic,consumer'
 
         for prop in self.server_prop_overrides:
             override_configs[prop[0]] = prop[1]


### PR DESCRIPTION
[Jira Link](https://issues.apache.org/jira/browse/KAFKA-16390)
Fix an issue that cause system test failing when using `AsyncKafkaConsumer`.
A configuration option, `group.coordinator.rebalance.protocols`, was introduced to specify the rebalance protocols used by the group coordinator. By default, the rebalance protocol is set to `classic`. When the new group coordinator is enabled, the rebalance protocols are set to `classic,consumer`.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
