### PR TITLE
KAFKA-17273: Migrate BootstrapControllersIntegrationTest to use ClusterTestExtensions

### DIFF
--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -119,6 +119,9 @@
       <allow pkg="org.apache.kafka.clients"/>
       <allow pkg="org.apache.kafka.metadata" />
     </subpackage>
+    <subpackage name="server">
+      <allow pkg="kafka.test" />
+    </subpackage>
   </subpackage>
 
   <subpackage name="admin">


### PR DESCRIPTION
The other sub tasks need to define custom configs for broker/controller, and hence using `ClusterTestExtensions` is more suitable to this test class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
