### PR TITLE
Update 'tag' field in BrokerHeartbeatRequest.json to int for consistency.

### DIFF
--- a/clients/src/main/resources/common/message/BrokerHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/BrokerHeartbeatRequest.json
@@ -31,7 +31,7 @@
       "about": "True if the broker wants to be fenced, false otherwise." },
     { "name": "WantShutDown", "type": "bool", "versions": "0+",
       "about": "True if the broker wants to be shut down, false otherwise." },
-    { "name": "OfflineLogDirs", "type":  "[]uuid", "versions": "1+", "taggedVersions": "1+", "tag": "0",
+    { "name": "OfflineLogDirs", "type":  "[]uuid", "versions": "1+", "taggedVersions": "1+", "tag": 0,
       "about": "Log directories that failed and went offline." }
   ]
 }


### PR DESCRIPTION
Field 'tag' should be of type int, not type string. It works as string as the JSON parser is permissive, however it's inconsistent as in all other descriptors it is of type int.