### PR TITLE
KAFKA-17269 Fix ConcurrentModificationException caused by NioEchoServer.closeNewChannels

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -356,10 +356,12 @@ public class NioEchoServer extends Thread {
     }
 
     public void closeSocketChannels() throws IOException {
-        for (SocketChannel channel : socketChannels) {
-            channel.close();
+        synchronized (socketChannels) {
+            for (SocketChannel channel : socketChannels) {
+                channel.close();
+            }
+            socketChannels.clear();
         }
-        socketChannels.clear();
     }
 
     public void closeNewChannels() throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -363,10 +363,12 @@ public class NioEchoServer extends Thread {
     }
 
     public void closeNewChannels() throws IOException {
-        for (SocketChannel channel : newChannels) {
-            channel.close();
+        synchronized (newChannels) {
+            for (SocketChannel channel : newChannels) {
+                channel.close();
+            }
+            newChannels.clear();
         }
-        newChannels.clear();
     }
 
     public void close() throws IOException, InterruptedException {


### PR DESCRIPTION
`NioEchoServer#closeNewChannels` did not handle multi-threading synchronization. Add `synchronized` handling to prevent `java.util.ConcurrentModificationException`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
