### PR TITLE
KAFKA-17288: Removed tracking partition member epoch (KIP-932)

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
@@ -114,13 +114,6 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
     private final TimelineHashMap<Uuid, TimelineHashMap<Integer, String>> invertedTargetAssignment;
 
     /**
-     * The current partition epoch maps each topic-partitions to their current epoch where
-     * the epoch is the epoch of their owners. When a member revokes a partition, it removes
-     * its epochs from this map. When a member gets a partition, it adds its epochs to this map.
-     */
-    protected final TimelineHashMap<Uuid, TimelineHashMap<Integer, Integer>> currentPartitionEpoch;
-
-    /**
      * The metadata refresh deadline. It consists of a timestamp in milliseconds together with
      * the group epoch at the time of setting it. The metadata refresh time is considered as a
      * soft state (read that it is not stored in a timeline data structure). It is like this
@@ -146,7 +139,6 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
         this.targetAssignmentEpoch = new TimelineInteger(snapshotRegistry);
         this.targetAssignment = new TimelineHashMap<>(snapshotRegistry, 0);
         this.invertedTargetAssignment = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.currentPartitionEpoch = new TimelineHashMap<>(snapshotRegistry, 0);
     }
 
     /**
@@ -354,26 +346,6 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
      */
     public Map<String, Assignment> targetAssignment() {
         return Collections.unmodifiableMap(targetAssignment);
-    }
-
-    /**
-     * Returns the current epoch of a partition or -1 if the partition
-     * does not have one.
-     *
-     * @param topicId       The topic id.
-     * @param partitionId   The partition id.
-     *
-     * @return The epoch or -1.
-     */
-    public int currentPartitionEpoch(
-        Uuid topicId, int partitionId
-    ) {
-        Map<Integer, Integer> partitions = currentPartitionEpoch.get(topicId);
-        if (partitions == null) {
-            return -1;
-        } else {
-            return partitions.getOrDefault(partitionId, -1);
-        }
     }
 
     /**
@@ -589,73 +561,6 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
             }
         }
         return HOMOGENEOUS;
-    }
-
-    /**
-     * Removes the partition epochs based on the provided assignment.
-     *
-     * @param assignment    The assignment.
-     * @param expectedEpoch The expected epoch.
-     * @throws IllegalStateException if the epoch does not match the expected one.
-     * package-private for testing.
-     */
-    public void removePartitionEpochs(
-        Map<Uuid, Set<Integer>> assignment,
-        int expectedEpoch
-    ) {
-        assignment.forEach((topicId, assignedPartitions) -> {
-            currentPartitionEpoch.compute(topicId, (__, partitionsOrNull) -> {
-                if (partitionsOrNull != null) {
-                    assignedPartitions.forEach(partitionId -> {
-                        Integer prevValue = partitionsOrNull.remove(partitionId);
-                        if (prevValue != expectedEpoch) {
-                            throw new IllegalStateException(
-                                String.format("Cannot remove the epoch %d from %s-%s because the partition is " +
-                                    "still owned at a different epoch %d", expectedEpoch, topicId, partitionId, prevValue));
-                        }
-                    });
-                    if (partitionsOrNull.isEmpty()) {
-                        return null;
-                    } else {
-                        return partitionsOrNull;
-                    }
-                } else {
-                    throw new IllegalStateException(
-                        String.format("Cannot remove the epoch %d from %s because it does not have any epoch",
-                            expectedEpoch, topicId));
-                }
-            });
-        });
-    }
-
-    /**
-     * Adds the partitions epoch based on the provided assignment.
-     *
-     * @param assignment    The assignment.
-     * @param epoch         The new epoch.
-     * @throws IllegalStateException if the partition already has an epoch assigned.
-     * package-private for testing.
-     */
-    public void addPartitionEpochs(
-        Map<Uuid, Set<Integer>> assignment,
-        int epoch
-    ) {
-        assignment.forEach((topicId, assignedPartitions) -> {
-            currentPartitionEpoch.compute(topicId, (__, partitionsOrNull) -> {
-                if (partitionsOrNull == null) {
-                    partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, assignedPartitions.size());
-                }
-                for (Integer partitionId : assignedPartitions) {
-                    Integer prevValue = partitionsOrNull.put(partitionId, epoch);
-                    if (prevValue != null) {
-                        throw new IllegalStateException(
-                            String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
-                                "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
-                    }
-                }
-                return partitionsOrNull;
-            });
-        });
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroup.java
@@ -162,7 +162,6 @@ public class ShareGroup extends ModernGroup<ShareGroupMember> {
 
         ShareGroupMember oldMember = members.put(newMember.memberId(), newMember);
         maybeUpdateSubscribedTopicNamesAndGroupSubscriptionType(oldMember, newMember);
-        maybeUpdatePartitionEpoch(oldMember, newMember);
         maybeUpdateGroupState();
     }
 
@@ -174,7 +173,6 @@ public class ShareGroup extends ModernGroup<ShareGroupMember> {
     public void removeMember(String memberId) {
         ShareGroupMember oldMember = members.remove(memberId);
         maybeUpdateSubscribedTopicNamesAndGroupSubscriptionType(oldMember, null);
-        maybeRemovePartitionEpoch(oldMember);
         maybeUpdateGroupState();
     }
 
@@ -249,33 +247,6 @@ public class ShareGroup extends ModernGroup<ShareGroupMember> {
         }
 
         state.set(newState);
-    }
-
-    /**
-     * Updates the partition epochs based on the old and the new member.
-     *
-     * @param oldMember The old member.
-     * @param newMember The new member.
-     */
-    private void maybeUpdatePartitionEpoch(
-        ShareGroupMember oldMember,
-        ShareGroupMember newMember
-    ) {
-        maybeRemovePartitionEpoch(oldMember);
-        addPartitionEpochs(newMember.assignedPartitions(), newMember.memberEpoch());
-    }
-
-    /**
-     * Removes the partition epochs for the provided member.
-     *
-     * @param oldMember The old member.
-     */
-    private void maybeRemovePartitionEpoch(
-        ShareGroupMember oldMember
-    ) {
-        if (oldMember != null) {
-            removePartitionEpochs(oldMember.assignedPartitions(), oldMember.memberEpoch());
-        }
     }
 
     public ShareGroupDescribeResponseData.DescribedGroup asDescribedGroup(


### PR DESCRIPTION
Partition epochs are tracked for consumer groups where epoch is the current assigned member epoch. As share groups have partitions shared hence maintaing the partition epochs is not required.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
