### PR TITLE
MINOR: Remove GroupMetadataManager#isGroupOpenForProducer unused method

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -209,14 +209,6 @@ class GroupMetadataManager(brokerId: Int,
     }
   }
 
-  // visible for testing
-  private[group] def isGroupOpenForProducer(producerId: Long, groupId: String) = openGroupsForProducer.get(producerId) match {
-    case Some(groups) =>
-      groups.contains(groupId)
-    case None =>
-      false
-  }
-
   /**
    * Get the group associated with the given groupId or null if not found
    */


### PR DESCRIPTION
I found GroupMetadataManager#isGroupOpenForProducer didn't use in project, thus we should remove it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
