### PR TITLE
KAFKA-16913 - Support external schemas in JSONConverter

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -69,6 +69,8 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
 
     private static final Map<Schema.Type, JsonToConnectTypeConverter> TO_CONNECT_CONVERTERS = new EnumMap<>(Schema.Type.class);
 
+    private Schema schema = null;
+
     static {
         TO_CONNECT_CONVERTERS.put(Schema.Type.BOOLEAN, (schema, value, config) -> value.booleanValue());
         TO_CONNECT_CONVERTERS.put(Schema.Type.INT8, (schema, value, config) -> (byte) value.intValue());
@@ -293,6 +295,17 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
 
         fromConnectSchemaCache = new SynchronizedCache<>(new LRUCache<>(config.schemaCacheSize()));
         toConnectSchemaCache = new SynchronizedCache<>(new LRUCache<>(config.schemaCacheSize()));
+                
+        try {
+            byte[] schemaContent = config.schemaFileContent();
+            if (schemaContent != null && schemaContent.length > 0) {
+                JsonNode schemaNode = deserializer.deserialize("", schemaContent);
+                this.schema = asConnectSchema(schemaNode);
+            }
+        } catch (SerializationException e) {
+            throw new DataException("Provided schema is invalid , please recheck the schema you have provided", e);
+        }
+            
     }
 
     @Override
@@ -347,19 +360,21 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
             throw new DataException("Converting byte[] to Kafka Connect data failed due to serialization error: ", e);
         }
 
-        if (config.schemasEnabled() && (!jsonValue.isObject() || jsonValue.size() != 2 || !jsonValue.has(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME) || !jsonValue.has(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME)))
-            throw new DataException("JsonConverter with schemas.enable requires \"schema\" and \"payload\" fields and may not contain additional fields." +
+        if (config.schemasEnabled()) {
+            if (this.schema != null){
+                return new SchemaAndValue(schema, convertToConnect(schema, jsonValue, config));
+            } else if (!jsonValue.isObject() || jsonValue.size() != 2 || !jsonValue.has(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME) || !jsonValue.has(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME)) {
+                throw new DataException("JsonConverter with schemas.enable requires \"schema\" and \"payload\" fields and may not contain additional fields." +
                     " If you are trying to deserialize plain JSON data, set schemas.enable=false in your converter configuration.");
-
-        // The deserialized data should either be an envelope object containing the schema and the payload or the schema
-        // was stripped during serialization and we need to fill in an all-encompassing schema.
-        if (!config.schemasEnabled()) {
+            }
+        } else {
+            // The deserialized data should either be an envelope object containing the schema and the payload or the schema
+            // was stripped during serialization and we need to fill in an all-encompassing schema.
             ObjectNode envelope = JSON_NODE_FACTORY.objectNode();
             envelope.set(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME, null);
             envelope.set(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME, jsonValue);
             jsonValue = envelope;
         }
-
         Schema schema = asConnectSchema(jsonValue.get(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME));
         return new SchemaAndValue(
                 schema,
@@ -688,7 +703,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
                 }
             }
 
-            throw new DataException("Couldn't convert " + value + " to JSON.");
+            throw new DataException("Couldn't  " + value + " to JSON.");
         } catch (ClassCastException e) {
             String schemaTypeStr = (schema != null) ? schema.type().toString() : "unknown schema";
             throw new DataException("Invalid type for " + schemaTypeStr + ": " + value.getClass());

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -69,6 +69,8 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
 
     private static final Map<Schema.Type, JsonToConnectTypeConverter> TO_CONNECT_CONVERTERS = new EnumMap<>(Schema.Type.class);
 
+    // if a schema is provided in config, this schema will 
+    // be used for all messages
     private Schema schema = null;
 
     static {
@@ -297,13 +299,13 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
         toConnectSchemaCache = new SynchronizedCache<>(new LRUCache<>(config.schemaCacheSize()));
                 
         try {
-            byte[] schemaContent = config.schemaFileContent();
+            final byte[] schemaContent = config.schemaContent();
             if (schemaContent != null && schemaContent.length > 0) {
-                JsonNode schemaNode = deserializer.deserialize("", schemaContent);
+                final JsonNode schemaNode = deserializer.deserialize("", schemaContent);
                 this.schema = asConnectSchema(schemaNode);
             }
         } catch (SerializationException e) {
-            throw new DataException("Provided schema is invalid , please recheck the schema you have provided", e);
+            throw new DataException("Failed to parse schema in converter config due to serialization error: ", e);
         }
             
     }
@@ -703,7 +705,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
                 }
             }
 
-            throw new DataException("Couldn't  " + value + " to JSON.");
+            throw new DataException("Couldn't convert " + value + " to JSON.");
         } catch (ClassCastException e) {
             String schemaTypeStr = (schema != null) ? schema.type().toString() : "unknown schema";
             throw new DataException("Invalid type for " + schemaTypeStr + ": " + value.getClass());

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -363,7 +363,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
         }
 
         if (config.schemasEnabled()) {
-            if (this.schema != null){
+            if (this.schema != null) {
                 return new SchemaAndValue(schema, convertToConnect(schema, jsonValue, config));
             } else if (!jsonValue.isObject() || jsonValue.size() != 2 || !jsonValue.has(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME) || !jsonValue.has(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME)) {
                 throw new DataException("JsonConverter with schemas.enable requires \"schema\" and \"payload\" fields and may not contain additional fields." +

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -40,8 +40,8 @@ public class JsonConverterConfig extends ConverterConfig {
     private static final String SCHEMAS_CACHE_SIZE_DOC = "The maximum number of schemas that can be cached in this converter instance.";
     private static final String SCHEMAS_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
-    public static final String SCHEMA_FILE_CONTENT_CONFIG = "schema.content";
-    public static final String SCHEMA_FILE_CONTENT_DEFAULT = null;
+    public static final String SCHEMA_CONTENT_CONFIG = "schema.content";
+    public static final String SCHEMA_CONTENT_DEFAULT = null;
     private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will should be in the contents of each message.";
     private static final String SCHEMA_CONTENT_DISPLAY = "Schema Content";
 
@@ -58,8 +58,6 @@ public class JsonConverterConfig extends ConverterConfig {
 
     private static final ConfigDef CONFIG;
 
-
-
     static {
         String group = "Schemas";
         int orderInGroup = 0;
@@ -68,7 +66,7 @@ public class JsonConverterConfig extends ConverterConfig {
                       orderInGroup++, Width.MEDIUM, SCHEMAS_ENABLE_DISPLAY);
         CONFIG.define(SCHEMAS_CACHE_SIZE_CONFIG, Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT, Importance.HIGH, SCHEMAS_CACHE_SIZE_DOC, group,
                       orderInGroup++, Width.MEDIUM, SCHEMAS_CACHE_SIZE_DISPLAY);
-        CONFIG.define(SCHEMA_FILE_CONTENT_CONFIG, Type.STRING, SCHEMA_FILE_CONTENT_DEFAULT, Importance.HIGH, SCHEMA_CONTENT_DOC, group, 
+        CONFIG.define(SCHEMA_CONTENT_CONFIG, Type.STRING, SCHEMA_CONTENT_DEFAULT, Importance.HIGH, SCHEMA_CONTENT_DOC, group, 
                       orderInGroup++, Width.MEDIUM, SCHEMA_CONTENT_DISPLAY);
 
         group = "Serialization";
@@ -83,7 +81,7 @@ public class JsonConverterConfig extends ConverterConfig {
         CONFIG.define(
                 REPLACE_NULL_WITH_DEFAULT_CONFIG, Type.BOOLEAN, REPLACE_NULL_WITH_DEFAULT_DEFAULT,
                 Importance.LOW, REPLACE_NULL_WITH_DEFAULT_DOC, group, orderInGroup++,
-                Width.MEDIUM, REPLACE_NULL_WITH_DEFAULT_DISPLAY);        
+                Width.MEDIUM, REPLACE_NULL_WITH_DEFAULT_DISPLAY);
     }
 
     public static ConfigDef configDef() {
@@ -95,8 +93,7 @@ public class JsonConverterConfig extends ConverterConfig {
     private final int schemaCacheSize;
     private final DecimalFormat decimalFormat;
     private final boolean replaceNullWithDefault;
-    private final byte[] schemaFileContent;
-
+    private final byte[] schemaContent;
 
     @SuppressWarnings("this-escape")
     public JsonConverterConfig(Map<String, ?> props) {
@@ -105,8 +102,8 @@ public class JsonConverterConfig extends ConverterConfig {
         this.schemaCacheSize = getInt(SCHEMAS_CACHE_SIZE_CONFIG);
         this.decimalFormat = DecimalFormat.valueOf(getString(DECIMAL_FORMAT_CONFIG).toUpperCase(Locale.ROOT));
         this.replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
-        String schemaFileContentStr = getString(SCHEMA_FILE_CONTENT_CONFIG);
-        this.schemaFileContent = schemaFileContentStr == null ? null : schemaFileContentStr.getBytes();
+        String schemaContentStr = getString(SCHEMA_CONTENT_CONFIG);
+        this.schemaContent = schemaContentStr == null ? null : schemaContentStr.getBytes();
     }
 
     /**
@@ -145,11 +142,15 @@ public class JsonConverterConfig extends ConverterConfig {
     }
 
     /**
+     * If a default schema is provided in the converter config, this will be
+     * used for all messages.
      * 
+     * This is only relevant if schemas are enabled.
+     *
      * @return Schema Contents, will return null if no value is provided
      */
-    public byte[] schemaFileContent() {
-        return schemaFileContent;
+    public byte[] schemaContent() {
+        return schemaContent;
     }
 
 }

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.connect.storage.ConverterConfig;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -103,7 +104,7 @@ public class JsonConverterConfig extends ConverterConfig {
         this.decimalFormat = DecimalFormat.valueOf(getString(DECIMAL_FORMAT_CONFIG).toUpperCase(Locale.ROOT));
         this.replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
         String schemaContentStr = getString(SCHEMA_CONTENT_CONFIG);
-        this.schemaContent = schemaContentStr == null ? null : schemaContentStr.getBytes();
+        this.schemaContent = schemaContentStr == null ? null : schemaContentStr.getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -29,6 +29,7 @@ import java.util.Map;
 /**
  * Configuration options for {@link JsonConverter} instances.
  */
+@SuppressWarnings("this-escape")
 public class JsonConverterConfig extends ConverterConfig {
 
     public static final String SCHEMAS_ENABLE_CONFIG = "schemas.enable";
@@ -96,7 +97,6 @@ public class JsonConverterConfig extends ConverterConfig {
     private final boolean replaceNullWithDefault;
     private final byte[] schemaContent;
 
-    @SuppressWarnings("this-escape")
     public JsonConverterConfig(Map<String, ?> props) {
         super(CONFIG, props);
         this.schemasEnabled = getBoolean(SCHEMAS_ENABLE_CONFIG);

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -40,6 +40,11 @@ public class JsonConverterConfig extends ConverterConfig {
     private static final String SCHEMAS_CACHE_SIZE_DOC = "The maximum number of schemas that can be cached in this converter instance.";
     private static final String SCHEMAS_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
+    public static final String SCHEMA_FILE_CONTENT_CONFIG = "schema.content";
+    public static final String SCHEMA_FILE_CONTENT_DEFAULT = null;
+    private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will should be in the contents of each message.";
+    private static final String SCHEMA_CONTENT_DISPLAY = "Schema Content";
+
     public static final String DECIMAL_FORMAT_CONFIG = "decimal.format";
     public static final String DECIMAL_FORMAT_DEFAULT = DecimalFormat.BASE64.name();
     private static final String DECIMAL_FORMAT_DOC = "Controls which format this converter will serialize decimals in."
@@ -53,6 +58,8 @@ public class JsonConverterConfig extends ConverterConfig {
 
     private static final ConfigDef CONFIG;
 
+
+
     static {
         String group = "Schemas";
         int orderInGroup = 0;
@@ -61,6 +68,8 @@ public class JsonConverterConfig extends ConverterConfig {
                       orderInGroup++, Width.MEDIUM, SCHEMAS_ENABLE_DISPLAY);
         CONFIG.define(SCHEMAS_CACHE_SIZE_CONFIG, Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT, Importance.HIGH, SCHEMAS_CACHE_SIZE_DOC, group,
                       orderInGroup++, Width.MEDIUM, SCHEMAS_CACHE_SIZE_DISPLAY);
+        CONFIG.define(SCHEMA_FILE_CONTENT_CONFIG, Type.STRING, SCHEMA_FILE_CONTENT_DEFAULT, Importance.HIGH, SCHEMA_CONTENT_DOC, group, 
+                      orderInGroup++, Width.MEDIUM, SCHEMA_CONTENT_DISPLAY);
 
         group = "Serialization";
         orderInGroup = 0;
@@ -74,7 +83,7 @@ public class JsonConverterConfig extends ConverterConfig {
         CONFIG.define(
                 REPLACE_NULL_WITH_DEFAULT_CONFIG, Type.BOOLEAN, REPLACE_NULL_WITH_DEFAULT_DEFAULT,
                 Importance.LOW, REPLACE_NULL_WITH_DEFAULT_DOC, group, orderInGroup++,
-                Width.MEDIUM, REPLACE_NULL_WITH_DEFAULT_DISPLAY);
+                Width.MEDIUM, REPLACE_NULL_WITH_DEFAULT_DISPLAY);        
     }
 
     public static ConfigDef configDef() {
@@ -86,6 +95,8 @@ public class JsonConverterConfig extends ConverterConfig {
     private final int schemaCacheSize;
     private final DecimalFormat decimalFormat;
     private final boolean replaceNullWithDefault;
+    private final byte[] schemaFileContent;
+
 
     @SuppressWarnings("this-escape")
     public JsonConverterConfig(Map<String, ?> props) {
@@ -94,6 +105,8 @@ public class JsonConverterConfig extends ConverterConfig {
         this.schemaCacheSize = getInt(SCHEMAS_CACHE_SIZE_CONFIG);
         this.decimalFormat = DecimalFormat.valueOf(getString(DECIMAL_FORMAT_CONFIG).toUpperCase(Locale.ROOT));
         this.replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        String schemaFileContentStr = getString(SCHEMA_FILE_CONTENT_CONFIG);
+        this.schemaFileContent = schemaFileContentStr == null ? null : schemaFileContentStr.getBytes();
     }
 
     /**
@@ -129,6 +142,14 @@ public class JsonConverterConfig extends ConverterConfig {
      */
     public boolean replaceNullWithDefault() {
         return replaceNullWithDefault;
+    }
+
+    /**
+     * 
+     * @return Schema Contents, will return null if no value is provided
+     */
+    public byte[] schemaFileContent() {
+        return schemaFileContent;
     }
 
 }

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -978,6 +978,41 @@ public class JsonConverterTest {
         assertEquals(AppInfoParser.getVersion(), converter.version());
     }
 
+    @Test
+    public void testSchemaContentIsNull(){
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, null), false);
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
+    }
+
+    @Test
+    public void testSchemaContentIsEmptyString(){
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, ""), false);
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
+    }
+
+    @Test
+    public void testSchemaContentValidSchema(){
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"type\": \"string\" }"), false);
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "\"foo-bar-baz\"".getBytes()));
+    }
+
+    @Test
+    public void testSchemaContentInValidSchema(){
+        assertThrows(
+            DataException.class,
+            () -> converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"string\" }"), false),
+            " Provided schema is invalid , please recheck the schema you have provided");
+    }
+
+    @Test
+    public void testSchemaContentLooksLikeSchema(){
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"type\": \"struct\", \"fields\": [{\"field\": \"schema\", \"type\": \"struct\",\"fields\": [{\"field\": \"type\", \"type\": \"string\" }]}, {\"field\": \"payload\", \"type\": \"string\"}]}"), false);
+        SchemaAndValue connectData = converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes());
+        assertEquals("foo-bar-baz", ((Struct)connectData.value()).getString("payload"));
+    }
+
+
+
     private JsonNode parse(byte[] json) {
         try {
             return objectMapper.readTree(json);

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -979,36 +979,36 @@ public class JsonConverterTest {
     }
 
     @Test
-    public void testSchemaContentIsNull(){
-        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, null), false);
+    public void testSchemaContentIsNull() {
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_CONTENT_CONFIG, null), false);
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
     }
 
     @Test
-    public void testSchemaContentIsEmptyString(){
-        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, ""), false);
+    public void testSchemaContentIsEmptyString() {
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_CONTENT_CONFIG, ""), false);
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
     }
 
     @Test
-    public void testSchemaContentValidSchema(){
-        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"type\": \"string\" }"), false);
+    public void testSchemaContentValidSchema() {
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_CONTENT_CONFIG, "{ \"type\": \"string\" }"), false);
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectData(TOPIC, "\"foo-bar-baz\"".getBytes()));
     }
 
     @Test
-    public void testSchemaContentInValidSchema(){
+    public void testSchemaContentInValidSchema() {
         assertThrows(
             DataException.class,
-            () -> converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"string\" }"), false),
+            () -> converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_CONTENT_CONFIG, "{ \"string\" }"), false),
             " Provided schema is invalid , please recheck the schema you have provided");
     }
 
     @Test
-    public void testSchemaContentLooksLikeSchema(){
-        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_FILE_CONTENT_CONFIG, "{ \"type\": \"struct\", \"fields\": [{\"field\": \"schema\", \"type\": \"struct\",\"fields\": [{\"field\": \"type\", \"type\": \"string\" }]}, {\"field\": \"payload\", \"type\": \"string\"}]}"), false);
+    public void testSchemaContentLooksLikeSchema() {
+        converter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMA_CONTENT_CONFIG, "{ \"type\": \"struct\", \"fields\": [{\"field\": \"schema\", \"type\": \"struct\",\"fields\": [{\"field\": \"type\", \"type\": \"string\" }]}, {\"field\": \"payload\", \"type\": \"string\"}]}"), false);
         SchemaAndValue connectData = converter.toConnectData(TOPIC, "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes());
-        assertEquals("foo-bar-baz", ((Struct)connectData.value()).getString("payload"));
+        assertEquals("foo-bar-baz", ((Struct) connectData.value()).getString("payload"));
     }
 
 


### PR DESCRIPTION
When using a connector that requires a schema, such as JDBC connectors, with JSON messages, the current JSONConverter necessitates including the schema within every message. To address this, we are introducing a new parameter, schema.content, which allows you to provide the schema externally. This approach not only reduces the size of the messages but also facilitates the use of more complex schemas.

KIP : https://cwiki.apache.org/confluence/display/KAFKA/KIP-1054%3A+Support+external+schemas+in+JSONConverter

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
