### PR TITLE
KAFKA-16533; Update voter handling

### DIFF
--- a/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
+++ b/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
@@ -22,6 +22,8 @@
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "0+" },
+    { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "0+",
+      "about": "The current leader epoch of the partition, -1 for unknown leader epoch" },
     { "name": "VoterId", "type": "int32", "versions": "0+",
       "about": "The replica id of the voter getting updated in the topic partition" },
     { "name": "VoterDirectoryId", "type": "uuid", "versions": "0+",

--- a/clients/src/main/resources/common/message/UpdateRaftVoterResponse.json
+++ b/clients/src/main/resources/common/message/UpdateRaftVoterResponse.json
@@ -23,6 +23,16 @@
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error" }
+      "about": "The error code, or 0 if there was no error" },
+    { "name": "CurrentLeader", "type": "CurrentLeader", "versions": "0+",
+      "taggedVersions": "0+", "tag": 0, "fields": [
+        { "name": "LeaderId", "type": "int32", "versions": "0+", "default": "-1", "entityType" : "brokerId",
+          "about": "The replica id of the current leader or -1 if the leader is unknown" },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1",
+          "about": "The latest known leader epoch" },
+        { "name": "Host", "type": "string", "versions": "0+", "about": "The node's hostname" },
+        { "name": "Port", "type": "int32", "versions": "0+", "about": "The node's port" }
+      ]
+    }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1365,8 +1365,16 @@ public class RequestResponseTest {
     }
 
     private UpdateRaftVoterResponse createUpdateRaftVoterResponse() {
-        return new UpdateRaftVoterResponse(new UpdateRaftVoterResponseData().
-            setErrorCode((short) 0));
+        return new UpdateRaftVoterResponse(
+            new UpdateRaftVoterResponseData()
+                .setErrorCode((short) 0)
+                .setCurrentLeader(new UpdateRaftVoterResponseData.CurrentLeader()
+                    .setLeaderId(1)
+                    .setLeaderEpoch(2)
+                    .setHost("localhost")
+                    .setPort(9999)
+                )
+        );
     }
 
     private DescribeTopicPartitionsResponse createDescribeTopicPartitionsResponse() {
@@ -3020,7 +3028,7 @@ public class RequestResponseTest {
                             .setName("topic")
                             .setPartitions(Collections.singletonList(73))).iterator())))
                     .iterator());
-            return AddPartitionsToTxnRequest.Builder.forBroker(transactions).build(version);  
+            return AddPartitionsToTxnRequest.Builder.forBroker(transactions).build(version);
         }
     }
 
@@ -3029,7 +3037,7 @@ public class RequestResponseTest {
         AddPartitionsToTxnResponseData.AddPartitionsToTxnResult result = AddPartitionsToTxnResponse.resultForTransaction(
                 txnId, Collections.singletonMap(new TopicPartition("t", 0), Errors.NONE));
         AddPartitionsToTxnResponseData data = new AddPartitionsToTxnResponseData().setThrottleTimeMs(0);
-        
+
         if (version < 4) {
             data.setResultsByTopicV3AndBelow(result.topicResults());
         } else {

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -45,6 +45,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.raft.{Endpoints, FileQuorumStateStore, KafkaNetworkChannel, KafkaRaftClient, KafkaRaftClientDriver, LeaderAndEpoch, QuorumConfig, RaftClient, ReplicatedLog}
 import org.apache.kafka.server.ProcessRole
+import org.apache.kafka.server.common.Features
 import org.apache.kafka.server.common.serialization.RecordSerde
 import org.apache.kafka.server.util.{FileLock, KafkaScheduler}
 import org.apache.kafka.server.fault.FaultHandler
@@ -153,7 +154,7 @@ class KafkaRaftManager[T](
   threadNamePrefixOpt: Option[String],
   val controllerQuorumVotersFuture: CompletableFuture[JMap[Integer, InetSocketAddress]],
   bootstrapServers: JCollection[InetSocketAddress],
-  controllerListeners: Endpoints,
+  localListeners: Endpoints,
   fatalFaultHandler: FaultHandler
 ) extends RaftManager[T] with Logging {
 
@@ -236,7 +237,8 @@ class KafkaRaftManager[T](
       logContext,
       clusterId,
       bootstrapServers,
-      controllerListeners,
+      localListeners,
+      Features.KRAFT_VERSION.supportedVersionRange(),
       raftConfig
     )
   }

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -1095,6 +1095,6 @@ class ControllerApis(
 
   def handleUpdateRaftVoter(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
-    throw new UnsupportedVersionException("handleUpdateRaftVoter is not supported yet.")
+    handleRaftRequest(request, response => new UpdateRaftVoterResponse(response.asInstanceOf[UpdateRaftVoterResponseData]))
   }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/Endpoints.java
+++ b/raft/src/main/java/org/apache/kafka/raft/Endpoints.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
+import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.message.VotersRecord;
 import org.apache.kafka.common.network.ListenerName;
@@ -128,6 +129,21 @@ public final class Endpoints {
                     .setPort(entry.getValue().getPort())
             );
         }
+        return listeners;
+    }
+
+    public UpdateRaftVoterRequestData.ListenerCollection toUpdateVoterRequest() {
+        UpdateRaftVoterRequestData.ListenerCollection listeners =
+            new UpdateRaftVoterRequestData.ListenerCollection(endpoints.size());
+        for (Map.Entry<ListenerName, InetSocketAddress> entry : endpoints.entrySet()) {
+            listeners.add(
+                new UpdateRaftVoterRequestData.Listener()
+                    .setName(entry.getKey().value())
+                    .setHost(entry.getValue().getHostString())
+                    .setPort(entry.getValue().getPort())
+            );
+        }
+
         return listeners;
     }
 
@@ -264,6 +280,18 @@ public final class Endpoints {
     public static Endpoints fromAddVoterRequest(AddRaftVoterRequestData.ListenerCollection endpoints) {
         Map<ListenerName, InetSocketAddress> listeners = new HashMap<>(endpoints.size());
         for (AddRaftVoterRequestData.Listener endpoint : endpoints) {
+            listeners.put(
+                ListenerName.normalised(endpoint.name()),
+                InetSocketAddress.createUnresolved(endpoint.host(), endpoint.port())
+            );
+        }
+
+        return new Endpoints(listeners);
+    }
+
+    public static Endpoints fromUpdateVoterRequest(UpdateRaftVoterRequestData.ListenerCollection endpoints) {
+        Map<ListenerName, InetSocketAddress> listeners = new HashMap<>(endpoints.size());
+        for (UpdateRaftVoterRequestData.Listener endpoint : endpoints) {
             listeners.put(
                 ListenerName.normalised(endpoint.name()),
                 InetSocketAddress.createUnresolved(endpoint.host(), endpoint.port())

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.AddRaftVoterRequestData;
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
@@ -174,6 +175,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private final int fetchMaxWaitMs;
     private final String clusterId;
     private final Endpoints localListeners;
+    private final SupportedVersionRange localSupportedKRaftVersion;
     private final NetworkChannel channel;
     private final ReplicatedLog log;
     private final Random random;
@@ -230,6 +232,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         String clusterId,
         Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
+        SupportedVersionRange localSupportedKRaftVersion,
         QuorumConfig quorumConfig
     ) {
         this(
@@ -246,6 +249,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             clusterId,
             bootstrapServers,
             localListeners,
+            localSupportedKRaftVersion,
             logContext,
             new Random(),
             quorumConfig
@@ -266,6 +270,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         String clusterId,
         Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
+        SupportedVersionRange localSupportedKRaftVersion,
         LogContext logContext,
         Random random,
         QuorumConfig quorumConfig
@@ -283,6 +288,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         this.time = time;
         this.clusterId = clusterId;
         this.localListeners = localListeners;
+        this.localSupportedKRaftVersion = localSupportedKRaftVersion;
         this.fetchMaxWaitMs = fetchMaxWaitMs;
         this.logger = logContext.logger(KafkaRaftClient.class);
         this.random = random;
@@ -497,6 +503,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             nodeDirectoryId,
             partitionState,
             localListeners,
+            localSupportedKRaftVersion,
             quorumConfig.electionTimeoutMs(),
             quorumConfig.fetchTimeoutMs(),
             quorumStateStore,

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -556,7 +556,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             logContext
         );
 
-        // Specialized remove voter handler
+        // Specialized update voter handler
         this.updateVoterHandler = new UpdateVoterHandler(
             nodeId,
             partitionState,
@@ -2069,10 +2069,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             );
         }
 
-        Optional<Errors> leaderValidation = validateLeaderOnlyRequest(quorum.epoch());
-        if (leaderValidation.isPresent()) {
+        Optional<Errors> leaderValidationError = validateLeaderOnlyRequest(quorum.epoch());
+        if (leaderValidationError.isPresent()) {
             return completedFuture(
-                new AddRaftVoterResponseData().setErrorCode(leaderValidation.get().code())
+                new AddRaftVoterResponseData().setErrorCode(leaderValidationError.get().code())
             );
         }
 
@@ -2152,10 +2152,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             );
         }
 
-        Optional<Errors> leaderValidation = validateLeaderOnlyRequest(quorum.epoch());
-        if (leaderValidation.isPresent()) {
+        Optional<Errors> leaderValidationError = validateLeaderOnlyRequest(quorum.epoch());
+        if (leaderValidationError.isPresent()) {
             return completedFuture(
-                new RemoveRaftVoterResponseData().setErrorCode(leaderValidation.get().code())
+                new RemoveRaftVoterResponseData().setErrorCode(leaderValidationError.get().code())
             );
         }
 
@@ -2192,11 +2192,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             );
         }
 
-        Optional<Errors> leaderValidation = validateLeaderOnlyRequest(data.currentLeaderEpoch());
-        if (leaderValidation.isPresent()) {
+        Optional<Errors> leaderValidationError = validateLeaderOnlyRequest(data.currentLeaderEpoch());
+        if (leaderValidationError.isPresent()) {
             return completedFuture(
                 RaftUtil.updateVoterResponse(
-                    leaderValidation.get(),
+                    leaderValidationError.get(),
                     requestMetadata.listenerName(),
                     quorum.leaderAndEpoch(),
                     quorum.leaderEndpoints()

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-// TODO: the leader needs to update itself
 /**
  * In the context of LeaderState, an acknowledged voter means one who has acknowledged the current leader by either
  * responding to a `BeginQuorumEpoch` request from the leader or by beginning to send `Fetch` requests.

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.raft.internals.BatchAccumulator;
@@ -84,6 +85,7 @@ public class QuorumState {
     private final QuorumStateStore store;
     private final KRaftControlRecordStateMachine partitionState;
     private final Endpoints localListeners;
+    private final SupportedVersionRange localSupportedKRaftVersion;
     private final Random random;
     private final int electionTimeoutMs;
     private final int fetchTimeoutMs;
@@ -96,6 +98,7 @@ public class QuorumState {
         Uuid localDirectoryId,
         KRaftControlRecordStateMachine partitionState,
         Endpoints localListeners,
+        SupportedVersionRange localSupportedKRaftVersion,
         int electionTimeoutMs,
         int fetchTimeoutMs,
         QuorumStateStore store,
@@ -107,6 +110,7 @@ public class QuorumState {
         this.localDirectoryId = localDirectoryId;
         this.partitionState = partitionState;
         this.localListeners = localListeners;
+        this.localSupportedKRaftVersion = localSupportedKRaftVersion;
         this.electionTimeoutMs = electionTimeoutMs;
         this.fetchTimeoutMs = fetchTimeoutMs;
         this.store = store;
@@ -550,6 +554,7 @@ public class QuorumState {
             candidateState.grantingVoters(),
             accumulator,
             localListeners,
+            localSupportedKRaftVersion,
             fetchTimeoutMs,
             logContext
         );

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -545,7 +545,7 @@ public class RaftUtil {
             .setErrorCode(error.code())
             .setErrorMessage(errorMessage);
     }
-    
+
     public static RemoveRaftVoterRequestData removeVoterRequest(
         String clusterId,
         ReplicaKey voter
@@ -567,7 +567,6 @@ public class RaftUtil {
             .setErrorMessage(errorMessage);
     }
 
-    // TODO: add tests
     public static UpdateRaftVoterRequestData updateVoterRequest(
         String clusterId,
         ReplicaKey voter,
@@ -589,7 +588,6 @@ public class RaftUtil {
         return request;
     }
 
-    // TODO: add tests
     public static UpdateRaftVoterResponseData updateVoterResponse(
         Errors error,
         ListenerName listenerName,

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -18,6 +18,7 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.message.AddRaftVoterRequestData;
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
@@ -32,6 +33,8 @@ import org.apache.kafka.common.message.FetchSnapshotRequestData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
 import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
+import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.network.ListenerName;
@@ -564,6 +567,52 @@ public class RaftUtil {
             .setErrorMessage(errorMessage);
     }
 
+    // TODO: add tests
+    public static UpdateRaftVoterRequestData updateVoterRequest(
+        String clusterId,
+        ReplicaKey voter,
+        int epoch,
+        SupportedVersionRange supportedVersions,
+        Endpoints endpoints
+    ) {
+        UpdateRaftVoterRequestData request = new UpdateRaftVoterRequestData()
+            .setClusterId(clusterId)
+            .setCurrentLeaderEpoch(epoch)
+            .setVoterId(voter.id())
+            .setVoterDirectoryId(voter.directoryId().orElse(ReplicaKey.NO_DIRECTORY_ID))
+            .setListeners(endpoints.toUpdateVoterRequest());
+
+        request.kRaftVersionFeature()
+            .setMinSupportedVersion(supportedVersions.min())
+            .setMaxSupportedVersion(supportedVersions.max());
+
+        return request;
+    }
+
+    // TODO: add tests
+    public static UpdateRaftVoterResponseData updateVoterResponse(
+        Errors error,
+        ListenerName listenerName,
+        LeaderAndEpoch leaderAndEpoch,
+        Endpoints endpoints
+    ) {
+        UpdateRaftVoterResponseData response = new UpdateRaftVoterResponseData()
+            .setErrorCode(error.code());
+
+        response.currentLeader()
+            .setLeaderId(leaderAndEpoch.leaderId().orElse(-1))
+            .setLeaderEpoch(leaderAndEpoch.epoch());
+
+        Optional<InetSocketAddress> address = endpoints.address(listenerName);
+        if (address.isPresent()) {
+            response.currentLeader()
+                .setHost(address.get().getHostString())
+                .setPort(address.get().getPort());
+        }
+
+        return response;
+    }
+
     private static List<DescribeQuorumResponseData.ReplicaState> toReplicaStates(
         short apiVersion,
         int leaderId,
@@ -634,6 +683,14 @@ public class RaftUtil {
     }
 
     public static Optional<ReplicaKey> removeVoterRequestVoterKey(RemoveRaftVoterRequestData request) {
+        if (request.voterId() < 0) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ReplicaKey.of(request.voterId(), request.voterDirectoryId()));
+        }
+    }
+
+    public static Optional<ReplicaKey> updateVoterRequestVoterKey(UpdateRaftVoterRequestData request) {
         if (request.voterId() < 0) {
             return Optional.empty();
         } else {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
@@ -87,12 +87,12 @@ public final class AddVoterHandler {
         Endpoints voterEndpoints,
         long currentTimeMs
     ) {
-        // Check if there are any pending add or remove voter requests
+        // Check if there are any pending voter change requests
         if (leaderState.isOperationPending(currentTimeMs)) {
             return CompletableFuture.completedFuture(
                 RaftUtil.addVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
-                    "Request timed out waiting for leader to handle previous add or remove voter request"
+                    "Request timed out waiting for leader to handle previous voter change request"
                 )
             );
         }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandlerState.java
@@ -18,15 +18,13 @@
 package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
-import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.raft.Endpoints;
-import org.apache.kafka.raft.RaftUtil;
 
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 
-public final class AddVoterHandlerState implements AutoCloseable {
+public final class AddVoterHandlerState {
     private final ReplicaKey voterKey;
     private final Endpoints voterEndpoints;
     private final Timer timeout;
@@ -83,10 +81,5 @@ public final class AddVoterHandlerState implements AutoCloseable {
 
     public CompletableFuture<AddRaftVoterResponseData> future() {
         return future;
-    }
-
-    @Override
-    public void close() {
-        future.complete(RaftUtil.addVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER, null));
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -77,12 +77,12 @@ public final class RemoveVoterHandler {
         ReplicaKey voterKey,
         long currentTimeMs
     ) {
-        // Check if there are any pending add or remove voter requests
+        // Check if there are any pending voter change requests
         if (leaderState.isOperationPending(currentTimeMs)) {
             return CompletableFuture.completedFuture(
                 RaftUtil.removeVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
-                    "Request timed out waiting for leader to handle previous add or remove voter request"
+                    "Request timed out waiting for leader to handle previous voter change request"
                 )
             );
         }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CompletableFuture;
  * 2. Check that the cluster supports kraft.version 1, otherwise return the UNSUPPORTED_VERSION error.
  * 3. Check that there are no uncommitted voter changes, otherwise return the REQUEST_TIMED_OUT error.
  * 4. Append the updated VotersRecord to the log. The KRaft internal listener will read this
- *    uncommitted record from the log and add the new voter to the set of voters.
+ *    uncommitted record from the log and remove the voter from the set of voters.
  * 5. Wait for the VotersRecord to commit using the majority of the new set of voters. Return a
  *    REQUEST_TIMED_OUT error if it doesn't commit in time.
  * 6. Send the RemoveVoter successful response to the client.

--- a/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
@@ -109,8 +109,8 @@ public final class UpdateVoterHandler {
             );
         }
 
+        // KAFKA-16538 will implement the case when the kraft.version is 0
         // Check that the cluster supports kraft.version >= 1
-        // TODO: File a jira to handle the kraft.version == 0
         KRaftVersion kraftVersion = partitionState.lastKraftVersion();
         if (!kraftVersion.isReconfigSupported()) {
             return CompletableFuture.completedFuture(

--- a/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.feature.SupportedVersionRange;
+import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
+import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.raft.LeaderAndEpoch;
+import org.apache.kafka.raft.LeaderState;
+import org.apache.kafka.raft.LogOffsetMetadata;
+import org.apache.kafka.raft.RaftUtil;
+import org.apache.kafka.server.common.KRaftVersion;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * TODO: document this.
+ *
+ * 1. Wait until there are no uncommitted add or remove voter records. Note that the implementation
+ *    may just return a REQUEST_TIMED_OUT error if there are pending operations.
+ * 2. Wait for the LeaderChangeMessage control record from the current epoch to get committed. Note
+ *    that the implementation may just return a REQUEST_TIMED_OUT error if there are pending operations.
+ * 3. Check that the updated voter supports the current kraft.version.
+ * 4. If the replica id tracked doesn't have a replica directory id, update it with the replica
+ *    directory id provided in the request.
+ * 5. Append the updated VotersRecord to the log if the finalized kraft.version is greater than 0.
+ * 6. The KRaft internal listener will read this record from the log and update the voter's
+ *    information. This includes updating the endpoint used by the KRaft NetworkClient.
+ * 7. Wait for the VotersRecord to commit using the majority of the new set of voters.
+ * 8. Send the UpdateVoter response to the client.
+ */
+public final class UpdateVoterHandler {
+    private final OptionalInt localId;
+    private final KRaftControlRecordStateMachine partitionState;
+    private final ListenerName defaultListenerName;
+    private final Time time;
+    private final long requestTimeoutMs;
+
+    public UpdateVoterHandler(
+        OptionalInt localId,
+        KRaftControlRecordStateMachine partitionState,
+        ListenerName defaultListenerName,
+        Time time,
+        long requestTimeoutMs
+    ) {
+        this.localId = localId;
+        this.partitionState = partitionState;
+        this.defaultListenerName = defaultListenerName;
+        this.time = time;
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    public CompletableFuture<UpdateRaftVoterResponseData> handleUpdateVoterRequest(
+        LeaderState<?> leaderState,
+        ListenerName requestListenerName,
+        ReplicaKey voterKey,
+        Endpoints voterEndpoints,
+        UpdateRaftVoterRequestData.KRaftVersionFeature supportedKraftVersions,
+        long currentTimeMs
+    ) {
+        // Check if there are any pending voter change requests
+        if (leaderState.isOperationPending(currentTimeMs)) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Check that the leader has established a HWM and committed the current epoch
+        Optional<Long> highWatermark = leaderState.highWatermark().map(LogOffsetMetadata::offset);
+        if (!highWatermark.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Check that the cluster supports kraft.version >= 1
+        // TODO: File a jira to handle the kraft.version == 0
+        KRaftVersion kraftVersion = partitionState.lastKraftVersion();
+        if (!kraftVersion.isReconfigSupported()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.UNSUPPORTED_VERSION,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Check that there are no uncommitted VotersRecord
+        Optional<LogHistory.Entry<VoterSet>> votersEntry = partitionState.lastVoterSetEntry();
+        if (!votersEntry.isPresent() || votersEntry.get().offset() >= highWatermark.get()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.REQUEST_TIMED_OUT,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Check that the supported version range is valid
+        if (!validVersionRange(kraftVersion, supportedKraftVersions)) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.INVALID_REQUEST,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Check that endpoinds includes the default listener
+        if (!voterEndpoints.address(defaultListenerName).isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.INVALID_REQUEST,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        // Update the voter
+        Optional<VoterSet> updatedVoters = votersEntry
+            .get()
+            .value()
+            .updateVoter(
+                VoterSet.VoterNode.of(
+                    voterKey,
+                    voterEndpoints,
+                    new SupportedVersionRange(
+                        supportedKraftVersions.minSupportedVersion(),
+                        supportedKraftVersions.maxSupportedVersion()
+                    )
+                )
+            );
+        if (!updatedVoters.isPresent()) {
+            return CompletableFuture.completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.VOTER_NOT_FOUND,
+                    requestListenerName,
+                    new LeaderAndEpoch(
+                        localId,
+                        leaderState.epoch()
+                    ),
+                    leaderState.leaderEndpoints()
+                )
+            );
+        }
+
+        UpdateVoterHandlerState state = new UpdateVoterHandlerState(
+            leaderState.appendVotersRecord(updatedVoters.get(), currentTimeMs),
+            requestListenerName,
+            time.timer(requestTimeoutMs)
+        );
+        leaderState.resetUpdateVoterHandlerState(Errors.UNKNOWN_SERVER_ERROR, Optional.of(state));
+
+        return state.future();
+    }
+
+    public void highWatermarkUpdated(LeaderState<?> leaderState) {
+        leaderState.updateVoterHandlerState().ifPresent(current -> {
+            leaderState.highWatermark().ifPresent(highWatermark -> {
+                if (highWatermark.offset() > current.lastOffset()) {
+                    // VotersRecord with the updated voter was committed; complete the RPC
+                    leaderState.resetUpdateVoterHandlerState(Errors.NONE, Optional.empty());
+                }
+            });
+        });
+    }
+
+    private boolean validVersionRange(
+        KRaftVersion finalizedVersion,
+        UpdateRaftVoterRequestData.KRaftVersionFeature supportedKraftVersions
+    ) {
+        return supportedKraftVersions.minSupportedVersion() <= finalizedVersion.featureLevel() &&
+            supportedKraftVersions.maxSupportedVersion() >= finalizedVersion.featureLevel();
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -95,6 +95,16 @@ public final class VoterSet {
             .map(address -> new Node(voterId, address.getHostString(), address.getPort()));
     }
 
+    // TODO: write documentation
+    public boolean voterNodeNeedsUpdate(VoterNode updatedVoterNode) {
+        return Optional.ofNullable(voters.get(updatedVoterNode.voterKey().id()))
+            .map(
+                node -> node.isVoter(updatedVoterNode.voterKey()) &&
+                        !node.equals(updatedVoterNode)
+            )
+            .orElse(false);
+    }
+
     /**
      * Returns if the node is a voter in the set of voters.
      *

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -209,6 +209,20 @@ public final class VoterSet {
         return Optional.empty();
     }
 
+    // TODO: write tests
+    // TODO: write documentation
+    public Optional<VoterSet> updateVoter(VoterNode voter) {
+        VoterNode oldVoter = voters.get(voter.voterKey().id());
+        if (oldVoter != null && oldVoter.isVoter(voter.voterKey())) {
+            HashMap<Integer, VoterNode> newVoters = new HashMap<>(voters);
+            newVoters.put(voter.voterKey().id(), voter);
+
+            return Optional.of(new VoterSet(newVoters));
+        }
+
+        return Optional.empty();
+    }
+
     /**
      * Converts a voter set to a voters record for a given version.
      *

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -96,7 +96,7 @@ public final class VoterSet {
     }
 
     /**
-     * Return true the provided voter node is a voter and would cause a change in the voter set.
+     * Return true if the provided voter node is a voter and would cause a change in the voter set.
      *
      * @param updatedVoterNode the updated voter node
      * @return true if the updated voter node is different than the node in the voter set; otherwise false.

--- a/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/VoterSet.java
@@ -95,7 +95,12 @@ public final class VoterSet {
             .map(address -> new Node(voterId, address.getHostString(), address.getPort()));
     }
 
-    // TODO: write documentation
+    /**
+     * Return true the provided voter node is a voter and would cause a change in the voter set.
+     *
+     * @param updatedVoterNode the updated voter node
+     * @return true if the updated voter node is different than the node in the voter set; otherwise false.
+     */
     public boolean voterNodeNeedsUpdate(VoterNode updatedVoterNode) {
         return Optional.ofNullable(voters.get(updatedVoterNode.voterKey().id()))
             .map(
@@ -219,8 +224,12 @@ public final class VoterSet {
         return Optional.empty();
     }
 
-    // TODO: write tests
-    // TODO: write documentation
+    /**
+     * Updates a voter in the voter set.
+     *
+     * @param voter the updated voter
+     * @return a new voter set if the voter was updated, otherwise {@code Optional.empty()}
+     */
     public Optional<VoterSet> updateVoter(VoterNode voter) {
         VoterNode oldVoter = voters.get(voter.voterKey().id());
         if (oldVoter != null && oldVoter.isVoter(voter.voterKey())) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -1603,7 +1603,11 @@ public class KafkaRaftClientReconfigTest {
 
         // Expect reply for UpdateVoter request
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.NONE);
+        context.assertSentUpdateVoterResponse(
+            Errors.NONE,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1680,7 +1684,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+        context.assertSentUpdateVoterResponse(
+            Errors.INCONSISTENT_CLUSTER_ID,
+            OptionalInt.of(local.id()),
+            epoch
+        );
 
         // invalid cluster id is rejected
         context.deliverRequest(
@@ -1693,7 +1701,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.INCONSISTENT_CLUSTER_ID);
+        context.assertSentUpdateVoterResponse(
+            Errors.INCONSISTENT_CLUSTER_ID,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1722,7 +1734,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.FENCED_LEADER_EPOCH);
+        context.assertSentUpdateVoterResponse(
+            Errors.FENCED_LEADER_EPOCH,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1751,7 +1767,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.UNKNOWN_LEADER_EPOCH);
+        context.assertSentUpdateVoterResponse(
+            Errors.UNKNOWN_LEADER_EPOCH,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1776,7 +1796,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+        context.assertSentUpdateVoterResponse(
+            Errors.NOT_LEADER_OR_FOLLOWER,
+            OptionalInt.empty(),
+            context.currentEpoch()
+        );
     }
 
     @Test
@@ -1837,7 +1861,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.REQUEST_TIMED_OUT);
+        context.assertSentUpdateVoterResponse(
+            Errors.REQUEST_TIMED_OUT,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1854,6 +1882,7 @@ public class KafkaRaftClientReconfigTest {
             .build();
 
         context.becomeLeader();
+        int epoch = context.currentEpoch();
 
         // Attempt to update the follower
         InetSocketAddress defaultAddress = InetSocketAddress.createUnresolved(
@@ -1876,10 +1905,14 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.REQUEST_TIMED_OUT);
+        context.assertSentUpdateVoterResponse(
+            Errors.REQUEST_TIMED_OUT,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
-    // TODO: Mentioned that a Jira is going to fix this
+    // KAFKA-16538 is going to allow UpdateVoter RPC when the kraft.version is 0
     @Test
     void testUpdateVoterWithKraftVersion0() throws Exception {
         ReplicaKey local = replicaKey(randomeReplicaId(), true);
@@ -1924,7 +1957,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.UNSUPPORTED_VERSION);
+        context.assertSentUpdateVoterResponse(
+            Errors.UNSUPPORTED_VERSION,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -1971,7 +2008,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.VOTER_NOT_FOUND);
+        context.assertSentUpdateVoterResponse(
+            Errors.VOTER_NOT_FOUND,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -2018,7 +2059,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.VOTER_NOT_FOUND);
+        context.assertSentUpdateVoterResponse(
+            Errors.VOTER_NOT_FOUND,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -2075,7 +2120,11 @@ public class KafkaRaftClientReconfigTest {
 
         // Expect a timeout error
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.REQUEST_TIMED_OUT);
+        context.assertSentUpdateVoterResponse(
+            Errors.REQUEST_TIMED_OUT,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -2130,7 +2179,11 @@ public class KafkaRaftClientReconfigTest {
         // Leader completes the UpdateVoter RPC when resigning
         context.client.resign(epoch);
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.NOT_LEADER_OR_FOLLOWER);
+        context.assertSentUpdateVoterResponse(
+            Errors.NOT_LEADER_OR_FOLLOWER,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test
@@ -2196,7 +2249,11 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         context.pollUntilResponse();
-        context.assertSentUpdateVoterResponse(Errors.REQUEST_TIMED_OUT);
+        context.assertSentUpdateVoterResponse(
+            Errors.REQUEST_TIMED_OUT,
+            OptionalInt.of(local.id()),
+            epoch
+        );
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -2730,7 +2730,12 @@ public class KafkaRaftClientTest {
         context.collectEndQuorumRequests(
             epoch,
             Utils.mkSet(closeFollower.id(), laggingFollower.id()),
-            Optional.of(Arrays.asList(closeFollower.id(), laggingFollower.id()))
+            Optional.of(
+                Arrays.asList(
+                    replicaKey(closeFollower.id(), false),
+                    replicaKey(laggingFollower.id(), false)
+                )
+            )
         );
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
 import org.apache.kafka.server.common.KRaftVersion;
+import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,6 +76,7 @@ public class LeaderStateTest {
             voters.voterIds(),
             accumulator,
             voters.listeners(localReplicaKey.id()),
+            KRaftVersionTest.supportedVersionRange(),
             fetchTimeoutMs,
             logContext
         );
@@ -120,6 +122,7 @@ public class LeaderStateTest {
                 Collections.emptySet(),
                 null,
                 Endpoints.empty(),
+                KRaftVersionTest.supportedVersionRange(),
                 fetchTimeoutMs,
                 logContext
             )

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.KRaftVersion;
-import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -76,7 +76,7 @@ public class LeaderStateTest {
             voters.voterIds(),
             accumulator,
             voters.listeners(localReplicaKey.id()),
-            KRaftVersionTest.supportedVersionRange(),
+            Features.KRAFT_VERSION.supportedVersionRange(),
             fetchTimeoutMs,
             logContext
         );
@@ -122,7 +122,7 @@ public class LeaderStateTest {
                 Collections.emptySet(),
                 null,
                 Endpoints.empty(),
-                KRaftVersionTest.supportedVersionRange(),
+                Features.KRAFT_VERSION.supportedVersionRange(),
                 fetchTimeoutMs,
                 logContext
             )

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -25,8 +25,8 @@ import org.apache.kafka.raft.internals.KRaftControlRecordStateMachine;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.KRaftVersion;
-import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -81,7 +81,7 @@ public class QuorumStateTest {
             localDirectoryId,
             mockPartitionState,
             localId.isPresent() ? voterSet.listeners(localId.getAsInt()) : Endpoints.empty(),
-            KRaftVersionTest.supportedVersionRange(),
+            Features.KRAFT_VERSION.supportedVersionRange(),
             electionTimeoutMs,
             fetchTimeoutMs,
             store,

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
 import org.apache.kafka.server.common.KRaftVersion;
+import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -80,6 +81,7 @@ public class QuorumStateTest {
             localDirectoryId,
             mockPartitionState,
             localId.isPresent() ? voterSet.listeners(localId.getAsInt()) : Endpoints.empty(),
+            KRaftVersionTest.supportedVersionRange(),
             electionTimeoutMs,
             fetchTimeoutMs,
             store,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -66,8 +66,8 @@ import org.apache.kafka.raft.internals.BatchBuilder;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.StringSerde;
 import org.apache.kafka.raft.internals.VoterSet;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.KRaftVersion;
-import org.apache.kafka.server.common.KRaftVersionTest;
 import org.apache.kafka.server.common.serialization.RecordSerde;
 import org.apache.kafka.snapshot.RecordsSnapshotWriter;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -411,7 +411,7 @@ public final class RaftClientTestContext {
                 clusterId,
                 bootstrapServers,
                 localListeners,
-                KRaftVersionTest.supportedVersionRange(),
+                Features.KRAFT_VERSION.supportedVersionRange(),
                 logContext,
                 random,
                 quorumConfig
@@ -1173,6 +1173,7 @@ public final class RaftClientTestContext {
         RaftResponse.Outbound response = sentResponses.get(0);
         assertInstanceOf(UpdateRaftVoterResponseData.class, response.data());
 
+        // TODO: check the leader id, leader epocha and leader endpoint
         UpdateRaftVoterResponseData updateVoterResponse = (UpdateRaftVoterResponseData) response.data();
         assertEquals(error, Errors.forCode(updateVoterResponse.errorCode()));
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.MockLog.LogBatch;
 import org.apache.kafka.raft.MockLog.LogEntry;
 import org.apache.kafka.raft.internals.BatchMemoryPool;
+import org.apache.kafka.server.common.KRaftVersionTest;
 import org.apache.kafka.server.common.serialization.RecordSerde;
 import org.apache.kafka.snapshot.RecordsSnapshotReader;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -791,6 +792,7 @@ public class RaftEventSimulationTest {
                 clusterId,
                 Collections.emptyList(),
                 endpointsFromId(nodeId, channel.listenerName()),
+                KRaftVersionTest.supportedVersionRange(),
                 logContext,
                 random,
                 quorumConfig

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.MockLog.LogBatch;
 import org.apache.kafka.raft.MockLog.LogEntry;
 import org.apache.kafka.raft.internals.BatchMemoryPool;
-import org.apache.kafka.server.common.KRaftVersionTest;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.serialization.RecordSerde;
 import org.apache.kafka.snapshot.RecordsSnapshotReader;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -792,7 +792,7 @@ public class RaftEventSimulationTest {
                 clusterId,
                 Collections.emptyList(),
                 endpointsFromId(nodeId, channel.listenerName()),
-                KRaftVersionTest.supportedVersionRange(),
+                Features.KRAFT_VERSION.supportedVersionRange(),
                 logContext,
                 random,
                 quorumConfig

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.raft.MockQuorumStateStore;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.QuorumState;
 import org.apache.kafka.server.common.KRaftVersion;
+import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -82,6 +83,7 @@ public class KafkaRaftMetricsTest {
             localDirectoryId,
             mockPartitionState,
             voterSet.listeners(localId),
+            KRaftVersionTest.supportedVersionRange(),
             electionTimeoutMs,
             fetchTimeoutMs,
             new MockQuorumStateStore(),

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -26,8 +26,8 @@ import org.apache.kafka.raft.LogOffsetMetadata;
 import org.apache.kafka.raft.MockQuorumStateStore;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.QuorumState;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.KRaftVersion;
-import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -83,7 +83,7 @@ public class KafkaRaftMetricsTest {
             localDirectoryId,
             mockPartitionState,
             voterSet.listeners(localId),
-            KRaftVersionTest.supportedVersionRange(),
+            Features.KRAFT_VERSION.supportedVersionRange(),
             electionTimeoutMs,
             fetchTimeoutMs,
             new MockQuorumStateStore(),

--- a/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
@@ -18,10 +18,10 @@ package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.feature.SupportedVersionRange;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.server.common.KRaftVersionTest;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -339,7 +339,7 @@ public final class VoterSetTest {
                     )
                 )
             ),
-            new SupportedVersionRange((short) 0, (short) 0)
+            KRaftVersionTest.supportedVersionRange()
         );
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/VoterSetTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.Endpoints;
-import org.apache.kafka.server.common.KRaftVersionTest;
+import org.apache.kafka.server.common.Features;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -339,7 +339,7 @@ public final class VoterSetTest {
                     )
                 )
             ),
-            KRaftVersionTest.supportedVersionRange()
+            Features.KRAFT_VERSION.supportedVersionRange()
         );
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/common/Features.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/Features.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.server.common;
 
+import org.apache.kafka.common.feature.SupportedVersionRange;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -84,6 +86,13 @@ public enum Features {
 
     public short latestTesting() {
         return featureVersions[featureVersions.length - 1].featureLevel();
+    }
+
+    public SupportedVersionRange supportedVersionRange() {
+        return new SupportedVersionRange(
+            minimumProduction(),
+            latestTesting()
+        );
     }
 
     /**

--- a/server-common/src/main/java/org/apache/kafka/server/common/KRaftVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/KRaftVersion.java
@@ -84,7 +84,6 @@ public enum KRaftVersion implements FeatureVersion {
         throw new IllegalStateException("Unsupported KRaft feature level: " + this);
     }
 
-    // TODO: write test
     public short kraftVersionRecordVersion() {
         switch (this) {
             case KRAFT_VERSION_1:
@@ -93,7 +92,6 @@ public enum KRaftVersion implements FeatureVersion {
         throw new IllegalStateException("Unsupported KRaft feature level: " + this);
     }
 
-    // TODO: write test
     public short votersRecordVersion() {
         switch (this) {
             case KRAFT_VERSION_1:

--- a/server-common/src/main/java/org/apache/kafka/server/common/KRaftVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/KRaftVersion.java
@@ -81,6 +81,24 @@ public enum KRaftVersion implements FeatureVersion {
             case KRAFT_VERSION_1:
                 return (short) 1;
         }
-        throw new RuntimeException("Unknown KRaft feature level: " + this);
+        throw new IllegalStateException("Unsupported KRaft feature level: " + this);
+    }
+
+    // TODO: write test
+    public short kraftVersionRecordVersion() {
+        switch (this) {
+            case KRAFT_VERSION_1:
+                return (short) 0;
+        }
+        throw new IllegalStateException("Unsupported KRaft feature level: " + this);
+    }
+
+    // TODO: write test
+    public short votersRecordVersion() {
+        switch (this) {
+            case KRAFT_VERSION_1:
+                return (short) 0;
+        }
+        throw new IllegalStateException("Unsupported KRaft feature level: " + this);
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.kafka.server.common;
 
+import org.apache.kafka.common.feature.SupportedVersionRange;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class KRaftVersionTest {
+public final class KRaftVersionTest {
     @Test
     public void testFeatureLevel() {
         for (int i = 0; i < KRaftVersion.values().length; i++) {
@@ -58,5 +60,12 @@ class KRaftVersionTest {
                     throw new RuntimeException("Unsupported value " + i);
             }
         }
+    }
+
+    public static SupportedVersionRange supportedVersionRange() {
+        return new SupportedVersionRange(
+            KRaftVersion.values()[0].featureLevel(),
+            KRaftVersion.values()[KRaftVersion.values().length - 1].featureLevel()
+        );
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
@@ -17,9 +17,12 @@
 
 package org.apache.kafka.server.common;
 
+import org.apache.kafka.common.record.ControlRecordUtils;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class KRaftVersionTest {
     @Test
@@ -56,6 +59,54 @@ public final class KRaftVersionTest {
                     break;
                 default:
                     throw new RuntimeException("Unsupported value " + i);
+            }
+        }
+    }
+
+    @Test
+    public void testKraftVersionRecordVersion() {
+        for (KRaftVersion kraftVersion : KRaftVersion.values()) {
+            switch (kraftVersion) {
+                case KRAFT_VERSION_0:
+                    assertThrows(
+                        IllegalStateException.class,
+                        () -> kraftVersion.kraftVersionRecordVersion()
+                    );
+                    break;
+
+                case KRAFT_VERSION_1:
+                    assertEquals(
+                        ControlRecordUtils.KRAFT_VERSION_CURRENT_VERSION,
+                        kraftVersion.kraftVersionRecordVersion()
+                    );
+                    break;
+
+                default:
+                    throw new RuntimeException("Unsupported value " + kraftVersion);
+            }
+        }
+    }
+
+    @Test
+    public void tesVotersRecordVersion() {
+        for (KRaftVersion kraftVersion : KRaftVersion.values()) {
+            switch (kraftVersion) {
+                case KRAFT_VERSION_0:
+                    assertThrows(
+                        IllegalStateException.class,
+                        () -> kraftVersion.votersRecordVersion()
+                    );
+                    break;
+
+                case KRAFT_VERSION_1:
+                    assertEquals(
+                        ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION,
+                        kraftVersion.votersRecordVersion()
+                    );
+                    break;
+
+                default:
+                    throw new RuntimeException("Unsupported value " + kraftVersion);
             }
         }
     }

--- a/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/KRaftVersionTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.server.common;
 
-import org.apache.kafka.common.feature.SupportedVersionRange;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,12 +58,5 @@ public final class KRaftVersionTest {
                     throw new RuntimeException("Unsupported value " + i);
             }
         }
-    }
-
-    public static SupportedVersionRange supportedVersionRange() {
-        return new SupportedVersionRange(
-            KRaftVersion.values()[0].featureLevel(),
-            KRaftVersion.values()[KRaftVersion.values().length - 1].featureLevel()
-        );
     }
 }


### PR DESCRIPTION
Add support for handling the update voter RPC. The update voter RPC is used to automatically update the voters supported kraft versions and available endpoints as the operator upgrades and reconfigures the KRaft controllers.

The add voter RPC is handled as follow:

1. Check that the leader has fenced the previous leader(s) by checking that the HWM is known, otherwise return the REQUEST_TIMED_OUT error.
2. Check that the cluster supports kraft.version 1, otherwise return the UNSUPPORTED_VERSION error.
3. Check that there are no uncommitted voter changes, otherwise return the REQUEST_TIMED_OUT error.
4. Check that the updated voter still supports the currently finalized kraft.version, otherwise return the INVALID_REQUEST error.
5. Check that the updated voter is still listening on the default listener.
6. Append the updated VotersRecord to the log. The KRaft internal listener will read this uncommitted record from the log and update the voter in the set of voters.
7. Wait for the VotersRecord to commit using the majority of the voters. Return a REQUEST_TIMED_OUT error if it doesn't commit in time.
8. Send the UpdateVoter successful response to the voter.

Lastly, this change also implements the ability for the leader to update its own entry in the voter set when it becomes leader for an epoch. This is done by updating the voter set and writing a control batch as the first batch in a new leader epoch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
