### PR TITLE
KAFKA-17252: Always track last-read session key from config topic in Kafka Connect, even during startup

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -578,12 +578,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         SecretKey key;
         long expiration;
         synchronized (this) {
-            // This happens on startup; the snapshot contains the session key,
-            // but no callback in the config update listener has been fired for it yet.
-            if (sessionKey == null && configState.sessionKey() != null) {
-                sessionKey = configState.sessionKey().key();
-                keyExpiration = configState.sessionKey().creationTimestamp() + keyRotationIntervalMs;
-            }
             key = sessionKey;
             expiration = keyExpiration;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
@@ -164,7 +164,9 @@ public interface ConfigBackingStore {
         void onConnectorTargetStateChange(String connector);
 
         /**
-         * Invoked when the leader has distributed a new session key
+         * Invoked whenever a (possibly-stale) session key is read
+         * <p>
+         * <strong>Note:</strong> this method, unlike others, is invoked even during store startup.
          * @param sessionKey the {@link SessionKey session key}
          */
         void onSessionKeyUpdate(SessionKey sessionKey);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -1231,8 +1231,8 @@ public class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore impleme
                 (long) creationTimestamp
         );
 
-        if (started)
-            updateListener.onSessionKeyUpdate(KafkaConfigBackingStore.this.sessionKey);
+        // we notify the listener of all session key updates, even if we haven't completed startup
+        updateListener.onSessionKeyUpdate(KafkaConfigBackingStore.this.sessionKey);
     }
 
     private void processLoggerLevelRecord(String namespace, SchemaAndValue value) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3026,6 +3026,8 @@ public class DistributedHerderTest {
 
         startBackgroundHerder();
 
+        configUpdateListener.onSessionKeyUpdate(configState.sessionKey());
+
         FutureCallback<Void> fencing = new FutureCallback<>();
         herder.fenceZombieSourceTasks(CONN1, fencing);
 
@@ -3087,6 +3089,7 @@ public class DistributedHerderTest {
         expectHerderShutdown();
 
         startBackgroundHerder();
+        configUpdateListener.onSessionKeyUpdate(sessionKey);
 
         FutureCallback<Void> fencing = new FutureCallback<>();
         herder.fenceZombieSourceTasks(CONN1, fencing);
@@ -3129,6 +3132,7 @@ public class DistributedHerderTest {
         expectHerderShutdown();
 
         startBackgroundHerder();
+        configUpdateListener.onSessionKeyUpdate(sessionKey);
 
         FutureCallback<Void> fencing = new FutureCallback<>();
         herder.fenceZombieSourceTasks(CONN1, fencing);
@@ -3187,6 +3191,7 @@ public class DistributedHerderTest {
         expectHerderShutdown();
 
         startBackgroundHerder();
+        configUpdateListener.onSessionKeyUpdate(sessionKey);
 
         FutureCallback<Void> fencing = new FutureCallback<>();
         herder.fenceZombieSourceTasks(CONN1, fencing);
@@ -3285,6 +3290,7 @@ public class DistributedHerderTest {
         expectHerderShutdown();
 
         startBackgroundHerder();
+        configUpdateListener.onSessionKeyUpdate(sessionKey);
 
         List<FutureCallback<Void>> stackedFencingRequests = new ArrayList<>();
         tasksPerConnector.forEach((connector, numStackedRequests) -> {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-17252)

With the current session key tracking logic on trunk, there's a small chance that a herder may not updated its [sessionKey field](https://github.com/apache/kafka/blob/8438c4339e0a103d95575336a9f3653698cd0b8e/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java#L219) to contain a session key, even if a key is present in the topic and has been read by the `KafkaConfigBackingStore`'s work thread.

This is because the backing store does not notify its listener of new records consumed from the config topic while it is starting up, which for most record types (connector configs, target states, restart requests, etc.) is perfectly valid. However, for session keys, it's fine to notify the herder, since the only thing that it does is [update a few fields](https://github.com/apache/kafka/blob/8438c4339e0a103d95575336a9f3653698cd0b8e/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java#L2508-L2522).

This should hopefully address some flaky test failures we've seen for the `DedicatedMirrorIntegrationTest::testMultiNodeCluster` case, like the one [here](https://ge.apache.org/starting/s/52il7msnknzp2/tests/task/:connect:mirror:test/details/org.apache.kafka.connect.mirror.integration.DedicatedMirrorIntegrationTest/testMultiNodeCluster()?top-execution=1).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
