### PR TITLE
KAFKA-12823 Remove Deprecated method KStream#through

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -16,7 +16,6 @@
  */
 package kafka.tools;
 
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -51,7 +51,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
  * {@code KStream}, {@link KTable},
  * {@link GlobalKTable}, or can be aggregated into a {@link KTable}. Kafka
  * Streams DSL can be mixed-and-matched with Processor API (PAPI) (c.f.
- * {@link Topology}) via  {@link #process(ProcessorSupplier, String...) process(...)},
+ * {@link Topology}) via null {@link #process(ProcessorSupplier, String...) process(...)},
  * {@link #transform(TransformerSupplier, String...) transform(...)}, and
  * {@link #transformValues(ValueTransformerSupplier, String...) transformValues(...)}.
  *
@@ -1013,6 +1013,7 @@ public interface KStream<K, V> {
      * @return {@code KStream} that contains the exact same repartitioned
      * records as this {@code KStream}.
      */
+    @Deprecated
     KStream<K, V> repartition();
 
     /**
@@ -4050,13 +4051,14 @@ public interface KStream<K, V> {
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
      * {@link #repartition()} should be performed before {@code
-     * flatTransform()}. <p> Transforming records might
-     * r
-     * esult in an internal data redistribution if a key based operator (like an
+     * flatTransform()}. <p> Transforming records might r
+     * esult
+     * i
+     * n an internal data redistribution if a key based operator (like an
      * aggregation or join) is applied to the result {@code KStream}. (cf.
      * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
      * <p>
-     * Note that it is possible to emit records by using      {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
+     * Note that it is possible to emit records by using null null     {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
      * context#forward()} in
      * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
@@ -4199,13 +4201,14 @@ public interface KStream<K, V> {
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
      * {@link #repartition()} should be performed before {@code
-     * flatTransform()}. <p> Transforming records might
-     * r
-     * esult in an internal data redistribution if a key based operator (like an
+     * flatTransform()}. <p> Transforming records might r
+     * esult
+     * i
+     * n an internal data redistribution if a key based operator (like an
      * aggregation or join) is applied to the result {@code KStream}. (cf.
      * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
      * <p>
-     * Note that it is possible to emit records by using      {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
+     * Note that it is possible to emit records by using null null     {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
      * context#forward()} in
      * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
@@ -4904,11 +4907,13 @@ public interface KStream<K, V> {
      * }
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
-     * {@link #repartition()} should be performed before {@code flatTransformValues()}.
+     * {@link #repartition()} should be performed before {@code      flatTransformValues()}.
      * <
      * p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * S
+     * ett ing a new value preserves data co-location with respect to the key.
+     * Thus,
+     * <em>no</em> internal data redistribution is required if a key based
      * operator (like an aggregation or join) is applied to the result
      * {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})
@@ -5049,11 +5054,13 @@ public interface KStream<K, V> {
      * }
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
-     * {@link #repartition()} should be performed before {@code flatTransformValues()}.
+     * {@link #repartition()} should be performed before {@code      flatTransformValues()}.
      * <
      * p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * S
+     * ett ing a new value preserves data co-location with respect to the key.
+     * Thus,
+     * <em>no</em> internal data redistribution is required if a key based
      * operator (like an aggregation or join) is applied to the result
      * {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -4908,8 +4908,7 @@ public interface KStream<K, V> {
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
      * {@link #repartition()} should be performed before {@code      flatTransformValues()}.
-     * <
-     * p>
+     * <p>
      * S
      * ett ing a new value preserves data co-location with respect to the key.
      * Thus,
@@ -5055,8 +5054,7 @@ public interface KStream<K, V> {
      * }</pre> Even if any upstream operation was key-changing, no
      * auto-repartition is triggered. If repartitioning is required, a call to
      * {@link #repartition()} should be performed before {@code      flatTransformValues()}.
-     * <
-     * p>
+     * <p>
      * S
      * ett ing a new value preserves data co-location with respect to the key.
      * Thus,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -36,19 +36,22 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 /**
- * {@code KStream} is an abstraction of a <i>record stream</i> of {@link KeyValue} pairs, i.e., each record is an
- * independent entity/event in the real world.
- * For example a user X might buy two items I1 and I2, and thus there might be two records {@code <K:I1>, <K:I2>}
- * in the stream.
+ * {@code KStream} is an abstraction of a <i>record stream</i> of
+ * {@link KeyValue} pairs, i.e., each record is an independent entity/event in
+ * the real world. For example a user X might buy two items I1 and I2, and thus
+ * there might be two records {@code <K:I1>, <K:I2>} in the stream.
  * <p>
- * A {@code KStream} is either {@link StreamsBuilder#stream(String) defined from one or multiple Kafka topics} that
- * are consumed message by message or the result of a {@code KStream} transformation.
- * A {@link KTable} can also be {@link KTable#toStream() converted} into a {@code KStream}.
+ * A {@code KStream} is either
+ * {@link StreamsBuilder#stream(String) defined from one or multiple Kafka topics}
+ * that are consumed message by message or the result of a {@code KStream}
+ * transformation. A {@link KTable} can also be
+ * {@link KTable#toStream() converted} into a {@code KStream}.
  * <p>
- * A {@code KStream} can be transformed record by record, joined with another {@code KStream}, {@link KTable},
- * {@link GlobalKTable}, or can be aggregated into a {@link KTable}.
- * Kafka Streams DSL can be mixed-and-matched with Processor API (PAPI) (c.f. {@link Topology}) via
- * {@link #process(ProcessorSupplier, String...) process(...)},
+ * A {@code KStream} can be transformed record by record, joined with another
+ * {@code KStream}, {@link KTable},
+ * {@link GlobalKTable}, or can be aggregated into a {@link KTable}. Kafka
+ * Streams DSL can be mixed-and-matched with Processor API (PAPI) (c.f.
+ * {@link Topology}) via  {@link #process(ProcessorSupplier, String...) process(...)},
  * {@link #transform(TransformerSupplier, String...) transform(...)}, and
  * {@link #transformValues(ValueTransformerSupplier, String...) transformValues(...)}.
  *
@@ -61,62 +64,74 @@ import org.apache.kafka.streams.state.StoreBuilder;
 public interface KStream<K, V> {
 
     /**
-     * Create a new {@code KStream} that consists of all records of this stream which satisfy the given predicate.
-     * All records that do not satisfy the predicate are dropped.
-     * This is a stateless record-by-record operation.
+     * Create a new {@code KStream} that consists of all records of this stream
+     * which satisfy the given predicate. All records that do not satisfy the
+     * predicate are dropped. This is a stateless record-by-record operation.
      *
-     * @param predicate a filter {@link Predicate} that is applied to each record
-     * @return a {@code KStream} that contains only those records that satisfy the given predicate
+     * @param predicate a filter {@link Predicate} that is applied to each
+     * record
+     * @return a {@code KStream} that contains only those records that satisfy
+     * the given predicate
      * @see #filterNot(Predicate)
      */
     KStream<K, V> filter(final Predicate<? super K, ? super V> predicate);
 
     /**
-     * Create a new {@code KStream} that consists of all records of this stream which satisfy the given predicate.
-     * All records that do not satisfy the predicate are dropped.
-     * This is a stateless record-by-record operation.
+     * Create a new {@code KStream} that consists of all records of this stream
+     * which satisfy the given predicate. All records that do not satisfy the
+     * predicate are dropped. This is a stateless record-by-record operation.
      *
-     * @param predicate a filter {@link Predicate} that is applied to each record
-     * @param named     a {@link Named} config used to name the processor in the topology
-     * @return a {@code KStream} that contains only those records that satisfy the given predicate
+     * @param predicate a filter {@link Predicate} that is applied to each
+     * record
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @return a {@code KStream} that contains only those records that satisfy
+     * the given predicate
      * @see #filterNot(Predicate)
      */
     KStream<K, V> filter(final Predicate<? super K, ? super V> predicate, final Named named);
 
     /**
-     * Create a new {@code KStream} that consists all records of this stream which do <em>not</em> satisfy the given
-     * predicate.
-     * All records that <em>do</em> satisfy the predicate are dropped.
-     * This is a stateless record-by-record operation.
+     * Create a new {@code KStream} that consists all records of this stream
+     * which do <em>not</em> satisfy the given predicate. All records that
+     * <em>do</em> satisfy the predicate are dropped. This is a stateless
+     * record-by-record operation.
      *
-     * @param predicate a filter {@link Predicate} that is applied to each record
-     * @return a {@code KStream} that contains only those records that do <em>not</em> satisfy the given predicate
+     * @param predicate a filter {@link Predicate} that is applied to each
+     * record
+     * @return a {@code KStream} that contains only those records that do
+     * <em>not</em> satisfy the given predicate
      * @see #filter(Predicate)
      */
     KStream<K, V> filterNot(final Predicate<? super K, ? super V> predicate);
 
     /**
-     * Create a new {@code KStream} that consists all records of this stream which do <em>not</em> satisfy the given
-     * predicate.
-     * All records that <em>do</em> satisfy the predicate are dropped.
-     * This is a stateless record-by-record operation.
+     * Create a new {@code KStream} that consists all records of this stream
+     * which do <em>not</em> satisfy the given predicate. All records that
+     * <em>do</em> satisfy the predicate are dropped. This is a stateless
+     * record-by-record operation.
      *
-     * @param predicate a filter {@link Predicate} that is applied to each record
-     * @param named     a {@link Named} config used to name the processor in the topology
-     * @return a {@code KStream} that contains only those records that do <em>not</em> satisfy the given predicate
+     * @param predicate a filter {@link Predicate} that is applied to each
+     * record
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @return a {@code KStream} that contains only those records that do
+     * <em>not</em> satisfy the given predicate
      * @see #filter(Predicate)
      */
     KStream<K, V> filterNot(final Predicate<? super K, ? super V> predicate, final Named named);
 
     /**
-     * Set a new key (with possibly new type) for each input record.
-     * The provided {@link KeyValueMapper} is applied to each input record and computes a new key for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V>}.
-     * This is a stateless record-by-record operation.
+     * Set a new key (with possibly new type) for each input record. The
+     * provided {@link KeyValueMapper} is applied to each input record and
+     * computes a new key for it. Thus, an input record {@code <K,V>} can be
+     * transformed into an output record {@code <K':V>}. This is a stateless
+     * record-by-record operation.
      * <p>
-     * For example, you can use this transformation to set a key for a key-less input record {@code <null,V>} by
-     * extracting a key from the value within your {@link KeyValueMapper}. The example below computes the new key as the
-     * length of the value string.
+     * For example, you can use this transformation to set a key for a key-less
+     * input record {@code <null,V>} by extracting a key from the value within
+     * your {@link KeyValueMapper}. The example below computes the new key as
+     * the length of the value string.
      * <pre>{@code
      * KStream<Byte[], String> keyLessStream = builder.stream("key-less-topic");
      * KStream<Integer, String> keyedStream = keyLessStream.selectKey(new KeyValueMapper<Byte[], String, Integer> {
@@ -124,13 +139,15 @@ public interface KStream<K, V> {
      *         return value.length();
      *     }
      * });
-     * }</pre>
-     * Setting a new key might result in an internal data redistribution if a key based operator (like an aggregation or
-     * join) is applied to the result {@code KStream}.
+     * }</pre> Setting a new key might result in an internal data redistribution
+     * if a key based operator (like an aggregation or join) is applied to the
+     * result {@code KStream}.
      *
-     * @param mapper a {@link KeyValueMapper} that computes a new key for each record
-     * @param <KR>   the new key type of the result stream
-     * @return a {@code KStream} that contains records with new key (possibly of different type) and unmodified value
+     * @param mapper a {@link KeyValueMapper} that computes a new key for each
+     * record
+     * @param <KR> the new key type of the result stream
+     * @return a {@code KStream} that contains records with new key (possibly of
+     * different type) and unmodified value
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -141,14 +158,16 @@ public interface KStream<K, V> {
     <KR> KStream<KR, V> selectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper);
 
     /**
-     * Set a new key (with possibly new type) for each input record.
-     * The provided {@link KeyValueMapper} is applied to each input record and computes a new key for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V>}.
-     * This is a stateless record-by-record operation.
+     * Set a new key (with possibly new type) for each input record. The
+     * provided {@link KeyValueMapper} is applied to each input record and
+     * computes a new key for it. Thus, an input record {@code <K,V>} can be
+     * transformed into an output record {@code <K':V>}. This is a stateless
+     * record-by-record operation.
      * <p>
-     * For example, you can use this transformation to set a key for a key-less input record {@code <null,V>} by
-     * extracting a key from the value within your {@link KeyValueMapper}. The example below computes the new key as the
-     * length of the value string.
+     * For example, you can use this transformation to set a key for a key-less
+     * input record {@code <null,V>} by extracting a key from the value within
+     * your {@link KeyValueMapper}. The example below computes the new key as
+     * the length of the value string.
      * <pre>{@code
      * KStream<Byte[], String> keyLessStream = builder.stream("key-less-topic");
      * KStream<Integer, String> keyedStream = keyLessStream.selectKey(new KeyValueMapper<Byte[], String, Integer> {
@@ -156,14 +175,17 @@ public interface KStream<K, V> {
      *         return value.length();
      *     }
      * });
-     * }</pre>
-     * Setting a new key might result in an internal data redistribution if a key based operator (like an aggregation or
-     * join) is applied to the result {@code KStream}.
+     * }</pre> Setting a new key might result in an internal data redistribution
+     * if a key based operator (like an aggregation or join) is applied to the
+     * result {@code KStream}.
      *
-     * @param mapper a {@link KeyValueMapper} that computes a new key for each record
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <KR>   the new key type of the result stream
-     * @return a {@code KStream} that contains records with new key (possibly of different type) and unmodified value
+     * @param mapper a {@link KeyValueMapper} that computes a new key for each
+     * record
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <KR> the new key type of the result stream
+     * @return a {@code KStream} that contains records with new key (possibly of
+     * different type) and unmodified value
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -172,17 +194,20 @@ public interface KStream<K, V> {
      * @see #flatMapValues(ValueMapperWithKey)
      */
     <KR> KStream<KR, V> selectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper,
-                                  final Named named);
+            final Named named);
 
     /**
-     * Transform each record of the input stream into a new record in the output stream (both key and value type can be
-     * altered arbitrarily).
-     * The provided {@link KeyValueMapper} is applied to each input record and computes a new output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * This is a stateless record-by-record operation (cf. {@link #transform(TransformerSupplier, String...)} for
-     * stateful record transformation).
+     * Transform each record of the input stream into a new record in the output
+     * stream (both key and value type can be altered arbitrarily). The provided
+     * {@link KeyValueMapper} is applied to each input record and computes a new
+     * output record. Thus, an input record {@code <K,V>} can be transformed
+     * into an output record {@code <K':V'>}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #transform(TransformerSupplier, String...)} for stateful record
+     * transformation).
      * <p>
-     * The example below normalizes the String key to upper-case letters and counts the number of token of the value string.
+     * The example below normalizes the String key to upper-case letters and
+     * counts the number of token of the value string.
      * <pre>{@code
      * KStream<String, String> inputStream = builder.stream("topic");
      * KStream<String, Integer> outputStream = inputStream.map(new KeyValueMapper<String, String, KeyValue<String, Integer>> {
@@ -190,16 +215,18 @@ public interface KStream<K, V> {
      *         return new KeyValue<>(key.toUpperCase(), value.split(" ").length);
      *     }
      * });
-     * }</pre>
-     * The provided {@link KeyValueMapper} must return a {@link KeyValue} type and must not return {@code null}.
+     * }</pre> The provided {@link KeyValueMapper} must return a
+     * {@link KeyValue} type and must not return {@code null}.
      * <p>
-     * Mapping records might result in an internal data redistribution if a key based operator (like an aggregation or
-     * join) is applied to the result {@code KStream}. (cf. {@link #mapValues(ValueMapper)})
+     * Mapping records might result in an internal data redistribution if a key
+     * based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #mapValues(ValueMapper)})
      *
      * @param mapper a {@link KeyValueMapper} that computes a new output record
-     * @param <KR>   the key type of the result stream
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with new key and value (possibly both of different type)
+     * @param <KR> the key type of the result stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with new key and value
+     * (possibly both of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -213,14 +240,17 @@ public interface KStream<K, V> {
     <KR, VR> KStream<KR, VR> map(final KeyValueMapper<? super K, ? super V, ? extends KeyValue<? extends KR, ? extends VR>> mapper);
 
     /**
-     * Transform each record of the input stream into a new record in the output stream (both key and value type can be
-     * altered arbitrarily).
-     * The provided {@link KeyValueMapper} is applied to each input record and computes a new output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * This is a stateless record-by-record operation (cf. {@link #transform(TransformerSupplier, String...)} for
-     * stateful record transformation).
+     * Transform each record of the input stream into a new record in the output
+     * stream (both key and value type can be altered arbitrarily). The provided
+     * {@link KeyValueMapper} is applied to each input record and computes a new
+     * output record. Thus, an input record {@code <K,V>} can be transformed
+     * into an output record {@code <K':V'>}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #transform(TransformerSupplier, String...)} for stateful record
+     * transformation).
      * <p>
-     * The example below normalizes the String key to upper-case letters and counts the number of token of the value string.
+     * The example below normalizes the String key to upper-case letters and
+     * counts the number of token of the value string.
      * <pre>{@code
      * KStream<String, String> inputStream = builder.stream("topic");
      * KStream<String, Integer> outputStream = inputStream.map(new KeyValueMapper<String, String, KeyValue<String, Integer>> {
@@ -228,17 +258,20 @@ public interface KStream<K, V> {
      *         return new KeyValue<>(key.toUpperCase(), value.split(" ").length);
      *     }
      * });
-     * }</pre>
-     * The provided {@link KeyValueMapper} must return a {@link KeyValue} type and must not return {@code null}.
+     * }</pre> The provided {@link KeyValueMapper} must return a
+     * {@link KeyValue} type and must not return {@code null}.
      * <p>
-     * Mapping records might result in an internal data redistribution if a key based operator (like an aggregation or
-     * join) is applied to the result {@code KStream}. (cf. {@link #mapValues(ValueMapper)})
+     * Mapping records might result in an internal data redistribution if a key
+     * based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #mapValues(ValueMapper)})
      *
      * @param mapper a {@link KeyValueMapper} that computes a new output record
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <KR>   the key type of the result stream
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with new key and value (possibly both of different type)
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <KR> the key type of the result stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with new key and value
+     * (possibly both of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -250,14 +283,16 @@ public interface KStream<K, V> {
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      */
     <KR, VR> KStream<KR, VR> map(final KeyValueMapper<? super K, ? super V, ? extends KeyValue<? extends KR, ? extends VR>> mapper,
-                                 final Named named);
+            final Named named);
 
     /**
-     * Transform the value of each input record into a new value (with possible new type) of the output record.
-     * The provided {@link ValueMapper} is applied to each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * This is a stateless record-by-record operation (cf.
-     * {@link #transformValues(ValueTransformerSupplier, String...)} for stateful value transformation).
+     * Transform the value of each input record into a new value (with possible
+     * new type) of the output record. The provided {@link ValueMapper} is
+     * applied to each input record value and computes a new value for it. Thus,
+     * an input record {@code <K,V>} can be transformed into an output record
+     * {@code <K:V'>}. This is a stateless record-by-record operation (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...)} for
+     * stateful value transformation).
      * <p>
      * The example below counts the number of token of the value string.
      * <pre>{@code
@@ -267,14 +302,15 @@ public interface KStream<K, V> {
      *         return value.split(" ").length;
      *     }
      * });
-     * }</pre>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #map(KeyValueMapper)})
+     * }</pre> Setting a new value preserves data co-location with respect to
+     * the key. Thus, <em>no</em> internal data redistribution is required if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #map(KeyValueMapper)})
      *
      * @param mapper a {@link ValueMapper} that computes a new output value
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -287,11 +323,13 @@ public interface KStream<K, V> {
     <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper);
 
     /**
-     * Transform the value of each input record into a new value (with possible new type) of the output record.
-     * The provided {@link ValueMapper} is applied to each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * This is a stateless record-by-record operation (cf.
-     * {@link #transformValues(ValueTransformerSupplier, String...)} for stateful value transformation).
+     * Transform the value of each input record into a new value (with possible
+     * new type) of the output record. The provided {@link ValueMapper} is
+     * applied to each input record value and computes a new value for it. Thus,
+     * an input record {@code <K,V>} can be transformed into an output record
+     * {@code <K:V'>}. This is a stateless record-by-record operation (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...)} for
+     * stateful value transformation).
      * <p>
      * The example below counts the number of token of the value string.
      * <pre>{@code
@@ -301,15 +339,17 @@ public interface KStream<K, V> {
      *         return value.split(" ").length;
      *     }
      * });
-     * }</pre>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #map(KeyValueMapper)})
+     * }</pre> Setting a new value preserves data co-location with respect to
+     * the key. Thus, <em>no</em> internal data redistribution is required if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #map(KeyValueMapper)})
      *
      * @param mapper a {@link ValueMapper} that computes a new output value
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -320,14 +360,16 @@ public interface KStream<K, V> {
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      */
     <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper,
-                                  final Named named);
+            final Named named);
 
     /**
-     * Transform the value of each input record into a new value (with possible new type) of the output record.
-     * The provided {@link ValueMapperWithKey} is applied to each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * This is a stateless record-by-record operation (cf.
-     * {@link #transformValues(ValueTransformerWithKeySupplier, String...)} for stateful value transformation).
+     * Transform the value of each input record into a new value (with possible
+     * new type) of the output record. The provided {@link ValueMapperWithKey}
+     * is applied to each input record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output
+     * record {@code <K:V'>}. This is a stateless record-by-record operation
+     * (cf. {@link #transformValues(ValueTransformerWithKeySupplier, String...)}
+     * for stateful value transformation).
      * <p>
      * The example below counts the number of tokens of key and value strings.
      * <pre>{@code
@@ -337,15 +379,18 @@ public interface KStream<K, V> {
      *         return readOnlyKey.split(" ").length + value.split(" ").length;
      *     }
      * });
-     * }</pre>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #map(KeyValueMapper)})
+     * }</pre> Note that the key is read-only and should not be modified, as
+     * this can lead to corrupt partitioning. So, setting a new value preserves
+     * data co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #map(KeyValueMapper)})
      *
-     * @param mapper a {@link ValueMapperWithKey} that computes a new output value
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param mapper a {@link ValueMapperWithKey} that computes a new output
+     * value
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -358,11 +403,13 @@ public interface KStream<K, V> {
     <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> mapper);
 
     /**
-     * Transform the value of each input record into a new value (with possible new type) of the output record.
-     * The provided {@link ValueMapperWithKey} is applied to each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * This is a stateless record-by-record operation (cf.
-     * {@link #transformValues(ValueTransformerWithKeySupplier, String...)} for stateful value transformation).
+     * Transform the value of each input record into a new value (with possible
+     * new type) of the output record. The provided {@link ValueMapperWithKey}
+     * is applied to each input record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output
+     * record {@code <K:V'>}. This is a stateless record-by-record operation
+     * (cf. {@link #transformValues(ValueTransformerWithKeySupplier, String...)}
+     * for stateful value transformation).
      * <p>
      * The example below counts the number of tokens of key and value strings.
      * <pre>{@code
@@ -372,16 +419,20 @@ public interface KStream<K, V> {
      *         return readOnlyKey.split(" ").length + value.split(" ").length;
      *     }
      * });
-     * }</pre>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #map(KeyValueMapper)})
+     * }</pre> Note that the key is read-only and should not be modified, as
+     * this can lead to corrupt partitioning. So, setting a new value preserves
+     * data co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #map(KeyValueMapper)})
      *
-     * @param mapper a {@link ValueMapperWithKey} that computes a new output value
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param mapper a {@link ValueMapperWithKey} that computes a new output
+     * value
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -392,18 +443,21 @@ public interface KStream<K, V> {
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      */
     <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> mapper,
-                                  final Named named);
+            final Named named);
 
     /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * The provided {@link KeyValueMapper} is applied to each input record and computes zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transform(TransformerSupplier, String...)} for
-     * stateful record transformation).
+     * Transform each record of the input stream into zero or more records in
+     * the output stream (both key and value type can be altered arbitrarily).
+     * The provided {@link KeyValueMapper} is applied to each input record and
+     * computes zero or more output records. Thus, an input record {@code <K,V>}
+     * can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
+     * This is a stateless record-by-record operation (cf.
+     * {@link #transform(TransformerSupplier, String...)} for stateful record
+     * transformation).
      * <p>
-     * The example below splits input records {@code <null:String>} containing sentences as values into their words
-     * and emit a record {@code <word:1>} for each word.
+     * The example below splits input records {@code <null:String>} containing
+     * sentences as values into their words and emit a record {@code <word:1>}
+     * for each word.
      * <pre>{@code
      * KStream<byte[], String> inputStream = builder.stream("topic");
      * KStream<String, Integer> outputStream = inputStream.flatMap(
@@ -419,17 +473,20 @@ public interface KStream<K, V> {
      *             return result;
      *         }
      *     });
-     * }</pre>
-     * The provided {@link KeyValueMapper} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link KeyValueMapper} must return an
+     * {@link Iterable} (e.g., any {@link java.util.Collection} type) and the
+     * return value must not be {@code null}.
      * <p>
-     * Flat-mapping records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}. (cf. {@link #flatMapValues(ValueMapper)})
+     * Flat-mapping records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatMapValues(ValueMapper)})
      *
-     * @param mapper a {@link KeyValueMapper} that computes the new output records
-     * @param <KR>   the key type of the result stream
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param mapper a {@link KeyValueMapper} that computes the new output
+     * records
+     * @param <KR> the key type of the result stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -446,15 +503,18 @@ public interface KStream<K, V> {
     <KR, VR> KStream<KR, VR> flatMap(final KeyValueMapper<? super K, ? super V, ? extends Iterable<? extends KeyValue<? extends KR, ? extends VR>>> mapper);
 
     /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * The provided {@link KeyValueMapper} is applied to each input record and computes zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transform(TransformerSupplier, String...)} for
-     * stateful record transformation).
+     * Transform each record of the input stream into zero or more records in
+     * the output stream (both key and value type can be altered arbitrarily).
+     * The provided {@link KeyValueMapper} is applied to each input record and
+     * computes zero or more output records. Thus, an input record {@code <K,V>}
+     * can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
+     * This is a stateless record-by-record operation (cf.
+     * {@link #transform(TransformerSupplier, String...)} for stateful record
+     * transformation).
      * <p>
-     * The example below splits input records {@code <null:String>} containing sentences as values into their words
-     * and emit a record {@code <word:1>} for each word.
+     * The example below splits input records {@code <null:String>} containing
+     * sentences as values into their words and emit a record {@code <word:1>}
+     * for each word.
      * <pre>{@code
      * KStream<byte[], String> inputStream = builder.stream("topic");
      * KStream<String, Integer> outputStream = inputStream.flatMap(
@@ -470,18 +530,22 @@ public interface KStream<K, V> {
      *             return result;
      *         }
      *     });
-     * }</pre>
-     * The provided {@link KeyValueMapper} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link KeyValueMapper} must return an
+     * {@link Iterable} (e.g., any {@link java.util.Collection} type) and the
+     * return value must not be {@code null}.
      * <p>
-     * Flat-mapping records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}. (cf. {@link #flatMapValues(ValueMapper)})
+     * Flat-mapping records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatMapValues(ValueMapper)})
      *
-     * @param mapper a {@link KeyValueMapper} that computes the new output records
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <KR>   the key type of the result stream
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param mapper a {@link KeyValueMapper} that computes the new output
+     * records
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <KR> the key type of the result stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #mapValues(ValueMapper)
@@ -496,19 +560,23 @@ public interface KStream<K, V> {
      * @see #flatTransformValues(ValueTransformerWithKeySupplier, String...)
      */
     <KR, VR> KStream<KR, VR> flatMap(final KeyValueMapper<? super K, ? super V, ? extends Iterable<? extends KeyValue<? extends KR, ? extends VR>>> mapper,
-                                     final Named named);
+            final Named named);
 
     /**
-     * Create a new {@code KStream} by transforming the value of each record in this stream into zero or more values
-     * with the same key in the new stream.
-     * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
-     * stream (value type can be altered arbitrarily).
-     * The provided {@link ValueMapper} is applied to each input record and computes zero or more output values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transformValues(ValueTransformerSupplier, String...)}
-     * for stateful value transformation).
+     * Create a new {@code KStream} by transforming the value of each record in
+     * this stream into zero or more values with the same key in the new stream.
+     * Transform the value of each input record into zero or more records with
+     * the same (unmodified) key in the output stream (value type can be altered
+     * arbitrarily). The provided {@link ValueMapper} is applied to each input
+     * record and computes zero or more output values. Thus, an input record
+     * {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. This is a stateless record-by-record
+     * operation (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...)} for
+     * stateful value transformation).
      * <p>
-     * The example below splits input records {@code <null:String>} containing sentences as values into their words.
+     * The example below splits input records {@code <null:String>} containing
+     * sentences as values into their words.
      * <pre>{@code
      * KStream<byte[], String> inputStream = builder.stream("topic");
      * KStream<byte[], String> outputStream = inputStream.flatMapValues(new ValueMapper<String, Iterable<String>> {
@@ -516,17 +584,20 @@ public interface KStream<K, V> {
      *         return Arrays.asList(value.split(" "));
      *     }
      * });
-     * }</pre>
-     * The provided {@link ValueMapper} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link ValueMapper} must return an {@link Iterable}
+     * (e.g., any {@link java.util.Collection} type) and the return value must
+     * not be {@code null}.
      * <p>
-     * Splitting a record into multiple records with the same key preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
+     * Splitting a record into multiple records with the same key preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #flatMap(KeyValueMapper)})
      *
      * @param mapper a {@link ValueMapper} the computes the new output values
-     * @param <VR>      the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified keys and new values of different type
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified keys and new values of different type
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -542,16 +613,20 @@ public interface KStream<K, V> {
     <VR> KStream<K, VR> flatMapValues(final ValueMapper<? super V, ? extends Iterable<? extends VR>> mapper);
 
     /**
-     * Create a new {@code KStream} by transforming the value of each record in this stream into zero or more values
-     * with the same key in the new stream.
-     * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
-     * stream (value type can be altered arbitrarily).
-     * The provided {@link ValueMapper} is applied to each input record and computes zero or more output values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transformValues(ValueTransformerSupplier, String...)}
-     * for stateful value transformation).
+     * Create a new {@code KStream} by transforming the value of each record in
+     * this stream into zero or more values with the same key in the new stream.
+     * Transform the value of each input record into zero or more records with
+     * the same (unmodified) key in the output stream (value type can be altered
+     * arbitrarily). The provided {@link ValueMapper} is applied to each input
+     * record and computes zero or more output values. Thus, an input record
+     * {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. This is a stateless record-by-record
+     * operation (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...)} for
+     * stateful value transformation).
      * <p>
-     * The example below splits input records {@code <null:String>} containing sentences as values into their words.
+     * The example below splits input records {@code <null:String>} containing
+     * sentences as values into their words.
      * <pre>{@code
      * KStream<byte[], String> inputStream = builder.stream("topic");
      * KStream<byte[], String> outputStream = inputStream.flatMapValues(new ValueMapper<String, Iterable<String>> {
@@ -559,18 +634,22 @@ public interface KStream<K, V> {
      *         return Arrays.asList(value.split(" "));
      *     }
      * });
-     * }</pre>
-     * The provided {@link ValueMapper} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link ValueMapper} must return an {@link Iterable}
+     * (e.g., any {@link java.util.Collection} type) and the return value must
+     * not be {@code null}.
      * <p>
-     * Splitting a record into multiple records with the same key preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
+     * Splitting a record into multiple records with the same key preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #flatMap(KeyValueMapper)})
      *
      * @param mapper a {@link ValueMapper} the computes the new output values
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <VR>      the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified keys and new values of different type
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified keys and new values of different type
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -584,19 +663,23 @@ public interface KStream<K, V> {
      * @see #flatTransformValues(ValueTransformerWithKeySupplier, String...)
      */
     <VR> KStream<K, VR> flatMapValues(final ValueMapper<? super V, ? extends Iterable<? extends VR>> mapper,
-                                      final Named named);
+            final Named named);
+
     /**
-     * Create a new {@code KStream} by transforming the value of each record in this stream into zero or more values
-     * with the same key in the new stream.
-     * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
-     * stream (value type can be altered arbitrarily).
-     * The provided {@link ValueMapperWithKey} is applied to each input record and computes zero or more output values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transformValues(ValueTransformerWithKeySupplier, String...)}
-     * for stateful value transformation).
+     * Create a new {@code KStream} by transforming the value of each record in
+     * this stream into zero or more values with the same key in the new stream.
+     * Transform the value of each input record into zero or more records with
+     * the same (unmodified) key in the output stream (value type can be altered
+     * arbitrarily). The provided {@link ValueMapperWithKey} is applied to each
+     * input record and computes zero or more output values. Thus, an input
+     * record {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. This is a stateless record-by-record
+     * operation (cf.
+     * {@link #transformValues(ValueTransformerWithKeySupplier, String...)} for
+     * stateful value transformation).
      * <p>
-     * The example below splits input records {@code <Integer:String>}, with key=1, containing sentences as values
-     * into their words.
+     * The example below splits input records {@code <Integer:String>}, with
+     * key=1, containing sentences as values into their words.
      * <pre>{@code
      * KStream<Integer, String> inputStream = builder.stream("topic");
      * KStream<Integer, String> outputStream = inputStream.flatMapValues(new ValueMapper<Integer, String, Iterable<String>> {
@@ -608,18 +691,22 @@ public interface KStream<K, V> {
      *         }
      *     }
      * });
-     * }</pre>
-     * The provided {@link ValueMapperWithKey} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link ValueMapperWithKey} must return an
+     * {@link Iterable} (e.g., any {@link java.util.Collection} type) and the
+     * return value must not be {@code null}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, splitting a record into multiple records with the same key preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
+     * Note that the key is read-only and should not be modified, as this can
+     * lead to corrupt partitioning. So, splitting a record into multiple
+     * records with the same key preserves data co-location with respect to the
+     * key. Thus, <em>no</em> internal data redistribution is required if a key
+     * based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
      *
-     * @param mapper a {@link ValueMapperWithKey} the computes the new output values
-     * @param <VR>      the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified keys and new values of different type
+     * @param mapper a {@link ValueMapperWithKey} the computes the new output
+     * values
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified keys and new values of different type
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -635,17 +722,20 @@ public interface KStream<K, V> {
     <VR> KStream<K, VR> flatMapValues(final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends VR>> mapper);
 
     /**
-     * Create a new {@code KStream} by transforming the value of each record in this stream into zero or more values
-     * with the same key in the new stream.
-     * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
-     * stream (value type can be altered arbitrarily).
-     * The provided {@link ValueMapperWithKey} is applied to each input record and computes zero or more output values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * This is a stateless record-by-record operation (cf. {@link #transformValues(ValueTransformerWithKeySupplier, String...)}
-     * for stateful value transformation).
+     * Create a new {@code KStream} by transforming the value of each record in
+     * this stream into zero or more values with the same key in the new stream.
+     * Transform the value of each input record into zero or more records with
+     * the same (unmodified) key in the output stream (value type can be altered
+     * arbitrarily). The provided {@link ValueMapperWithKey} is applied to each
+     * input record and computes zero or more output values. Thus, an input
+     * record {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. This is a stateless record-by-record
+     * operation (cf.
+     * {@link #transformValues(ValueTransformerWithKeySupplier, String...)} for
+     * stateful value transformation).
      * <p>
-     * The example below splits input records {@code <Integer:String>}, with key=1, containing sentences as values
-     * into their words.
+     * The example below splits input records {@code <Integer:String>}, with
+     * key=1, containing sentences as values into their words.
      * <pre>{@code
      * KStream<Integer, String> inputStream = builder.stream("topic");
      * KStream<Integer, String> outputStream = inputStream.flatMapValues(new ValueMapper<Integer, String, Iterable<String>> {
@@ -657,19 +747,24 @@ public interface KStream<K, V> {
      *         }
      *     }
      * });
-     * }</pre>
-     * The provided {@link ValueMapperWithKey} must return an {@link Iterable} (e.g., any {@link java.util.Collection} type)
-     * and the return value must not be {@code null}.
+     * }</pre> The provided {@link ValueMapperWithKey} must return an
+     * {@link Iterable} (e.g., any {@link java.util.Collection} type) and the
+     * return value must not be {@code null}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, splitting a record into multiple records with the same key preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
+     * Note that the key is read-only and should not be modified, as this can
+     * lead to corrupt partitioning. So, splitting a record into multiple
+     * records with the same key preserves data co-location with respect to the
+     * key. Thus, <em>no</em> internal data redistribution is required if a key
+     * based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatMap(KeyValueMapper)})
      *
-     * @param mapper a {@link ValueMapperWithKey} the computes the new output values
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param <VR>      the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified keys and new values of different type
+     * @param mapper a {@link ValueMapperWithKey} the computes the new output
+     * values
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified keys and new values of different type
      * @see #selectKey(KeyValueMapper)
      * @see #map(KeyValueMapper)
      * @see #flatMap(KeyValueMapper)
@@ -683,21 +778,23 @@ public interface KStream<K, V> {
      * @see #flatTransformValues(ValueTransformerWithKeySupplier, String...)
      */
     <VR> KStream<K, VR> flatMapValues(final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends VR>> mapper,
-                                      final Named named);
+            final Named named);
 
     /**
-     * Print the records of this KStream using the options provided by {@link Printed}
-     * Note that this is mainly for debugging/testing purposes, and it will try to flush on each record print.
-     * It <em>SHOULD NOT</em> be used for production usage if performance requirements are concerned.
+     * Print the records of this KStream using the options provided by
+     * {@link Printed} Note that this is mainly for debugging/testing purposes,
+     * and it will try to flush on each record print. It <em>SHOULD NOT</em> be
+     * used for production usage if performance requirements are concerned.
      *
      * @param printed options for printing
      */
     void print(final Printed<K, V> printed);
 
     /**
-     * Perform an action on each record of {@code KStream}.
-     * This is a stateless record-by-record operation (cf. {@link #process(ProcessorSupplier, String...)}).
-     * Note that this is a terminal operation that returns void.
+     * Perform an action on each record of {@code KStream}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #process(ProcessorSupplier, String...)}). Note that this is a
+     * terminal operation that returns void.
      *
      * @param action an action to perform on each record
      * @see #process(ProcessorSupplier, String...)
@@ -705,24 +802,28 @@ public interface KStream<K, V> {
     void foreach(final ForeachAction<? super K, ? super V> action);
 
     /**
-     * Perform an action on each record of {@code KStream}.
-     * This is a stateless record-by-record operation (cf. {@link #process(ProcessorSupplier, String...)}).
-     * Note that this is a terminal operation that returns void.
+     * Perform an action on each record of {@code KStream}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #process(ProcessorSupplier, String...)}). Note that this is a
+     * terminal operation that returns void.
      *
      * @param action an action to perform on each record
-     * @param named  a {@link Named} config used to name the processor in the topology
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
      * @see #process(ProcessorSupplier, String...)
      */
     void foreach(final ForeachAction<? super K, ? super V> action, final Named named);
 
     /**
-     * Perform an action on each record of {@code KStream}.
-     * This is a stateless record-by-record operation (cf. {@link #process(ProcessorSupplier, String...)}).
+     * Perform an action on each record of {@code KStream}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #process(ProcessorSupplier, String...)}).
      * <p>
-     * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
-     * and returns an unchanged stream.
+     * Peek is a non-terminal operation that triggers a side effect (such as
+     * logging or statistics collection) and returns an unchanged stream.
      * <p>
-     * Note that since this operation is stateless, it may execute multiple times for a single record in failure cases.
+     * Note that since this operation is stateless, it may execute multiple
+     * times for a single record in failure cases.
      *
      * @param action an action to perform on each record
      * @see #process(ProcessorSupplier, String...)
@@ -731,30 +832,35 @@ public interface KStream<K, V> {
     KStream<K, V> peek(final ForeachAction<? super K, ? super V> action);
 
     /**
-     * Perform an action on each record of {@code KStream}.
-     * This is a stateless record-by-record operation (cf. {@link #process(ProcessorSupplier, String...)}).
+     * Perform an action on each record of {@code KStream}. This is a stateless
+     * record-by-record operation (cf.
+     * {@link #process(ProcessorSupplier, String...)}).
      * <p>
-     * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
-     * and returns an unchanged stream.
+     * Peek is a non-terminal operation that triggers a side effect (such as
+     * logging or statistics collection) and returns an unchanged stream.
      * <p>
-     * Note that since this operation is stateless, it may execute multiple times for a single record in failure cases.
+     * Note that since this operation is stateless, it may execute multiple
+     * times for a single record in failure cases.
      *
      * @param action an action to perform on each record
-     * @param named  a {@link Named} config used to name the processor in the topology
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
      * @see #process(ProcessorSupplier, String...)
      * @return itself
      */
     KStream<K, V> peek(final ForeachAction<? super K, ? super V> action, final Named named);
 
     /**
-     * Creates an array of {@code KStream} from this stream by branching the records in the original stream based on
-     * the supplied predicates.
-     * Each record is evaluated against the supplied predicates, and predicates are evaluated in order.
-     * Each stream in the result array corresponds position-wise (index) to the predicate in the supplied predicates.
-     * The branching happens on first-match: A record in the original stream is assigned to the corresponding result
-     * stream for the first predicate that evaluates to true, and is assigned to this stream only.
-     * A record will be dropped if none of the predicates evaluate to true.
-     * This is a stateless record-by-record operation.
+     * Creates an array of {@code KStream} from this stream by branching the
+     * records in the original stream based on the supplied predicates. Each
+     * record is evaluated against the supplied predicates, and predicates are
+     * evaluated in order. Each stream in the result array corresponds
+     * position-wise (index) to the predicate in the supplied predicates. The
+     * branching happens on first-match: A record in the original stream is
+     * assigned to the corresponding result stream for the first predicate that
+     * evaluates to true, and is assigned to this stream only. A record will be
+     * dropped if none of the predicates evaluate to true. This is a stateless
+     * record-by-record operation.
      *
      * @param predicates the ordered list of {@link Predicate} instances
      * @return multiple distinct substreams of this {@code KStream}
@@ -765,16 +871,19 @@ public interface KStream<K, V> {
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
 
     /**
-     * Creates an array of {@code KStream} from this stream by branching the records in the original stream based on
-     * the supplied predicates.
-     * Each record is evaluated against the supplied predicates, and predicates are evaluated in order.
-     * Each stream in the result array corresponds position-wise (index) to the predicate in the supplied predicates.
-     * The branching happens on first-match: A record in the original stream is assigned to the corresponding result
-     * stream for the first predicate that evaluates to true, and is assigned to this stream only.
-     * A record will be dropped if none of the predicates evaluate to true.
-     * This is a stateless record-by-record operation.
+     * Creates an array of {@code KStream} from this stream by branching the
+     * records in the original stream based on the supplied predicates. Each
+     * record is evaluated against the supplied predicates, and predicates are
+     * evaluated in order. Each stream in the result array corresponds
+     * position-wise (index) to the predicate in the supplied predicates. The
+     * branching happens on first-match: A record in the original stream is
+     * assigned to the corresponding result stream for the first predicate that
+     * evaluates to true, and is assigned to this stream only. A record will be
+     * dropped if none of the predicates evaluate to true. This is a stateless
+     * record-by-record operation.
      *
-     * @param named  a {@link Named} config used to name the processor in the topology
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
      * @param predicates the ordered list of {@link Predicate} instances
      * @return multiple distinct substreams of this {@code KStream}
      * @deprecated since 2.8. Use {@link #split(Named)} instead.
@@ -784,161 +893,194 @@ public interface KStream<K, V> {
     KStream<K, V>[] branch(final Named named, final Predicate<? super K, ? super V>... predicates);
 
     /**
-     * Split this stream into different branches. The returned {@link BranchedKStream} instance can be used for routing
-     * the records to different branches depending on evaluation against the supplied predicates.
+     * Split this stream into different branches. The returned
+     * {@link BranchedKStream} instance can be used for routing the records to
+     * different branches depending on evaluation against the supplied
+     * predicates.
      * <p>
-     *     Note: Stream branching is a stateless record-by-record operation.
-     *     Please check {@link BranchedKStream} for detailed description and usage example
+     * Note: Stream branching is a stateless record-by-record operation. Please
+     * check {@link BranchedKStream} for detailed description and usage example
      *
-     * @return {@link BranchedKStream} that provides methods for routing the records to different branches.
+     * @return {@link BranchedKStream} that provides methods for routing the
+     * records to different branches.
      */
     BranchedKStream<K, V> split();
 
     /**
-     * Split this stream into different branches. The returned {@link BranchedKStream} instance can be used for routing
-     * the records to different branches depending on evaluation against the supplied predicates.
+     * Split this stream into different branches. The returned
+     * {@link BranchedKStream} instance can be used for routing the records to
+     * different branches depending on evaluation against the supplied
+     * predicates.
      * <p>
-     *     Note: Stream branching is a stateless record-by-record operation.
-     *     Please check {@link BranchedKStream} for detailed description and usage example
+     * Note: Stream branching is a stateless record-by-record operation. Please
+     * check {@link BranchedKStream} for detailed description and usage example
      *
-     * @param named  a {@link Named} config used to name the processor in the topology and also to set the name prefix
-     *               for the resulting branches (see {@link BranchedKStream})
-     * @return {@link BranchedKStream} that provides methods for routing the records to different branches.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology and also to set the name prefix for the resulting branches (see
+     * {@link BranchedKStream})
+     * @return {@link BranchedKStream} that provides methods for routing the
+     * records to different branches.
      */
     BranchedKStream<K, V> split(final Named named);
 
     /**
      * Merge this stream and the given stream into one larger stream.
      * <p>
-     * There is no ordering guarantee between records from this {@code KStream} and records from
-     * the provided {@code KStream} in the merged stream.
-     * Relative order is preserved within each input stream though (ie, records within one input
-     * stream are processed in order).
+     * There is no ordering guarantee between records from this {@code KStream}
+     * and records from the provided {@code KStream} in the merged stream.
+     * Relative order is preserved within each input stream though (ie, records
+     * within one input stream are processed in order).
      *
      * @param stream a stream which is to be merged into this stream
-     * @return a merged stream containing all records from this and the provided {@code KStream}
+     * @return a merged stream containing all records from this and the provided
+     * {@code KStream}
      */
     KStream<K, V> merge(final KStream<K, V> stream);
 
     /**
      * Merge this stream and the given stream into one larger stream.
      * <p>
-     * There is no ordering guarantee between records from this {@code KStream} and records from
-     * the provided {@code KStream} in the merged stream.
-     * Relative order is preserved within each input stream though (ie, records within one input
-     * stream are processed in order).
+     * There is no ordering guarantee between records from this {@code KStream}
+     * and records from the provided {@code KStream} in the merged stream.
+     * Relative order is preserved within each input stream though (ie, records
+     * within one input stream are processed in order).
      *
      * @param stream a stream which is to be merged into this stream
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @return a merged stream containing all records from this and the provided {@code KStream}
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @return a merged stream containing all records from this and the provided
+     * {@code KStream}
      */
     KStream<K, V> merge(final KStream<K, V> stream, final Named named);
 
     /**
-     * Materialize this stream to a topic and creates a new {@code KStream} from the topic using default serializers,
-     * deserializers, and producer's default partitioning strategy.
-     * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
+     * Materialize this stream to a topic and creates a new {@code KStream} from
+     * the topic using default serializers, deserializers, and producer's
+     * default partitioning strategy. The specified topic should be manually
+     * created before it is used (i.e., before the Kafka Streams application is
      * started).
      * <p>
      * This is similar to calling {@link #to(String) #to(someTopicName)} and
      * {@link StreamsBuilder#stream(String) StreamsBuilder#stream(someTopicName)}.
      * Note that {@code through()} uses a hard coded {@link org.apache.kafka.streams.processor.FailOnInvalidTimestamp
-     * timestamp extractor} and does not allow to customize it, to ensure correct timestamp propagation.
+     * timestamp extractor} and does not allow to customize it, to ensure
+     * correct timestamp propagation.
      *
      * @param topic the topic name
-     * @return a {@code KStream} that contains the exact same (and potentially repartitioned) records as this {@code KStream}
+     * @return a {@code KStream} that contains the exact same (and potentially
+     * repartitioned) records as this {@code KStream}
      * @deprecated since 2.6; use {@link #repartition()} instead
      */
-    
     /**
-     * Materialize this stream to a topic and creates a new {@code KStream} from the topic using the
-     * {@link Produced} instance for configuration of the {@link Serde key serde}, {@link Serde value serde},
-     * and {@link StreamPartitioner}.
-     * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
+     * Materialize this stream to a topic and creates a new {@code KStream} from
+     * the topic using the {@link Produced} instance for configuration of the
+     * {@link Serde key serde}, {@link Serde value serde}, and
+     * {@link StreamPartitioner}. The specified topic should be manually created
+     * before it is used (i.e., before the Kafka Streams application is
      * started).
      * <p>
-     * This is similar to calling {@link #to(String, Produced) to(someTopic, Produced.with(keySerde, valueSerde)}
-     * and {@link StreamsBuilder#stream(String, Consumed) StreamsBuilder#stream(someTopicName, Consumed.with(keySerde, valueSerde))}.
+     * This is similar to calling
+     * {@link #to(String, Produced) to(someTopic, Produced.with(keySerde, valueSerde)}
+     * and
+     * {@link StreamsBuilder#stream(String, Consumed) StreamsBuilder#stream(someTopicName, Consumed.with(keySerde, valueSerde))}.
      * Note that {@code through()} uses a hard coded {@link org.apache.kafka.streams.processor.FailOnInvalidTimestamp
-     * timestamp extractor} and does not allow to customize it, to ensure correct timestamp propagation.
+     * timestamp extractor} and does not allow to customize it, to ensure
+     * correct timestamp propagation.
      *
-     * @param topic     the topic name
-     * @param produced  the options to use when producing to the topic
-     * @return a {@code KStream} that contains the exact same (and potentially repartitioned) records as this {@code KStream}
+     * @param topic the topic name
+     * @param produced the options to use when producing to the topic
+     * @return a {@code KStream} that contains the exact same (and potentially
+     * repartitioned) records as this {@code KStream}
      * @deprecated since 2.6; use {@link #repartition(Repartitioned)} instead
      */
-
-
     /**
-     * Materialize this stream to an auto-generated repartition topic and create a new {@code KStream}
-     * from the auto-generated topic using default serializers, deserializers, and producer's default partitioning strategy.
-     * The number of partitions is determined based on the upstream topics partition numbers.
+     * Materialize this stream to an auto-generated repartition topic and create
+     * a new {@code KStream} from the auto-generated topic using default
+     * serializers, deserializers, and producer's default partitioning strategy.
+     * The number of partitions is determined based on the upstream topics
+     * partition numbers.
      * <p>
-     * The created topic is considered as an internal topic and is meant to be used only by the current Kafka Streams instance.
-     * Similar to auto-repartitioning, the topic will be created with infinite retention time and data will be automatically purged by Kafka Streams.
-     * The topic will be named as "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * The created topic is considered as an internal topic and is meant to be
+     * used only by the current Kafka Streams instance. Similar to
+     * auto-repartitioning, the topic will be created with infinite retention
+     * time and data will be automatically purged by Kafka Streams. The topic
+     * will be named as "${applicationId}-&lt;name&gt;-repartition", where
+     * "applicationId" is user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      *
-     * @return {@code KStream} that contains the exact same repartitioned records as this {@code KStream}.
+     * @return {@code KStream} that contains the exact same repartitioned
+     * records as this {@code KStream}.
      */
     KStream<K, V> repartition();
 
     /**
-     * Materialize this stream to an auto-generated repartition topic and create a new {@code KStream}
-     * from the auto-generated topic using {@link Serde key serde}, {@link Serde value serde}, {@link StreamPartitioner},
-     * number of partitions, and topic name part as defined by {@link Repartitioned}.
+     * Materialize this stream to an auto-generated repartition topic and create
+     * a new {@code KStream} from the auto-generated topic using
+     * {@link Serde key serde}, {@link Serde value serde}, {@link StreamPartitioner},
+     * number of partitions, and topic name part as defined by
+     * {@link Repartitioned}.
      * <p>
-     * The created topic is considered as an internal topic and is meant to be used only by the current Kafka Streams instance.
-     * Similar to auto-repartitioning, the topic will be created with infinite retention time and data will be automatically purged by Kafka Streams.
-     * The topic will be named as "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is either provided via {@link Repartitioned#as(String)} or an internally
-     * generated name, and "-repartition" is a fixed suffix.
+     * The created topic is considered as an internal topic and is meant to be
+     * used only by the current Kafka Streams instance. Similar to
+     * auto-repartitioning, the topic will be created with infinite retention
+     * time and data will be automatically purged by Kafka Streams. The topic
+     * will be named as "${applicationId}-&lt;name&gt;-repartition", where
+     * "applicationId" is user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is either provided via {@link Repartitioned#as(String)} or
+     * an internally generated name, and "-repartition" is a fixed suffix.
      *
      * @param repartitioned the {@link Repartitioned} instance used to specify {@link Serdes},
-     *                      {@link StreamPartitioner} which determines how records are distributed among partitions of the topic,
-     *                      part of the topic name, and number of partitions for a repartition topic.
-     * @return a {@code KStream} that contains the exact same repartitioned records as this {@code KStream}.
+     *                      {@link StreamPartitioner} which determines how records are distributed
+     * among partitions of the topic, part of the topic name, and number of
+     * partitions for a repartition topic.
+     * @return a {@code KStream} that contains the exact same repartitioned
+     * records as this {@code KStream}.
      */
     KStream<K, V> repartition(final Repartitioned<K, V> repartitioned);
 
     /**
-     * Materialize this stream to a topic using default serializers specified in the config and producer's
-     * default partitioning strategy.
-     * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
-     * started).
+     * Materialize this stream to a topic using default serializers specified in
+     * the config and producer's default partitioning strategy. The specified
+     * topic should be manually created before it is used (i.e., before the
+     * Kafka Streams application is started).
      *
      * @param topic the topic name
      */
     void to(final String topic);
 
     /**
-     * Materialize this stream to a topic using the provided {@link Produced} instance.
-     * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
-     * started).
+     * Materialize this stream to a topic using the provided {@link Produced}
+     * instance. The specified topic should be manually created before it is
+     * used (i.e., before the Kafka Streams application is started).
      *
-     * @param topic       the topic name
-     * @param produced    the options to use when producing to the topic
+     * @param topic the topic name
+     * @param produced the options to use when producing to the topic
      */
     void to(final String topic,
             final Produced<K, V> produced);
 
     /**
-     * Dynamically materialize this stream to topics using default serializers specified in the config and producer's
-     * default partitioning strategy.
-     * The topic names for each record to send to is dynamically determined based on the {@link TopicNameExtractor}.
+     * Dynamically materialize this stream to topics using default serializers
+     * specified in the config and producer's default partitioning strategy. The
+     * topic names for each record to send to is dynamically determined based on
+     * the {@link TopicNameExtractor}.
      *
-     * @param topicExtractor    the extractor to determine the name of the Kafka topic to write to for each record
+     * @param topicExtractor the extractor to determine the name of the Kafka
+     * topic to write to for each record
      */
     void to(final TopicNameExtractor<K, V> topicExtractor);
 
     /**
-     * Dynamically materialize this stream to topics using the provided {@link Produced} instance.
-     * The topic names for each record to send to is dynamically determined based on the {@link TopicNameExtractor}.
+     * Dynamically materialize this stream to topics using the provided
+     * {@link Produced} instance. The topic names for each record to send to is
+     * dynamically determined based on the {@link TopicNameExtractor}.
      *
-     * @param topicExtractor    the extractor to determine the name of the Kafka topic to write to for each record
-     * @param produced          the options to use when producing to the topic
+     * @param topicExtractor the extractor to determine the name of the Kafka
+     * topic to write to for each record
+     * @param produced the options to use when producing to the topic
      */
     void to(final TopicNameExtractor<K, V> topicExtractor,
             final Produced<K, V> produced);
@@ -948,24 +1090,33 @@ public interface KStream<K, V> {
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic will be created in Kafka.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic will be created in Kafka. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KTable} is partitioned
-     * correctly on its key.
-     * Note that you cannot enable {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case, because
-     * repartition topics are considered transient and don't allow to recover the result {@link KTable} in cause of
-     * a failure; hence, a dedicated changelog topic is required to guarantee fault-tolerance.
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KTable} is partitioned
+     * correctly on its key. Note that you cannot enable
+     * {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case,
+     * because repartition topics are considered transient and don't allow to
+     * recover the result {@link KTable} in cause of a failure; hence, a
+     * dedicated changelog topic is required to guarantee fault-tolerance.
      * <p>
-     * Note that this is a logical operation and only changes the "interpretation" of the stream, i.e., each record of
-     * it was a "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs {@code KTable}).
+     * Note that this is a logical operation and only changes the
+     * "interpretation" of the stream, i.e., each record of it was a
+     * "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs
+     * {@code KTable}).
      *
-     * @return a {@link KTable} that contains the same records as this {@code KStream}
+     * @return a {@link KTable} that contains the same records as this
+     * {@code KStream}
      */
     KTable<K, V> toTable();
 
@@ -974,25 +1125,35 @@ public interface KStream<K, V> {
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic will be created in Kafka.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic will be created in Kafka. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KTable} is partitioned
-     * correctly on its key.
-     * Note that you cannot enable {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case, because
-     * repartition topics are considered transient and don't allow to recover the result {@link KTable} in cause of
-     * a failure; hence, a dedicated changelog topic is required to guarantee fault-tolerance.
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KTable} is partitioned
+     * correctly on its key. Note that you cannot enable
+     * {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case,
+     * because repartition topics are considered transient and don't allow to
+     * recover the result {@link KTable} in cause of a failure; hence, a
+     * dedicated changelog topic is required to guarantee fault-tolerance.
      * <p>
-     * Note that this is a logical operation and only changes the "interpretation" of the stream, i.e., each record of
-     * it was a "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs {@code KTable}).
+     * Note that this is a logical operation and only changes the
+     * "interpretation" of the stream, i.e., each record of it was a
+     * "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs
+     * {@code KTable}).
      *
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @return a {@link KTable} that contains the same records as this {@code KStream}
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @return a {@link KTable} that contains the same records as this
+     * {@code KStream}
      */
     KTable<K, V> toTable(final Named named);
 
@@ -1001,26 +1162,35 @@ public interface KStream<K, V> {
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic will be created in Kafka.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic will be created in Kafka. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KTable} is partitioned
-     * correctly on its key.
-     * Note that you cannot enable {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case, because
-     * repartition topics are considered transient and don't allow to recover the result {@link KTable} in cause of
-     * a failure; hence, a dedicated changelog topic is required to guarantee fault-tolerance.
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KTable} is partitioned
+     * correctly on its key. Note that you cannot enable
+     * {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case,
+     * because repartition topics are considered transient and don't allow to
+     * recover the result {@link KTable} in cause of a failure; hence, a
+     * dedicated changelog topic is required to guarantee fault-tolerance.
      * <p>
-     * Note that this is a logical operation and only changes the "interpretation" of the stream, i.e., each record of
-     * it was a "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs {@code KTable}).
+     * Note that this is a logical operation and only changes the
+     * "interpretation" of the stream, i.e., each record of it was a
+     * "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs
+     * {@code KTable}).
      *
-     * @param materialized an instance of {@link Materialized} used to describe how the state store of the
-     *                            resulting table should be materialized.
-     * @return a {@link KTable} that contains the same records as this {@code KStream}
+     * @param materialized an instance of {@link Materialized} used to describe
+     * how the state store of the resulting table should be materialized.
+     * @return a {@link KTable} that contains the same records as this
+     * {@code KStream}
      */
     KTable<K, V> toTable(final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
 
@@ -1029,165 +1199,215 @@ public interface KStream<K, V> {
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic will be created in Kafka.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic will be created in Kafka. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KTable} is partitioned
-     * correctly on its key.
-     * Note that you cannot enable {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case, because
-     * repartition topics are considered transient and don't allow to recover the result {@link KTable} in cause of
-     * a failure; hence, a dedicated changelog topic is required to guarantee fault-tolerance.
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KTable} is partitioned
+     * correctly on its key. Note that you cannot enable
+     * {@link StreamsConfig#TOPOLOGY_OPTIMIZATION_CONFIG} config for this case,
+     * because repartition topics are considered transient and don't allow to
+     * recover the result {@link KTable} in cause of a failure; hence, a
+     * dedicated changelog topic is required to guarantee fault-tolerance.
      * <p>
-     * Note that this is a logical operation and only changes the "interpretation" of the stream, i.e., each record of
-     * it was a "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs {@code KTable}).
+     * Note that this is a logical operation and only changes the
+     * "interpretation" of the stream, i.e., each record of it was a
+     * "fact/event" and is re-interpreted as update now (cf. {@link KStream} vs
+     * {@code KTable}).
      *
-     * @param named  a {@link Named} config used to name the processor in the topology
-     * @param materialized an instance of {@link Materialized} used to describe how the state store of the
-     *                            resulting table should be materialized.
-     * @return a {@link KTable} that contains the same records as this {@code KStream}
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param materialized an instance of {@link Materialized} used to describe
+     * how the state store of the resulting table should be materialized.
+     * @return a {@link KTable} that contains the same records as this
+     * {@code KStream}
      */
     KTable<K, V> toTable(final Named named,
-                         final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
+            final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
 
     /**
-     * Group the records of this {@code KStream} on a new key that is selected using the provided {@link KeyValueMapper}
-     * and default serializers and deserializers.
-     * {@link KGroupedStream} can be further grouped with other streams to form a {@link CogroupedKStream}.
-     * Grouping a stream on the record key is required before an aggregation operator can be applied to the data
-     * (cf. {@link KGroupedStream}).
-     * The {@link KeyValueMapper} selects a new key (which may or may not be of the same type) while preserving the
-     * original values.
-     * If the new record key is {@code null} the record will not be included in the resulting {@link KGroupedStream}
+     * Group the records of this {@code KStream} on a new key that is selected
+     * using the provided {@link KeyValueMapper} and default serializers and
+     * deserializers. {@link KGroupedStream} can be further grouped with other
+     * streams to form a {@link CogroupedKStream}. Grouping a stream on the
+     * record key is required before an aggregation operator can be applied to
+     * the data (cf. {@link KGroupedStream}). The {@link KeyValueMapper} selects
+     * a new key (which may or may not be of the same type) while preserving the
+     * original values. If the new record key is {@code null} the record will
+     * not be included in the resulting {@link KGroupedStream}
      * <p>
-     * Because a new key is selected, an internal repartitioning topic may need to be created in Kafka if a
-     * later operator depends on the newly selected key.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * Because a new key is selected, an internal repartitioning topic may need
+     * to be created in Kafka if a later operator depends on the newly selected
+     * key. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * All data of this stream will be redistributed through the repartitioning topic by writing all records to it,
-     * and rereading all records from it, such that the resulting {@link KGroupedStream} is partitioned on the new key.
+     * All data of this stream will be redistributed through the repartitioning
+     * topic by writing all records to it, and rereading all records from it,
+     * such that the resulting {@link KGroupedStream} is partitioned on the new
+     * key.
      * <p>
-     * This operation is equivalent to calling {@link #selectKey(KeyValueMapper)} followed by {@link #groupByKey()}.
-     * If the key type is changed, it is recommended to use {@link #groupBy(KeyValueMapper, Grouped)} instead.
+     * This operation is equivalent to calling
+     * {@link #selectKey(KeyValueMapper)} followed by {@link #groupByKey()}. If
+     * the key type is changed, it is recommended to use
+     * {@link #groupBy(KeyValueMapper, Grouped)} instead.
      *
-     * @param keySelector a {@link KeyValueMapper} that computes a new key for grouping
-     * @param <KR>        the key type of the result {@link KGroupedStream}
-     * @return a {@link KGroupedStream} that contains the grouped records of the original {@code KStream}
+     * @param keySelector a {@link KeyValueMapper} that computes a new key for
+     * grouping
+     * @param <KR> the key type of the result {@link KGroupedStream}
+     * @return a {@link KGroupedStream} that contains the grouped records of the
+     * original {@code KStream}
      */
     <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> keySelector);
 
     /**
-     * Group the records of this {@code KStream} on a new key that is selected using the provided {@link KeyValueMapper}
-     * and {@link Serde}s as specified by {@link Grouped}.
-     * {@link KGroupedStream} can be further grouped with other streams to form a {@link CogroupedKStream}.
-     * Grouping a stream on the record key is required before an aggregation operator can be applied to the data
-     * (cf. {@link KGroupedStream}).
-     * The {@link KeyValueMapper} selects a new key (which may or may not be of the same type) while preserving the
-     * original values.
-     * If the new record key is {@code null} the record will not be included in the resulting {@link KGroupedStream}.
+     * Group the records of this {@code KStream} on a new key that is selected
+     * using the provided {@link KeyValueMapper} and {@link Serde}s as specified
+     * by {@link Grouped}. {@link KGroupedStream} can be further grouped with
+     * other streams to form a {@link CogroupedKStream}. Grouping a stream on
+     * the record key is required before an aggregation operator can be applied
+     * to the data (cf. {@link KGroupedStream}). The {@link KeyValueMapper}
+     * selects a new key (which may or may not be of the same type) while
+     * preserving the original values. If the new record key is {@code null} the
+     * record will not be included in the resulting {@link KGroupedStream}.
      * <p>
-     * Because a new key is selected, an internal repartitioning topic may need to be created in Kafka if a later
-     * operator depends on the newly selected key.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is either provided via {@link org.apache.kafka.streams.kstream.Grouped#as(String)} or an
+     * Because a new key is selected, an internal repartitioning topic may need
+     * to be created in Kafka if a later operator depends on the newly selected
+     * key. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is either provided via
+     * {@link org.apache.kafka.streams.kstream.Grouped#as(String)} or an
      * internally generated name.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * All data of this stream will be redistributed through the repartitioning topic by writing all records to it,
-     * and rereading all records from it, such that the resulting {@link KGroupedStream} is partitioned on the new key.
+     * All data of this stream will be redistributed through the repartitioning
+     * topic by writing all records to it, and rereading all records from it,
+     * such that the resulting {@link KGroupedStream} is partitioned on the new
+     * key.
      * <p>
-     * This operation is equivalent to calling {@link #selectKey(KeyValueMapper)} followed by {@link #groupByKey()}.
+     * This operation is equivalent to calling
+     * {@link #selectKey(KeyValueMapper)} followed by {@link #groupByKey()}.
      *
-     * @param keySelector a {@link KeyValueMapper} that computes a new key for grouping
-     * @param grouped     the {@link Grouped} instance used to specify {@link org.apache.kafka.common.serialization.Serdes}
-     *                    and part of the name for a repartition topic if repartitioning is required.
-     * @param <KR>        the key type of the result {@link KGroupedStream}
-     * @return a {@link KGroupedStream} that contains the grouped records of the original {@code KStream}
+     * @param keySelector a {@link KeyValueMapper} that computes a new key for
+     * grouping
+     * @param grouped the {@link Grouped} instance used to specify
+     * {@link org.apache.kafka.common.serialization.Serdes} and part of the name
+     * for a repartition topic if repartitioning is required.
+     * @param <KR> the key type of the result {@link KGroupedStream}
+     * @return a {@link KGroupedStream} that contains the grouped records of the
+     * original {@code KStream}
      */
     <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> keySelector,
-                                       final Grouped<KR, V> grouped);
+            final Grouped<KR, V> grouped);
 
     /**
-     * Group the records by their current key into a {@link KGroupedStream} while preserving the original values
-     * and default serializers and deserializers.
-     * {@link KGroupedStream} can be further grouped with other streams to form a {@link CogroupedKStream}.
-     * Grouping a stream on the record key is required before an aggregation operator can be applied to the data
-     * (cf. {@link KGroupedStream}).
-     * If a record key is {@code null} the record will not be included in the resulting {@link KGroupedStream}.
+     * Group the records by their current key into a {@link KGroupedStream}
+     * while preserving the original values and default serializers and
+     * deserializers. {@link KGroupedStream} can be further grouped with other
+     * streams to form a {@link CogroupedKStream}. Grouping a stream on the
+     * record key is required before an aggregation operator can be applied to
+     * the data (cf. {@link KGroupedStream}). If a record key is {@code null}
+     * the record will not be included in the resulting {@link KGroupedStream}.
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic may need to be created in
-     * Kafka if a later operator depends on the newly selected key.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic may need to be created in Kafka if a later operator
+     * depends on the newly selected key. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KGroupedStream} is partitioned
-     * correctly on its key.
-     * If the last key changing operator changed the key type, it is recommended to use
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KGroupedStream} is
+     * partitioned correctly on its key. If the last key changing operator
+     * changed the key type, it is recommended to use
      * {@link #groupByKey(org.apache.kafka.streams.kstream.Grouped)} instead.
      *
-     * @return a {@link KGroupedStream} that contains the grouped records of the original {@code KStream}
+     * @return a {@link KGroupedStream} that contains the grouped records of the
+     * original {@code KStream}
      * @see #groupBy(KeyValueMapper)
      */
     KGroupedStream<K, V> groupByKey();
 
     /**
-     * Group the records by their current key into a {@link KGroupedStream} while preserving the original values
-     * and using the serializers as defined by {@link Grouped}.
-     * {@link KGroupedStream} can be further grouped with other streams to form a {@link CogroupedKStream}.
-     * Grouping a stream on the record key is required before an aggregation operator can be applied to the data
-     * (cf. {@link KGroupedStream}).
-     * If a record key is {@code null} the record will not be included in the resulting {@link KGroupedStream}.
+     * Group the records by their current key into a {@link KGroupedStream}
+     * while preserving the original values and using the serializers as defined
+     * by {@link Grouped}. {@link KGroupedStream} can be further grouped with
+     * other streams to form a {@link CogroupedKStream}. Grouping a stream on
+     * the record key is required before an aggregation operator can be applied
+     * to the data (cf. {@link KGroupedStream}). If a record key is {@code null}
+     * the record will not be included in the resulting {@link KGroupedStream}.
      * <p>
      * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
      * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
-     * {@link #transform(TransformerSupplier, String...)}) an internal repartitioning topic may need to be created in
-     * Kafka if a later operator depends on the newly selected key.
-     * This topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * &lt;name&gt; is either provided via {@link org.apache.kafka.streams.kstream.Grouped#as(String)} or an internally
-     * generated name, and "-repartition" is a fixed suffix.
+     * {@link #transform(TransformerSupplier, String...)}) an internal
+     * repartitioning topic may need to be created in Kafka if a later operator
+     * depends on the newly selected key. This topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * &lt;name&gt; is either provided via
+     * {@link org.apache.kafka.streams.kstream.Grouped#as(String)} or an
+     * internally generated name, and "-repartition" is a fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * For this case, all data of this stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the resulting {@link KGroupedStream} is partitioned
-     * correctly on its key.
+     * For this case, all data of this stream will be redistributed through the
+     * repartitioning topic by writing all records to it, and rereading all
+     * records from it, such that the resulting {@link KGroupedStream} is
+     * partitioned correctly on its key.
      *
-     * @param  grouped  the {@link Grouped} instance used to specify {@link Serdes}
-     *                  and part of the name for a repartition topic if repartitioning is required.
-     * @return a {@link KGroupedStream} that contains the grouped records of the original {@code KStream}
+     * @param grouped the {@link Grouped} instance used to specify
+     * {@link Serdes} and part of the name for a repartition topic if
+     * repartitioning is required.
+     * @return a {@link KGroupedStream} that contains the grouped records of the
+     * original {@code KStream}
      * @see #groupBy(KeyValueMapper)
      */
     KGroupedStream<K, V> groupByKey(final Grouped<K, V> grouped);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed inner equi join with default serializers and deserializers. The
+     * join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. If an input record key or value is
+     * {@code null} the record will not be included in the join operation and
+     * thus no output record will be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1212,59 +1432,74 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
-     * internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key and within the joining window intervals
      * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
      * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
-                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                 final JoinWindows windows);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed inner equi join with default serializers and deserializers. The
+     * join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records. If an
+     * input record key or value is {@code null} the record will not be included
+     * in the join operation and thus no output record will be added to the
+     * resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1289,59 +1524,75 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
-     * internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key and within the joining window
+     * intervals
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
-                                 final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                 final JoinWindows windows);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed inner equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. If an input record key or value is
+     * {@code null} the record will not be included in the join operation and
+     * thus no output record will be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1366,63 +1617,79 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
-     * internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>           the value type of the other stream
-     * @param <VR>           the value type of the result stream
-     * @param otherStream    the {@code KStream} to be joined with this stream
-     * @param joiner         a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows        the specification of the {@link JoinWindows}
-     * @param streamJoined   a {@link StreamJoined} used to configure join stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} used to configure join stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key and within the joining window intervals
      * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
      * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
-                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                 final JoinWindows windows,
-                                 final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed inner equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records. If an
+     * input record key or value is {@code null} the record will not be included
+     * in the join operation and thus no output record will be added to the
+     * resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1447,64 +1714,81 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
-     * internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>           the value type of the other stream
-     * @param <VR>           the value type of the result stream
-     * @param otherStream    the {@code KStream} to be joined with this stream
-     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows        the specification of the {@link JoinWindows}
-     * @param streamJoined   a {@link StreamJoined} used to configure join stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} used to configure join stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key and within the joining window
+     * intervals
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
-                                 final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                 final JoinWindows windows,
-                                 final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
+
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
-     * produce at least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed left equi join with default serializers and deserializers. In
+     * contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join},
+     * all records from this stream will produce at least one output record (cf.
+     * below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
-     * {@link ValueJoiner} will be called with a {@code null} value for the other stream.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. Furthermore, for each input record of
+     * this {@code KStream} that does not satisfy the join predicate the
+     * provided {@link ValueJoiner} will be called with a {@code null} value for
+     * the other stream. If an input record value is {@code null} the record
+     * will not be included in the join operation and thus no output record will
+     * be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1529,62 +1813,81 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key plus one for each non-matching record of
      * this {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoiner, JoinWindows)
      * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
-                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                     final JoinWindows windows);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
+
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all records from this stream will
-     * produce at least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed left equi join with default serializers and deserializers. In
+     * contrast to
+     * {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all
+     * records from this stream will produce at least one output record (cf.
+     * below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
-     * {@link ValueJoinerWithKey} will be called with a {@code null} value for the other stream.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of this {@code KStream} that does not
+     * satisfy the join predicate the provided {@link ValueJoinerWithKey} will
+     * be called with a {@code null} value for the other stream. If an input
+     * record value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1609,63 +1912,81 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
-     * this {@code KStream} and within the joining window intervals
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key plus one for each non-matching
+     * record of this {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                     final JoinWindows windows);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed left equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
-     * produce at least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed left equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. In contrast to
+     * {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records
+     * from this stream will produce at least one output record (cf. below). The
+     * join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
-     * {@link ValueJoiner} will be called with a {@code null} value for the other stream.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. Furthermore, for each input record of
+     * this {@code KStream} that does not satisfy the join predicate the
+     * provided {@link ValueJoiner} will be called with a {@code null} value for
+     * the other stream. If an input record value is {@code null} the record
+     * will not be included in the join operation and thus no output record will
+     * be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1690,67 +2011,87 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>         the value type of the other stream
-     * @param <VR>         the value type of the result stream
-     * @param otherStream  the {@code KStream} to be joined with this stream
-     * @param joiner       a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows      the specification of the {@link JoinWindows}
-     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes
+     * and state stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key plus one for each non-matching record of
      * this {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoiner, JoinWindows, StreamJoined)
      * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
-                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                     final JoinWindows windows,
-                                     final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed left equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all records from this stream will
-     * produce at least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed left equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. In contrast to
+     * {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all
+     * records from this stream will produce at least one output record (cf.
+     * below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
-     * {@link ValueJoinerWithKey} will be called with a {@code null} value for the other stream.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of this {@code KStream} that does not
+     * satisfy the join predicate the provided {@link ValueJoinerWithKey} will
+     * be called with a {@code null} value for the other stream. If an input
+     * record value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1775,65 +2116,83 @@ public interface KStream<K, V> {
      * <td></td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>         the value type of the other stream
-     * @param <VR>         the value type of the result stream
-     * @param otherStream  the {@code KStream} to be joined with this stream
-     * @param joiner       a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows      the specification of the {@link JoinWindows}
-     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
-     * this {@code KStream} and within the joining window intervals
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes
+     * and state stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key plus one for each non-matching
+     * record of this {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                     final JoinWindows windows,
-                                     final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
+
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
-     * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all records from both streams will produce at
-     * least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed outer equi join with default serializers and deserializers. In
+     * contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}
+     * or {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all
+     * records from both streams will produce at least one output record (cf.
+     * below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
-     * {@link ValueJoiner} will be called with a {@code null} value for this/other stream, respectively.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. Furthermore, for each input record of
+     * both {@code KStream}s that does not satisfy the join predicate the
+     * provided {@link ValueJoiner} will be called with a {@code null} value for
+     * this/other stream, respectively. If an input record value is {@code null}
+     * the record will not be included in the join operation and thus no output
+     * record will be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1858,63 +2217,82 @@ public interface KStream<K, V> {
      * <td>&lt;K3:ValueJoiner(null,c)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key plus one for each non-matching record of
      * both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoiner, JoinWindows)
      * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
      */
     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
-                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                      final JoinWindows windows);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
+
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
-     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join}, all records from both streams will produce at
-     * least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed outer equi join with default serializers and deserializers. In
+     * contrast to
+     * {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join},
+     * all records from both streams will produce at least one output record
+     * (cf. below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
-     * {@link ValueJoinerWithKey} will be called with a {@code null} value for this/other stream, respectively.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of both {@code KStream}s that does not
+     * satisfy the join predicate the provided {@link ValueJoinerWithKey} will
+     * be called with a {@code null} value for this/other stream, respectively.
+     * If an input record value is {@code null} the record will not be included
+     * in the join operation and thus no output record will be added to the
+     * resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -1939,64 +2317,82 @@ public interface KStream<K, V> {
      * <td>&lt;K3:ValueJoinerWithKey(K3,null,c)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names. For failure and recovery each
+     * store will be backed by an internal changelog topic that will be created
+     * in Kafka. The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
      * @param otherStream the {@code KStream} to be joined with this stream
-     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows     the specification of the {@link JoinWindows}
-     * @param <VO>        the value type of the other stream
-     * @param <VR>        the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
-     * both {@code KStream} and within the joining window intervals
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key plus one for each non-matching
+     * record of both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
-                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                      final JoinWindows windows);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
-     * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all records from both streams will produce at
-     * least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed outer equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. In contrast to
+     * {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all
+     * records from both streams will produce at least one output record (cf.
+     * below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoiner} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
-     * {@link ValueJoiner} will be called with a {@code null} value for this/other stream, respectively.
-     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary
+     * type) for the result record. The key of the result record is the same as
+     * for both joining input records. Furthermore, for each input record of
+     * both {@code KStream}s that does not satisfy the join predicate the
+     * provided {@link ValueJoiner} will be called with a {@code null} value for
+     * this/other stream, respectively. If an input record key or value is
+     * {@code null} the record will not be included in the join operation and
+     * thus no output record will be added to the resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -2021,68 +2417,88 @@ public interface KStream<K, V> {
      * <td>&lt;K3:ValueJoiner(null,c)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>         the value type of the other stream
-     * @param <VR>         the value type of the result stream
-     * @param otherStream  the {@code KStream} to be joined with this stream
-     * @param joiner       a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param windows      the specification of the {@link JoinWindows}
-     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes
+     * and state stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key plus one for each non-matching record of
      * both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoiner, JoinWindows, StreamJoined)
      * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
-                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                      final JoinWindows windows,
-                                      final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join using the
-     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
-     * serde}, {@link Serde the other stream's value serde}, and used state stores.
-     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
-     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join}, all records from both streams will produce at
-     * least one output record (cf. below).
-     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
-     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
-     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * Join records of this stream with another {@code KStream}'s records using
+     * windowed outer equi join using the {@link StreamJoined} instance for
+     * configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state
+     * stores. In contrast to
+     * {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join},
+     * all records from both streams will produce at least one output record
+     * (cf. below). The join is computed on the records' key with join attribute
+     * {@code thisKStream.key == otherKStream.key}. Furthermore, two records are
+     * only joined if their timestamps are close to each other as defined by the
+     * given {@link JoinWindows}, i.e., the window defines an additional join
+     * predicate on the record timestamps.
      * <p>
-     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
-     * a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * The key of the result record is the same as for both joining input records.
-     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
-     * {@link ValueJoinerWithKey} will be called with a {@code null} value for this/other stream, respectively.
-     * If an input record value is {@code null} the record will not be included in the join operation and thus no
-     * output record will be added to the resulting {@code KStream}.
+     * For each pair of records meeting both join predicates the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with
+     * arbitrary type) for the result record. Note that the key is read-only and
+     * should not be modified, as this can lead to undefined behaviour. The key
+     * of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of both {@code KStream}s that does not
+     * satisfy the join predicate the provided {@link ValueJoinerWithKey} will
+     * be called with a {@code null} value for this/other stream, respectively.
+     * If an input record value is {@code null} the record will not be included
+     * in the join operation and thus no output record will be added to the
+     * resulting {@code KStream}.
      * <p>
      * Example (assuming all input records belong to the correct windows):
      * <table border='1'>
@@ -2107,63 +2523,80 @@ public interface KStream<K, V> {
      * <td>&lt;K3:ValueJoinerWithKey(K3,null,c)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
-     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} (for one
+     * input stream) before doing the join and specify the "correct" number of
+     * partitions via {@link Repartitioned} parameter. Furthermore, both input
+     * streams need to be co-partitioned on the join key (i.e., use the same
+     * partitioner). If this requirement is not met, Kafka Streams will
+     * automatically repartition the data, i.e., it will create an internal
+     * repartitioning topic in Kafka and write and re-read the data via this
+     * topic before the actual join. The repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * Repartitioning can happen for one or both of the joining {@code KStream}s.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen for one or both of the joining
+     * {@code KStream}s. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      * <p>
-     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
-     * unless a name is provided via a {@code Materialized} instance.
-     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
-     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
-     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
-     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * Both of the joining {@code KStream}s will be materialized in local state
+     * stores with auto-generated store names, unless a name is provided via a
+     * {@code Materialized} instance. For failure and recovery each store will
+     * be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named
+     * "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed
+     * suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      *
-     * @param <VO>         the value type of the other stream
-     * @param <VR>         the value type of the result stream
-     * @param otherStream  the {@code KStream} to be joined with this stream
-     * @param joiner       a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param windows      the specification of the {@link JoinWindows}
-     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
-     * both {@code KStream} and within the joining window intervals
+     * @param <VO> the value type of the other stream
+     * @param <VR> the value type of the result stream
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param windows the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes
+     * and state stores
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key plus one for each non-matching
+     * record of both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
-                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
-                                      final JoinWindows windows,
-                                      final StreamJoined<K, V, VO> streamJoined);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+            final JoinWindows windows,
+            final StreamJoined<K, V, VO> streamJoined);
+
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed inner equi join with default serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link KTable} the provided {@link ValueJoiner} will be called to compute
+     * a value (with arbitrary type) for the result record. The key of the
+     * result record is the same as for both joining input records. If an
+     * {@code KStream} input record key or value is {@code null} the record will
+     * not be included in the join operation and thus no output record will be
+     * added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2192,56 +2625,68 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoiner(C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key
      * @see #leftJoin(KTable, ValueJoiner)
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
-                                 final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
+            final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed inner equi join with default serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link KTable} the provided {@link ValueJoinerWithKey} will be called to
+     * compute a value (with arbitrary type) for the result record. Note that
+     * the key is read-only and should not be modified, as this can lead to
+     * undefined behaviour.
      *
-     * The key of the result record is the same as for both joining input records.
-     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * The key of the result record is the same as for both joining input
+     * records. If an {@code KStream} input record key or value is {@code null}
+     * the record will not be included in the join operation and thus no output
+     * record will be added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2270,54 +2715,65 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key
      * @see #leftJoin(KTable, ValueJoinerWithKey)
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
-                                 final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed inner equi join with default serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link KTable} the provided {@link ValueJoiner} will be called to compute
+     * a value (with arbitrary type) for the result record. The key of the
+     * result record is the same as for both joining input records. If an
+     * {@code KStream} input record key or value is {@code null} the record will
+     * not be included in the join operation and thus no output record will be
+     * added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2346,59 +2802,71 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoiner(C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param joined      a {@link Joined} instance that defines the serdes to
-     *                    be used to serialize/deserialize inputs of the joined streams
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param joined a {@link Joined} instance that defines the serdes to be
+     * used to serialize/deserialize inputs of the joined streams
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one for each matched
+     * record-pair with the same key
      * @see #leftJoin(KTable, ValueJoiner, Joined)
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
-                                 final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
-                                 final Joined<K, V, VT> joined);
+            final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
+            final Joined<K, V, VT> joined);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
-     * serializers and deserializers.
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed inner equi join with default serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as for both joining input records.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * 
-     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link KTable} the provided {@link ValueJoinerWithKey} will be called to
+     * compute a value (with arbitrary type) for the result record. The key of
+     * the result record is the same as for both joining input records. Note
+     * that the key is read-only and should not be modified, as this can lead to
+     * undefined behaviour.
+     *
+     * If an {@code KStream} input record key or value is {@code null} the
+     * record will not be included in the join operation and thus no output
+     * record will be added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2427,60 +2895,72 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param joined      a {@link Joined} instance that defines the serdes to
-     *                    be used to serialize/deserialize inputs of the joined streams
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param joined a {@link Joined} instance that defines the serdes to be
+     * used to serialize/deserialize inputs of the joined streams
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one for each
+     * matched record-pair with the same key
      * @see #leftJoin(KTable, ValueJoinerWithKey, Joined)
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
-                                 final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
-                                 final Joined<K, V, VT> joined);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
+            final Joined<K, V, VT> joined);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from this stream will produce an
-     * output record (cf. below).
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed left equi join with default serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records
+     * from this stream will produce an output record (cf. below). The join is a
+     * primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoiner}.
-     * The key of the result record is the same as for both joining input records.
-     * If an {@code KStream} input record value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link KTable} the provided {@link ValueJoiner} will be called
+     * to compute a value (with arbitrary type) for the result record. If no
+     * {@link KTable} record was found during lookup, a {@code null} value will
+     * be provided to {@link ValueJoiner}. The key of the result record is the
+     * same as for both joining input records. If an {@code KStream} input
+     * record value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2509,58 +2989,70 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoiner(C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #join(KTable, ValueJoiner)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
-                                     final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
+            final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all records from this stream will produce an
-     * output record (cf. below).
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed left equi join with default serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all
+     * records from this stream will produce an output record (cf. below). The
+     * join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoinerWithKey}.
-     * The key of the result record is the same as for both joining input records.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If an {@code KStream} input record value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link KTable} the provided {@link ValueJoinerWithKey} will be
+     * called to compute a value (with arbitrary type) for the result record. If
+     * no {@link KTable} record was found during lookup, a {@code null} value
+     * will be provided to {@link ValueJoinerWithKey}. The key of the result
+     * record is the same as for both joining input records. Note that the key
+     * is read-only and should not be modified, as this can lead to undefined
+     * behaviour. If an {@code KStream} input record value is {@code null} the
+     * record will not be included in the join operation and thus no output
+     * record will be added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2589,57 +3081,69 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param <VT>   the value type of the table
-     * @param <VR>   the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #join(KTable, ValueJoinerWithKey)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from this stream will produce an
-     * output record (cf. below).
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed left equi join with default serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records
+     * from this stream will produce an output record (cf. below). The join is a
+     * primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoiner}.
-     * The key of the result record is the same as for both joining input records.
-     * If an {@code KStream} input record value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link KTable} the provided {@link ValueJoiner} will be called
+     * to compute a value (with arbitrary type) for the result record. If no
+     * {@link KTable} record was found during lookup, a {@code null} value will
+     * be provided to {@link ValueJoiner}. The key of the result record is the
+     * same as for both joining input records. If an {@code KStream} input
+     * record value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2668,61 +3172,73 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoiner(C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table   the {@link KTable} to be joined with this stream
-     * @param joiner  a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param joined  a {@link Joined} instance that defines the serdes to
-     *                be used to serialize/deserialize inputs and outputs of the joined streams
-     * @param <VT>    the value type of the table
-     * @param <VR>    the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param joined a {@link Joined} instance that defines the serdes to be
+     * used to serialize/deserialize inputs and outputs of the joined streams
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #join(KTable, ValueJoiner, Joined)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
-                                     final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
-                                     final Joined<K, V, VT> joined);
+            final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
+            final Joined<K, V, VT> joined);
 
     /**
-     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
-     * serializers and deserializers.
-     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all records from this stream will produce an
-     * output record (cf. below).
-     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
-     * {@link KTable} state.
-     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
-     * will not produce any result records.
+     * Join records of this stream with {@link KTable}'s records using
+     * non-windowed left equi join with default serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all
+     * records from this stream will produce an output record (cf. below). The
+     * join is a primary key table lookup join with join attribute
+     * {@code stream.key == table.key}. "Table lookup join" means, that results
+     * are only computed if {@code KStream} records are processed. This is done
+     * by performing a lookup for matching records in the <em>current</em>
+     * (i.e., processing time) internal {@link KTable} state. In contrast,
+     * processing {@link KTable} input records will only update the internal
+     * {@link KTable} state and will not produce any result records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoinerWithKey}.
-     * The key of the result record is the same as for both joining input records.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If an {@code KStream} input record value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link KTable} the provided {@link ValueJoinerWithKey} will be
+     * called to compute a value (with arbitrary type) for the result record. If
+     * no {@link KTable} record was found during lookup, a {@code null} value
+     * will be provided to {@link ValueJoinerWithKey}. The key of the result
+     * record is the same as for both joining input records. Note that the key
+     * is read-only and should not be modified, as this can lead to undefined
+     * behaviour. If an {@code KStream} input record value is {@code null} the
+     * record will not be included in the join operation and thus no output
+     * record will be added to the resulting {@code KStream}.
      * <p>
      * Example:
      * <table border='1'>
@@ -2751,336 +3267,405 @@ public interface KStream<K, V> {
      * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
      * </tr>
      * </table>
-     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
-     * partitions.
-     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
-     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
-     * {@link KTable}.
-     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
-     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
-     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
-     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * Both input streams (or to be more precise, their underlying source
+     * topics) need to have the same number of partitions. If this is not the
+     * case, you would need to call {@link #repartition(Repartitioned)} for this
+     * {@code KStream} before doing the join, specifying the same number of
+     * partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}. Furthermore, both input streams need to be co-partitioned
+     * on the join key (i.e., use the same partitioner); cf.
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}. If this
+     * requirement is not met, Kafka Streams will automatically repartition the
+     * data, i.e., it will create an internal repartitioning topic in Kafka and
+     * write and re-read the data via this topic before the actual join. The
+     * repartitioning topic will be named
+     * "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
-     * name, and "-repartition" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "&lt;name&gt;" is an internally generated name, and "-repartition" is a
+     * fixed suffix.
      * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * You can retrieve all generated internal topic names via
+     * {@link Topology#describe()}.
      * <p>
-     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
-     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
-     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
-     * correctly on its key.
+     * Repartitioning can happen only for this {@code KStream} but not for the
+     * provided {@link KTable}. For this case, all data of the stream will be
+     * redistributed through the repartitioning topic by writing all records to
+     * it, and rereading all records from it, such that the join input
+     * {@code KStream} is partitioned correctly on its key.
      *
-     * @param table   the {@link KTable} to be joined with this stream
-     * @param joiner  a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param joined  a {@link Joined} instance that defines the serdes to
-     *                be used to serialize/deserialize inputs and outputs of the joined streams
-     * @param <VT>    the value type of the table
-     * @param <VR>    the value type of the result stream
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param table the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param joined a {@link Joined} instance that defines the serdes to be
+     * used to serialize/deserialize inputs and outputs of the joined streams
+     * @param <VT> the value type of the table
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #join(KTable, ValueJoinerWithKey, Joined)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
-                                     final Joined<K, V, VT> joined);
+            final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
+            final Joined<K, V, VT> joined);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed inner equi join. The join is a primary key table lookup join
+     * with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link GlobalKTable} the provided {@link ValueJoiner} will be called to
+     * compute a value (with arbitrary type) for the result record. The key of
+     * the result record is the same as the key of this {@code KStream}. If a
+     * {@code KStream} input value is {@code null} the record will not be
+     * included in the join operation and thus no output record will be added to
+     * the resulting {@code KStream}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param joiner         a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
-                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                     final ValueJoiner<? super V, ? super GV, ? extends RV> joiner);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoiner<? super V, ? super GV, ? extends RV> joiner);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed inner equi join. The join is a primary key table lookup join
+     * with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as the key of this {@code KStream}.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link GlobalKTable} the provided {@link ValueJoinerWithKey} will be
+     * called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as the key of this
+     * {@code KStream}. Note that the key is read-only and should not be
+     * modified, as this can lead to undefined behaviour. If a {@code KStream}
+     * input value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
-                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed inner equi join. The join is a primary key table lookup join
+     * with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link GlobalKTable} the provided {@link ValueJoiner} will be called to
+     * compute a value (with arbitrary type) for the result record. The key of
+     * the result record is the same as the key of this {@code KStream}. If a
+     * {@code KStream} input value is {@code null} the record will not be
+     * included in the join operation and thus no output record will be added to
+     * the resulting {@code KStream}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param joiner         a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param named          a {@link Named} config used to name the processor in the topology
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param joiner a {@link ValueJoiner} that computes the join result for a
+     * pair of matching records
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
-                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                     final ValueJoiner<? super V, ? super GV, ? extends RV> joiner,
-                                     final Named named);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoiner<? super V, ? super GV, ? extends RV> joiner,
+            final Named named);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed inner equi join. The join is a primary key table lookup join
+     * with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
-     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as the key of this {@code KStream}.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
+     * For each {@code KStream} record that finds a corresponding record in
+     * {@link GlobalKTable} the provided {@link ValueJoinerWithKey} will be
+     * called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as the key of this
+     * {@code KStream}. Note that the key is read-only and should not be
+     * modified, as this can lead to undefined behaviour. If a {@code KStream}
+     * input value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting
+     * {@code KStream}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param named          a {@link Named} config used to name the processor in the topology
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result
+     * for a pair of matching records
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
-                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                     final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner,
-                                     final Named named);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner,
+            final Named named);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
-     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner-join}, all records from this stream
-     * will produce an output record (cf. below).
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed left equi join. In contrast to
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner-join}, all
+     * records from this stream will produce an output record (cf. below). The
+     * join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
-     * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
-     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link GlobalKTable} the provided {@link ValueJoiner} will be
+     * called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as this {@code KStream}. If a
+     * {@code KStream} input value is {@code null} the record will not be
+     * included in the join operation and thus no output record will be added to
+     * the resulting {@code KStream}. If no {@link GlobalKTable} record was
+     * found during lookup, a {@code null} value will be provided to
      * {@link ValueJoiner}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param valueJoiner    a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param valueJoiner a {@link ValueJoiner} that computes the join result
+     * for a pair of matching records
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
-                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                         final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
-     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join}, all records from this stream
-     * will produce an output record (cf. below).
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed left equi join. In contrast to
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join},
+     * all records from this stream will produce an output record (cf. below).
      * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
-     * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as this {@code KStream}.
-     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
-     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
-     * {@link ValueJoiner}.
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link GlobalKTable} the provided {@link ValueJoinerWithKey}
+     * will be called to compute a value (with arbitrary type) for the result
+     * record. The key of the result record is the same as this {@code KStream}.
+     * Note that the key is read-only and should not be modified, as this can
+     * lead to undefined behaviour. If a {@code KStream} input value is
+     * {@code null} the record will not be included in the join operation and
+     * thus no output record will be added to the resulting {@code KStream}. If
+     * no {@link GlobalKTable} record was found during lookup, a {@code null}
+     * value will be provided to {@link ValueJoiner}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param valueJoiner    a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param valueJoiner a {@link ValueJoinerWithKey} that computes the join
+     * result for a pair of matching records
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
-                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
-     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner-join}, all records from this stream
-     * will produce an output record (cf. below).
-     * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed left equi join. In contrast to
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner-join}, all
+     * records from this stream will produce an output record (cf. below). The
+     * join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
-     * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
-     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link GlobalKTable} the provided {@link ValueJoiner} will be
+     * called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as this {@code KStream}. If a
+     * {@code KStream} input value is {@code null} the record will not be
+     * included in the join operation and thus no output record will be added to
+     * the resulting {@code KStream}. If no {@link GlobalKTable} record was
+     * found during lookup, a {@code null} value will be provided to
      * {@link ValueJoiner}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param valueJoiner    a {@link ValueJoiner} that computes the join result for a pair of matching records
-     * @param named          a {@link Named} config used to name the processor in the topology
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param valueJoiner a {@link ValueJoiner} that computes the join result
+     * for a pair of matching records
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoiner}, one output for each
+     * input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
-                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                         final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner,
-                                         final Named named);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner,
+            final Named named);
 
     /**
-     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
-     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join}, all records from this stream
-     * will produce an output record (cf. below).
+     * Join records of this stream with {@link GlobalKTable}'s records using
+     * non-windowed left equi join. In contrast to
+     * {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join},
+     * all records from this stream will produce an output record (cf. below).
      * The join is a primary key table lookup join with join attribute
-     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
-     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
-     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
-     * state.
-     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
-     * state and will not produce any result records.
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}. "Table lookup
+     * join" means, that results are only computed if {@code KStream} records
+     * are processed. This is done by performing a lookup for matching records
+     * in the <em>current</em> internal {@link GlobalKTable} state. In contrast,
+     * processing {@link GlobalKTable} input records will only update the
+     * internal {@link GlobalKTable} state and will not produce any result
+     * records.
      * <p>
-     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
-     * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
-     * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join operation
-     * and thus no output record will be added to the resulting {@code KStream}.
-     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
+     * For each {@code KStream} record whether or not it finds a corresponding
+     * record in {@link GlobalKTable} the provided {@link ValueJoinerWithKey}
+     * will be called to compute a value (with arbitrary type) for the result
+     * record. The key of the result record is the same as this {@code KStream}.
+     * If a {@code KStream} input value is {@code null} the record will not be
+     * included in the join operation and thus no output record will be added to
+     * the resulting {@code KStream}. If no {@link GlobalKTable} record was
+     * found during lookup, a {@code null} value will be provided to
      * {@link ValueJoinerWithKey}.
      *
-     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
-     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
-     *                       to the key of the {@link GlobalKTable}
-     * @param valueJoiner    a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
-     * @param named          a {@link Named} config used to name the processor in the topology
-     * @param <GK>           the key type of {@link GlobalKTable}
-     * @param <GV>           the value type of the {@link GlobalKTable}
-     * @param <RV>           the value type of the resulting {@code KStream}
-     * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @param globalTable the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector instance of {@link KeyValueMapper} used to map from
+     * the (key, value) of this stream to the key of the {@link GlobalKTable}
+     * @param valueJoiner a {@link ValueJoinerWithKey} that computes the join
+     * result for a pair of matching records
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param <GK> the key type of {@link GlobalKTable}
+     * @param <GV> the value type of the {@link GlobalKTable}
+     * @param <RV> the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and
+     * values computed by the given {@link ValueJoinerWithKey}, one output for
+     * each input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
-                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
-                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner,
-                                         final Named named);
+            final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+            final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner,
+            final Named named);
 
     /**
-     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or one output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform each record of the input stream into zero or one record in the
+     * output stream (both key and value type can be altered arbitrarily). A
+     * {@link Transformer} (provided by the given {@link TransformerSupplier})
+     * is applied to each input record and returns zero or one output record.
+     * Thus, an input record {@code <K,V>} can be transformed into an output
+     * record {@code <K':V'>}. Attaching a state store makes this a stateful
+     * record-by-record operation (cf. {@link #map(KeyValueMapper) map()}). If
+     * you choose not to attach one, this operation is similar to the stateless
+     * {@link #map(KeyValueMapper) map()} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3095,9 +3680,10 @@ public interface KStream<K, V> {
      *         return new MyTransformer();
      *     }
      * }, "myTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link TransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given {@link TransformerSupplier}
+     * to implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyTransformerSupplier implements TransformerSupplier {
      *     // supply transformer
@@ -3121,13 +3707,15 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transform(new MyTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
-     * transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * in which case no record is emitted.
+     * With either strategy, within the {@link Transformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link Transformer} must return a
+     * {@link KeyValue} type in {@link Transformer#transform(Object, Object)
+     * transform()}. The return value of
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} may
+     * be {@code null}, in which case no record is emitted.
      * <pre>{@code
      * class MyTransformer implements Transformer {
      *     private ProcessorContext context;
@@ -3149,68 +3737,86 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code transform()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code transform()}.
      * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
+     * Transforming records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()}
+     * )
      * <p>
-     * Note that it is possible to emit multiple records for each input record by using
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} in
+     * Note that it is possible to emit multiple records for each input record
+     * by using
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * in {@link Transformer#transform(Object, Object) Transformer#transform()}
+     * and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the
+     * type of the stream would only be detected at runtime. To ensure
+     * type-safety at compile-time,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * should not be used in
      * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time,
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
-     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()}.
-     * The supplier should always generate a new instance each time {@link TransformerSupplier#get()} gets called. Creating
-     * a single {@link Transformer} object and returning the same object reference in {@link TransformerSupplier#get()} would be
-     * a violation of the supplier pattern and leads to runtime exceptions.
+     * If in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()}
+     * multiple records need to be emitted for each input record, it is
+     * recommended to use {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()}. The supplier should always generate a new instance each
+     * time {@link TransformerSupplier#get()} gets called. Creating a single
+     * {@link Transformer} object and returning the same object reference in
+     * {@link TransformerSupplier#get()} would be a violation of the supplier
+     * pattern and leads to runtime exceptions.
      *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a newly constructed
-     *                            {@link Transformer}
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param transformerSupplier an instance of {@link TransformerSupplier}
+     * that generates a newly constructed {@link Transformer}
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <K1> the key type of the new stream
+     * @param <V1> the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #map(KeyValueMapper)
      * @see #flatTransform(TransformerSupplier, String...)
      * @see #transformValues(ValueTransformerSupplier, String...)
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      * @see #process(ProcessorSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#process(ProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#process(ProcessorSupplier, String...)} instead.
      */
     @Deprecated
     <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
-                                       final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
-     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or one output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform each record of the input stream into zero or one record in the
+     * output stream (both key and value type can be altered arbitrarily). A
+     * {@link Transformer} (provided by the given {@link TransformerSupplier})
+     * is applied to each input record and returns zero or one output record.
+     * Thus, an input record {@code <K,V>} can be transformed into an output
+     * record {@code <K':V'>}. Attaching a state store makes this a stateful
+     * record-by-record operation (cf. {@link #map(KeyValueMapper) map()}). If
+     * you choose not to attach one, this operation is similar to the stateless
+     * {@link #map(KeyValueMapper) map()} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3225,9 +3831,10 @@ public interface KStream<K, V> {
      *         return new MyTransformer();
      *     }
      * }, "myTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link TransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given {@link TransformerSupplier}
+     * to implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyTransformerSupplier implements TransformerSupplier {
      *     // supply transformer
@@ -3251,13 +3858,15 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transform(new MyTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
-     * transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * in which case no record is emitted.
+     * With either strategy, within the {@link Transformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link Transformer} must return a
+     * {@link KeyValue} type in {@link Transformer#transform(Object, Object)
+     * transform()}. The return value of
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} may
+     * be {@code null}, in which case no record is emitted.
      * <pre>{@code
      * class MyTransformer implements Transformer {
      *     private ProcessorContext context;
@@ -3279,69 +3888,88 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code transform()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code transform()}.
      * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
+     * Transforming records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()}
+     * )
      * <p>
-     * Note that it is possible to emit multiple records for each input record by using
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} in
+     * Note that it is possible to emit multiple records for each input record
+     * by using
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * in {@link Transformer#transform(Object, Object) Transformer#transform()}
+     * and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the
+     * type of the stream would only be detected at runtime. To ensure
+     * type-safety at compile-time,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * should not be used in
      * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time,
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
-     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()}.
-     * The supplier should always generate a new instance each time {@link TransformerSupplier#get()} gets called. Creating
-     * a single {@link Transformer} object and returning the same object reference in {@link TransformerSupplier#get()} would be
-     * a violation of the supplier pattern and leads to runtime exceptions.
+     * If in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()}
+     * multiple records need to be emitted for each input record, it is
+     * recommended to use {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()}. The supplier should always generate a new instance each
+     * time {@link TransformerSupplier#get()} gets called. Creating a single
+     * {@link Transformer} object and returning the same object reference in
+     * {@link TransformerSupplier#get()} would be a violation of the supplier
+     * pattern and leads to runtime exceptions.
      *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a newly constructed
-     *                            {@link Transformer}
-     * @param named               a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param transformerSupplier an instance of {@link TransformerSupplier}
+     * that generates a newly constructed {@link Transformer}
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <K1> the key type of the new stream
+     * @param <V1> the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #map(KeyValueMapper)
      * @see #flatTransform(TransformerSupplier, String...)
      * @see #transformValues(ValueTransformerSupplier, String...)
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      * @see #process(ProcessorSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#process(ProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#process(ProcessorSupplier, Named, String...)} instead.
      */
     @Deprecated
     <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
-                                       final Named named,
-                                       final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform each record of the input stream into zero or more records in
+     * the output stream (both key and value type can be altered arbitrarily). A
+     * {@link Transformer} (provided by the given {@link TransformerSupplier})
+     * is applied to each input record and returns zero or more output records.
+     * Thus, an input record {@code <K,V>} can be transformed into output
+     * records {@code <K':V'>, <K'':V''>, ...}. Attaching a state store makes
+     * this a stateful record-by-record operation (cf.
+     * {@link #flatMap(KeyValueMapper) flatMap()}). If you choose not to attach
+     * one, this operation is similar to the stateless
+     * {@link #flatMap(KeyValueMapper) flatMap()} but allows access to the
+     * {@code ProcessorContext} and record metadata. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3356,9 +3984,10 @@ public interface KStream<K, V> {
      *         return new MyTransformer();
      *     }
      * }, "myTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link TransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given {@link TransformerSupplier}
+     * to implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyTransformerSupplier implements TransformerSupplier {
      *     // supply transformer
@@ -3382,13 +4011,17 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransform(new MyTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
-     * type) in {@link Transformer#transform(Object, Object) transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
+     * With either strategy, within the {@link Transformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link Transformer} must return an
+     * {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
+     * type) in {@link Transformer#transform(Object, Object) transform()}. The
+     * return value of
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} may
+     * be {@code null}, which is equal to returning an empty
+     * {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
      * <pre>{@code
      * class MyTransformer implements Transformer {
      *     private ProcessorContext context;
@@ -3414,64 +4047,78 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransform()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code
+     * flatTransform()}. <p> Transforming records might
+     * r
+     * esult in an internal data redistribution if a key based operator (like an
+     * aggregation or join) is applied to the result {@code KStream}. (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
      * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
-     * <p>
-     * Note that it is possible to emit records by using
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
-     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * Note that it is possible to emit records by using      {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
+     * context#forward()} in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time,
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * Be aware that a mismatch between the types of the emitted records and the
+     * type of the stream would only be detected at runtime. To ensure
+     * type-safety at compile-time,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * should not be used in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * The supplier should always generate a new instance each time {@link TransformerSupplier#get()} gets called. Creating
-     * a single {@link Transformer} object and returning the same object reference in {@link TransformerSupplier#get()} would be
-     * a violation of the supplier pattern and leads to runtime exceptions.
+     * The supplier should always generate a new instance each time
+     * {@link TransformerSupplier#get()} gets called. Creating a single
+     * {@link Transformer} object and returning the same object reference in
+     * {@link TransformerSupplier#get()} would be a violation of the supplier
+     * pattern and leads to runtime exceptions.
      *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a newly constructed {@link Transformer}
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param transformerSupplier an instance of {@link TransformerSupplier}
+     * that generates a newly constructed {@link Transformer}
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <K1> the key type of the new stream
+     * @param <V1> the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #flatMap(KeyValueMapper)
      * @see #transform(TransformerSupplier, String...)
      * @see #transformValues(ValueTransformerSupplier, String...)
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      * @see #process(ProcessorSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#process(ProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#process(ProcessorSupplier, String...)} instead.
      */
     @Deprecated
     <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                           final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform each record of the input stream into zero or more records in
+     * the output stream (both key and value type can be altered arbitrarily). A
+     * {@link Transformer} (provided by the given {@link TransformerSupplier})
+     * is applied to each input record and returns zero or more output records.
+     * Thus, an input record {@code <K,V>} can be transformed into output
+     * records {@code <K':V'>, <K'':V''>, ...}. Attaching a state store makes
+     * this a stateful record-by-record operation (cf.
+     * {@link #flatMap(KeyValueMapper) flatMap()}). If you choose not to attach
+     * one, this operation is similar to the stateless
+     * {@link #flatMap(KeyValueMapper) flatMap()} but allows access to the
+     * {@code ProcessorContext} and record metadata. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3486,9 +4133,10 @@ public interface KStream<K, V> {
      *         return new MyTransformer();
      *     }
      * }, "myTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link TransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given {@link TransformerSupplier}
+     * to implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyTransformerSupplier implements TransformerSupplier {
      *     // supply transformer
@@ -3512,13 +4160,17 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransform(new MyTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
-     * type) in {@link Transformer#transform(Object, Object) transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
+     * With either strategy, within the {@link Transformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link Transformer} must return an
+     * {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
+     * type) in {@link Transformer#transform(Object, Object) transform()}. The
+     * return value of
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} may
+     * be {@code null}, which is equal to returning an empty
+     * {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
      * <pre>{@code
      * class MyTransformer implements Transformer {
      *     private ProcessorContext context;
@@ -3544,65 +4196,80 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransform()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code
+     * flatTransform()}. <p> Transforming records might
+     * r
+     * esult in an internal data redistribution if a key based operator (like an
+     * aggregation or join) is applied to the result {@code KStream}. (cf.
+     * {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
      * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
-     * <p>
-     * Note that it is possible to emit records by using
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
-     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * Note that it is possible to emit records by using      {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)
+     * context#forward()} in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time,
-     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * Be aware that a mismatch between the types of the emitted records and the
+     * type of the stream would only be detected at runtime. To ensure
+     * type-safety at compile-time,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) context#forward()}
+     * should not be used in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
      * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * The supplier should always generate a new instance each time {@link TransformerSupplier#get()} gets called. Creating
-     * a single {@link Transformer} object and returning the same object reference in {@link TransformerSupplier#get()} would be
-     * a violation of the supplier pattern and leads to runtime exceptions.
+     * The supplier should always generate a new instance each time
+     * {@link TransformerSupplier#get()} gets called. Creating a single
+     * {@link Transformer} object and returning the same object reference in
+     * {@link TransformerSupplier#get()} would be a violation of the supplier
+     * pattern and leads to runtime exceptions.
      *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a newly constructed {@link Transformer}
-     * @param named               a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @param transformerSupplier an instance of {@link TransformerSupplier}
+     * that generates a newly constructed {@link Transformer}
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <K1> the key type of the new stream
+     * @param <V1> the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key
+     * and value (possibly of different type)
      * @see #flatMap(KeyValueMapper)
      * @see #transform(TransformerSupplier, String...)
      * @see #transformValues(ValueTransformerSupplier, String...)
      * @see #transformValues(ValueTransformerWithKeySupplier, String...)
      * @see #process(ProcessorSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#process(ProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#process(ProcessorSupplier, Named, String...)} instead.
      */
     @Deprecated
     <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                           final Named named,
-                                           final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into a new value (with possibly
+     * a new type) of the output record. A {@link ValueTransformer} (provided by
+     * the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes a new value for it. Thus, an input record
+     * {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #mapValues(ValueMapper) mapValues()}). If you choose not to
+     * attach one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapper) mapValues()} but allows access to the
+     * {@code ProcessorContext} and record metadata. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3617,9 +4284,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformer();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerSupplier implements ValueTransformerSupplier {
      *     // supply transformer
@@ -3643,15 +4312,18 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transformValues(new MyValueTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
-     * pairs can be emitted via
+     * With either strategy, within the {@link ValueTransformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformer} must return
+     * the new value in {@link ValueTransformer#transform(Object) transform()}.
+     * In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()}, no
+     * additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformer} tries to emit a {@link KeyValue} pair.
      * <pre>{@code
      * class MyValueTransformer implements ValueTransformer {
      *     private StateStore state;
@@ -3671,49 +4343,65 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before
      * {@code transformValues()}.
      * <p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a newly constructed {@link ValueTransformer}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformer} object
-     *                                 and returning the same object reference in {@link ValueTransformer} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerSupplier} that generates a newly constructed
+     * {@link ValueTransformer} The supplier should always generate a new
+     * instance. Creating a single {@link ValueTransformer} object and returning
+     * the same object reference in {@link ValueTransformer} is a violation of
+     * the supplier pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                        final String... stateStoreNames);
+            final String... stateStoreNames);
+
     /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into a new value (with possibly
+     * a new type) of the output record. A {@link ValueTransformer} (provided by
+     * the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes a new value for it. Thus, an input record
+     * {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #mapValues(ValueMapper) mapValues()}). If you choose not to
+     * attach one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapper) mapValues()} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3728,9 +4416,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformer();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerSupplier implements ValueTransformerSupplier {
      *     // supply transformer
@@ -3754,15 +4444,18 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transformValues(new MyValueTransformerSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
-     * pairs can be emitted via
+     * With either strategy, within the {@link ValueTransformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformer} must return
+     * the new value in {@link ValueTransformer#transform(Object) transform()}.
+     * In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()}, no
+     * additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformer} tries to emit a {@link KeyValue} pair.
      * <pre>{@code
      * class MyValueTransformer implements ValueTransformer {
      *     private StateStore state;
@@ -3782,52 +4475,69 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before
      * {@code transformValues()}.
      * <p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a newly constructed {@link ValueTransformer}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformer} object
-     *                                 and returning the same object reference in {@link ValueTransformer} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerSupplier} that generates a newly constructed
+     * {@link ValueTransformer} The supplier should always generate a new
+     * instance. Creating a single {@link ValueTransformer} object and returning
+     * the same object reference in {@link ValueTransformer} is a violation of
+     * the supplier pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                        final Named named,
-                                        final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into a new value (with possibly
+     * a new type) of the output record. A {@link ValueTransformerWithKey}
+     * (provided by the given {@link ValueTransformerWithKeySupplier}) is
+     * applied to each input record value and computes a new value for it. Thus,
+     * an input record {@code <K,V>} can be transformed into an output record
+     * {@code <K:V'>}. Attaching a state store makes this a stateful
+     * record-by-record operation (cf.
+     * {@link #mapValues(ValueMapperWithKey) mapValues()}). If you choose not to
+     * attach one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapperWithKey) mapValues()} but allows access to
+     * the {@code ProcessorContext} and record metadata. This is essentially
+     * mixing the Processor API into the DSL, and provides all the functionality
+     * of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3842,9 +4552,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformer();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerWithKeySupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerWithKeySupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerWithKeySupplier implements ValueTransformerWithKeySupplier {
      *     // supply transformer
@@ -3868,17 +4580,21 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transformValues(new MyValueTransformerWithKeySupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformerWithKey}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return the new value in
-     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * With either strategy, within the {@link ValueTransformerWithKey}, the
+     * state is obtained via the {@link ProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformerWithKey} must
+     * return the new value in
+     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}. In
+     * contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformerWithKey} tries to emit a {@link KeyValue}
+     * pair.
      * <pre>{@code
      * class MyValueTransformerWithKey implements ValueTransformerWithKey {
      *     private StateStore state;
@@ -3898,51 +4614,69 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before
      * {@code transformValues()}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     * Note that the key is read-only and should not be modified, as this can
+     * lead to corrupt partitioning. So, setting a new value preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #transform(TransformerSupplier, String...)})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a newly constructed {@link ValueTransformerWithKey}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformerWithKey} object
-     *                                 and returning the same object reference in {@link ValueTransformerWithKey} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerWithKeySupplier} that generates a newly
+     * constructed {@link ValueTransformerWithKey} The supplier should always
+     * generate a new instance. Creating a single
+     * {@link ValueTransformerWithKey} object and returning the same object
+     * reference in {@link ValueTransformerWithKey} is a violation of the
+     * supplier pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                        final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into a new value (with possibly
+     * a new type) of the output record. A {@link ValueTransformerWithKey}
+     * (provided by the given {@link ValueTransformerWithKeySupplier}) is
+     * applied to each input record value and computes a new value for it. Thus,
+     * an input record {@code <K,V>} can be transformed into an output record
+     * {@code <K:V'>}. Attaching a state store makes this a stateful
+     * record-by-record operation (cf.
+     * {@link #mapValues(ValueMapperWithKey) mapValues()}). If you choose not to
+     * attach one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapperWithKey) mapValues()} but allows access to
+     * the {@code ProcessorContext} and record metadata. This is essentially
+     * mixing the Processor API into the DSL, and provides all the functionality
+     * of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -3957,9 +4691,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformerWithKey();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerWithKeySupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerWithKeySupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerWithKeySupplier implements ValueTransformerWithKeySupplier {
      *     // supply transformer
@@ -3983,17 +4719,21 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.transformValues(new MyValueTransformerWithKeySupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformerWithKey}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return the new value in
-     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * With either strategy, within the {@link ValueTransformerWithKey}, the
+     * state is obtained via the {@link ProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformerWithKey} must
+     * return the new value in
+     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}. In
+     * contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformerWithKey} tries to emit a {@link KeyValue}
+     * pair.
      * <pre>{@code
      * class MyValueTransformerWithKey implements ValueTransformerWithKey {
      *     private StateStore state;
@@ -4013,53 +4753,73 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before
      * {@code transformValues()}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     * Note that the key is read-only and should not be modified, as this can
+     * lead to corrupt partitioning. So, setting a new value preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf.
+     * {@link #transform(TransformerSupplier, String...)})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a newly constructed {@link ValueTransformerWithKey}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformerWithKey} object
-     *                                 and returning the same object reference in {@link ValueTransformerWithKey} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerWithKeySupplier} that generates a newly
+     * constructed {@link ValueTransformerWithKey} The supplier should always
+     * generate a new instance. Creating a single
+     * {@link ValueTransformerWithKey} object and returning the same object
+     * reference in {@link ValueTransformerWithKey} is a violation of the
+     * supplier pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and
+     * new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                        final Named named,
-                                        final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
+
     /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into zero or more new values
+     * (with possibly a new type) and emit for each new value a record with the
+     * same key of the input record and the value. A {@link ValueTransformer}
+     * (provided by the given {@link ValueTransformerSupplier}) is applied to
+     * each input record value and computes zero or more new values. Thus, an
+     * input record {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #mapValues(ValueMapper) mapValues()}). If you choose not to attach
+     * one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapper) mapValues()} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4074,9 +4834,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformer();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerSupplier implements ValueTransformerSupplier {
      *     // supply transformer
@@ -4100,20 +4862,23 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransformValues(new MyValueTransformer());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
+     * With either strategy, within the {@link ValueTransformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformer} must return
+     * an {@link java.lang.Iterable} type (e.g., any
      * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
-     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * transform()}. If the return value of
+     * {@link ValueTransformer#transform(Object) ValueTransformer#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no
+     * records are emitted. In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformer} tries to emit a {@link KeyValue} pair.
      * <pre>{@code
      * class MyValueTransformer implements ValueTransformer {
      *     private StateStore state;
@@ -4137,54 +4902,69 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code flatTransformValues()}.
+     * <
+     * p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a newly constructed {@link ValueTransformer}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformer} object
-     *                                 and returning the same object reference in {@link ValueTransformer} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerSupplier} that generates a newly constructed
+     * {@link ValueTransformer} The supplier should always generate a new
+     * instance. Creating a single {@link ValueTransformer} object and returning
+     * the same object reference in {@link ValueTransformer} is a violation of
+     * the supplier pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified key and new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
      * @see #flatTransform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into zero or more new values
+     * (with possibly a new type) and emit for each new value a record with the
+     * same key of the input record and the value. A {@link ValueTransformer}
+     * (provided by the given {@link ValueTransformerSupplier}) is applied to
+     * each input record value and computes zero or more new values. Thus, an
+     * input record {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #mapValues(ValueMapper) mapValues()}). If you choose not to attach
+     * one, this operation is similar to the stateless
+     * {@link #mapValues(ValueMapper) mapValues()} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions
+     * can be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4199,9 +4979,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformer();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerSupplier implements ValueTransformerSupplier {
      *     // supply transformer
@@ -4225,20 +5007,23 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransformValues(new MyValueTransformer());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
+     * With either strategy, within the {@link ValueTransformer}, the state is
+     * obtained via the {@link ProcessorContext}. To trigger periodic actions
+     * via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformer} must return
+     * an {@link java.lang.Iterable} type (e.g., any
      * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
-     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * transform()}. If the return value of
+     * {@link ValueTransformer#transform(Object) ValueTransformer#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no
+     * records are emitted. In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformer} tries to emit a {@link KeyValue} pair.
      * <pre>{@code
      * class MyValueTransformer implements ValueTransformer {
      *     private StateStore state;
@@ -4262,56 +5047,73 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code flatTransformValues()}.
+     * <
+     * p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a newly constructed {@link ValueTransformer}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformer} object
-     *                                 and returning the same object reference in {@link ValueTransformer} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerSupplier} that generates a newly constructed
+     * {@link ValueTransformer} The supplier should always generate a new
+     * instance. Creating a single {@link ValueTransformer} object and returning
+     * the same object reference in {@link ValueTransformer} is a violation of
+     * the supplier pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified key and new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
      * @see #flatTransform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final Named named,
-                                            final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
-     * be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into zero or more new values
+     * (with possibly a new type) and emit for each new value a record with the
+     * same key of the input record and the value. A
+     * {@link ValueTransformerWithKey} (provided by the given
+     * {@link ValueTransformerWithKeySupplier}) is applied to each input record
+     * value and computes zero or more new values. Thus, an input record
+     * {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}). If you
+     * choose not to attach one, this operation is similar to the stateless
+     * {@link #flatMapValues(ValueMapperWithKey) flatMapValues()} but allows
+     * access to the {@code ProcessorContext} and record metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4326,9 +5128,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformerWithKey();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerWithKeySupplier implements ValueTransformerWithKeySupplier {
      *     // supply transformer
@@ -4352,20 +5156,24 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransformValues(new MyValueTransformerWithKey());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformerWithKey}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
+     * With either strategy, within the {@link ValueTransformerWithKey}, the
+     * state is obtained via the {@link ProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformerWithKey} must
+     * return an {@link java.lang.Iterable} type (e.g., any
      * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * transform()}. If the return value of
+     * {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no
+     * records are emitted. In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformerWithKey} tries to emit a {@link KeyValue}
+     * pair.
      * <pre>{@code
      * class MyValueTransformerWithKey implements ValueTransformerWithKey {
      *     private StateStore state;
@@ -4389,55 +5197,74 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransformValues()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code
+     * flatTransformValues()}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * N
+     * o
+     * te that the key is read-only and should not be modified, as this can lead
+     * to corrupt partitioning. So, setting a new value preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a newly constructed {@link ValueTransformerWithKey}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformerWithKey} object
-     *                                 and returning the same object reference in {@link ValueTransformerWithKey} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerWithKeySupplier} that generates a newly
+     * constructed {@link ValueTransformerWithKey} The supplier should always
+     * generate a new instance. Creating a single
+     * {@link ValueTransformerWithKey} object and returning the same object
+     * reference in {@link ValueTransformerWithKey} is a violation of the
+     * supplier pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified key and new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
      * @see #flatTransform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
-     * be observed and additional periodic actions can be performed.
+     * Transform the value of each input record into zero or more new values
+     * (with possibly a new type) and emit for each new value a record with the
+     * same key of the input record and the value. A
+     * {@link ValueTransformerWithKey} (provided by the given
+     * {@link ValueTransformerWithKeySupplier}) is applied to each input record
+     * value and computes zero or more new values. Thus, an input record
+     * {@code <K,V>} can be transformed into output records
+     * {@code <K:V'>, <K:V''>, ...}. Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}). If you
+     * choose not to attach one, this operation is similar to the stateless
+     * {@link #flatMapValues(ValueMapperWithKey) flatMapValues()} but allows
+     * access to the {@code ProcessorContext} and record metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the transformer to use state stores, the stores must be added to the topology and connected to the
-     * transformer using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the transformer to use state stores, the stores must be
+     * added to the topology and connected to the transformer using at least one
+     * of two strategies (though it's not required to connect global state
+     * stores; read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the transformer.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * transformer.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4452,9 +5279,11 @@ public interface KStream<K, V> {
      *         return new MyValueTransformerWithKey();
      *     }
      * }, "myValueTransformState");
-     * }</pre>
-     * The second strategy is for the given {@link ValueTransformerSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the transformer.
+     * }</pre> The second strategy is for the given
+     * {@link ValueTransformerSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the transformer.
      * <pre>{@code
      * class MyValueTransformerWithKeySupplier implements ValueTransformerWithKeySupplier {
      *     // supply transformer
@@ -4478,20 +5307,24 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.flatTransformValues(new MyValueTransformerWithKey());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link ValueTransformerWithKey}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
+     * With either strategy, within the {@link ValueTransformerWithKey}, the
+     * state is obtained via the {@link ProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered. The {@link ValueTransformerWithKey} must
+     * return an {@link java.lang.Iterable} type (e.g., any
      * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via
+     * transform()}. If the return value of
+     * {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no
+     * records are emitted. In contrast to
+     * {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()},
+     * no additional {@link KeyValue} pairs can be emitted via
      * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if
+     * the {@link ValueTransformerWithKey} tries to emit a {@link KeyValue}
+     * pair.
      * <pre>{@code
      * class MyValueTransformerWithKey implements ValueTransformerWithKey {
      *     private StateStore state;
@@ -4515,56 +5348,72 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before
-     * {@code flatTransformValues()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code
+     * flatTransformValues()}.
      * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * N
+     * o
+     * te that the key is read-only and should not be modified, as this can lead
+     * to corrupt partitioning. So, setting a new value preserves data
+     * co-location with respect to the key. Thus, <em>no</em> internal data
+     * redistribution is required if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
      * flatTransform()})
      *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a newly constructed {@link ValueTransformerWithKey}
-     *                                 The supplier should always generate a new instance. Creating a single {@link ValueTransformerWithKey} object
-     *                                 and returning the same object reference in {@link ValueTransformerWithKey} is a
-     *                                 violation of the supplier pattern and leads to runtime exceptions.
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor; not required if the supplier
-     *                                 implements {@link ConnectedStoreProvider#stores()}
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
+     * @param valueTransformerSupplier an instance of
+     * {@link ValueTransformerWithKeySupplier} that generates a newly
+     * constructed {@link ValueTransformerWithKey} The supplier should always
+     * generate a new instance. Creating a single
+     * {@link ValueTransformerWithKey} object and returning the same object
+     * reference in {@link ValueTransformerWithKey} is a violation of the
+     * supplier pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
+     * @param <VR> the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with
+     * unmodified key and new values (possibly of different type)
      * @see #mapValues(ValueMapper)
      * @see #mapValues(ValueMapperWithKey)
      * @see #transform(TransformerSupplier, String...)
      * @see #flatTransform(TransformerSupplier, String...)
-     * @deprecated Since 3.3. Use {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)} instead.
+     * @deprecated Since 3.3. Use
+     * {@link KStream#processValues(FixedKeyProcessorSupplier, Named, String...)}
+     * instead.
      */
     @Deprecated
     <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final Named named,
-                                            final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
      * Process all records in this stream, one record at a time, by applying a
-     * {@link org.apache.kafka.streams.processor.Processor} (provided by the given
-     * {@link org.apache.kafka.streams.processor.ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * Note that this is a terminal operation that returns void.
+     * {@link org.apache.kafka.streams.processor.Processor} (provided by the
+     * given {@link org.apache.kafka.streams.processor.ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #foreach(ForeachAction)}). If you choose not to attach one,
+     * this operation is similar to the stateless
+     * {@link #foreach(ForeachAction)} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed. Note that this is a terminal operation that returns void.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4579,10 +5428,11 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link org.apache.kafka.streams.processor.ProcessorSupplier}
-     * to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements ProcessorSupplier {
      *     // supply processor
@@ -4606,9 +5456,12 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.process(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link org.apache.kafka.streams.processor.Processor},
-     * the state is obtained via the {@link org.apache.kafka.streams.processor.ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the
+     * {@link org.apache.kafka.streams.processor.Processor}, the state is
+     * obtained via the
+     * {@link org.apache.kafka.streams.processor.ProcessorContext}. To trigger
+     * periodic actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements Processor {
@@ -4628,45 +5481,56 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      *
-     * @param processorSupplier an instance of {@link org.apache.kafka.streams.processor.ProcessorSupplier}
-     *                          that generates a newly constructed {@link org.apache.kafka.streams.processor.Processor}
-     *                          The supplier should always generate a new instance. Creating a single
-     *                          {@link org.apache.kafka.streams.processor.Processor} object
-     *                          and returning the same object reference in
-     *                          {@link org.apache.kafka.streams.processor.ProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
+     * @param processorSupplier an instance of
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier} that
+     * generates a newly constructed
+     * {@link org.apache.kafka.streams.processor.Processor} The supplier should
+     * always generate a new instance. Creating a single
+     * {@link org.apache.kafka.streams.processor.Processor} object and returning
+     * the same object reference in
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier#get()} is a
+     * violation of the supplier pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
      * @see #foreach(ForeachAction)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.0. Use {@link KStream#process(org.apache.kafka.streams.processor.api.ProcessorSupplier, java.lang.String...)} instead.
+     * @deprecated Since 3.0. Use
+     * {@link KStream#process(org.apache.kafka.streams.processor.api.ProcessorSupplier, java.lang.String...)}
+     * instead.
      */
     @Deprecated
     void process(final org.apache.kafka.streams.processor.ProcessorSupplier<? super K, ? super V> processorSupplier,
-                 final String... stateStoreNames);
+            final String... stateStoreNames);
 
     /**
      * Process all records in this stream, one record at a time, by applying a
-     * {@link org.apache.kafka.streams.processor.Processor} (provided by the given
-     * {@link org.apache.kafka.streams.processor.ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * Note that this is a terminal operation that returns void.
+     * {@link org.apache.kafka.streams.processor.Processor} (provided by the
+     * given {@link org.apache.kafka.streams.processor.ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #foreach(ForeachAction)}). If you choose not to attach one,
+     * this operation is similar to the stateless
+     * {@link #foreach(ForeachAction)} but allows access to the
+     * {@code ProcessorContext} and record metadata. This is essentially mixing
+     * the Processor API into the DSL, and provides all the functionality of the
+     * PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed. Note that this is a terminal operation that returns void.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4681,10 +5545,11 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link org.apache.kafka.streams.processor.ProcessorSupplier}
-     * to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier} to implement
+     * {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements ProcessorSupplier {
      *     // supply processor
@@ -4708,9 +5573,12 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.process(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link org.apache.kafka.streams.processor.Processor},
-     * the state is obtained via the {@link org.apache.kafka.streams.processor.ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the
+     * {@link org.apache.kafka.streams.processor.Processor}, the state is
+     * obtained via the
+     * {@link org.apache.kafka.streams.processor.ProcessorContext}. To trigger
+     * periodic actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements Processor {
@@ -4730,45 +5598,57 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      *
-     * @param processorSupplier an instance of {@link org.apache.kafka.streams.processor.ProcessorSupplier}
-     *                          that generates a newly constructed {@link org.apache.kafka.streams.processor.Processor}
-     *                          The supplier should always generate a new instance. Creating a single
-     *                          {@link org.apache.kafka.streams.processor.Processor} object
-     *                          and returning the same object reference in
-     *                          {@link org.apache.kafka.streams.processor.ProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param named             a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames   the names of the state store used by the processor
+     * @param processorSupplier an instance of
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier} that
+     * generates a newly constructed
+     * {@link org.apache.kafka.streams.processor.Processor} The supplier should
+     * always generate a new instance. Creating a single
+     * {@link org.apache.kafka.streams.processor.Processor} object and returning
+     * the same object reference in
+     * {@link org.apache.kafka.streams.processor.ProcessorSupplier#get()} is a
+     * violation of the supplier pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state store used by the processor
      * @see #foreach(ForeachAction)
      * @see #transform(TransformerSupplier, String...)
-     * @deprecated Since 3.0. Use {@link KStream#process(org.apache.kafka.streams.processor.api.ProcessorSupplier, org.apache.kafka.streams.kstream.Named, java.lang.String...)} instead.
+     * @deprecated Since 3.0. Use
+     * {@link KStream#process(org.apache.kafka.streams.processor.api.ProcessorSupplier, org.apache.kafka.streams.kstream.Named, java.lang.String...)}
+     * instead.
      */
     @Deprecated
     void process(final org.apache.kafka.streams.processor.ProcessorSupplier<? super K, ? super V> processorSupplier,
-                 final Named named,
-                 final String... stateStoreNames);
+            final Named named,
+            final String... stateStoreNames);
 
     /**
-     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
-     * {@link ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper)}
-     * but allows access to the {@link org.apache.kafka.streams.processor.api.ProcessorContext}
-     * and {@link org.apache.kafka.streams.processor.api.Record} metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Process all records in this stream, one record at a time, by applying a
+     * {@link Processor} (provided by the given {@link ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #map(KeyValueMapper)}). If you choose not to attach one, this
+     * operation is similar to the stateless {@link #map(KeyValueMapper)} but
+     * allows access to the
+     * {@link org.apache.kafka.streams.processor.api.ProcessorContext} and
+     * {@link org.apache.kafka.streams.processor.api.Record} metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4783,9 +5663,10 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link ProcessorSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given {@link ProcessorSupplier} to
+     * implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements ProcessorSupplier {
      *     // supply processor
@@ -4809,8 +5690,9 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.process(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Processor}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the {@link Processor}, the state is obtained
+     * via the {@link ProcessorContext}. To trigger periodic actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements Processor {
@@ -4830,45 +5712,56 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      * <p>
-     * Processing records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #processValues(FixedKeyProcessorSupplier, String...)})
+     * Processing records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf.
+     * {@link #processValues(FixedKeyProcessorSupplier, String...)})
      *
-     * @param processorSupplier an instance of {@link ProcessorSupplier} that generates a newly constructed {@link Processor}
-     *                          The supplier should always generate a new instance. Creating a single {@link Processor} object
-     *                          and returning the same object reference in {@link ProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames     the names of the state stores used by the processor; not required if the supplier
-     *                            implements {@link ConnectedStoreProvider#stores()}
+     * @param processorSupplier an instance of {@link ProcessorSupplier} that
+     * generates a newly constructed {@link Processor} The supplier should
+     * always generate a new instance. Creating a single {@link Processor}
+     * object and returning the same object reference in
+     * {@link ProcessorSupplier#get()} is a violation of the supplier pattern
+     * and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state stores used by the
+     * processor; not required if the supplier implements
+     * {@link ConnectedStoreProvider#stores()}
      * @see #map(KeyValueMapper)
      * @see #transform(TransformerSupplier, String...)
      */
     <KOut, VOut> KStream<KOut, VOut> process(
-        final ProcessorSupplier<? super K, ? super V, KOut, VOut> processorSupplier,
-        final String... stateStoreNames
+            final ProcessorSupplier<? super K, ? super V, KOut, VOut> processorSupplier,
+            final String... stateStoreNames
     );
 
     /**
-     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
-     * {@link ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper)}
-     * but allows access to the {@link org.apache.kafka.streams.processor.api.ProcessorContext}
-     * and {@link org.apache.kafka.streams.processor.api.Record} metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Process all records in this stream, one record at a time, by applying a
+     * {@link Processor} (provided by the given {@link ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation
+     * (cf. {@link #map(KeyValueMapper)}). If you choose not to attach one, this
+     * operation is similar to the stateless {@link #map(KeyValueMapper)} but
+     * allows access to the
+     * {@link org.apache.kafka.streams.processor.api.ProcessorContext} and
+     * {@link org.apache.kafka.streams.processor.api.Record} metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4883,9 +5776,10 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link ProcessorSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given {@link ProcessorSupplier} to
+     * implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements ProcessorSupplier {
      *     // supply processor
@@ -4909,8 +5803,9 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.process(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link Processor}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the {@link Processor}, the state is obtained
+     * via the {@link ProcessorContext}. To trigger periodic actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements Processor {
@@ -4930,46 +5825,58 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      * <p>
-     * Processing records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #processValues(FixedKeyProcessorSupplier, Named, String...)})
+     * Processing records might result in an internal data redistribution if a
+     * key based operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf.
+     * {@link #processValues(FixedKeyProcessorSupplier, Named, String...)})
      *
-     * @param processorSupplier an instance of {@link ProcessorSupplier} that generates a newly constructed {@link Processor}
-     *                          The supplier should always generate a new instance. Creating a single {@link Processor} object
-     *                          and returning the same object reference in {@link ProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param named             a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames   the names of the state store used by the processor
+     * @param processorSupplier an instance of {@link ProcessorSupplier} that
+     * generates a newly constructed {@link Processor} The supplier should
+     * always generate a new instance. Creating a single {@link Processor}
+     * object and returning the same object reference in
+     * {@link ProcessorSupplier#get()} is a violation of the supplier pattern
+     * and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state store used by the processor
      * @see #map(KeyValueMapper)
      * @see #processValues(FixedKeyProcessorSupplier, Named, String...)
      */
     <KOut, VOut> KStream<KOut, VOut> process(
-        final ProcessorSupplier<? super K, ? super V, KOut, VOut> processorSupplier,
-        final Named named,
-        final String... stateStoreNames
+            final ProcessorSupplier<? super K, ? super V, KOut, VOut> processorSupplier,
+            final Named named,
+            final String... stateStoreNames
     );
 
     /**
-     * Process all records in this stream, one record at a time, by applying a {@link FixedKeyProcessor} (provided by the given
-     * {@link FixedKeyProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper)}
-     * but allows access to the {@link org.apache.kafka.streams.processor.api.ProcessorContext}
-     * and {@link org.apache.kafka.streams.processor.api.Record} metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Process all records in this stream, one record at a time, by applying a
+     * {@link FixedKeyProcessor} (provided by the given
+     * {@link FixedKeyProcessorSupplier}). Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #mapValues(ValueMapper)}). If you choose not to attach one, this
+     * operation is similar to the stateless {@link #mapValues(ValueMapper)} but
+     * allows access to the
+     * {@link org.apache.kafka.streams.processor.api.ProcessorContext} and
+     * {@link org.apache.kafka.streams.processor.api.Record} metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -4984,9 +5891,10 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link ProcessorSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given {@link ProcessorSupplier} to
+     * implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements FixedKeyProcessorSupplier {
      *     // supply processor
@@ -5010,8 +5918,10 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.processValues(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link FixedKeyProcessor}, the state is obtained via the {@link FixedKeyProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the {@link FixedKeyProcessor}, the state is
+     * obtained via the {@link FixedKeyProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements FixedKeyProcessor {
@@ -5031,44 +5941,55 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      * <p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #process(ProcessorSupplier, String...)})
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #process(ProcessorSupplier, String...)})
      *
-     * @param processorSupplier an instance of {@link FixedKeyProcessorSupplier} that generates a newly constructed {@link FixedKeyProcessor}
-     *                          The supplier should always generate a new instance. Creating a single {@link FixedKeyProcessor} object
-     *                          and returning the same object reference in {@link FixedKeyProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param stateStoreNames   the names of the state store used by the processor
+     * @param processorSupplier an instance of {@link FixedKeyProcessorSupplier}
+     * that generates a newly constructed {@link FixedKeyProcessor} The supplier
+     * should always generate a new instance. Creating a single
+     * {@link FixedKeyProcessor} object and returning the same object reference
+     * in {@link FixedKeyProcessorSupplier#get()} is a violation of the supplier
+     * pattern and leads to runtime exceptions.
+     * @param stateStoreNames the names of the state store used by the processor
      * @see #mapValues(ValueMapper)
      * @see #process(ProcessorSupplier, Named, String...)
      */
     <VOut> KStream<K, VOut> processValues(
-        final FixedKeyProcessorSupplier<? super K, ? super V, VOut> processorSupplier,
-        final String... stateStoreNames
+            final FixedKeyProcessorSupplier<? super K, ? super V, VOut> processorSupplier,
+            final String... stateStoreNames
     );
 
     /**
-     * Process all records in this stream, one record at a time, by applying a {@link FixedKeyProcessor} (provided by the given
-     * {@link FixedKeyProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper)}
-     * but allows access to the {@link org.apache.kafka.streams.processor.api.ProcessorContext}
-     * and {@link org.apache.kafka.streams.processor.api.Record} metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
+     * Process all records in this stream, one record at a time, by applying a
+     * {@link FixedKeyProcessor} (provided by the given
+     * {@link FixedKeyProcessorSupplier}). Attaching a state store makes this a
+     * stateful record-by-record operation (cf.
+     * {@link #mapValues(ValueMapper)}). If you choose not to attach one, this
+     * operation is similar to the stateless {@link #mapValues(ValueMapper)} but
+     * allows access to the
+     * {@link org.apache.kafka.streams.processor.api.ProcessorContext} and
+     * {@link org.apache.kafka.streams.processor.api.Record} metadata. This is
+     * essentially mixing the Processor API into the DSL, and provides all the
+     * functionality of the PAPI. Furthermore, via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the
+     * processing progress can be observed and additional periodic actions can
+     * be performed.
      * <p>
-     * In order for the processor to use state stores, the stores must be added to the topology and connected to the
-     * processor using at least one of two strategies (though it's not required to connect global state stores; read-only
-     * access to global state stores is available by default).
+     * In order for the processor to use state stores, the stores must be added
+     * to the topology and connected to the processor using at least one of two
+     * strategies (though it's not required to connect global state stores;
+     * read-only access to global state stores is available by default).
      * <p>
-     * The first strategy is to manually add the {@link StoreBuilder}s via {@link Topology#addStateStore(StoreBuilder, String...)},
-     * and specify the store names via {@code stateStoreNames} so they will be connected to the processor.
+     * The first strategy is to manually add the {@link StoreBuilder}s via
+     * {@link Topology#addStateStore(StoreBuilder, String...)}, and specify the
+     * store names via {@code stateStoreNames} so they will be connected to the
+     * processor.
      * <pre>{@code
      * // create store
      * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
@@ -5083,9 +6004,10 @@ public interface KStream<K, V> {
      *         return new MyProcessor();
      *     }
      * }, "myProcessorState");
-     * }</pre>
-     * The second strategy is for the given {@link ProcessorSupplier} to implement {@link ConnectedStoreProvider#stores()},
-     * which provides the {@link StoreBuilder}s to be automatically added to the topology and connected to the processor.
+     * }</pre> The second strategy is for the given {@link ProcessorSupplier} to
+     * implement {@link ConnectedStoreProvider#stores()}, which provides the
+     * {@link StoreBuilder}s to be automatically added to the topology and
+     * connected to the processor.
      * <pre>{@code
      * class MyProcessorSupplier implements FixedKeyProcessorSupplier {
      *     // supply processor
@@ -5109,8 +6031,10 @@ public interface KStream<K, V> {
      * KStream outputStream = inputStream.processValues(new MyProcessorSupplier());
      * }</pre>
      * <p>
-     * With either strategy, within the {@link FixedKeyProcessor}, the state is obtained via the {@link FixedKeyProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * With either strategy, within the {@link FixedKeyProcessor}, the state is
+     * obtained via the {@link FixedKeyProcessorContext}. To trigger periodic
+     * actions via
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
      * a schedule must be registered.
      * <pre>{@code
      * class MyProcessor implements FixedKeyProcessor {
@@ -5130,26 +6054,30 @@ public interface KStream<K, V> {
      *         // can access this.state
      *     }
      * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #repartition()} should be performed before {@code process()}.
+     * }</pre> Even if any upstream operation was key-changing, no
+     * auto-repartition is triggered. If repartitioning is required, a call to
+     * {@link #repartition()} should be performed before {@code process()}.
      * <p>
      * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #process(ProcessorSupplier, String...)})
+     * Thus, <em>no</em> internal data redistribution is required if a key based
+     * operator (like an aggregation or join) is applied to the result
+     * {@code KStream}. (cf. {@link #process(ProcessorSupplier, String...)})
      *
-     * @param processorSupplier an instance of {@link FixedKeyProcessorSupplier} that generates a newly constructed {@link FixedKeyProcessor}
-     *                          The supplier should always generate a new instance. Creating a single {@link FixedKeyProcessor} object
-     *                          and returning the same object reference in {@link FixedKeyProcessorSupplier#get()} is a
-     *                          violation of the supplier pattern and leads to runtime exceptions.
-     * @param named             a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames   the names of the state store used by the processor
+     * @param processorSupplier an instance of {@link FixedKeyProcessorSupplier}
+     * that generates a newly constructed {@link FixedKeyProcessor} The supplier
+     * should always generate a new instance. Creating a single
+     * {@link FixedKeyProcessor} object and returning the same object reference
+     * in {@link FixedKeyProcessorSupplier#get()} is a violation of the supplier
+     * pattern and leads to runtime exceptions.
+     * @param named a {@link Named} config used to name the processor in the
+     * topology
+     * @param stateStoreNames the names of the state store used by the processor
      * @see #mapValues(ValueMapper)
      * @see #process(ProcessorSupplier, Named, String...)
      */
     <VOut> KStream<K, VOut> processValues(
-        final FixedKeyProcessorSupplier<? super K, ? super V, VOut> processorSupplier,
-        final Named named,
-        final String... stateStoreNames
+            final FixedKeyProcessorSupplier<? super K, ? super V, VOut> processorSupplier,
+            final Named named,
+            final String... stateStoreNames
     );
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -849,10 +849,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains the exact same (and potentially repartitioned) records as this {@code KStream}
      * @deprecated since 2.6; use {@link #repartition()} instead
      */
-    // TODO: when removed, update `StreamsResetter` description of --intermediate-topics
-    @Deprecated
-    KStream<K, V> through(final String topic);
-
+    
     /**
      * Materialize this stream to a topic and creates a new {@code KStream} from the topic using the
      * {@link Produced} instance for configuration of the {@link Serde key serde}, {@link Serde value serde},
@@ -870,9 +867,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains the exact same (and potentially repartitioned) records as this {@code KStream}
      * @deprecated since 2.6; use {@link #repartition(Repartitioned)} instead
      */
-    @Deprecated
-    KStream<K, V> through(final String topic,
-                          final Produced<K, V> produced);
+
 
     /**
      * Materialize this stream to an auto-generated repartition topic and create a new {@code KStream}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -562,6 +562,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
     
     @Override
+    @Deprecated
     public KStream<K, V> repartition() {
         return doRepartition(Repartitioned.as(null));
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -560,40 +560,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             mergeNode,
             builder);
     }
-
-    @Deprecated
-    @Override
-    public KStream<K, V> through(final String topic) {
-        return through(topic, Produced.with(keySerde, valueSerde, null));
-    }
-
-    @Deprecated
-    @Override
-    public KStream<K, V> through(final String topic,
-                                 final Produced<K, V> produced) {
-        Objects.requireNonNull(topic, "topic can't be null");
-        Objects.requireNonNull(produced, "produced can't be null");
-
-        final ProducedInternal<K, V> producedInternal = new ProducedInternal<>(produced);
-        if (producedInternal.keySerde() == null) {
-            producedInternal.withKeySerde(keySerde);
-        }
-        if (producedInternal.valueSerde() == null) {
-            producedInternal.withValueSerde(valueSerde);
-        }
-        to(topic, producedInternal);
-
-        return builder.stream(
-            Collections.singleton(topic),
-            new ConsumedInternal<>(
-                producedInternal.keySerde(),
-                producedInternal.valueSerde(),
-                new FailOnInvalidTimestamp(),
-                null
-            )
-        );
-    }
-
+    
     @Override
     public KStream<K, V> repartition() {
         return doRepartition(Repartitioned.as(null));

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -363,39 +363,6 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def split(named: Named): BranchedKStream[K, V] =
     new BranchedKStream(inner.split(named))
 
-  /**
-   * Materialize this stream to a topic and creates a new [[KStream]] from the topic using the `Produced` instance for
-   * configuration of the `Serde key serde`, `Serde value serde`, and `StreamPartitioner`
-   * <p>
-   * The user can either supply the `Produced` instance as an implicit in scope or they can also provide implicit
-   * key and value serdes that will be converted to a `Produced` instance implicitly.
-   * <p>
-   * {{{
-   * Example:
-   *
-   * // brings implicit serdes in scope
-   * import Serdes._
-   *
-   * //..
-   * val clicksPerRegion: KStream[String, Long] = //..
-   *
-   * // Implicit serdes in scope will generate an implicit Produced instance, which
-   * // will be passed automatically to the call of through below
-   * clicksPerRegion.through(topic)
-   *
-   * // Similarly you can create an implicit Produced and it will be passed implicitly
-   * // to the through call
-   * }}}
-   *
-   * @param topic    the topic name
-   * @param produced the instance of Produced that gives the serdes and `StreamPartitioner`
-   * @return a [[KStream]] that contains the exact same (and potentially repartitioned) records as this [[KStream]]
-   * @see `org.apache.kafka.streams.kstream.KStream#through`
-   * @deprecated use `repartition()` instead
-   */
-  @deprecated("use `repartition()` instead", "2.6.0")
-  def through(topic: String)(implicit produced: Produced[K, V]): KStream[K, V] =
-    new KStream(inner.through(topic, produced))
 
   /**
    * Materialize this stream to a topic and creates a new [[KStream]] from the topic using the `Repartitioned` instance

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -16,6 +16,25 @@
  */
 package org.apache.kafka.tools;
 
+import java.io.IOException;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsOptions;
@@ -35,25 +54,6 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandDefaultOptions;
 import org.apache.kafka.server.util.CommandLineUtils;
-
-import java.io.IOException;
-import java.text.ParseException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import joptsimple.OptionException;
 import joptsimple.OptionSpec;
@@ -93,7 +93,7 @@ public class StreamsResetter {
     private static final String USAGE = "This tool helps to quickly reset an application in order to reprocess "
             + "its data from scratch.\n"
             + "* This tool resets offsets of input topics to the earliest available offset (by default), or to a specific defined position"
-            + " and it skips to the end of intermediate topics (topics that are input and output topics, e.g., used by deprecated through() method).\n"
+            + " and it skips to the end of intermediate topics (topics that are input and output topics.\n"
             + "* This tool deletes the internal topics that were created by Kafka Streams (topics starting with "
             + "\"<application.id>-\").\n"
             + "The tool finds these internal topics automatically. If the topics flagged automatically for deletion by "


### PR DESCRIPTION
Removed the deprecated methods: 

- org.apache.kafka.streams.scala.kstream.KStream#through
- org.apache.kafka.streams.kstream.KStream#through(java.lang.String)
- org.apache.kafka.streams.kstream.KStream#through(java.lang.String, org.apache.kafka.streams.kstream.Produced<K,V>) 
- removed implementations in KStreamImpl.java


and updated StreamsResetter to reflect changes.