### PR TITLE
MINOR: Fix consumer group warmup in MirrorMaker 2 integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -594,8 +595,16 @@ public class EmbeddedKafkaCluster {
     }
 
     public KafkaConsumer<byte[], byte[]> createConsumerAndSubscribeTo(Map<String, Object> consumerProps, String... topics) {
+        return createConsumerAndSubscribeTo(consumerProps, null, topics);
+    }
+
+    public KafkaConsumer<byte[], byte[]> createConsumerAndSubscribeTo(Map<String, Object> consumerProps, ConsumerRebalanceListener rebalanceListener, String... topics) {
         KafkaConsumer<byte[], byte[]> consumer = createConsumer(consumerProps);
-        consumer.subscribe(Arrays.asList(topics));
+        if (rebalanceListener != null) {
+            consumer.subscribe(Arrays.asList(topics), rebalanceListener);
+        } else {
+            consumer.subscribe(Arrays.asList(topics));
+        }
         return consumer;
     }
 


### PR DESCRIPTION
We've been seeing some flaky test failures since we modified the consumer group warmup logic with the exception `java.lang.IllegalStateException: You can only check the position for partitions assigned to this consumer.`

These are caused because, even after `Consumer::poll` has returned, it's possible that the consumer has not yet joined the group or been assigned topic partitions.

These failures occurred on a pull request [here](https://ge.apache.org/s/uxzbygqa2cifm/tests/task/:connect:mirror:test/details/org.apache.kafka.connect.mirror.integration.MirrorConnectorsIntegrationBaseTest/testReplicationWithEmptyPartition()?top-execution=1), and on trunk [here](https://ge.apache.org/s/5lsuaeqmmjrq2/tests/task/:connect:mirror:test/details/org.apache.kafka.connect.mirror.integration.MirrorConnectorsIntegrationSSLTest/testNoCheckpointsIfNoRecordsAreMirrored()?top-execution=1).

To address this, some retry logic is added during consumer warmup to ensure (for real this time!) that the consumer has joined the group and fetched offsets for every applicable topic partition before committing offsets.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
