### PR TITLE
KAFKA-17279: Handle retriable errors from offset fetches

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1457,19 +1457,16 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             if (responseError != Errors.NONE) {
                 log.debug("Offset fetch failed: {}", responseError.message());
 
-                if (responseError == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
-                    // just retry
-                    future.raise(responseError);
-                } else if (responseError == Errors.COORDINATOR_NOT_AVAILABLE ||
-                           responseError == Errors.NOT_COORDINATOR) {
+                if (responseError == Errors.COORDINATOR_NOT_AVAILABLE ||
+                    responseError == Errors.NOT_COORDINATOR) {
                     // re-discover the coordinator and retry
                     markCoordinatorUnknown(responseError);
                     future.raise(responseError);
+                } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
+                    future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
                 } else if (responseError.exception() instanceof RetriableException) {
                     // retry
                     future.raise(responseError);
-                } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
-                    future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
                 } else {
                     future.raise(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1460,9 +1460,13 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 if (responseError == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
                     // just retry
                     future.raise(responseError);
-                } else if (responseError == Errors.NOT_COORDINATOR) {
+                } else if (responseError == Errors.COORDINATOR_NOT_AVAILABLE ||
+                           responseError == Errors.NOT_COORDINATOR) {
                     // re-discover the coordinator and retry
                     markCoordinatorUnknown(responseError);
+                    future.raise(responseError);
+                } else if (responseError.exception() instanceof RetriableException) {
+                    // retry
                     future.raise(responseError);
                 } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                     future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -87,6 +87,8 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -3206,14 +3208,21 @@ public abstract class ConsumerCoordinatorTest {
         assertThrows(KafkaException.class, () -> coordinator.initWithCommittedOffsetsIfNeeded(time.timer(Long.MAX_VALUE)));
     }
 
-    @Test
-    public void testRefreshOffsetNotCoordinatorForConsumer() {
+    @ParameterizedTest
+    @CsvSource({
+        "NOT_COORDINATOR, true",
+        "COORDINATOR_NOT_AVAILABLE, true",
+        "NETWORK_EXCEPTION, false",
+    })
+    public void testRefreshOffsetRetriableErrors(Errors error, boolean expectCoordinatorRelookup) {
         client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
 
         subscriptions.assignFromUser(singleton(t1p));
-        client.prepareResponse(offsetFetchResponse(Errors.NOT_COORDINATOR, Collections.emptyMap()));
-        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        client.prepareResponse(offsetFetchResponse(error, Collections.emptyMap()));
+        if (expectCoordinatorRelookup) {
+            client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        }
         client.prepareResponse(offsetFetchResponse(t1p, Errors.NONE, "", 100L));
         coordinator.initWithCommittedOffsetsIfNeeded(time.timer(Long.MAX_VALUE));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3214,7 +3214,7 @@ public abstract class ConsumerCoordinatorTest {
         "COORDINATOR_NOT_AVAILABLE, true",
         "NETWORK_EXCEPTION, false",
     })
-    public void testRefreshOffsetRetriableErrors(Errors error, boolean expectCoordinatorRelookup) {
+    public void testRefreshOffsetRetriableErrorCoordinatorLookup(Errors error, boolean expectCoordinatorRelookup) {
         client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3151,21 +3151,6 @@ public abstract class ConsumerCoordinatorTest {
     }
 
     @Test
-    public void testRefreshOffsetLoadInProgress() {
-        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
-        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
-
-        subscriptions.assignFromUser(singleton(t1p));
-        client.prepareResponse(offsetFetchResponse(Errors.COORDINATOR_LOAD_IN_PROGRESS, Collections.emptyMap()));
-        client.prepareResponse(offsetFetchResponse(t1p, Errors.NONE, "", 100L));
-        coordinator.initWithCommittedOffsetsIfNeeded(time.timer(Long.MAX_VALUE));
-
-        assertEquals(Collections.emptySet(), subscriptions.initializingPartitions());
-        assertTrue(subscriptions.hasAllFetchPositions());
-        assertEquals(100L, subscriptions.position(t1p).offset);
-    }
-
-    @Test
     public void testRefreshOffsetsGroupNotAuthorized() {
         client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
@@ -3212,6 +3197,7 @@ public abstract class ConsumerCoordinatorTest {
     @CsvSource({
         "NOT_COORDINATOR, true",
         "COORDINATOR_NOT_AVAILABLE, true",
+        "COORDINATOR_LOAD_IN_PROGRESS, false",
         "NETWORK_EXCEPTION, false",
     })
     public void testRefreshOffsetRetriableErrorCoordinatorLookup(Errors error, boolean expectCoordinatorRelookup) {


### PR DESCRIPTION
Handle retriable errors from offset fetches in ConsumerCoordinator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
