### PR TITLE
KAFKA-17203: StreamThread leaking producer instances

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -515,8 +515,7 @@ public class TaskManager {
     private void handleTasksPendingInitialization() {
         // All tasks pending initialization are not part of the usual bookkeeping
         for (final Task task : tasks.drainPendingTasksToInit()) {
-            task.suspend();
-            task.closeClean();
+            closeTaskClean(task, Collections.emptySet(), Collections.emptyMap());
         }
     }
 


### PR DESCRIPTION
In test like `EosIntegrationTest.shouldCheckpointRestoredOffsetsWhenClosingCleanDuringRestoringStateUpdaterEnabled`, the task may throw `TaskCorruptedException`. After rebalancing, if some pending tasks need to be drained, the `TaskManager` should use `activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(task.id());` to close producer as well, or there may have producer thread leak.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
