### PR TITLE
MINOR: Add text and link to blog in announcement template email

### DIFF
--- a/release/templates.py
+++ b/release/templates.py
@@ -88,6 +88,9 @@ All of the changes in this release can be found in the release notes:
 https://www.apache.org/dist/kafka/{release_version}/RELEASE_NOTES.html
 
 
+An overview of the release can be found in our announcement blog post:
+https://kafka.apache.org/blog
+
 You can download the source and binary release (Scala <VERSIONS>) from:
 https://kafka.apache.org/downloads#{release_version}
 


### PR DESCRIPTION
The blog is "new" compared to the existence of the announcement email template. I added a section for the blog in the template so nobody forgets about it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
