### PR TITLE
KAFKA-17201: SelectorTest.testInboundConnectionsCountInConnectionCreationMetric leaks sockets and threads

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -44,6 +44,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -823,6 +824,7 @@ public class SelectorTest {
     @Test
     public void testInboundConnectionsCountInConnectionCreationMetric() throws Exception {
         int conns = 5;
+        List<Thread> threads = new ArrayList<>(conns);
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(0));
@@ -831,11 +833,17 @@ public class SelectorTest {
             for (int i = 0; i < conns; i++) {
                 Thread sender = createSender(serverAddress, randomPayload(1));
                 sender.start();
-                SocketChannel channel = ss.accept();
-                channel.configureBlocking(false);
-
-                selector.register(Integer.toString(i), channel);
+                threads.add(sender);
+                try (SocketChannel channel = ss.accept()) {
+                    channel.configureBlocking(false);
+                    selector.register(Integer.toString(i), channel);
+                }
             }
+        }
+
+        // Ensure all threads complete their execution
+        for (Thread thread : threads) {
+            thread.join();
         }
 
         assertEquals((double) conns, getMetric("connection-creation-total").metricValue());


### PR DESCRIPTION
Currently, the sockets and threads created in `testInboundConnectionsCountInConnectionCreationMetric` have not been closed, and this issue needs to be fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
