### PR TITLE
KAFKA-17268: Fix NPE when closing a non-started acceptor

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -708,7 +708,10 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
 
   private def closeAll(): Unit = {
     debug("Closing server socket, selector, and any throttled sockets.")
-    CoreUtils.swallow(serverChannel.close(), this, Level.ERROR)
+    // The serverChannel will be null if Acceptor's thread is not started
+    if (serverChannel != null) {
+      CoreUtils.swallow(serverChannel.close(), this, Level.ERROR)
+    }
     CoreUtils.swallow(nioSelector.close(), this, Level.ERROR)
     throttledSockets.foreach(throttledSocket => closeSocket(throttledSocket.socket, this))
     throttledSockets.clear()


### PR DESCRIPTION
As titile, the `serverChannel` will be null if `Acceptor`'s thread is not started. Hence, closing a non-started will produce NPE


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
