### PR TITLE
KAFKA-17139: Throw SchemaException to faill the mirror task as it can not recover by retry.

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
@@ -150,6 +151,9 @@ public class MirrorSourceTask extends SourceTask {
             }
         } catch (WakeupException e) {
             return null;
+        } catch (SchemaException e) {
+            log.error("Failure during poll.", e);
+            throw e;
         } catch (KafkaException e) {
             log.warn("Failure during poll.", e);
             return null;


### PR DESCRIPTION

*More detailed description of your change,
MirrorSourceTask will try to retry when get KafkaException, but SchemaException is not able to recover from retry. Which will make the mirror traffic stopped. So it's better to fail the mirror task when get SchemaException.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
