### PR TITLE
KAFKA-16154: Broker returns offset for LATEST_TIERED_TIMESTAMP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2141,6 +2141,7 @@ project(':tools') {
     testImplementation project(':connect:runtime')
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':storage:storage-api').sourceSets.main.output
+    testImplementation project(':storage').sourceSets.test.output
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -284,6 +284,8 @@
     <allow pkg="org.apache.kafka.storage.internals" />
     <allow pkg="org.apache.kafka.server.config" />
     <allow pkg="org.apache.kafka.server.common" />
+    <allow pkg="org.apache.kafka.server.log.remote.metadata.storage" />
+    <allow pkg="org.apache.kafka.server.log.remote.storage" />
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.clients.admin" />
     <allow pkg="org.apache.kafka.clients.producer" />

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4862,7 +4862,7 @@ public class KafkaAdminClient extends AdminClient {
             return ListOffsetsRequest.MAX_TIMESTAMP;
         } else if (offsetSpec instanceof OffsetSpec.EarliestLocalSpec) {
             return ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP;
-        } else if (offsetSpec instanceof OffsetSpec.LatestTierSpec) {
+        } else if (offsetSpec instanceof OffsetSpec.LatestTieredSpec) {
             return ListOffsetsRequest.LATEST_TIERED_TIMESTAMP;
         }
         return ListOffsetsRequest.LATEST_TIMESTAMP;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4860,6 +4860,10 @@ public class KafkaAdminClient extends AdminClient {
             return ListOffsetsRequest.EARLIEST_TIMESTAMP;
         } else if (offsetSpec instanceof OffsetSpec.MaxTimestampSpec) {
             return ListOffsetsRequest.MAX_TIMESTAMP;
+        } else if (offsetSpec instanceof OffsetSpec.EarliestLocalSpec) {
+            return ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP;
+        } else if (offsetSpec instanceof OffsetSpec.LatestTierSpec) {
+            return ListOffsetsRequest.LATEST_TIERED_TIMESTAMP;
         }
         return ListOffsetsRequest.LATEST_TIMESTAMP;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
@@ -73,18 +73,20 @@ public class OffsetSpec {
     }
 
     /**
-     * Used to retrieve the offset with the local log start offset,
-     * log start offset is the offset of a log above which reads are guaranteed to be served
-     * from the disk of the leader broker, when Tiered Storage is not enabled, it behaves the same
-     * as the earliest timestamp
+     * Used to retrieve the local log start offset.
+     * Local log start offset is the offset of a log above which reads
+     * are guaranteed to be served from the disk of the leader broker.
+     * <br/>
+     * Note: When tiered Storage is not enabled, it behaves the same as retrieving the earliest timestamp offset.
      */
     public static OffsetSpec earliestLocalSpec() {
         return new EarliestLocalSpec();
     }
 
     /**
-     * Used to retrieve the offset with the highest offset of data stored in remote storage,
-     * and when Tiered Storage is not enabled, we won't return any offset (i.e. Unknown offset)
+     * Used to retrieve the highest offset of data stored in remote storage.
+     * <br/>
+     * Note: When tiered storage is not enabled, we will return unknown offset.
      */
     public static OffsetSpec latestTierSpec() {
         return new LatestTierSpec();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
@@ -27,7 +27,7 @@ public class OffsetSpec {
     public static class LatestSpec extends OffsetSpec { }
     public static class MaxTimestampSpec extends OffsetSpec { }
     public static class EarliestLocalSpec extends OffsetSpec { }
-    public static class LatestTierSpec extends OffsetSpec { }
+    public static class LatestTieredSpec extends OffsetSpec { }
     public static class TimestampSpec extends OffsetSpec {
         private final long timestamp;
 
@@ -79,7 +79,7 @@ public class OffsetSpec {
      * <br/>
      * Note: When tiered Storage is not enabled, it behaves the same as retrieving the earliest timestamp offset.
      */
-    public static OffsetSpec earliestLocalSpec() {
+    public static OffsetSpec earliestLocal() {
         return new EarliestLocalSpec();
     }
 
@@ -88,7 +88,7 @@ public class OffsetSpec {
      * <br/>
      * Note: When tiered storage is not enabled, we will return unknown offset.
      */
-    public static OffsetSpec latestTierSpec() {
-        return new LatestTierSpec();
+    public static OffsetSpec latestTiered() {
+        return new LatestTieredSpec();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
@@ -26,6 +26,8 @@ public class OffsetSpec {
     public static class EarliestSpec extends OffsetSpec { }
     public static class LatestSpec extends OffsetSpec { }
     public static class MaxTimestampSpec extends OffsetSpec { }
+    public static class EarliestLocalSpec extends OffsetSpec { }
+    public static class LatestTierSpec extends OffsetSpec { }
     public static class TimestampSpec extends OffsetSpec {
         private final long timestamp;
 
@@ -70,4 +72,21 @@ public class OffsetSpec {
         return new MaxTimestampSpec();
     }
 
+    /**
+     * Used to retrieve the offset with the local log start offset,
+     * log start offset is the offset of a log above which reads are guaranteed to be served
+     * from the disk of the leader broker, when Tiered Storage is not enabled, it behaves the same
+     * as the earliest timestamp
+     */
+    public static OffsetSpec earliestLocalSpec() {
+        return new EarliestLocalSpec();
+    }
+
+    /**
+     * Used to retrieve the offset with the highest offset of data stored in remote storage,
+     * and when Tiered Storage is not enabled, we won't return any offset (i.e. Unknown offset)
+     */
+    public static OffsetSpec latestTierSpec() {
+        return new LatestTierSpec();
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -5864,7 +5864,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(env.cluster(), Errors.NONE));
 
-            env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.earliestLocalSpec()));
+            env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.earliestLocal()));
 
             TestUtils.waitForCondition(() -> env.kafkaClient().requests().stream().anyMatch(request ->
                 request.requestBuilder().apiKey().messageType == ApiMessageType.LIST_OFFSETS && request.requestBuilder().oldestAllowedVersion() == 9
@@ -5892,7 +5892,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(env.cluster(), Errors.NONE));
 
-            env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.latestTierSpec()));
+            env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.latestTiered()));
 
             TestUtils.waitForCondition(() -> env.kafkaClient().requests().stream().anyMatch(request ->
                     request.requestBuilder().apiKey().messageType == ApiMessageType.LIST_OFFSETS && request.requestBuilder().oldestAllowedVersion() == 9

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -132,7 +132,7 @@ public class GetOffsetShell {
                     .ofType(String.class);
             timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: No offset is returned, if the timestamp greater than recently committed record timestamp is given.]")
                     .withRequiredArg()
-                    .describedAs("<timestamp> / -1 or latest / -2 or earliest / -3 or max-timestamp")
+                    .describedAs("<timestamp> / -1 or latest / -2 or earliest / -3 or max-timestamp / -4 or earliest-local / -5 or latest-tiered")
                     .ofType(String.class)
                     .defaultsTo("latest");
             commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client.")
@@ -284,9 +284,9 @@ public class GetOffsetShell {
             case "max-timestamp":
                 return OffsetSpec.maxTimestamp();
             case "earliest-local":
-                return OffsetSpec.earliestLocalSpec();
+                return OffsetSpec.earliestLocal();
             case "latest-tiered":
-                return OffsetSpec.latestTierSpec();
+                return OffsetSpec.latestTiered();
             default:
                 long timestamp;
 
@@ -304,9 +304,9 @@ public class GetOffsetShell {
                 } else if (timestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
                     return OffsetSpec.maxTimestamp();
                 } else if (timestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
-                    return OffsetSpec.earliestLocalSpec();
+                    return OffsetSpec.earliestLocal();
                 } else if (timestamp == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP) {
-                    return OffsetSpec.latestTierSpec();
+                    return OffsetSpec.latestTiered();
                 } else {
                     return OffsetSpec.forTimestamp(timestamp);
                 }

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -283,6 +283,10 @@ public class GetOffsetShell {
                 return OffsetSpec.latest();
             case "max-timestamp":
                 return OffsetSpec.maxTimestamp();
+            case "earliest-local":
+                return OffsetSpec.earliestLocalSpec();
+            case "latest-tiered":
+                return OffsetSpec.latestTierSpec();
             default:
                 long timestamp;
 
@@ -299,6 +303,10 @@ public class GetOffsetShell {
                     return OffsetSpec.latest();
                 } else if (timestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
                     return OffsetSpec.maxTimestamp();
+                } else if (timestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
+                    return OffsetSpec.earliestLocalSpec();
+                } else if (timestamp == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP) {
+                    return OffsetSpec.latestTierSpec();
                 } else {
                     return OffsetSpec.forTimestamp(timestamp);
                 }

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -275,7 +275,8 @@ public class GetOffsetShell {
         }
     }
 
-    private OffsetSpec parseOffsetSpec(String listOffsetsTimestamp) throws TerseException {
+    // visible for tseting
+    static OffsetSpec parseOffsetSpec(String listOffsetsTimestamp) throws TerseException {
         switch (listOffsetsTimestamp) {
             case "earliest":
                 return OffsetSpec.earliest();
@@ -294,7 +295,7 @@ public class GetOffsetShell {
                     timestamp = Long.parseLong(listOffsetsTimestamp);
                 } catch (NumberFormatException e) {
                     throw new TerseException("Malformed time argument " + listOffsetsTimestamp + ". " +
-                            "Please use -1 or latest / -2 or earliest / -3 or max-timestamp, or a specified long format timestamp");
+                            "Please use -1 or latest / -2 or earliest / -3 or max-timestamp / -4 or earliest-local / -5 or latest-tiered, or a specified long format timestamp");
                 }
 
                 if (timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP) {

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellParsingTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellParsingTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.server.util.TopicPartitionFilter;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -241,6 +242,13 @@ public class GetOffsetShellParsingTest {
     @Test
     public void testInvalidTimeValue() {
         assertThrows(TerseException.class, () -> GetOffsetShell.execute("--bootstrap-server", "localhost:9092", "--time", "invalid"));
+    }
+
+    @Test
+    public void testInvalidOffset() {
+        assertEquals("Malformed time argument foo. " +
+                        "Please use -1 or latest / -2 or earliest / -3 or max-timestamp / -4 or earliest-local / -5 or latest-tiered, or a specified long format timestamp",
+                assertThrows(TerseException.class, () -> GetOffsetShell.parseOffsetSpec("foo")).getMessage());
     }
 
     private TopicPartition getTopicPartition(String topic, Integer partition) {

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -148,8 +148,9 @@ public class GetOffsetShellTest {
                 ClusterConfig.defaultBuilder()
                         .setTypes(Collections.singleton(ZK))
                         .setServerProperties(serverProperties)
-                        // align listener name since in KafkaClusterTestKit the default broker listener name is EXTERNAL
-                        // while ZK is PLAINTEXT
+                        // we set REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP to EXTERNAL, so we need to
+                        // align listener name here as KafkaClusterTestKit (RAFT/CO_RAFT) the default
+                        // broker listener name is EXTERNAL while in ZK it is PLAINTEXT
                         .setListenerName("EXTERNAL")
                         .build(),
                 ClusterConfig.defaultBuilder()

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -136,10 +136,10 @@ public class GetOffsetShellTest {
     private static List<ClusterConfig> withRemoteStorage() {
         Map<String, String> serverProperties = new HashMap<>();
         serverProperties.put(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX + TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, "1");
+        serverProperties.put(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX + TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, "1");
         serverProperties.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true");
         serverProperties.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, LocalTieredStorage.class.getName());
         serverProperties.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_PROP, "1000");
-        serverProperties.put(TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, "1");
         serverProperties.put(ServerLogConfigs.LOG_CLEANUP_INTERVAL_MS_CONFIG, "1000");
         serverProperties.put(ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_CONFIG, "100");
         serverProperties.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP, "EXTERNAL");

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -149,7 +149,7 @@ public class GetOffsetShellTest {
                         .setTypes(Collections.singleton(ZK))
                         .setServerProperties(serverProperties)
                         // we set REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP to EXTERNAL, so we need to
-                        // align listener name here as KafkaClusterTestKit (RAFT/CO_RAFT) the default
+                        // align listener name here as KafkaClusterTestKit (KRAFT/CO_KRAFT) the default
                         // broker listener name is EXTERNAL while in ZK it is PLAINTEXT
                         .setListenerName("EXTERNAL")
                         .build(),

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -514,7 +514,7 @@ public class GetOffsetShellTest {
 
     private List<Row> executeAndParse(String... args) {
         String out = ToolsTestUtils.captureStandardOut(() -> GetOffsetShell.mainNoExit(addBootstrapServer(args)));
-        System.out.println(out);
+
         return Arrays.stream(out.split(System.lineSeparator()))
                 .map(i -> i.split(":"))
                 .filter(i -> i.length >= 2)


### PR DESCRIPTION
This pr support EarliestLocalSpec LatestTierSpec in GetOffsetShell, and add integration tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
