### PR TITLE
KAFKA-17228: Static member using new protocol should always replace the one using the old protocol

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2232,9 +2232,9 @@ public class GroupMetadataManager {
                     group.groupId(), memberId, instanceId, useClassicProtocol ? "classic" : "consumer");
                 return newMember;
             } else {
-                if (!useClassicProtocol) {
-                    // Static member rejoins with a different member id so it should replace
-                    // the previous instance iff the previous member had sent a leave group.
+                if (!useClassicProtocol && !existingStaticMemberOrNull.useClassicProtocol()) {
+                    // If both the rejoining static member and the existing static member use the consumer
+                    // protocol, replace the previous instance iff the previous member had sent a leave group.
                     throwIfInstanceIdIsUnreleased(existingStaticMemberOrNull, group.groupId(), memberId, instanceId);
                 }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -97,7 +97,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,6 +129,8 @@ import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGro
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupJoinKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupRebalanceTimeoutKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.groupSessionTimeoutKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_CLIENT_ADDRESS;
+import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_CLIENT_ID;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupMember.EMPTY_ASSIGNMENT;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
 import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
@@ -355,8 +356,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(100)
             .setPreviousMemberEpoch(99)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2, 3)))
@@ -482,8 +483,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(1)
             .setPreviousMemberEpoch(0)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -534,8 +535,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -581,8 +582,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -636,8 +637,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -649,8 +650,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -710,8 +711,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.UNRELEASED_PARTITIONS)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(0)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -777,8 +778,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -789,8 +790,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     // Use zar only here to ensure that metadata needs to be recomputed.
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
                     .setServerAssignorName("range")
@@ -870,8 +871,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -883,8 +884,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId2)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     // Use zar only here to ensure that metadata needs to be recomputed.
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
                     .setServerAssignorName("range")
@@ -946,8 +947,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.UNRELEASED_PARTITIONS)
             .setInstanceId(memberId3)
             .setPreviousMemberEpoch(0)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -1003,8 +1004,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -1017,8 +1018,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -1112,8 +1113,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(0)
             .setPreviousMemberEpoch(0)
             .setInstanceId(memberId2)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -1127,8 +1128,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(0)
             .setInstanceId(memberId2)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -1180,8 +1181,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Collections.singletonList("foo"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -1193,8 +1194,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Collections.singletonList("foo"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -1296,8 +1297,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(0)
             .setPreviousMemberEpoch(0)
             .setInstanceId("instance-id-2")
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Collections.singletonList("foo"))
             .setServerAssignorName("range")
@@ -1310,8 +1311,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(0)
             .setInstanceId("instance-id-2")
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -1374,8 +1375,8 @@ public class GroupMetadataManagerTest {
             .setInstanceId(memberId1)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -1387,8 +1388,8 @@ public class GroupMetadataManagerTest {
             .setInstanceId(memberId2)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             // Use zar only here to ensure that metadata needs to be recomputed.
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
@@ -1476,8 +1477,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1489,8 +1490,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId2)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     // Use zar only here to ensure that metadata needs to be recomputed.
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
                     .setServerAssignorName("range")
@@ -1567,8 +1568,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1616,8 +1617,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1664,8 +1665,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1705,8 +1706,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(100)
             .setPreviousMemberEpoch(99)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2, 3)))
@@ -1797,8 +1798,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1843,8 +1844,8 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -1989,8 +1990,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2002,8 +2003,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2424,8 +2425,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2437,8 +2438,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2576,8 +2577,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2634,8 +2635,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -2687,8 +2688,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setRebalanceTimeoutMs(5000)
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
@@ -2763,8 +2764,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setAssignedPartitions(mkAssignment(
@@ -3531,8 +3532,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.UNREVOKED_PARTITIONS)
                     .setMemberEpoch(9)
                     .setPreviousMemberEpoch(9)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
@@ -3544,8 +3545,8 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setServerAssignorName("range")
                     .build())
@@ -9648,8 +9649,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(1)
             .setPreviousMemberEpoch(0)
             .setRebalanceTimeoutMs(5000)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName(NoOpPartitionAssignor.NAME)
             .setAssignedPartitions(Collections.emptyMap())
@@ -9750,21 +9751,17 @@ public class GroupMetadataManagerTest {
             ))))
         );
 
-        Map<String, byte[]> assignments = new HashMap<String, byte[]>() {
-            {
-                put(
-                    memberId1,
-                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
-                        new TopicPartition(fooTopicName, 0),
-                        new TopicPartition(barTopicName, 0)
-                    ))))
-                );
-            }
-        };
+        Map<String, byte[]> assignments = Collections.singletonMap(
+            memberId1,
+            Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
+                new TopicPartition(fooTopicName, 0),
+                new TopicPartition(barTopicName, 0)
+            ))))
+        );
 
         // Create a stable classic group with member 1.
         ClassicGroup group = context.createClassicGroup(groupId);
-        group.setProtocolName(Optional.ofNullable("range"));
+        group.setProtocolName(Optional.of("range"));
         group.add(
             new ClassicGroupMember(
                 memberId1,
@@ -9818,8 +9815,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(1)
             .setPreviousMemberEpoch(0)
             .setState(MemberState.UNRELEASED_PARTITIONS)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setServerAssignorName("range")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(5000)
@@ -9843,16 +9840,8 @@ public class GroupMetadataManagerTest {
             // The subscription metadata hasn't been updated during the conversion, so a new one is computed.
             CoordinatorRecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
                 {
-                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 1, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                        }
-                    }));
-                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                        }
-                    }));
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 1, mkMapOfPartitionRacks(1)));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, mkMapOfPartitionRacks(1)));
                 }
             }),
 
@@ -9935,9 +9924,7 @@ public class GroupMetadataManagerTest {
             .setMetadata(Utils.toArray(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
                 Arrays.asList(fooTopicName, barTopicName),
                 null,
-                Arrays.asList(
-                    new TopicPartition(barTopicName, 0)
-                )
+                Collections.singletonList(new TopicPartition(barTopicName, 0))
             ))))
         );
 
@@ -9952,7 +9939,7 @@ public class GroupMetadataManagerTest {
                 );
                 put(
                     memberId2,
-                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
+                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Collections.singletonList(
                         new TopicPartition(barTopicName, 0)
                     ))))
                 );
@@ -9961,7 +9948,7 @@ public class GroupMetadataManagerTest {
 
         // Construct a stable group with two members.
         ClassicGroup group = context.createClassicGroup(groupId);
-        group.setProtocolName(Optional.ofNullable("range"));
+        group.setProtocolName(Optional.of("range"));
         group.add(
             new ClassicGroupMember(
                 memberId1,
@@ -10055,8 +10042,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(1)
             .setPreviousMemberEpoch(0)
             .setState(MemberState.UNRELEASED_PARTITIONS)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setServerAssignorName("range")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(5000)
@@ -10086,17 +10073,8 @@ public class GroupMetadataManagerTest {
             // The subscription metadata hasn't been updated during the conversion, so a new one is computed.
             CoordinatorRecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
                 {
-                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 2, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                            put(1, new HashSet<>(Arrays.asList("rack1", "rack2")));
-                        }
-                    }));
-                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                        }
-                    }));
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 2, mkMapOfPartitionRacks(2)));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, mkMapOfPartitionRacks(1)));
                 }
             }),
 
@@ -10152,26 +10130,22 @@ public class GroupMetadataManagerTest {
             ))))
         );
 
-        Map<String, byte[]> assignments = new HashMap<String, byte[]>() {
-            {
-                put(
-                    memberId,
-                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(
-                        Collections.singletonList(new TopicPartition(fooTopicName, 0))
-                    )))
-                );
-            }
-        };
+        Map<String, byte[]> assignments = Collections.singletonMap(
+            memberId,
+            Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(
+                Collections.singletonList(new TopicPartition(fooTopicName, 0))
+            )))
+        );
 
         // Create a stable classic group with a static member.
         ClassicGroup group = context.createClassicGroup(groupId);
-        group.setProtocolName(Optional.ofNullable(NoOpPartitionAssignor.NAME));
+        group.setProtocolName(Optional.of(NoOpPartitionAssignor.NAME));
         group.add(
             new ClassicGroupMember(
                 memberId,
-                Optional.ofNullable(instanceId),
-                "client",
-                "localhost/127.0.0.1",
+                Optional.of(instanceId),
+                DEFAULT_CLIENT_ID,
+                DEFAULT_CLIENT_ADDRESS.toString(),
                 10000,
                 5000,
                 "consumer",
@@ -10186,7 +10160,6 @@ public class GroupMetadataManagerTest {
 
         context.replay(CoordinatorRecordHelpers.newGroupMetadataRecord(group, assignments, metadataImage.features().metadataVersion()));
         context.commit();
-        group = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
 
         // The static member rejoins with new protocol, triggering the upgrade.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
@@ -10202,8 +10175,8 @@ public class GroupMetadataManagerTest {
             .setInstanceId(instanceId)
             .setMemberEpoch(0)
             .setPreviousMemberEpoch(0)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Collections.singletonList(fooTopicName))
             .setRebalanceTimeoutMs(10000)
             .setClassicMemberMetadata(
@@ -10263,11 +10236,7 @@ public class GroupMetadataManagerTest {
             // The subscription metadata hasn't been updated during the conversion, so a new one is computed.
             CoordinatorRecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
                 {
-                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 1, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                        }
-                    }));
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 1, mkMapOfPartitionRacks(1)));
                 }
             }),
 
@@ -10283,10 +10252,153 @@ public class GroupMetadataManagerTest {
 
         assertRecordsEquals(expectedRecords, result.records());
         context.assertSessionTimeout(groupId, newMemberId, 45000);
+    }
 
-        // Simulate a failed replay. The context is rolled back and the group is converted back to the classic group.
-        context.rollback();
-        assertEquals(group, context.groupMetadataManager.getOrMaybeCreateClassicGroup("group-id", false));
+    @Test
+    public void testConsumerGroupHeartbeatFromExistingClassicStaticMember() {
+        String groupId = "group-id";
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String instanceId1 = "instance-id-1";
+        String instanceId2 = "instance-id-2";
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        List<ConsumerGroupMemberMetadataValue.ClassicProtocol> protocols = Collections.singletonList(
+            new ConsumerGroupMemberMetadataValue.ClassicProtocol()
+                .setName("range")
+                .setMetadata(Utils.toArray(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                    Arrays.asList(fooTopicName, barTopicName),
+                    null,
+                    Arrays.asList(
+                        new TopicPartition(fooTopicName, 0),
+                        new TopicPartition(fooTopicName, 1),
+                        new TopicPartition(fooTopicName, 2),
+                        new TopicPartition(barTopicName, 0),
+                        new TopicPartition(barTopicName, 1)
+                    )
+                ))))
+        );
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder(memberId1)
+            .setInstanceId(instanceId1)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName(NoOpPartitionAssignor.NAME)
+            .setRebalanceTimeoutMs(45000)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(protocols)
+            )
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2),
+                mkTopicAssignment(barTopicId, 0, 1)))
+            .build();
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
+            .setInstanceId(instanceId2)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName(NoOpPartitionAssignor.NAME)
+            .setRebalanceTimeoutMs(45000)
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 2)))
+            .build();
+
+        // Consumer group with two static members.
+        // Member 1 uses the classic protocol and member 2 uses the consumer protocol.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConsumerGroupMigrationPolicy(ConsumerGroupMigrationPolicy.UPGRADE)
+            .withConsumerGroupAssignors(Collections.singletonList(new NoOpPartitionAssignor()))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member1)
+                .withMember(member2)
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        context.replay(CoordinatorRecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
+            {
+                put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
+                put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
+            }
+        }));
+
+        context.commit();
+
+        // The member 1 with the classic protocol upgrades, heartbeating with new protocol.
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setInstanceId(instanceId1)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor(NoOpPartitionAssignor.NAME)
+                .setSubscribedTopicNames(new ArrayList<>(member1.subscribedTopicNames()))
+                .setTopicPartitions(Collections.emptyList()));
+
+        String newMemberId1 = result.response().memberId();
+        ConsumerGroupMember expectedReplacingConsumerMember = new ConsumerGroupMember.Builder(newMemberId1)
+            .setInstanceId(instanceId1)
+            .setMemberEpoch(0)
+            .setPreviousMemberEpoch(0)
+            .setState(MemberState.STABLE)
+            .setClientId(member1.clientId())
+            .setClientHost(member1.clientHost())
+            .setServerAssignorName(NoOpPartitionAssignor.NAME)
+            .setSubscribedTopicNames(new ArrayList<>(member1.subscribedTopicNames()))
+            .setRebalanceTimeoutMs(member1.rebalanceTimeoutMs())
+            .setAssignedPartitions(member1.assignedPartitions())
+            .setClassicMemberMetadata(member1.classicMemberMetadata().get())
+            .build();
+
+        ConsumerGroupMember expectedFinalConsumerMember = new ConsumerGroupMember.Builder(expectedReplacingConsumerMember)
+            .setMemberEpoch(10)
+            .setRebalanceTimeoutMs(5000)
+            .setClassicMemberMetadata(null)
+            .build();
+
+        List<CoordinatorRecord> expectedRecords = Arrays.asList(
+            // Remove the existing static member 1 because the rejoining member replaces it.
+            CoordinatorRecordHelpers.newCurrentAssignmentTombstoneRecord(groupId, memberId1),
+            CoordinatorRecordHelpers.newTargetAssignmentTombstoneRecord(groupId, memberId1),
+            CoordinatorRecordHelpers.newMemberSubscriptionTombstoneRecord(groupId, memberId1),
+
+            // Create the new static member 1.
+            CoordinatorRecordHelpers.newMemberSubscriptionRecord(groupId, expectedReplacingConsumerMember),
+            CoordinatorRecordHelpers.newTargetAssignmentRecord(groupId, newMemberId1, member1.assignedPartitions()),
+            CoordinatorRecordHelpers.newCurrentAssignmentRecord(groupId, expectedReplacingConsumerMember),
+
+            // The static member rejoins the new consumer group.
+            CoordinatorRecordHelpers.newMemberSubscriptionRecord(groupId, expectedFinalConsumerMember),
+
+            // The newly created static member 1 takes the assignment from the existing member 1.
+            // Bump its member epoch and transition to STABLE.
+            CoordinatorRecordHelpers.newCurrentAssignmentRecord(groupId, expectedFinalConsumerMember)
+        );
+
+        assertRecordsEquals(expectedRecords, result.records());
+        context.assertSessionTimeout(groupId, newMemberId1, 45000);
     }
 
     @Test
@@ -10348,9 +10460,7 @@ public class GroupMetadataManagerTest {
             .setMetadata(Utils.toArray(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
                 Arrays.asList(fooTopicName, barTopicName),
                 null,
-                Arrays.asList(
-                    new TopicPartition(barTopicName, 0)
-                )
+                Collections.singletonList(new TopicPartition(barTopicName, 0))
             ))))
         );
 
@@ -10365,7 +10475,7 @@ public class GroupMetadataManagerTest {
                 );
                 put(
                     memberId2,
-                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
+                    Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Collections.singletonList(
                         new TopicPartition(barTopicName, 0)
                     ))))
                 );
@@ -10374,7 +10484,7 @@ public class GroupMetadataManagerTest {
 
         // Construct a stable group with two members.
         ClassicGroup group = context.createClassicGroup(groupId);
-        group.setProtocolName(Optional.ofNullable("range"));
+        group.setProtocolName(Optional.of("range"));
         group.add(
             new ClassicGroupMember(
                 memberId1,
@@ -10486,8 +10596,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(2)
             .setPreviousMemberEpoch(0)
             .setState(MemberState.UNRELEASED_PARTITIONS)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setServerAssignorName("range")
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(5000)
@@ -10517,17 +10627,8 @@ public class GroupMetadataManagerTest {
             // The subscription metadata hasn't been updated during the conversion, so a new one is computed.
             CoordinatorRecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
                 {
-                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 2, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                            put(1, new HashSet<>(Arrays.asList("rack1", "rack2")));
-                        }
-                    }));
-                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, new HashMap<Integer, Set<String>>() {
-                        {
-                            put(0, new HashSet<>(Arrays.asList("rack0", "rack1")));
-                        }
-                    }));
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 2, mkMapOfPartitionRacks(2)));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 1, mkMapOfPartitionRacks(1)));
                 }
             }),
 
@@ -10688,8 +10789,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -10706,8 +10807,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -10766,11 +10867,7 @@ public class GroupMetadataManagerTest {
             new TopicPartition(barTopicName, 0),
             new TopicPartition(barTopicName, 1)
         ))));
-        Map<String, byte[]> assignments = new HashMap<String, byte[]>() {
-            {
-                put(memberId1, assignment);
-            }
-        };
+        Map<String, byte[]> assignments = Collections.singletonMap(memberId1, assignment);
 
         ClassicGroup expectedClassicGroup = new ClassicGroup(
             new LogContext(),
@@ -10779,9 +10876,9 @@ public class GroupMetadataManagerTest {
             context.time,
             context.metrics,
             10,
-            Optional.ofNullable(ConsumerProtocol.PROTOCOL_TYPE),
-            Optional.ofNullable("range"),
-            Optional.ofNullable(memberId1),
+            Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
+            Optional.of("range"),
+            Optional.of(memberId1),
             Optional.of(context.time.milliseconds())
         );
         expectedClassicGroup.add(
@@ -10880,8 +10977,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -10898,8 +10995,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -10963,11 +11060,7 @@ public class GroupMetadataManagerTest {
             new TopicPartition(barTopicName, 0),
             new TopicPartition(barTopicName, 1)
         ))));
-        Map<String, byte[]> assignments = new HashMap<String, byte[]>() {
-            {
-                put(memberId1, assignment);
-            }
-        };
+        Map<String, byte[]> assignments = Collections.singletonMap(memberId1, assignment);
 
         ClassicGroup expectedClassicGroup = new ClassicGroup(
             new LogContext(),
@@ -10976,9 +11069,9 @@ public class GroupMetadataManagerTest {
             context.time,
             context.metrics,
             10,
-            Optional.ofNullable(ConsumerProtocol.PROTOCOL_TYPE),
-            Optional.ofNullable("range"),
-            Optional.ofNullable(memberId1),
+            Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
+            Optional.of("range"),
+            Optional.of(memberId1),
             Optional.of(context.time.milliseconds())
         );
         expectedClassicGroup.add(
@@ -11070,8 +11163,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(30000)
@@ -11088,8 +11181,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(30000)
@@ -11179,11 +11272,7 @@ public class GroupMetadataManagerTest {
             new TopicPartition(barTopicName, 0),
             new TopicPartition(barTopicName, 1)
         ))));
-        Map<String, byte[]> assignments = new HashMap<String, byte[]>() {
-            {
-                put(memberId1, assignment);
-            }
-        };
+        Map<String, byte[]> assignments = Collections.singletonMap(memberId1, assignment);
 
         ClassicGroup expectedClassicGroup = new ClassicGroup(
             new LogContext(),
@@ -11192,9 +11281,9 @@ public class GroupMetadataManagerTest {
             context.time,
             context.metrics,
             11,
-            Optional.ofNullable(ConsumerProtocol.PROTOCOL_TYPE),
-            Optional.ofNullable("range"),
-            Optional.ofNullable(memberId1),
+            Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
+            Optional.of("range"),
+            Optional.of(memberId1),
             Optional.of(context.time.milliseconds())
         );
         expectedClassicGroup.add(
@@ -11404,8 +11493,8 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(0)
                 .setState(MemberState.STABLE)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
+                .setClientId(DEFAULT_CLIENT_ID)
+                .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                 .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                 .setRebalanceTimeoutMs(500)
                 .setAssignedPartitions(assignor.targetPartitions(newMemberId))
@@ -11575,8 +11664,8 @@ public class GroupMetadataManagerTest {
             .setPreviousMemberEpoch(0)
             .setInstanceId(instanceId)
             .setState(MemberState.STABLE)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
             .setRebalanceTimeoutMs(500)
             .setClassicMemberMetadata(
@@ -11689,8 +11778,8 @@ public class GroupMetadataManagerTest {
             .setPreviousMemberEpoch(0)
             .setInstanceId(instanceId)
             .setState(MemberState.STABLE)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Collections.singletonList(fooTopicName))
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1)))
@@ -11767,8 +11856,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
@@ -11789,8 +11878,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 1)))
@@ -11835,8 +11924,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
             .setRebalanceTimeoutMs(500)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setState(MemberState.STABLE)
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName, zarTopicName))
             .setAssignedPartitions(mkAssignment(
@@ -11995,8 +12084,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
@@ -12017,8 +12106,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 1)))
@@ -12065,8 +12154,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
             .setRebalanceTimeoutMs(500)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setState(MemberState.UNRELEASED_PARTITIONS)
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName, zarTopicName))
             .setAssignedPartitions(mkAssignment(
@@ -12237,8 +12326,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
@@ -12259,8 +12348,8 @@ public class GroupMetadataManagerTest {
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
                     .setRebalanceTimeoutMs(500)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
+                    .setClientId(DEFAULT_CLIENT_ID)
+                    .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
                     .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName))
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 1)))
@@ -12306,8 +12395,8 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(10)
             .setRebalanceTimeoutMs(500)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setState(MemberState.UNREVOKED_PARTITIONS)
             .setSubscribedTopicNames(Arrays.asList(fooTopicName, barTopicName, zarTopicName))
             .setAssignedPartitions(mkAssignment(
@@ -13263,8 +13352,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -13280,8 +13369,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(9)
             .setPreviousMemberEpoch(8)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -13297,8 +13386,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -13457,8 +13546,8 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
@@ -13473,9 +13562,9 @@ public class GroupMetadataManagerTest {
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
-            .setSubscribedTopicNames(Arrays.asList("foo"))
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(Collections.singletonList("foo"))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(barTopicId, 0)))
@@ -13840,8 +13929,8 @@ public class GroupMetadataManagerTest {
         );
 
         ShareGroupMember expectedMember = new ShareGroupMember.Builder(memberId)
-            .setClientId("client")
-            .setClientHost("localhost/127.0.0.1")
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .build();
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -117,6 +117,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class GroupMetadataManagerTestContext {
+    static final String DEFAULT_CLIENT_ID = "client";
+    static final InetAddress DEFAULT_CLIENT_ADDRESS = InetAddress.getLoopbackAddress();
 
     public static void assertNoOrEmptyResult(List<MockCoordinatorTimer.ExpiredTimeout<Void, CoordinatorRecord>> timeouts) {
         assertTrue(timeouts.size() <= 1);
@@ -578,11 +580,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.CONSUMER_GROUP_HEARTBEAT,
                 ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion(),
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -608,11 +610,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.SHARE_GROUP_HEARTBEAT,
                 ApiKeys.SHARE_GROUP_HEARTBEAT.latestVersion(),
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -760,11 +762,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.JOIN_GROUP,
                 joinGroupVersion,
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -910,11 +912,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.SYNC_GROUP,
                 ApiKeys.SYNC_GROUP.latestVersion(),
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -1202,11 +1204,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.HEARTBEAT,
                 ApiKeys.HEARTBEAT.latestVersion(),
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -1324,11 +1326,11 @@ public class GroupMetadataManagerTestContext {
             new RequestHeader(
                 ApiKeys.LEAVE_GROUP,
                 ApiKeys.LEAVE_GROUP.latestVersion(),
-                "client",
+                DEFAULT_CLIENT_ID,
                 0
             ),
             "1",
-            InetAddress.getLoopbackAddress(),
+            DEFAULT_CLIENT_ADDRESS,
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,


### PR DESCRIPTION
This patch enables the static member using the old protocol to be replaced in ConsumerGroupHeartbeat even if it hasn't sent a request to leave the group.

This helps in cases where existing static member rejoins and triggers a group upgrade, because the classic static consumer doesn't send leave group request before shutting down.

JIRA: https://issues.apache.org/jira/browse/KAFKA-17228

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
