### PR TITLE
MINOR: Rethrow caught exception instead of wrapping into LoginException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -62,12 +62,14 @@ public class LoginManager {
         this.loginMetadata = loginMetadata;
         this.login = Utils.newInstance(loginMetadata.loginClass);
         loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
-        try (AutoCloseable loginResources = this::closeResources) {
+        try {
             loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
             login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
             login.login();
+        } catch (Exception e) {
+            closeResources();
+            throw e;
         }
-        // caught exception will be rethrown here
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import javax.security.auth.Subject;
+import javax.security.auth.login.LoginException;
 
 import static java.util.Arrays.asList;
 
@@ -58,7 +59,7 @@ public class LoginManager {
     private int refCount;
 
     private LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
-                 LoginMetadata<?> loginMetadata) throws Exception {
+                 LoginMetadata<?> loginMetadata) throws LoginException {
         this.loginMetadata = loginMetadata;
         this.login = Utils.newInstance(loginMetadata.loginClass);
         loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
@@ -97,7 +98,7 @@ public class LoginManager {
      */
     public static LoginManager acquireLoginManager(JaasContext jaasContext, String saslMechanism,
                                                    Class<? extends Login> defaultLoginClass,
-                                                   Map<String, ?> configs) throws Exception {
+                                                   Map<String, ?> configs) throws LoginException {
         Class<? extends Login> loginClass = configuredClassOrDefault(configs, jaasContext,
                 saslMechanism, SaslConfigs.SASL_LOGIN_CLASS, defaultLoginClass);
         Class<? extends AuthenticateCallbackHandler> defaultLoginCallbackHandlerClass = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import javax.security.auth.Subject;
-import javax.security.auth.login.LoginException;
 
 import static java.util.Arrays.asList;
 
@@ -59,7 +58,7 @@ public class LoginManager {
     private int refCount;
 
     private LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
-                 LoginMetadata<?> loginMetadata) throws LoginException {
+                 LoginMetadata<?> loginMetadata) throws Exception {
         this.loginMetadata = loginMetadata;
         this.login = Utils.newInstance(loginMetadata.loginClass);
         loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
@@ -67,9 +66,8 @@ public class LoginManager {
             loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
             login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
             login.login();
-        } catch (Exception e) {
-            throw new LoginException(e.getMessage());
         }
+        // caught exception will be rethrown here
     }
 
     /**
@@ -97,7 +95,7 @@ public class LoginManager {
      */
     public static LoginManager acquireLoginManager(JaasContext jaasContext, String saslMechanism,
                                                    Class<? extends Login> defaultLoginClass,
-                                                   Map<String, ?> configs) throws LoginException {
+                                                   Map<String, ?> configs) throws Exception {
         Class<? extends Login> loginClass = configuredClassOrDefault(configs, jaasContext,
                 saslMechanism, SaslConfigs.SASL_LOGIN_CLASS, defaultLoginClass);
         Class<? extends AuthenticateCallbackHandler> defaultLoginCallbackHandlerClass = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -166,7 +166,7 @@ public class LoginManagerTest {
     }
 
     @Test
-    public void testLoginException() throws Exception {
+    public void testShouldReThrowExceptionOnErrorLoginAttempt() throws Exception {
         Map<String, Object> config = new HashMap<>();
         config.put(SaslConfigs.SASL_JAAS_CONFIG, dynamicPlainContext);
         config.put(SaslConfigs.SASL_LOGIN_CLASS, Login.class);


### PR DESCRIPTION
Instead of wrapping the caught exception into LoginException, we directly rethrow the original exception to ensure compatibility.