### PR TITLE
KAFKA-17236: Handle local log deletion when remote.log.copy.disabled=true

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -95,7 +95,9 @@ public class TopicConfig {
 
     public static final String REMOTE_LOG_COPY_DISABLE_CONFIG = "remote.log.copy.disable";
     public static final String REMOTE_LOG_COPY_DISABLE_DOC = "Determines whether tiered data for a topic should become read only," +
-            " and no more data uploading on a topic.";
+            " and no more data uploading on a topic. Once this config is set to true, the local retention configuration " +
+            "(i.e. local.retention.ms/bytes) becomes irrelevant, and all data expiration follows the topic-wide retention configuration" +
+            "(i.e. retention.ms/bytes).";
 
     public static final String REMOTE_LOG_DELETE_ON_DISABLE_CONFIG = "remote.log.delete.on.disable";
     public static final String REMOTE_LOG_DELETE_ON_DISABLE_DOC = "Determines whether tiered data for a topic should be " +

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -981,6 +981,7 @@ class LogManager(logDirs: Seq[File],
       LogConfig.validateNoInvalidRemoteStorageConfigsInZK(newLogConfig.values())
     }
     LogConfig.validateTurningOffRemoteStorageWithDelete(newLogConfig.values(), wasRemoteLogEnabled, isRemoteLogStorageEnabled)
+    LogConfig.validateRetentionConfigsWhenRemoteCopyDisabled(newLogConfig.values(), isRemoteLogStorageEnabled)
     if (logs.nonEmpty) {
       logs.foreach { log =>
         val oldLogConfig = log.updateConfig(newLogConfig)

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1485,6 +1485,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       // Segments are eligible for deletion when:
       //    1. they are uploaded to the remote storage
       //    2. log-start-offset was incremented higher than the largest offset in the candidate segment
+      // Note: when remote log copy is disabled, we will fall back to local log check using retention.ms/bytes
       if (remoteLogEnabledAndRemoteCopyEnabled()) {
         (upperBoundOffset > 0 && upperBoundOffset - 1 <= highestOffsetInRemoteStorage()) ||
           allowDeletionDueToLogStartOffsetIncremented

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1465,6 +1465,21 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   /**
+   * Check if this partition has, or will have remote logs, so that we should not delete local logs immediately.
+   * We will make sure `remoteLogEnabled` and:
+   *  (1) remote copy is enabled, which means local logs will keep uploading to the remote storage.
+   *  (2) remote copy is disabled, which means there will be no more logs uploaded to the remote storage.
+   *      And check (log start offset != local log start offset), which means the remote storage is not empty. In this case,
+   *      we delete local logs that are already uploaded to the remote storage. And then, when remote storage is empty
+   *      (log start offset == local log start offset) we can treat this topic as "remote log is disabled" and start to delete local logs.
+   *
+   * @return true if this partition has (or will have) remote logs
+   */
+  private def hasRemoteLogs(): Boolean = {
+    remoteLogEnabled() && (!config.remoteCopyDisabled() || logStartOffset != localLogStartOffset())
+  }
+
+  /**
    * Find segments starting from the oldest until the user-supplied predicate is false.
    * A final segment that is empty will never be returned.
    *
@@ -1478,7 +1493,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       // Segments are eligible for deletion when:
       //    1. they are uploaded to the remote storage
       //    2. log-start-offset was incremented higher than the largest offset in the candidate segment
-      if (remoteLogEnabled()) {
+      if (hasRemoteLogs()) {
         (upperBoundOffset > 0 && upperBoundOffset - 1 <= highestOffsetInRemoteStorage()) ||
           allowDeletionDueToLogStartOffsetIncremented
       } else {
@@ -1523,7 +1538,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   private def incrementStartOffset(startOffset: Long, reason: LogStartOffsetIncrementReason): Unit = {
-    if (remoteLogEnabled()) maybeIncrementLocalLogStartOffset(startOffset, reason)
+    if (hasRemoteLogs()) maybeIncrementLocalLogStartOffset(startOffset, reason)
     else maybeIncrementLogStartOffset(startOffset, reason)
   }
 
@@ -1571,7 +1586,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   private def deleteRetentionMsBreachedSegments(): Int = {
-    val retentionMs = localRetentionMs(config, remoteLogEnabled())
+    val retentionMs = localRetentionMs(config, hasRemoteLogs())
     if (retentionMs < 0) return 0
     val startMs = time.milliseconds
 
@@ -1583,7 +1598,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   private def deleteRetentionSizeBreachedSegments(): Int = {
-    val retentionSize: Long = localRetentionSize(config, remoteLogEnabled())
+    val retentionSize: Long = localRetentionSize(config, hasRemoteLogs())
     if (retentionSize < 0 || size < retentionSize) return 0
     var diff = size - retentionSize
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
@@ -2339,12 +2354,12 @@ object UnifiedLog extends Logging {
     }
   }
 
-  private[log] def localRetentionMs(config: LogConfig, remoteLogEnabled: Boolean): Long = {
-    if (remoteLogEnabled) config.remoteLogConfig.localRetentionMs else config.retentionMs
+  private[log] def localRetentionMs(config: LogConfig, hasRemoteLogs: Boolean): Long = {
+    if (hasRemoteLogs) config.remoteLogConfig.localRetentionMs else config.retentionMs
   }
 
-  private[log] def localRetentionSize(config: LogConfig, remoteLogEnabled: Boolean): Long = {
-    if (remoteLogEnabled) config.remoteLogConfig.localRetentionBytes else config.retentionSize
+  private[log] def localRetentionSize(config: LogConfig, hasRemoteLogs: Boolean): Long = {
+    if (hasRemoteLogs) config.remoteLogConfig.localRetentionBytes else config.retentionSize
   }
 
 }

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1476,7 +1476,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    * @return true if this partition has (or will have) remote logs
    */
   private def hasRemoteLogs(): Boolean = {
-    remoteLogEnabled() && (!config.remoteCopyDisabled() || logStartOffset != localLogStartOffset())
+    remoteLogEnabled() && (!config.remoteLogCopyDisable() || logStartOffset != localLogStartOffset())
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.checkpoint.LeaderEpochCheckpointFile
+import org.apache.kafka.storage.internals.log.LogConfig.{DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG, DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG}
 import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, FetchDataInfo, FetchIsolation, LazyIndex, LogAppendInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetsListener, LogSegment, ProducerStateManager, ProducerStateManagerConfig, TransactionIndex}
 
 import scala.jdk.CollectionConverters._
@@ -68,7 +69,9 @@ object LogTestUtils {
                       indexIntervalBytes: Int = ServerLogConfigs.LOG_INDEX_INTERVAL_BYTES_DEFAULT,
                       segmentIndexBytes: Int = ServerLogConfigs.LOG_INDEX_SIZE_MAX_BYTES_DEFAULT,
                       fileDeleteDelayMs: Long = ServerLogConfigs.LOG_DELETE_DELAY_MS_DEFAULT,
-                      remoteLogStorageEnable: Boolean = LogConfig.DEFAULT_REMOTE_STORAGE_ENABLE): LogConfig = {
+                      remoteLogStorageEnable: Boolean = LogConfig.DEFAULT_REMOTE_STORAGE_ENABLE,
+                      remoteCopyDisabled: Boolean = DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG,
+                      remoteLogDeleteOnDisable: Boolean = DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG): LogConfig = {
     val logProps = new Properties()
     logProps.put(TopicConfig.SEGMENT_MS_CONFIG, segmentMs: java.lang.Long)
     logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, segmentBytes: Integer)
@@ -83,6 +86,8 @@ object LogTestUtils {
     logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, segmentIndexBytes: Integer)
     logProps.put(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, fileDeleteDelayMs: java.lang.Long)
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, remoteLogStorageEnable: java.lang.Boolean)
+    logProps.put(TopicConfig.REMOTE_COPY_DISABLED_CONFIG, remoteCopyDisabled: java.lang.Boolean)
+    logProps.put(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, remoteLogDeleteOnDisable: java.lang.Boolean)
     new LogConfig(logProps)
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.checkpoint.LeaderEpochCheckpointFile
-import org.apache.kafka.storage.internals.log.LogConfig.{DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG, DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG}
+import org.apache.kafka.storage.internals.log.LogConfig.{DEFAULT_REMOTE_LOG_COPY_DISABLE_CONFIG, DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG}
 import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, FetchDataInfo, FetchIsolation, LazyIndex, LogAppendInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetsListener, LogSegment, ProducerStateManager, ProducerStateManagerConfig, TransactionIndex}
 
 import scala.jdk.CollectionConverters._
@@ -70,7 +70,7 @@ object LogTestUtils {
                       segmentIndexBytes: Int = ServerLogConfigs.LOG_INDEX_SIZE_MAX_BYTES_DEFAULT,
                       fileDeleteDelayMs: Long = ServerLogConfigs.LOG_DELETE_DELAY_MS_DEFAULT,
                       remoteLogStorageEnable: Boolean = LogConfig.DEFAULT_REMOTE_STORAGE_ENABLE,
-                      remoteCopyDisabled: Boolean = DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG,
+                      remoteLogCopyDisable: Boolean = DEFAULT_REMOTE_LOG_COPY_DISABLE_CONFIG,
                       remoteLogDeleteOnDisable: Boolean = DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG): LogConfig = {
     val logProps = new Properties()
     logProps.put(TopicConfig.SEGMENT_MS_CONFIG, segmentMs: java.lang.Long)
@@ -86,7 +86,7 @@ object LogTestUtils {
     logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, segmentIndexBytes: Integer)
     logProps.put(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, fileDeleteDelayMs: java.lang.Long)
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, remoteLogStorageEnable: java.lang.Boolean)
-    logProps.put(TopicConfig.REMOTE_COPY_DISABLED_CONFIG, remoteCopyDisabled: java.lang.Boolean)
+    logProps.put(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, remoteLogCopyDisable: java.lang.Boolean)
     logProps.put(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, remoteLogDeleteOnDisable: java.lang.Boolean)
     new LogConfig(logProps)
   }

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -4270,7 +4270,7 @@ class UnifiedLogTest {
     }
     assertEquals(5, log.logSegments.size)
     log.updateHighWatermark(log.logEndOffset)
-    // simulate calls to upload 3 segments to remote storage
+    // simulate calls to upload 2 segments to remote storage
     log.updateHighestOffsetInRemoteStorage(20)
 
     log.deleteOldSegments()
@@ -4278,7 +4278,7 @@ class UnifiedLogTest {
     assertEquals(0, log.logStartOffset)
     assertEquals(21, log.localLogStartOffset())
 
-    // simulate calls to upload 3 segments to remote storage
+    // simulate calls to upload the 3rd segments to remote storage
     log.updateHighestOffsetInRemoteStorage(30)
 
     // add remoteLogCopyDisable = true

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -4189,6 +4189,73 @@ class UnifiedLogTest {
   }
 
   @Test
+  def testRetentionOnLocalLogDeletionWhenRemoteCopyDisabled(): Unit = {
+    def createRecords = TestUtils.records(List(new SimpleRecord(mockTime.milliseconds(), "a".getBytes)))
+    val segmentBytes = createRecords.sizeInBytes()
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = segmentBytes, localRetentionBytes = 1, retentionBytes = segmentBytes * 5,
+          fileDeleteDelayMs = 0, remoteLogStorageEnable = true)
+    val log = createLog(logDir, logConfig, remoteStorageSystemEnable = true)
+
+    // Given 10 segments of 1 message each
+    for (_ <- 0 until 10) {
+      log.appendAsLeader(createRecords, leaderEpoch = 0)
+    }
+    assertEquals(10, log.logSegments.size)
+
+    log.updateHighWatermark(log.logEndOffset)
+    // simulate calls to upload 2 segments to remote storage
+    log.updateHighestOffsetInRemoteStorage(1)
+
+    log.deleteOldSegments()
+    assertEquals(8, log.logSegments.size())
+    assertEquals(0, log.logStartOffset)
+    assertEquals(2, log.localLogStartOffset())
+
+    // add remoteCopyDisabled = true
+    val copyDisabledLogConfig = LogTestUtils.createLogConfig(segmentBytes = segmentBytes, localRetentionBytes = 1, retentionBytes = segmentBytes * 5,
+      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteCopyDisabled = true)
+    log.updateConfig(copyDisabledLogConfig)
+
+    // No local logs will be deleted even though local retention bytes is 1 because there are still logs in remote storage
+    log.deleteOldSegments()
+    assertEquals(8, log.logSegments.size())
+    assertEquals(0, log.logStartOffset)
+    assertEquals(2, log.localLogStartOffset())
+
+    // simulate the remote logs are all deleted due to retention policy
+    log.updateLogStartOffsetFromRemoteTier(2)
+    assertEquals(8, log.logSegments.size())
+    assertEquals(2, log.logStartOffset)
+    assertEquals(2, log.localLogStartOffset())
+
+    // try to delete local logs again, 3 segments will be deleted this time because log start offset == local log start offset,
+    // which means no remote storage is empty. We'll treat this log as local logs and use retention.bytes for retention policy.
+    log.deleteOldSegments()
+    assertEquals(5, log.logSegments.size())
+    assertEquals(5, log.logStartOffset)
+    assertEquals(5, log.localLogStartOffset())
+
+    // add retentionMs = 1000
+    val retentionMsConfig = LogTestUtils.createLogConfig(segmentBytes = segmentBytes, localRetentionMs = 1, retentionMs = 1000,
+      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteCopyDisabled = true)
+    log.updateConfig(retentionMsConfig)
+
+    // Should not delete any logs because no logs expired
+    mockTime.sleep(10)
+    log.deleteOldSegments()
+    assertEquals(5, log.logSegments.size())
+    assertEquals(5, log.logStartOffset)
+    assertEquals(5, log.localLogStartOffset())
+
+    // Should delete all logs because all of them are expired based on retentionMs = 1000
+    mockTime.sleep(1000)
+    log.deleteOldSegments()
+    assertEquals(1, log.logSegments.size())
+    assertEquals(10, log.logStartOffset)
+    assertEquals(10, log.localLogStartOffset())
+  }
+
+  @Test
   def testIncrementLocalLogStartOffsetAfterLocalLogDeletion(): Unit = {
     val logConfig = LogTestUtils.createLogConfig(localRetentionBytes = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true)
     val log = createLog(logDir, logConfig, remoteStorageSystemEnable = true)
@@ -4204,12 +4271,50 @@ class UnifiedLogTest {
     assertEquals(5, log.logSegments.size)
     log.updateHighWatermark(log.logEndOffset)
     // simulate calls to upload 3 segments to remote storage
+    log.updateHighestOffsetInRemoteStorage(20)
+
+    log.deleteOldSegments()
+    assertEquals(3, log.logSegments.size())
+    assertEquals(0, log.logStartOffset)
+    assertEquals(21, log.localLogStartOffset())
+
+    // simulate calls to upload 3 segments to remote storage
     log.updateHighestOffsetInRemoteStorage(30)
 
+    // add remoteCopyDisabled = true
+    val copyDisabledLogConfig = LogTestUtils.createLogConfig(localRetentionBytes = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true,
+      remoteCopyDisabled = true)
+    log.updateConfig(copyDisabledLogConfig)
+
+    // the local log should still be deleted and local log start offset should be increased
     log.deleteOldSegments()
     assertEquals(2, log.logSegments.size())
     assertEquals(0, log.logStartOffset)
     assertEquals(31, log.localLogStartOffset())
+
+    // add retentionBytes = 1
+    val retentionByteLogConfig = LogTestUtils.createLogConfig(localRetentionBytes = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true,
+      remoteCopyDisabled = true, retentionBytes = 1)
+    log.updateConfig(retentionByteLogConfig)
+
+    // No local logs will be deleted even though retention bytes is 1 because there are still logs in remote storage
+    log.deleteOldSegments()
+    assertEquals(2, log.logSegments.size())
+    assertEquals(0, log.logStartOffset)
+    assertEquals(31, log.localLogStartOffset())
+
+    // simulate the remote logs are all deleted due to retention policy
+    log.updateLogStartOffsetFromRemoteTier(31)
+    assertEquals(2, log.logSegments.size())
+    assertEquals(31, log.logStartOffset)
+    assertEquals(31, log.localLogStartOffset())
+
+    // try to delete local logs again, 1 segment will be deleted this time because retentionBytes,
+    // and log start offset and local log start offset will both be updated
+    log.deleteOldSegments()
+    assertEquals(1, log.logSegments.size())
+    assertEquals(41, log.logStartOffset)
+    assertEquals(41, log.localLogStartOffset())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -4213,7 +4213,7 @@ class UnifiedLogTest {
 
     // add remoteCopyDisabled = true
     val copyDisabledLogConfig = LogTestUtils.createLogConfig(segmentBytes = segmentBytes, localRetentionBytes = 1, retentionBytes = segmentBytes * 5,
-      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteCopyDisabled = true)
+      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteLogCopyDisable = true)
     log.updateConfig(copyDisabledLogConfig)
 
     // No local logs will be deleted even though local retention bytes is 1 because there are still logs in remote storage
@@ -4237,7 +4237,7 @@ class UnifiedLogTest {
 
     // add retentionMs = 1000
     val retentionMsConfig = LogTestUtils.createLogConfig(segmentBytes = segmentBytes, localRetentionMs = 1, retentionMs = 1000,
-      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteCopyDisabled = true)
+      fileDeleteDelayMs = 0, remoteLogStorageEnable = true, remoteLogCopyDisable = true)
     log.updateConfig(retentionMsConfig)
 
     // Should not delete any logs because no logs expired
@@ -4281,9 +4281,9 @@ class UnifiedLogTest {
     // simulate calls to upload 3 segments to remote storage
     log.updateHighestOffsetInRemoteStorage(30)
 
-    // add remoteCopyDisabled = true
+    // add remoteLogCopyDisable = true
     val copyDisabledLogConfig = LogTestUtils.createLogConfig(localRetentionBytes = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true,
-      remoteCopyDisabled = true)
+      remoteLogCopyDisable = true)
     log.updateConfig(copyDisabledLogConfig)
 
     // the local log should still be deleted and local log start offset should be increased
@@ -4294,7 +4294,7 @@ class UnifiedLogTest {
 
     // add retentionBytes = 1
     val retentionByteLogConfig = LogTestUtils.createLogConfig(localRetentionBytes = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true,
-      remoteCopyDisabled = true, retentionBytes = 1)
+      remoteLogCopyDisable = true, retentionBytes = 1)
     log.updateConfig(retentionByteLogConfig)
 
     // No local logs will be deleted even though retention bytes is 1 because there are still logs in remote storage

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -639,6 +639,7 @@ public class LogConfig extends AbstractConfig {
             validateNoRemoteStorageForCompactedTopic(newConfigs);
             validateRemoteStorageRetentionSize(newConfigs);
             validateRemoteStorageRetentionTime(newConfigs);
+            validateRetentionConfigsWhenRemoteCopyDisabled(newConfigs, isRemoteLogStorageEnabled);
         } else {
             // The new config "remote.storage.enable" is false, validate if it's turning from true to false
             boolean wasRemoteLogEnabled = Boolean.parseBoolean(existingConfigs.getOrDefault(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"));
@@ -652,6 +653,24 @@ public class LogConfig extends AbstractConfig {
             throw new InvalidConfigurationException("It is invalid to disable remote storage without deleting remote data. " +
                     "If you want to keep the remote data and turn to read only, please set `remote.storage.enable=true,remote.log.copy.disable=true`. " +
                     "If you want to disable remote storage and delete all remote data, please set `remote.storage.enable=false,remote.log.delete.on.disable=true`.");
+        }
+    }
+
+    public static void validateRetentionConfigsWhenRemoteCopyDisabled(Map<?, ?> newConfigs, boolean isRemoteLogStorageEnabled) {
+        boolean isRemoteLogCopyDisabled = (Boolean) Utils.castToStringObjectMap(newConfigs).getOrDefault(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, false);
+        long retentionMs = (Long) newConfigs.get(TopicConfig.RETENTION_MS_CONFIG);
+        long localRetentionMs = (Long) newConfigs.get(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG);
+        long retentionBytes = (Long) newConfigs.get(TopicConfig.RETENTION_BYTES_CONFIG);
+        long localRetentionBytes = (Long) newConfigs.get(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG);
+        if (isRemoteLogStorageEnabled && isRemoteLogCopyDisabled) {
+            if (localRetentionBytes != -2 && localRetentionBytes != retentionBytes) {
+                throw new InvalidConfigurationException("When `remote.log.copy.disable` is set to true, the `local.retention.bytes` " +
+                        "and `retention.bytes` must be set to the identical value because there will be no more logs copied to the remote storage.");
+            }
+            if (localRetentionMs != -2 && localRetentionMs != retentionMs) {
+                throw new InvalidConfigurationException("When `remote.log.copy.disable` is set to true, the `local.retention.ms` " +
+                        "and `retention.ms` must be set to the identical value because there will be no more logs copied to the remote storage.");
+            }
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -186,7 +186,7 @@ public class LogConfig extends AbstractConfig {
     public static final long DEFAULT_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS = ServerLogConfigs.LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DEFAULT;
 
     public static final boolean DEFAULT_REMOTE_STORAGE_ENABLE = false;
-    public static final boolean DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG = false;
+    public static final boolean DEFAULT_REMOTE_LOG_COPY_DISABLE_CONFIG = false;
     public static final boolean DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG = false;
     public static final long DEFAULT_LOCAL_RETENTION_BYTES = -2; // It indicates the value to be derived from RetentionBytes
     public static final long DEFAULT_LOCAL_RETENTION_MS = -2; // It indicates the value to be derived from RetentionMs

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -186,6 +186,8 @@ public class LogConfig extends AbstractConfig {
     public static final long DEFAULT_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS = ServerLogConfigs.LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DEFAULT;
 
     public static final boolean DEFAULT_REMOTE_STORAGE_ENABLE = false;
+    public static final boolean DEFAULT_REMOTE_LOG_COPY_DISABLED_CONFIG = false;
+    public static final boolean DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG = false;
     public static final long DEFAULT_LOCAL_RETENTION_BYTES = -2; // It indicates the value to be derived from RetentionBytes
     public static final long DEFAULT_LOCAL_RETENTION_MS = -2; // It indicates the value to be derived from RetentionMs
 


### PR DESCRIPTION
The last piece of KIP-950 KRaft mode. 

Handle local log deletion when remote.log.copy.disabled=true. Based on the KIP-950:
> When tiered storage is disabled or becomes read-only on a topic, the local retention configuration becomes irrelevant, and all data expiration follows the topic-wide retention configuration exclusively.

In this PR, I did:

   1. added `remoteLogEnabledAndRemoteCopyEnabled` method to check if this topic enables tiered storage and remote log copy is enabled. We should adopt local.retention.ms/bytes when `remote.storage.enable=true,remote.log.copy.disable=false`.
   2. Changed to use `retention.bytes`/`retention.ms` when remote copy disabled.
   3. Added validation to ask users to set `local.retention.ms == retention.ms` and `local.retention.bytes == retention.bytes`
   4. added tests


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
