### PR TITLE
KAFKA-17239: Kafka admin client doesn't report node request-latency metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -536,7 +536,6 @@ public class KafkaAdminClient extends AdminClient {
                 adminAddresses.usingBootstrapControllers());
             metadataManager.update(Cluster.bootstrap(adminAddresses.addresses()), time.milliseconds());
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
-            System.out.println("reporters is " + reporters);
             Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
             MetricConfig metricConfig = new MetricConfig().samples(config.getInt(AdminClientConfig.METRICS_NUM_SAMPLES_CONFIG))
                 .timeWindow(config.getLong(AdminClientConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -41,6 +41,7 @@ import org.apache.kafka.clients.admin.internals.AdminApiFuture;
 import org.apache.kafka.clients.admin.internals.AdminApiFuture.SimpleAdminApiFuture;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler;
 import org.apache.kafka.clients.admin.internals.AdminBootstrapAddresses;
+import org.apache.kafka.clients.admin.internals.AdminFetchMetricsManager;
 import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
 import org.apache.kafka.clients.admin.internals.AllBrokersStrategy;
 import org.apache.kafka.clients.admin.internals.AlterConsumerGroupOffsetsHandler;
@@ -403,6 +404,7 @@ public class KafkaAdminClient extends AdminClient {
     private final ExponentialBackoff retryBackoff;
     private final boolean clientTelemetryEnabled;
     private final MetadataRecoveryStrategy metadataRecoveryStrategy;
+    private final AdminFetchMetricsManager adminFetchMetricsManager;
 
     /**
      * The telemetry requests client instance id.
@@ -534,6 +536,7 @@ public class KafkaAdminClient extends AdminClient {
                 adminAddresses.usingBootstrapControllers());
             metadataManager.update(Cluster.bootstrap(adminAddresses.addresses()), time.milliseconds());
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
+            System.out.println("reporters is " + reporters);
             Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
             MetricConfig metricConfig = new MetricConfig().samples(config.getInt(AdminClientConfig.METRICS_NUM_SAMPLES_CONFIG))
                 .timeWindow(config.getLong(AdminClientConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
@@ -617,6 +620,7 @@ public class KafkaAdminClient extends AdminClient {
             CommonClientConfigs.RETRY_BACKOFF_JITTER);
         this.clientTelemetryEnabled = config.getBoolean(AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG);
         this.metadataRecoveryStrategy = MetadataRecoveryStrategy.forName(config.getString(AdminClientConfig.METADATA_RECOVERY_STRATEGY_CONFIG));
+        this.adminFetchMetricsManager = new AdminFetchMetricsManager(metrics);
         config.logUnused();
         AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
         log.debug("Kafka admin client initialized");
@@ -1384,6 +1388,7 @@ public class KafkaAdminClient extends AdminClient {
                 } else {
                     try {
                         call.handleResponse(response.responseBody());
+                        adminFetchMetricsManager.recordLatency(response.destination(), response.requestLatencyMs());
                         if (log.isTraceEnabled())
                             log.trace("{} got response {}", call, response.responseBody());
                     } catch (Throwable t) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManager.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+
+public class AdminFetchMetricsManager {
+    private final Metrics metrics;
+
+    public AdminFetchMetricsManager(Metrics metrics) {
+        this.metrics = metrics;
+    }
+
+    public void recordLatency(String node, long requestLatencyMs) {
+        if (!node.isEmpty()) {
+            String nodeTimeName = "node-" + node + ".latency";
+            Sensor nodeRequestTime = this.metrics.getSensor(nodeTimeName);
+            if (nodeRequestTime != null)
+                nodeRequestTime.record(requestLatencyMs);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
@@ -223,7 +222,6 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -292,7 +290,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * See AdminClientIntegrationTest for an integration test.
  */
-//@Timeout(120)
+@Timeout(120)
 public class KafkaAdminClientTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClientTest.class);
     private static final String GROUP_ID = "group-0";
@@ -429,40 +427,6 @@ public class KafkaAdminClientTest {
         assertEquals(admin.getClientId(), mockMetricsReporter.clientId);
         assertEquals(2, admin.metrics.reporters().size());
         admin.close();
-    }
-
-    public static void main(String[] args) throws Exception {
-        new KafkaAdminClientTest().likangningTest();
-    }
-
-    @Test
-    public void likangningTest() throws Exception {
-        System.out.println("begin 123");
-        AdminClient sourceAdminClient = AdminClient.create(getCommonProperties());
-        for (int i = 0; i < Integer.MAX_VALUE; i++) {
-            ListTopicsResult listTopicsResult = sourceAdminClient.listTopics();
-            System.out.println("waiting");
-            Thread.sleep(5000);
-        }
-
-        synchronized (KafkaAdminClient.class) {
-            KafkaAdminClient.class.wait();
-        }
-    }
-
-    private static Properties getCommonProperties() {
-        Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        props.put(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG, "use_all_dns_ips");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
-        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
-        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "1");
-        props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "1");
-        return props;
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
@@ -222,6 +223,7 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -290,7 +292,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * See AdminClientIntegrationTest for an integration test.
  */
-@Timeout(120)
+//@Timeout(120)
 public class KafkaAdminClientTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClientTest.class);
     private static final String GROUP_ID = "group-0";
@@ -427,6 +429,40 @@ public class KafkaAdminClientTest {
         assertEquals(admin.getClientId(), mockMetricsReporter.clientId);
         assertEquals(2, admin.metrics.reporters().size());
         admin.close();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new KafkaAdminClientTest().likangningTest();
+    }
+
+    @Test
+    public void likangningTest() throws Exception {
+        System.out.println("begin 123");
+        AdminClient sourceAdminClient = AdminClient.create(getCommonProperties());
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            ListTopicsResult listTopicsResult = sourceAdminClient.listTopics();
+            System.out.println("waiting");
+            Thread.sleep(5000);
+        }
+
+        synchronized (KafkaAdminClient.class) {
+            KafkaAdminClient.class.wait();
+        }
+    }
+
+    private static Properties getCommonProperties() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG, "use_all_dns_ips");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
+        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "1");
+        props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "1");
+        return props;
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
@@ -53,11 +53,8 @@ public class AdminFetchMetricsManagerTest {
 
     @AfterEach
     public void tearDown() {
-        if (metrics != null) {
-            Utils.closeQuietly(metrics, "metrics");
-            metrics = null;
-        }
-
+        Utils.closeQuietly(metrics, "metrics");
+        metrics = null;
         adminFetchMetricsManager = null;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdminFetchMetricsManagerTest {
+    private static final double EPSILON = 0.0001;
+
+    private final Time time = new MockTime(1, 0, 0);
+    private Metrics metrics;
+    private AdminFetchMetricsManager adminFetchMetricsManager;
+
+
+    @BeforeEach
+    public void setup() {
+        metrics = new Metrics(time);
+        adminFetchMetricsManager = new AdminFetchMetricsManager(metrics);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (metrics != null) {
+            metrics.close();
+            metrics = null;
+        }
+
+        adminFetchMetricsManager = null;
+    }
+
+    @Test
+    public void testSingleNodeLatency() {
+        String connectionId = "0";
+        MetricName nodeLatencyAvg = metrics.metricName("request-latency-avg", "group");
+        MetricName nodeLatencyMax = metrics.metricName("request-latency-max", "group");
+        registerNodeLatencyMetric(connectionId, nodeLatencyAvg, nodeLatencyMax);
+
+        adminFetchMetricsManager.recordLatency(connectionId, 333);
+        mockSleepTimeWindow();
+        adminFetchMetricsManager.recordLatency(connectionId, 444);
+        assertEquals(388.5, metricValue(nodeLatencyAvg), EPSILON);
+        assertEquals(444, metricValue(nodeLatencyMax), EPSILON);
+        adminFetchMetricsManager.recordLatency(connectionId, 666);
+        assertEquals(481, metricValue(nodeLatencyAvg), EPSILON);
+        assertEquals(666, metricValue(nodeLatencyMax), EPSILON);
+
+        // first record(333) expired
+        mockSleepTimeWindow();
+        assertEquals(555, metricValue(nodeLatencyAvg), EPSILON);
+        assertEquals(666, metricValue(nodeLatencyMax), EPSILON);
+
+        // all records expired
+        mockSleepTimeWindow();
+        assertTrue(Double.isNaN(metricValue(nodeLatencyAvg)));
+        assertTrue(Double.isNaN(metricValue(nodeLatencyMax)));
+    }
+
+
+    @Test
+    public void testMultiNodeLatency() {
+        String connectionId = "0";
+        MetricName nodeLatencyAvg0 = metrics.metricName("request-latency-avg", "group", genericTag(connectionId));
+        MetricName nodeLatencyMax0 = metrics.metricName("request-latency-max", "group", genericTag(connectionId));
+        registerNodeLatencyMetric(connectionId, nodeLatencyAvg0, nodeLatencyMax0);
+        adminFetchMetricsManager.recordLatency(connectionId, 1);
+        adminFetchMetricsManager.recordLatency(connectionId, 1);
+
+
+        // Record metric against another node.
+        connectionId = "1";
+        MetricName nodeLatencyAvg1 = metrics.metricName("request-latency-avg", "group", genericTag(connectionId));
+        MetricName nodeLatencyMax1 = metrics.metricName("request-latency-max", "group", genericTag(connectionId));
+        registerNodeLatencyMetric(connectionId, nodeLatencyAvg1, nodeLatencyMax1);
+        adminFetchMetricsManager.recordLatency(connectionId, 10);
+        adminFetchMetricsManager.recordLatency(connectionId, 10);
+
+
+        // Node specific metric should not be affected.
+//        assertEquals(289.5, metricValue(nodeLatencyAvg), EPSILON);
+//        assertEquals(456, metricValue(nodeLatencyMax), EPSILON);
+    }
+
+    private Map<String, String> genericTag(String connectionId) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("node-id", "node-" + connectionId);
+        return tags;
+    }
+
+
+    private void mockSleepTimeWindow() {
+        time.sleep(metrics.config().timeWindowMs() + 1);
+    }
+
+    private void registerNodeLatencyMetric(String connectionId, MetricName nodeLatencyAvg, MetricName nodeLatencyMax) {
+        String nodeTimeName = "node-" + connectionId + ".latency";
+        Sensor nodeRequestTime = metrics.sensor(nodeTimeName);
+        nodeRequestTime.add(nodeLatencyAvg, new Avg());
+        nodeRequestTime.add(nodeLatencyMax, new Max());
+    }
+
+    private double metricValue(MetricNameTemplate name) {
+        MetricName metricName = metrics.metricInstance(name);
+        return metricValue(metricName);
+    }
+
+    private double metricValue(MetricNameTemplate name, Map<String, String> tags) {
+        MetricName metricName = metrics.metricInstance(name, tags);
+        return metricValue(metricName);
+    }
+
+    private double metricValue(MetricName metricName) {
+        KafkaMetric metric = metrics.metric(metricName);
+        return (Double) metric.metricValue();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
As titile, we should add request-latency metrics for node in admin client.

see discussion [https://github.com/apache/kafka/pull/16755](https://github.com/apache/kafka/pull/16755)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
