### PR TITLE
KAFKA-17232: MirrorCheckpointConnector does not generate task configs if initial consumer group load times out.

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -91,9 +91,6 @@ public class MirrorCheckpointConnector extends SourceConnector {
         scheduler = new Scheduler(getClass(), config.entityLabel(), config.adminTimeout());
         scheduler.execute(this::createInternalTopics, "creating internal topics");
         scheduler.execute(this::loadInitialConsumerGroups, "loading initial consumer groups");
-        if (Objects.isNull(knownConsumerGroups)) {
-            log.info("Initial consumer loading has not yet completed");
-        }
         scheduler.scheduleRepeatingDelayed(this::refreshConsumerGroups, config.refreshGroupsInterval(),
                 "refreshing consumer groups");
     }
@@ -138,6 +135,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
         if (Objects.isNull(knownConsumerGroups)) {
             // If knownConsumerGroup is null, it means the initial loading has not finished.
             // An exception should be thrown to trigger the retry behavior in the framework.
+            log.debug("Initial consumer loading has not yet completed");
             throw new RetriableException("Timeout while loading consumer groups.");
         }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 
 import org.junit.jupiter.api.Test;
 
@@ -89,9 +90,11 @@ public class MirrorCheckpointConnectorTest {
     public void testNoConsumerGroup() {
         MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
         MirrorCheckpointConnector connector = new MirrorCheckpointConnector(new HashSet<>(), config);
-        List<Map<String, String>> output = connector.taskConfigs(1);
-        // expect no task will be created
-        assertEquals(0, output.size(), "ConsumerGroup shouldn't exist");
+        assertThrows(
+                RetriableException.class,
+                () -> connector.taskConfigs(1),
+                "taskConfigs should throw exception when loading ConsumerGroup timeout"
+        );
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -90,10 +90,20 @@ public class MirrorCheckpointConnectorTest {
     public void testNoConsumerGroup() {
         MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
         MirrorCheckpointConnector connector = new MirrorCheckpointConnector(new HashSet<>(), config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect no task will be created
+        assertEquals(0, output.size(), "ConsumerGroup shouldn't exist");
+    }
+
+    @Test
+    public void testConsumerGroupInitializeTimeout() {
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
+        MirrorCheckpointConnector connector = new MirrorCheckpointConnector(null, config);
+
         assertThrows(
                 RetriableException.class,
                 () -> connector.taskConfigs(1),
-                "taskConfigs should throw exception when loading ConsumerGroup timeout"
+                "taskConfigs should throw exception when initial loading ConsumerGroup timeout"
         );
     }
 


### PR DESCRIPTION
We should avoid returning an empty config list after the `start()` method and before the consumer groups have been loaded. Returning an empty config list will shut down the tasks, even though they could continue running unaffected. Instead, we should throw an exception from `taskConfigs` to indicate that we are not ready to provide configurations and allow the framework to retry.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
