### PR TITLE
KAFKA-17227: Update zstd-jni lib

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -327,7 +327,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.6-3 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.6-4 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/docker/native/native-image-configs/resource-config.json
+++ b/docker/native/native-image-configs/resource-config.json
@@ -25,9 +25,9 @@
   }, {
     "pattern":"\\Qkafka/kafka-version.properties\\E"
   }, {
-    "pattern":"\\Qlinux/amd64/libzstd-jni-1.5.6-3.so\\E"
+    "pattern":"\\Qlinux/amd64/libzstd-jni-1.5.6-4.so\\E"
   }, {
-    "pattern":"\\Qlinux/aarch64/libzstd-jni-1.5.6-3.so\\E"
+    "pattern":"\\Qlinux/aarch64/libzstd-jni-1.5.6-4.so\\E"
   }, {
     "pattern":"\\Qnet/jpountz/util/linux/amd64/liblz4-java.so\\E"
   }, {

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -26,6 +26,7 @@
             when producing and consuming messages. This is due to the compression libraries <code>zstd-jni</code> and <code>snappy</code>.
             To remediate this problem you need to pass the following JVM flags to Kafka <code>ZstdTempFolder</code> and <code>org.xerial.snappy.tempdir</code> pointing to a directory with execution permissions.
             For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
+	    This is a known issue for version 3.8.0 as well.
         </li>
     </ul>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -19,6 +19,14 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
+<h4><a id="upgrade_3_9_0" href="#upgrade_3_9_0">Upgrading to 3.9.0 from any version 0.8.x through 3.8.x</a></h4>
+    <h5><a id="upgrade_390_notable" href="#upgrade_390_notable">Notable changes in 3.9.0</a></h5>
+    <ul>
+        <li>In case you run your Kakfa clusters with no execution permission for the /tmp partition, Kafka will refuse to start due to a change in <code>zstd-lib</code>.
+        To remediate this problem you need to pass the following environment variable to Kafka <code>ZstdTempFolder</code> pointing to a directory with execution permissions.
+        For example <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp"</code>.</li>
+    </ul>
+
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>
 
     <h5><a id="upgrade_380_notable" href="#upgrade_380_notable">Notable changes in 3.8.0</a></h5>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -22,9 +22,9 @@
 <h4><a id="upgrade_3_9_0" href="#upgrade_3_9_0">Upgrading to 3.9.0 from any version 0.8.x through 3.8.x</a></h4>
     <h5><a id="upgrade_390_notable" href="#upgrade_390_notable">Notable changes in 3.9.0</a></h5>
     <ul>
-        <li>In case you run your Kakfa clusters with no execution permission for the /tmp partition, Kafka will refuse to start due to a change in <code>zstd-jni</code> library.
-        To remediate this problem you need to pass the following environment variable to Kafka <code>ZstdTempFolder</code> pointing to a directory with execution permissions.
-        For example <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp"</code>.</li>
+        <li>In case you run your Kafka clusters with no execution permission for the <code>/tmp</code> partition, Kafka will refuse to start due to a change in <code>zstd-jni</code> library.
+        To remediate this problem you need to pass the following JVM flag to Kafka <code>ZstdTempFolder</code> pointing to a directory with execution permissions.
+        For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp"</code>.</li>
     </ul>
 
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -22,9 +22,11 @@
 <h4><a id="upgrade_3_9_0" href="#upgrade_3_9_0">Upgrading to 3.9.0 from any version 0.8.x through 3.8.x</a></h4>
     <h5><a id="upgrade_390_notable" href="#upgrade_390_notable">Notable changes in 3.9.0</a></h5>
     <ul>
-        <li>In case you run your Kafka clusters with no execution permission for the <code>/tmp</code> partition, Kafka will refuse to start due to a change in <code>zstd-jni</code> library.
-        To remediate this problem you need to pass the following JVM flag to Kafka <code>ZstdTempFolder</code> pointing to a directory with execution permissions.
-        For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp"</code>.</li>
+        <li>In case you run your Kafka clusters with no execution permission for the <code>/tmp</code> partition, Kafka will not work properly. It might either refuse to start or fail
+            when producing and consuming messages. This is due to the compression libraries <code>zstd-jni</code> and <code>snappy</code>.
+            To remediate this problem you need to pass the following JVM flags to Kafka <code>ZstdTempFolder</code> and <code>org.xerial.snappy.tempdir</code> pointing to a directory with execution permissions.
+            For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
+        </li>
     </ul>
 
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -22,7 +22,7 @@
 <h4><a id="upgrade_3_9_0" href="#upgrade_3_9_0">Upgrading to 3.9.0 from any version 0.8.x through 3.8.x</a></h4>
     <h5><a id="upgrade_390_notable" href="#upgrade_390_notable">Notable changes in 3.9.0</a></h5>
     <ul>
-        <li>In case you run your Kakfa clusters with no execution permission for the /tmp partition, Kafka will refuse to start due to a change in <code>zstd-lib</code>.
+        <li>In case you run your Kakfa clusters with no execution permission for the /tmp partition, Kafka will refuse to start due to a change in <code>zstd-jni</code> library.
         To remediate this problem you need to pass the following environment variable to Kafka <code>ZstdTempFolder</code> pointing to a directory with execution permissions.
         For example <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp"</code>.</li>
     </ul>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -157,6 +157,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.4",
+  // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   zstd: "1.5.6-4",
   junitPlatform: "1.10.2"
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -157,7 +157,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.4",
-  zstd: "1.5.6-3",
+  zstd: "1.5.6-4",
   junitPlatform: "1.10.2"
 ]
 


### PR DESCRIPTION
This might be a work-around to solve the issue found in [KAFKA-17227](https://issues.apache.org/jira/browse/KAFKA-17227)

There are no release notes for zstd-jni lib, but this is the interesting commit that might solve the issue:

https://github.com/luben/zstd-jni/commit/c057b94e0372be2e16e957e5e09b4fe3c84e8c22

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
