### PR TITLE
MINOR: Unify Log4j levels across Connect runtime and MirrorMaker 2 integration tests

### DIFF
--- a/connect/mirror/src/test/resources/log4j.properties
+++ b/connect/mirror/src/test/resources/log4j.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-log4j.rootLogger=ERROR, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -28,7 +28,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 # The following line includes no MDC context parameters:
 #log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n (%t)
 
-log4j.logger.org.reflections=OFF
-log4j.logger.kafka=OFF
+log4j.logger.org.reflections=ERROR
+log4j.logger.kafka=WARN
 log4j.logger.state.change.logger=OFF
-log4j.logger.org.apache.kafka.connect.mirror=INFO
+log4j.logger.org.apache.kafka.connect=DEBUG

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -30,6 +30,5 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 
 log4j.logger.org.reflections=ERROR
 log4j.logger.kafka=WARN
+log4j.logger.state.change.logger=OFF
 log4j.logger.org.apache.kafka.connect=DEBUG
-log4j.logger.org.apache.kafka.connect.runtime.distributed=DEBUG
-log4j.logger.org.apache.kafka.connect.integration=DEBUG


### PR DESCRIPTION
Debugging flaky tests in CI for MirrorMaker 2 is challenging because we have very conservative log levels. There are also some small discrepancies between the log levels for Kafka Connect and MirrorMaker 2 integration tests that can contribute to FUD.

This PR sets the same levels for both tests, and increases the verbosity for MM2 tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
