### PR TITLE
KAFKA-17146 Include note to remove migration znode

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4108,7 +4108,10 @@ listeners=CONTROLLER://:9093
             </li>
             <li>
               Using <code>zookeeper-shell.sh</code>, run <code>rmr /controller</code> so that one
-              of the brokers can become the new old-style controller.
+              of the brokers can become the new old-style controller. Additionally, run
+              <code>get /migration</code> followed by <code>rmr /migration</code> to clear the
+              migration state from ZooKeeper. This will allow you to re-attempt the migration
+              in the future. The data read from "/migration" can be useful for debugging.
             </li>
             <li>
               On each broker, remove the <code>zookeeper.metadata.migration.enable</code>,


### PR DESCRIPTION
When reverting the ZK migration, we must also remove the /migration ZNode in order to allow the migration to be re-attempted in the future.