### PR TITLE
KAFKA-17188: Ensure login and callback handler are closed upon encountering LoginException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -63,9 +63,9 @@ public class LoginManager {
         this.loginMetadata = loginMetadata;
         this.login = Utils.newInstance(loginMetadata.loginClass);
         loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
-        loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
-        login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
         try (AutoCloseable loginResources = this::closeResources) {
+            loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
+            login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
             login.login();
         } catch (Exception e) {
             throw new LoginException(e.getMessage());

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -54,11 +54,11 @@ public class LoginManager {
     private final AuthenticateCallbackHandler loginCallbackHandler;
     private int refCount;
 
-    LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
+    private LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
                  LoginMetadata<?> loginMetadata) throws LoginException {
         this.loginMetadata = loginMetadata;
-        this.login = createLogin();
-        this.loginCallbackHandler = createLoginCallbackHandler();
+        this.login = Utils.newInstance(loginMetadata.loginClass);
+        loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
         loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
         login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
         try {
@@ -166,14 +166,6 @@ public class LoginManager {
         }
     }
 
-    protected Login createLogin() {
-        return Utils.newInstance(loginMetadata.loginClass);
-    }
-
-    protected AuthenticateCallbackHandler createLoginCallbackHandler() {
-        return Utils.newInstance(loginMetadata.loginCallbackClass);
-    }
-
     @Override
     public String toString() {
         return "LoginManager(serviceName=" + serviceName() +
@@ -210,7 +202,7 @@ public class LoginManager {
         return clazz;
     }
 
-    static class LoginMetadata<T> {
+    private static class LoginMetadata<T> {
         final T configInfo;
         final Class<? extends Login> loginClass;
         final Class<? extends AuthenticateCallbackHandler> loginCallbackClass;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -61,7 +61,13 @@ public class LoginManager {
         loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
         loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
         login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
-        login.login();
+        try {
+            login.login();
+        } catch (Exception e) {
+            this.login.close();
+            this.loginCallbackHandler.close();
+            throw new LoginException(e.getMessage());
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -54,11 +54,11 @@ public class LoginManager {
     private final AuthenticateCallbackHandler loginCallbackHandler;
     private int refCount;
 
-    private LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
-                         LoginMetadata<?> loginMetadata) throws LoginException {
+    LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
+                 LoginMetadata<?> loginMetadata) throws LoginException {
         this.loginMetadata = loginMetadata;
-        this.login = Utils.newInstance(loginMetadata.loginClass);
-        loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
+        this.login = createLogin();
+        this.loginCallbackHandler = createLoginCallbackHandler();
         loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
         login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
         try {
@@ -166,6 +166,14 @@ public class LoginManager {
         }
     }
 
+    protected Login createLogin() {
+        return Utils.newInstance(loginMetadata.loginClass);
+    }
+
+    protected AuthenticateCallbackHandler createLoginCallbackHandler() {
+        return Utils.newInstance(loginMetadata.loginCallbackClass);
+    }
+
     @Override
     public String toString() {
         return "LoginManager(serviceName=" + serviceName() +
@@ -202,7 +210,7 @@ public class LoginManager {
         return clazz;
     }
 
-    private static class LoginMetadata<T> {
+    static class LoginMetadata<T> {
         final T configInfo;
         final Class<? extends Login> loginClass;
         final Class<? extends AuthenticateCallbackHandler> loginCallbackClass;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.Login;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
-
 import org.apache.kafka.common.utils.Utils;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -31,10 +31,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import javax.security.auth.login.LoginException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.security.auth.login.LoginException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -167,7 +167,7 @@ public class LoginManagerTest {
     @Test
     public void testLoginException() throws Exception {
         Map<String, Object> config = new HashMap<>();
-        config.put("sasl.jaas.config", dynamicPlainContext);
+        config.put(SaslConfigs.SASL_JAAS_CONFIG, dynamicPlainContext);
         config.put(SaslConfigs.SASL_LOGIN_CLASS, Login.class);
         config.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, AuthenticateCallbackHandler.class);
         JaasContext dynamicContext = JaasContext.loadClientContext(config);

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import javax.security.auth.login.LoginException;
 import java.util.Collections;
@@ -176,7 +177,7 @@ public class LoginManagerTest {
 
         doThrow(new LoginException("Expecting LoginException")).when(mockLogin).login();
 
-        try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
+        try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class, Mockito.CALLS_REAL_METHODS)) {
             mockedUtils.when(() -> Utils.newInstance(Login.class)).thenReturn(mockLogin);
             mockedUtils.when(() -> Utils.newInstance(AuthenticateCallbackHandler.class)).thenReturn(mockHandler);
 


### PR DESCRIPTION
Adding a try-catch in the LoginManager constructor to ensure `Login` and `AuthenticateCallbackHandler` are closed when login.login() throws an exception. 