### PR TITLE
KAFKA-13154 : Changes for the OffsetSpec.latest() to correctly represent the latest offset per partition

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -267,7 +267,11 @@ public class GetOffsetShell {
                 }
 
                 if (partitionInfo.offset() != ListOffsetsResponse.UNKNOWN_OFFSET) {
-                    partitionOffsets.put(partition, partitionInfo.offset());
+                    if (offsetSpec instanceof OffsetSpec.LatestSpec) {
+                        partitionOffsets.put(partition, partitionInfo.offset() - 1);
+                    } else {
+                        partitionOffsets.put(partition, partitionInfo.offset() - 1);
+                    }
                 }
             }
 

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -270,7 +270,7 @@ public class GetOffsetShell {
                     if (offsetSpec instanceof OffsetSpec.LatestSpec) {
                         partitionOffsets.put(partition, partitionInfo.offset() - 1);
                     } else {
-                        partitionOffsets.put(partition, partitionInfo.offset() - 1);
+                        partitionOffsets.put(partition, partitionInfo.offset());
                     }
                 }
             }


### PR DESCRIPTION
The current implementation of OffsetSpec.latest() is misleading behaviour.
For empty topic, the latest offset will be 0 (instead of -1, similar to `OffsetSpec.forTimestamp` method).
For topic with 1 message per partition, the latest returned offset will be 1 (instead of 0).
Updated OffsetSpec.latest() to correctly represent the latest offset per partition.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
