### PR TITLE
KAFKA-17276; replicaDirectoryId for Fetch and FetchSnapshot should be ignorable

### DIFF
--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -103,7 +103,7 @@
           "about": "The earliest available offset of the follower replica.  The field is only used when the request is sent by the follower."},
         { "name": "PartitionMaxBytes", "type": "int32", "versions": "0+",
           "about": "The maximum bytes to fetch from this partition.  See KIP-74 for cases where this limit may not be honored." },
-        { "name": "ReplicaDirectoryId", "type": "uuid", "versions": "17+", "taggedVersions": "17+", "tag": 0,
+        { "name": "ReplicaDirectoryId", "type": "uuid", "versions": "17+", "taggedVersions": "17+", "tag": 0, "ignorable": true,
           "about": "The directory id of the follower fetching" }
       ]}
     ]},

--- a/clients/src/main/resources/common/message/FetchSnapshotRequest.json
+++ b/clients/src/main/resources/common/message/FetchSnapshotRequest.json
@@ -46,7 +46,7 @@
             },
             { "name": "Position", "type": "int64", "versions": "0+",
               "about": "The byte position within the snapshot to start fetching from" },
-            { "name": "ReplicaDirectoryId", "type": "uuid", "versions": "1+", "taggedVersions": "1+", "tag": 0,
+            { "name": "ReplicaDirectoryId", "type": "uuid", "versions": "1+", "taggedVersions": "1+", "tag": 0, "ignorable": true,
               "about": "The directory id of the follower fetching" }
           ]
         }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17276
mark `FetchRequest.json` and `FetchSnapshotRequest.json` replicaDirectory is ignorable 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
