### PR TITLE
MINOR: Increase test producer max.block.ms in MirrorConnectorsIntegrationTransactionsTest

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit
 
 /**
  * Integration test for MirrorMaker2 in which source records are emitted with a transactional producer,
@@ -49,6 +50,12 @@ public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnector
         Map<String, Object> producerProps = new HashMap<>();
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "embedded-kafka-0");
+        // This may be the first transactional producer for the Kafka cluster, in which case
+        // Producer::initTransactions may take a while (especially on CI)
+        // To be tolerant of long initialization for the transaction log, selecting a
+        // transaction coordinator, etc., we configure our producer to wait a little longer
+        // than the default before timing out in that method
+        producerProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, TimeUnit.MINUTES.toMillis(5));
         KafkaProducer<byte[], byte[]> producer = cluster.kafka().createProducer(producerProps);
         producer.initTransactions();
         return producer;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit;
 
 /**
  * Integration test for MirrorMaker2 in which source records are emitted with a transactional producer,


### PR DESCRIPTION
We've been seeing some flaky failures lately for the `MirrorConnectorsIntegrationTransactionsTest` with this stack trace:

```
org.apache.kafka.common.errors.TimeoutException: Timeout expired after 60000ms while awaiting InitProducerId
```

(We don't get any other stack frames because the Kafka `TimeoutException` class [doesn't provide them](https://github.com/apache/kafka/blob/5afdb17092f99d956bf65fcb543de0b15c04e01f/clients/src/main/java/org/apache/kafka/common/errors/ApiException.java#L45-L49)).

One example of this failure can be found [here](https://ge.apache.org/s/52il7msnknzp2/tests/task/:connect:mirror:test/details/org.apache.kafka.connect.mirror.integration.MirrorConnectorsIntegrationTransactionsTest/testReplicationWithoutOffsetSyncWillNotCreateOffsetSyncsTopic()?top-execution=1).

After examining the logs for one of these failures, it looks like this is either due to a broker bug, or slow CI. During a successful run of the test, it took 23 seconds for `Producer::initTransactions` to complete. It's not inconceivable that when CI load is high, it may take higher than a minute for that same method to complete, which would explain the failures we've been seeing.

In order to be resilient against slow CI, or at least rule that out as a root cause, we can bump the producer's `max.block.ms` from its default of 1 minute to a higher timeout of 5 minutes, which should give it plenty of time to complete `initTransactions`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
