### PR TITLE
KAFKA-12830: Remove Deprecated constructor in TimeWindowedDeserializer and TimeWindowedSerde

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializer.java
@@ -37,11 +37,6 @@ public class TimeWindowedDeserializer<T> implements Deserializer<Windowed<T>> {
         this(null, null);
     }
 
-    @Deprecated
-    public TimeWindowedDeserializer(final Deserializer<T> inner) {
-        this(inner, Long.MAX_VALUE);
-    }
-
     public TimeWindowedDeserializer(final Deserializer<T> inner, final Long windowSize) {
         this.inner = inner;
         this.windowSize = windowSize;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
@@ -29,11 +29,6 @@ public class WindowedSerdes {
             super(new TimeWindowedSerializer<>(), new TimeWindowedDeserializer<>());
         }
 
-        @Deprecated
-        public TimeWindowedSerde(final Serde<T> inner) {
-            super(new TimeWindowedSerializer<>(inner.serializer()), new TimeWindowedDeserializer<>(inner.deserializer()));
-        }
-
         // This constructor can be used for serialize/deserialize a windowed topic
         public TimeWindowedSerde(final Serde<T> inner, final long windowSize) {
             super(new TimeWindowedSerializer<>(inner.serializer()), new TimeWindowedDeserializer<>(inner.deserializer(), windowSize));
@@ -56,14 +51,6 @@ public class WindowedSerdes {
         public SessionWindowedSerde(final Serde<T> inner) {
             super(new SessionWindowedSerializer<>(inner.serializer()), new SessionWindowedDeserializer<>(inner.deserializer()));
         }
-    }
-
-    /**
-     * Construct a {@code TimeWindowedSerde} object for the specified inner class type.
-     */
-    @Deprecated
-    public static <T> Serde<Windowed<T>> timeWindowedSerdeFrom(final Class<T> type) {
-        return new TimeWindowedSerde<>(Serdes.serdeFrom(type));
     }
 
     /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/Serdes.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/Serdes.scala
@@ -39,9 +39,6 @@ object Serdes {
   implicit def JavaInteger: Serde[java.lang.Integer] = JSerdes.Integer()
   implicit def UUID: Serde[util.UUID] = JSerdes.UUID()
 
-  implicit def timeWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.TimeWindowedSerde[T] =
-    new WindowedSerdes.TimeWindowedSerde[T](tSerde)
-
   implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T] =
     new WindowedSerdes.SessionWindowedSerde[T](tSerde)
 


### PR DESCRIPTION
The single argument constructor and a factory method of the following classes were deprecated in version 2.8:

org.apache.kafka.streams.kstream.TimeWindowedDeserializer#TimeWindowedDeserializer(org.apache.kafka.common.serialization.Deserializer<T>)
org.apache.kafka.streams.kstream.WindowedSerdes.TimeWindowedSerde#TimeWindowedSerde(org.apache.kafka.common.serialization.Serde<T>)
org.apache.kafka.streams.kstream.WindowedSerdes#timeWindowedSerdeFrom(java.lang.Class<T>)
 

See [KAFKA-10366](https://issues.apache.org/jira/browse/KAFKA-10366) & [KAFKA-9649](https://issues.apache.org/jira/browse/KAFKA-9649) and [KIP-659](https://cwiki.apache.org/confluence/display/KAFKA/KIP-659%3A+Improve+TimeWindowedDeserializer+and+TimeWindowedSerde+to+handle+window+size).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
