### PR TITLE
add custom produce request parsers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceRequestParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceRequestParser.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.message.ProduceRequestData;
+
+public class DefaultProduceRequestParser implements ProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version) {
+        return new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -18,11 +18,11 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.UnsupportedCompressionTypeException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.CompressionType;
@@ -39,7 +39,42 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.requests.ProduceResponse.INVALID_OFFSET;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ProduceRequest extends AbstractRequest {
+    public static final Logger log = LoggerFactory.getLogger(ProduceRequest.class);
+
+    public static final String PRODUCE_REQUEST_PARSER_PROPERTY = "org.apache.kafka.common.requests.ProduceRequestParser";
+    public static final String PRODUCE_REQUEST_PARSER_ENV = "KAFKA_PRODUCE_REQUEST_PARSER";
+    public static final String PRODUCE_REQUEST_PARSER_DEFAULT = "org.apache.kafka.common.requests.DefaultProduceRequestParser";
+
+    private static ProduceRequestParser produceRequestParser = null;
+    static {
+        String produceRequestParserClassName = null;
+        try {
+            produceRequestParserClassName = System.getProperty(PRODUCE_REQUEST_PARSER_PROPERTY);
+
+            if (null != produceRequestParserClassName) {
+                log.debug("ProduceRequestParser class {} from system property {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_PROPERTY);
+            } else {
+                produceRequestParserClassName = System.getenv(PRODUCE_REQUEST_PARSER_ENV);
+            }
+
+            if (null != produceRequestParserClassName) {
+                log.debug("ProduceRequestParser class {} from env {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_ENV);
+            } else {
+                produceRequestParserClassName = PRODUCE_REQUEST_PARSER_DEFAULT;
+                log.debug("ProduceRequestParser class {} default {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_DEFAULT);
+            }
+
+            produceRequestParser = (ProduceRequestParser) Class.forName(produceRequestParserClassName).getConstructor().newInstance();
+        } catch (Exception e) {
+            String message = "Failed to initialize " + produceRequestParserClassName;
+            log.error(message, e);
+            throw new InvalidConfigurationException(message, e);
+        }
+    };
 
     public static Builder forMagic(byte magic, ProduceRequestData data) {
         // Message format upgrades correspond with a bump in the produce request version. Older
@@ -252,7 +287,7 @@ public class ProduceRequest extends AbstractRequest {
     }
 
     public static ProduceRequest parse(ByteBuffer buffer, short version) {
-        return new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version);
+        return produceRequestParser.parse(buffer, version);
     }
 
     public static byte requiredMagicForVersion(short produceRequestVersion) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+public interface ProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version);
+}

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -302,6 +302,19 @@
       <tr><th>Default Value:</th><td>com.sun.security.auth.module.JndiLoginModule</td></tr>
       </tbody></table>
     </li>
+    <li>
+      <h4><a id="org.apache.kafka.common.requests.ProduceRequestParser"></a><a id="systemproperties_org.apache.kafka.common.requests.ProduceRequestParser" href="#systemproperties_org.apache.kafka.common.requests.ProduceRequestParser">org.apache.kafka.common.requests.ProduceRequestParser</a></h4>
+      <p>This system property is used to specify a custom ProduceRequest parser. By default <b>org.apache.kafka.common.requests.DefaultProduceRequestParser</b> is used.
+      <p>The same functionality may be achieved by setting environment variable <b>KAFKA_PRODUCE_REQUEST_PARSER</b> to the desired parser class.
+      <p><pre><code class="language-bash">-Dorg.apache.kafka.common.requests.ProduceRequestParser=org.example.kafka.requests.CustomProduceRequestParser</code></pre>
+      <p>or
+      <p><pre><code class="language-bash">export KAFKA_PRODUCE_REQUEST_PARSER=org.example.kafka.requests.CustomProduceRequestParser</code></pre>
+      <p>Where <b>org.example.kafka.requests.CustomProduceRequestParser</b> implements <b>org.apache.kafka.common.requests.ProduceRequestParser</b> interface.
+      <table><tbody>
+      <tr><th>Since:</th><td>4.0.0</td></tr>
+      <tr><th>Default Value:</th><td>org.apache.kafka.common.requests.DefaultProduceRequestParser</td></tr>
+      </tbody></table>
+    </li>
   </ul>
 
   <h3 class="anchor-heading"><a id="tieredstorageconfigs" class="anchor-link"></a><a href="#tieredstorageconfigs">3.10 Tiered Storage Configs</a></h3>


### PR DESCRIPTION
This PR adds ability to specify a custom produce request parser. A custom produce request parser would allow to intercept all incoming messages before they get into the broker and apply broker wide logic to the messages. This could be a trace , a filter, or a transform(such as lineage). 

The inline `new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version)` was moved out of [ProduceRequest.java](clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java) into its own class [ProduceRequestParser.java](clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java), and ProduceRequest class was augmented with the dynamic loading of a specified parser class. When no class is specified, the default one is loaded maintaining full backward compatibilty.  

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
