### PR TITLE
KAFKA-17230: Fix for consumer node latency metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -230,7 +230,7 @@ public abstract class AbstractFetch implements Closeable {
                 );
             }
 
-            metricsManager.recordLatency(resp.requestLatencyMs());
+            metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
         } finally {
             removePendingFetchRequest(fetchTarget, data.metadata().sessionId());
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -81,8 +81,14 @@ public class FetchMetricsManager {
         return throttleTime;
     }
 
-    void recordLatency(long requestLatencyMs) {
+    void recordLatency(String node, long requestLatencyMs) {
         fetchLatency.record(requestLatencyMs);
+        if (!node.isEmpty()) {
+            String nodeTimeName = "node-" + node + ".latency";
+            Sensor nodeRequestTime = this.metrics.getSensor(nodeTimeName);
+            if (nodeRequestTime != null)
+                nodeRequestTime.record(requestLatencyMs);
+        }
     }
 
     void recordBytesFetched(int bytes) {


### PR DESCRIPTION
*<b>Note: I checked the old versions and do not find this metric was ever working hence we might consider of removing this metric if it's not worth.</b>*

Kafka Consumer client registers node/connection latency metrics in [Selector.java](https://github.com/apache/kafka/blob/9d634629f29cd402a723d7e7bece18c8099065a4/clients/src/main/java/org/apache/kafka/common/network/Selector.java#L1359) but the values against the metric is never recorded. This seems to be an issue since inception. However, the same metric is also created for Kafka Producer but the value is recorded for Kafka Producer in [Sender.java](https://github.com/apache/kafka/blob/9d634629f29cd402a723d7e7bece18c8099065a4/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java#L1092). Hence node - request-latency-max and request-latency-avg appears correctly for Kafka Producer but is NaN for Kafka Consumer.

Though it's not clear which request latency this metric should hold i.e. all requests originating for consumer or any specific. The PR adds `fetch latency` as `node` `request-latency`. As the Kafka Producer also has several outgoing requests from client but records `produce latency` as  `node` `request-latency` hence similar concept is applied for consumer, which captures `fetch latency` as `node` `request-latency`.

Please let me know the feedback and what best this metric should hold.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
