### PR TITLE
KAFKA-17218: kafka-consumer-groups should handle describe groups with deleted topics

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.utils.Utils;
@@ -812,6 +813,9 @@ public class ConsumerGroupCommand {
                         : new Unknown()
                 ));
             } catch (InterruptedException | ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    return topicPartitions.stream().collect(Collectors.toMap(Function.identity(), tp -> new Unknown()));
+                }
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
The script will return "-" as placeholder for offsets and lag if topic partition is unknown when describe groups.

Note: 
- I added integration test only as there is no unit test for this command
- I moved `produceRecord` from `DeleteOffsetsConsumerGroupCommandIntegrationTest` to `ConsumerGroupCommandTestUtils` to be used in `DescribeConsumerGroupTest`. 
- I also changed `generator` method to allow passing server config to disable auto creation of the topic as topic keep getting recreated without `auto.create.topics.enable` disabled

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
