### PR TITLE
KAFKA-16666: Migrate GroupMetadataMessageFormatter` to tools module

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -1265,6 +1265,7 @@ object GroupMetadataManager {
   }
 
   // Formatter for use with tools to read group metadata history
+  @Deprecated
   class GroupMetadataMessageFormatter extends MessageFormatter {
     def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
       Option(consumerRecord.key).map(key => GroupMetadataManager.readMessageKey(ByteBuffer.wrap(key))).foreach {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/AbstractGroupMetadataFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/AbstractGroupMetadataFormatter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public abstract class AbstractGroupMetadataFormatter implements MessageFormatter {
+
+    private static final String VERSION = "version";
+    private static final String DATA = "data";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    static final String UNKNOWN = "unknown";
+
+    @Override
+    public void writeTo(ConsumerRecord<byte[], byte[]> consumerRecord, PrintStream output) {
+        ObjectNode json = new ObjectNode(JsonNodeFactory.instance);
+
+        byte[] key = consumerRecord.key();
+        if (Objects.nonNull(key)) {
+            short keyVersion = ByteBuffer.wrap(key).getShort();
+            JsonNode dataNode = readToGroupMetadataKey(ByteBuffer.wrap(key))
+                    .map(logKey -> transferMetadataToJsonNode(logKey, keyVersion))
+                    .orElseGet(() -> new TextNode(UNKNOWN));
+
+            if (dataNode instanceof NullNode) {
+                return;
+            }
+            json.putObject(KEY)
+                    .put(VERSION, keyVersion)
+                    .set(DATA, dataNode);
+        } else {
+            json.set(KEY, NullNode.getInstance());
+        }
+
+        byte[] value = consumerRecord.value();
+        if (Objects.nonNull(value)) {
+            short valueVersion = ByteBuffer.wrap(value).getShort();
+            JsonNode dataNode = readValueNode(ByteBuffer.wrap(value), valueVersion);
+
+            json.putObject(VALUE)
+                    .put(VERSION, valueVersion)
+                    .set(DATA, dataNode);
+        } else {
+            json.set(VALUE, NullNode.getInstance());
+        }
+
+        try {
+            output.write(json.toString().getBytes(UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<ApiMessage> readToGroupMetadataKey(ByteBuffer byteBuffer) {
+        short version = byteBuffer.getShort();
+        if (version >= OffsetCommitKey.LOWEST_SUPPORTED_VERSION
+                && version <= OffsetCommitKey.HIGHEST_SUPPORTED_VERSION) {
+            return Optional.of(new OffsetCommitKey(new ByteBufferAccessor(byteBuffer), version));
+        } else if (version >= GroupMetadataKey.LOWEST_SUPPORTED_VERSION && version <= GroupMetadataKey.HIGHEST_SUPPORTED_VERSION) {
+            return Optional.of(new GroupMetadataKey(new ByteBufferAccessor(byteBuffer), version));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    abstract JsonNode transferMetadataToJsonNode(ApiMessage logKey, short keyVersion);
+    abstract JsonNode readValueNode(ByteBuffer byteBuffer, short version);
+}

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
@@ -86,7 +86,14 @@ public abstract class ApiMessageFormatter implements MessageFormatter {
                 .orElseGet(() -> new TextNode(UNKNOWN));
     }
     
+    private JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
+        return readToValueMessage(byteBuffer)
+                .map(logValue -> transferValueMessageToJsonNode(logValue, version))
+                .orElseGet(() -> new TextNode(UNKNOWN));
+    }
+    
     abstract Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer);
     abstract JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version);
-    abstract JsonNode readToValueNode(ByteBuffer byteBuffer, short version);
+    abstract Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer);
+    abstract JsonNode transferValueMessageToJsonNode(ApiMessage message, short version);
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
@@ -18,19 +18,16 @@ package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.MessageFormatter;
-import org.apache.kafka.common.protocol.ApiMessage;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -49,7 +46,7 @@ public abstract class ApiMessageFormatter implements MessageFormatter {
         byte[] key = consumerRecord.key();
         if (Objects.nonNull(key)) {
             short keyVersion = ByteBuffer.wrap(key).getShort();
-            JsonNode dataNode = readToKeyNode(ByteBuffer.wrap(key), keyVersion);
+            JsonNode dataNode = readToKeyJson(ByteBuffer.wrap(key), keyVersion);
 
             if (dataNode instanceof NullNode) {
                 return;
@@ -64,7 +61,7 @@ public abstract class ApiMessageFormatter implements MessageFormatter {
         byte[] value = consumerRecord.value();
         if (Objects.nonNull(value)) {
             short valueVersion = ByteBuffer.wrap(value).getShort();
-            JsonNode dataNode = readToValueNode(ByteBuffer.wrap(value), valueVersion);
+            JsonNode dataNode = readToValueJson(ByteBuffer.wrap(value), valueVersion);
 
             json.putObject(VALUE)
                     .put(VERSION, valueVersion)
@@ -80,20 +77,6 @@ public abstract class ApiMessageFormatter implements MessageFormatter {
         }
     }
 
-    private JsonNode readToKeyNode(ByteBuffer byteBuffer, short version) {
-        return readToKeyMessage(byteBuffer)
-                .map(logKey -> transferKeyMessageToJsonNode(logKey, version))
-                .orElseGet(() -> new TextNode(UNKNOWN));
-    }
-    
-    private JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
-        return readToValueMessage(byteBuffer)
-                .map(logValue -> transferValueMessageToJsonNode(logValue, version))
-                .orElseGet(() -> new TextNode(UNKNOWN));
-    }
-    
-    protected abstract Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer);
-    protected abstract JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version);
-    protected abstract Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer);
-    protected abstract JsonNode transferValueMessageToJsonNode(ApiMessage message, short version);
+    protected abstract JsonNode readToKeyJson(ByteBuffer byteBuffer, short version);
+    protected abstract JsonNode readToValueJson(ByteBuffer byteBuffer, short version);
 }  

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ApiMessageFormatter.java
@@ -92,8 +92,8 @@ public abstract class ApiMessageFormatter implements MessageFormatter {
                 .orElseGet(() -> new TextNode(UNKNOWN));
     }
     
-    abstract Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer);
-    abstract JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version);
-    abstract Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer);
-    abstract JsonNode transferValueMessageToJsonNode(ApiMessage message, short version);
-}
+    protected abstract Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer);
+    protected abstract JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version);
+    protected abstract Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer);
+    protected abstract JsonNode transferValueMessageToJsonNode(ApiMessage message, short version);
+}  

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -372,6 +372,10 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                 System.err.println("WARNING: kafka.coordinator.group.GroupMetadataManager$OffsetsMessageFormatter is deprecated and will be removed in the next major release. " +
                         "Please use org.apache.kafka.tools.consumer.OffsetsMessageFormatter instead");
                 return className;
+            case "kafka.coordinator.group.GroupMetadataManager$GroupMetadataMessageFormatter":
+                System.err.println("WARNING: kafka.coordinator.group.GroupMetadataManager$GroupMetadataMessageFormatter is deprecated and will be removed in the next major release. " +
+                        "Please use org.apache.kafka.tools.consumer.GroupMetadataMessageFormatter instead");
+                return className;
             default:
                 return className;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatter.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
 
     @Override
-    Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= OffsetCommitKey.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitKey.HIGHEST_SUPPORTED_VERSION) {
@@ -47,7 +47,7 @@ public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version) {
+    protected JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version) {
         if (message instanceof OffsetCommitKey) {
             return NullNode.getInstance();
         } else if (message instanceof GroupMetadataKey) {
@@ -58,7 +58,7 @@ public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= GroupMetadataValue.LOWEST_SUPPORTED_VERSION
                 && version <= GroupMetadataValue.HIGHEST_SUPPORTED_VERSION) {
@@ -69,7 +69,7 @@ public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+    protected JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
         return GroupMetadataValueJsonConverter.write((GroupMetadataValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatter.java
@@ -58,13 +58,7 @@ public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
-        return readGroupMetaValue(byteBuffer)
-                .map(logValue -> GroupMetadataValueJsonConverter.write(logValue, version))
-                .orElseGet(() -> new TextNode(UNKNOWN));
-    }
-
-    private Optional<GroupMetadataValue> readGroupMetaValue(ByteBuffer byteBuffer) {
+    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= GroupMetadataValue.LOWEST_SUPPORTED_VERSION
                 && version <= GroupMetadataValue.HIGHEST_SUPPORTED_VERSION) {
@@ -72,5 +66,10 @@ public class GroupMetadataMessageFormatter extends ApiMessageFormatter {
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+        return GroupMetadataValueJsonConverter.write((GroupMetadataValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -61,13 +61,7 @@ public class OffsetsMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
-        return readToOffsetCommitValue(byteBuffer)
-                .map(logValue -> OffsetCommitValueJsonConverter.write(logValue, version))
-                .orElseGet(() -> new TextNode(UNKNOWN));
-    }
-
-    private Optional<OffsetCommitValue> readToOffsetCommitValue(ByteBuffer byteBuffer) {
+    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= OffsetCommitValue.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitValue.HIGHEST_SUPPORTED_VERSION) {
@@ -75,5 +69,10 @@ public class OffsetsMessageFormatter extends ApiMessageFormatter {
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+        return OffsetCommitValueJsonConverter.write((OffsetCommitValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/OffsetsMessageFormatter.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 public class OffsetsMessageFormatter extends ApiMessageFormatter {
 
     @Override
-    Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= OffsetCommitKey.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitKey.HIGHEST_SUPPORTED_VERSION) {
@@ -50,7 +50,7 @@ public class OffsetsMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferKeyMessageToJsonNode(ApiMessage logKey, short keyVersion) {
+    protected JsonNode transferKeyMessageToJsonNode(ApiMessage logKey, short keyVersion) {
         if (logKey instanceof OffsetCommitKey) {
             return OffsetCommitKeyJsonConverter.write((OffsetCommitKey) logKey, keyVersion);
         } else if (logKey instanceof GroupMetadataKey) {
@@ -61,7 +61,7 @@ public class OffsetsMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= OffsetCommitValue.LOWEST_SUPPORTED_VERSION
                 && version <= OffsetCommitValue.HIGHEST_SUPPORTED_VERSION) {
@@ -72,7 +72,7 @@ public class OffsetsMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+    protected JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
         return OffsetCommitValueJsonConverter.write((OffsetCommitValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
@@ -24,7 +24,6 @@ import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogValueJsonConverter;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -48,13 +47,7 @@ public class TransactionLogMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
-        return readToTransactionLogValue(byteBuffer)
-                .map(logValue -> TransactionLogValueJsonConverter.write(logValue, version))
-                .orElseGet(() -> new TextNode(UNKNOWN));
-    }
-
-    private Optional<TransactionLogValue> readToTransactionLogValue(ByteBuffer byteBuffer) {
+    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= TransactionLogValue.LOWEST_SUPPORTED_VERSION
                 && version <= TransactionLogValue.HIGHEST_SUPPORTED_VERSION) {
@@ -62,5 +55,10 @@ public class TransactionLogMessageFormatter extends ApiMessageFormatter {
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+        return TransactionLogValueJsonConverter.write((TransactionLogValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class TransactionLogMessageFormatter extends ApiMessageFormatter {
 
     @Override
-    Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= TransactionLogKey.LOWEST_SUPPORTED_VERSION
                 && version <= TransactionLogKey.HIGHEST_SUPPORTED_VERSION) {
@@ -42,12 +42,12 @@ public class TransactionLogMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version) {
+    protected JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version) {
         return TransactionLogKeyJsonConverter.write((TransactionLogKey) message, version);
     }
 
     @Override
-    Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
+    protected Optional<ApiMessage> readToValueMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= TransactionLogValue.LOWEST_SUPPORTED_VERSION
                 && version <= TransactionLogValue.HIGHEST_SUPPORTED_VERSION) {
@@ -58,7 +58,7 @@ public class TransactionLogMessageFormatter extends ApiMessageFormatter {
     }
 
     @Override
-    JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
+    protected JsonNode transferValueMessageToJsonNode(ApiMessage message, short version) {
         return TransactionLogValueJsonConverter.write((TransactionLogValue) message, version);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
@@ -16,8 +16,7 @@
  */
 package org.apache.kafka.tools.consumer;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKey;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKeyJsonConverter;
@@ -25,65 +24,15 @@ import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogValueJsonConverter;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 import java.util.Optional;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-public class TransactionLogMessageFormatter implements MessageFormatter {
-
-    private static final String VERSION = "version";
-    private static final String DATA = "data";
-    private static final String KEY = "key";
-    private static final String VALUE = "value";
-    private static final String UNKNOWN = "unknown";
+public class TransactionLogMessageFormatter extends ApiMessageFormatter {
 
     @Override
-    public void writeTo(ConsumerRecord<byte[], byte[]> consumerRecord, PrintStream output) {
-        ObjectNode json = new ObjectNode(JsonNodeFactory.instance);
-
-        byte[] key = consumerRecord.key();
-        if (Objects.nonNull(key)) {
-            short keyVersion = ByteBuffer.wrap(key).getShort();
-            JsonNode dataNode = readToTransactionLogKey(ByteBuffer.wrap(key))
-                    .map(logKey -> TransactionLogKeyJsonConverter.write(logKey, keyVersion))
-                    .orElseGet(() -> new TextNode(UNKNOWN));
-            json.putObject(KEY)
-                    .put(VERSION, keyVersion)
-                    .set(DATA, dataNode);
-        } else {
-            json.set(KEY, NullNode.getInstance());
-        }
-
-        byte[] value = consumerRecord.value();
-        if (Objects.nonNull(value)) {
-            short valueVersion = ByteBuffer.wrap(value).getShort();
-            JsonNode dataNode = readToTransactionLogValue(ByteBuffer.wrap(value))
-                    .map(logValue -> TransactionLogValueJsonConverter.write(logValue, valueVersion))
-                    .orElseGet(() -> new TextNode(UNKNOWN));
-            json.putObject(VALUE)
-                    .put(VERSION, valueVersion)
-                    .set(DATA, dataNode);
-        } else {
-            json.set(VALUE, NullNode.getInstance());
-        }
-
-        try {
-            output.write(json.toString().getBytes(UTF_8));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Optional<TransactionLogKey> readToTransactionLogKey(ByteBuffer byteBuffer) {
+    Optional<ApiMessage> readToKeyMessage(ByteBuffer byteBuffer) {
         short version = byteBuffer.getShort();
         if (version >= TransactionLogKey.LOWEST_SUPPORTED_VERSION
                 && version <= TransactionLogKey.HIGHEST_SUPPORTED_VERSION) {
@@ -91,6 +40,18 @@ public class TransactionLogMessageFormatter implements MessageFormatter {
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    JsonNode transferKeyMessageToJsonNode(ApiMessage message, short version) {
+        return TransactionLogKeyJsonConverter.write((TransactionLogKey) message, version);
+    }
+
+    @Override
+    JsonNode readToValueNode(ByteBuffer byteBuffer, short version) {
+        return readToTransactionLogValue(byteBuffer)
+                .map(logValue -> TransactionLogValueJsonConverter.write(logValue, version))
+                .orElseGet(() -> new TextNode(UNKNOWN));
     }
 
     private Optional<TransactionLogValue> readToTransactionLogValue(ByteBuffer byteBuffer) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -686,6 +686,20 @@ public class ConsoleConsumerOptionsTest {
         assertInstanceOf(OffsetsMessageFormatter.class,
                 new ConsoleConsumerOptions(offsetsMessageFormatter).formatter());
     }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testNewAndDeprecateGroupMetadataMessageFormatter() throws Exception {
+        String[] deprecatedGroupMetadataMessageFormatter =
+                generateArgsForFormatter("kafka.coordinator.group.GroupMetadataManager$GroupMetadataMessageFormatter");
+        assertInstanceOf(kafka.coordinator.group.GroupMetadataManager.GroupMetadataMessageFormatter.class,
+                new ConsoleConsumerOptions(deprecatedGroupMetadataMessageFormatter).formatter());
+
+        String[] groupMetadataMessageFormatter =
+                generateArgsForFormatter("org.apache.kafka.tools.consumer.GroupMetadataMessageFormatter");
+        assertInstanceOf(GroupMetadataMessageFormatter.class,
+                new ConsoleConsumerOptions(groupMetadataMessageFormatter).formatter());
+    }
     
     private String[] generateArgsForFormatter(String formatter) {
         return new String[]{

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/GroupMetadataMessageFormatterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
+import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GroupMetadataMessageFormatterTest {
+
+    private static final OffsetCommitKey OFFSET_COMMIT_KEY = new OffsetCommitKey()
+            .setGroup("group-id")
+            .setTopic("foo")
+            .setPartition(1);
+    private static final OffsetCommitValue OFFSET_COMMIT_VALUE = new OffsetCommitValue()
+            .setOffset(100L)
+            .setLeaderEpoch(10)
+            .setMetadata("metadata")
+            .setCommitTimestamp(1234L)
+            .setExpireTimestamp(-1L);
+    private static final GroupMetadataValue.MemberMetadata MEMBER_METADATA = new GroupMetadataValue.MemberMetadata()
+            .setMemberId("member-1")
+            .setClientId("client-1")
+            .setClientHost("host-1")
+            .setRebalanceTimeout(1000)
+            .setSessionTimeout(1500)
+            .setGroupInstanceId("group-instance-1")
+            .setSubscription(new byte[]{0, 1})
+            .setAssignment(new byte[]{1, 2});
+    private static final GroupMetadataKey GROUP_METADATA_KEY = new GroupMetadataKey()
+            .setGroup("group-id");
+    private static final GroupMetadataValue GROUP_METADATA_VALUE = new GroupMetadataValue()
+            .setProtocolType("consumer")
+            .setGeneration(1)
+            .setProtocol("range")
+            .setLeader("leader")
+            .setMembers(singletonList(MEMBER_METADATA))
+            .setCurrentStateTimestamp(1234L);
+    private static final String TOPIC = "TOPIC";
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 10, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 10, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":10,\"data\":\"unknown\"},\"value\":{\"version\":10,\"data\":\"unknown\"}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":{\"version\":0," +
+                            "\"data\":{\"protocolType\":\"consumer\",\"generation\":1,\"protocol\":\"range\"," +
+                            "\"leader\":\"leader\",\"members\":[{\"memberId\":\"member-1\",\"clientId\":\"client-1\"," +
+                            "\"clientHost\":\"host-1\",\"sessionTimeout\":1500,\"subscription\":\"AAE=\"," +
+                            "\"assignment\":\"AQI=\"}]}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 1, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":{\"version\":1," +
+                            "\"data\":{\"protocolType\":\"consumer\",\"generation\":1,\"protocol\":\"range\"," +
+                            "\"leader\":\"leader\",\"members\":[{\"memberId\":\"member-1\",\"clientId\":\"client-1\"," +
+                            "\"clientHost\":\"host-1\",\"rebalanceTimeout\":1000,\"sessionTimeout\":1500," +
+                            "\"subscription\":\"AAE=\",\"assignment\":\"AQI=\"}]}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":{\"version\":2," +
+                            "\"data\":{\"protocolType\":\"consumer\",\"generation\":1,\"protocol\":\"range\"," +
+                            "\"leader\":\"leader\",\"currentStateTimestamp\":1234,\"members\":[{\"memberId\":\"member-1\"," +
+                            "\"clientId\":\"client-1\",\"clientHost\":\"host-1\",\"rebalanceTimeout\":1000," +
+                            "\"sessionTimeout\":1500,\"subscription\":\"AAE=\",\"assignment\":\"AQI=\"}]}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 3, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":{\"version\":3," +
+                            "\"data\":{\"protocolType\":\"consumer\",\"generation\":1,\"protocol\":\"range\"," +
+                            "\"leader\":\"leader\",\"currentStateTimestamp\":1234,\"members\":[{\"memberId\":\"member-1\"," +
+                            "\"groupInstanceId\":\"group-instance-1\",\"clientId\":\"client-1\",\"clientHost\":\"host-1\"," +
+                            "\"rebalanceTimeout\":1000,\"sessionTimeout\":1500,\"subscription\":\"AAE=\",\"assignment\":\"AQI=\"}]}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 4, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":{\"version\":4," +
+                            "\"data\":{\"protocolType\":\"consumer\",\"generation\":1,\"protocol\":\"range\"," +
+                            "\"leader\":\"leader\",\"currentStateTimestamp\":1234,\"members\":[{\"memberId\":\"member-1\"," +
+                            "\"groupInstanceId\":\"group-instance-1\",\"clientId\":\"client-1\",\"clientHost\":\"host-1\"," +
+                            "\"rebalanceTimeout\":1000,\"sessionTimeout\":1500,\"subscription\":\"AAE=\",\"assignment\":\"AQI=\"}]}}}"
+                ),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 2, GROUP_METADATA_KEY).array(),
+                        null,
+                        "{\"key\":{\"version\":2,\"data\":{\"group\":\"group-id\"}},\"value\":null}"),
+                Arguments.of(
+                        null,
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 4, GROUP_METADATA_VALUE).array(),
+                        "{\"key\":null,\"value\":{\"version\":4,\"data\":{\"protocolType\":\"consumer\",\"generation\":1," +
+                            "\"protocol\":\"range\",\"leader\":\"leader\",\"currentStateTimestamp\":1234," +
+                            "\"members\":[{\"memberId\":\"member-1\",\"groupInstanceId\":\"group-instance-1\"," +
+                            "\"clientId\":\"client-1\",\"clientHost\":\"host-1\",\"rebalanceTimeout\":1000," +
+                            "\"sessionTimeout\":1500,\"subscription\":\"AAE=\",\"assignment\":\"AQI=\"}]}}}"),
+                Arguments.of(null, null, "{\"key\":null,\"value\":null}"),
+                Arguments.of(
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 0, OFFSET_COMMIT_KEY).array(),
+                        MessageUtil.toVersionPrefixedByteBuffer((short) 4, OFFSET_COMMIT_VALUE).array(),
+                        ""
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testTransactionLogMessageFormatter(byte[] keyBuffer, byte[] valueBuffer, String expectedOutput) {
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                TOPIC, 0, 0,
+                0L, TimestampType.CREATE_TIME, 0,
+                0, keyBuffer, valueBuffer,
+                new RecordHeaders(), Optional.empty());
+
+        try (MessageFormatter formatter = new GroupMetadataMessageFormatter()) {
+            formatter.configure(emptyMap());
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            formatter.writeTo(record, new PrintStream(out));
+            assertEquals(expectedOutput, out.toString());
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-16666

we need to migate GroupMetadataMessageFormatter from scala code to java code,and make the message format is json pattern
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
