### PR TITLE
KAFKA-17294: Handle retriable errors when fetching offsets in new consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.consumer.internals.metrics.OffsetCommitMetricsMa
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1188,12 +1188,12 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 .map(OffsetCommitRequestState::toUnsentRequest)
                 .collect(Collectors.toCollection(ArrayList::new));
 
+            failAndRemoveExpiredFetchRequests();
+
             // Partition the unsent offset fetch requests into sendable and non-sendable lists
             Map<Boolean, List<OffsetFetchRequestState>> partitionedBySendability =
                     unsentOffsetFetches.stream()
                             .collect(Collectors.partitioningBy(request -> request.canSendRequest(currentTimeMs)));
-
-            failAndRemoveExpiredFetchRequests();
 
             // Add all sendable offset fetch requests to the unsentRequests list and to the inflightOffsetFetches list
             for (OffsetFetchRequestState request : partitionedBySendability.get(true)) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -996,11 +996,13 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 // Re-discover the coordinator and retry
                 coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
                 future.completeExceptionally(responseError.exception());
+            } else if (responseError.exception() instanceof RetriableException) {
+                // If fail with a retriable KafkaException, then retry
+                future.completeExceptionally(responseError.exception());
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                 future.completeExceptionally(GroupAuthorizationException.forGroupId(groupId));
             } else {
-                // Fail with a non-retriable KafkaException for all unexpected errors (even if
-                // they are retriable)
+                // Fail with a non-retriable KafkaException for all unexpected errors
                 future.completeExceptionally(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -999,7 +999,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 // Re-discover the coordinator and retry
                 coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
                 future.completeExceptionally(exception);
-            } else if (exception instanceof RetriableException && !(exception instanceof TimeoutException)) {
+            } else if (exception instanceof RetriableException) {
                 // If fail with a retriable KafkaException, then retry (except for timeout)
                 future.completeExceptionally(exception);
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1000,7 +1000,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
                 future.completeExceptionally(exception);
             } else if (exception instanceof RetriableException) {
-                // If fail with a retriable KafkaException, then retry (except for timeout)
                 future.completeExceptionally(exception);
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                 future.completeExceptionally(GroupAuthorizationException.forGroupId(groupId));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1000,7 +1000,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
                 future.completeExceptionally(exception);
             } else if (exception instanceof RetriableException && !(exception instanceof TimeoutException)) {
-                // If fail with a retriable KafkaException, then retry
+                // If fail with a retriable KafkaException, then retry (except for timeout)
                 future.completeExceptionally(exception);
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                 future.completeExceptionally(GroupAuthorizationException.forGroupId(groupId));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1188,8 +1188,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
                 .map(OffsetCommitRequestState::toUnsentRequest)
                 .collect(Collectors.toCollection(ArrayList::new));
 
-            failAndRemoveExpiredFetchRequests();
-
             // Partition the unsent offset fetch requests into sendable and non-sendable lists
             Map<Boolean, List<OffsetFetchRequestState>> partitionedBySendability =
                     unsentOffsetFetches.stream()
@@ -1216,15 +1214,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
          */
         private void failAndRemoveExpiredCommitRequests() {
             Queue<OffsetCommitRequestState> requestsToPurge = new LinkedList<>(unsentOffsetCommits);
-            requestsToPurge.forEach(RetriableRequestState::maybeExpire);
-        }
-
-        /**
-         * Find the unsent fetch requests that have expired, remove them and complete their
-         * futures with a TimeoutException.
-         */
-        private void failAndRemoveExpiredFetchRequests() {
-            Queue<OffsetFetchRequestState> requestsToPurge = new LinkedList<>(unsentOffsetFetches);
             requestsToPurge.forEach(RetriableRequestState::maybeExpire);
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -651,7 +651,7 @@ public class CommitRequestManagerTest {
             error);
         // we only want to make sure to purge the outbound buffer for non-retriables, so retriable will be re-queued.
         ApiException exception = error.exception();
-        if (exception instanceof RetriableException && !(exception instanceof TimeoutException))
+        if (exception instanceof RetriableException)
             testRetriable(commitRequestManager, futures, error);
         else {
             testNonRetriable(futures);
@@ -674,7 +674,7 @@ public class CommitRequestManagerTest {
                 error);
 
         ApiException exception = error.exception();
-        if (exception instanceof RetriableException && !(exception instanceof TimeoutException)) {
+        if (exception instanceof RetriableException) {
             futures.forEach(f -> assertFalse(f.isDone()));
 
             // Insert a long enough sleep to force a timeout of the operation. Invoke poll() again so that each

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -688,7 +688,8 @@ public class CommitRequestManagerTest {
     }
 
     private boolean isRetriableOnOffsetFetch(Errors error) {
-        return error == Errors.NOT_COORDINATOR || error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.COORDINATOR_NOT_AVAILABLE;
+        return error == Errors.NOT_COORDINATOR || error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.COORDINATOR_NOT_AVAILABLE
+                || error == Errors.UNKNOWN_TOPIC_OR_PARTITION || error == Errors.REQUEST_TIMED_OUT || error == Errors.UNSTABLE_OFFSET_COMMIT;
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -1218,7 +1218,10 @@ public class CommitRequestManagerTest {
         time.sleep(defaultApiTimeoutMs);
         poll = commitRequestManager.poll(time.milliseconds());
         assertEquals(1, poll.unsentRequests.size());
-        futures.forEach(f -> assertTrue(f.isCompletedExceptionally()));
+        futures.forEach(f -> {
+            assertTrue(f.isCompletedExceptionally());
+            assertFutureThrows(f, TimeoutException.class);
+        });
     }
 
     private void testNonRetriable(final List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -1217,7 +1217,7 @@ public class CommitRequestManagerTest {
         // Sleep util timeout
         time.sleep(defaultApiTimeoutMs);
         poll = commitRequestManager.poll(time.milliseconds());
-        assertEquals(1, poll.unsentRequests.size());
+        assertEquals(0, poll.unsentRequests.size());
         futures.forEach(f -> {
             assertTrue(f.isCompletedExceptionally());
             assertFutureThrows(f, TimeoutException.class);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
@@ -650,8 +649,7 @@ public class CommitRequestManagerTest {
             1,
             error);
         // we only want to make sure to purge the outbound buffer for non-retriables, so retriable will be re-queued.
-        ApiException exception = error.exception();
-        if (exception instanceof RetriableException)
+        if (error.exception() instanceof RetriableException)
             testRetriable(commitRequestManager, futures, error);
         else {
             testNonRetriable(futures);
@@ -673,8 +671,7 @@ public class CommitRequestManagerTest {
                 1,
                 error);
 
-        ApiException exception = error.exception();
-        if (exception instanceof RetriableException) {
+        if (error.exception() instanceof RetriableException) {
             futures.forEach(f -> assertFalse(f.isDone()));
 
             // Insert a long enough sleep to force a timeout of the operation. Invoke poll() again so that each

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -650,7 +650,8 @@ public class CommitRequestManagerTest {
             1,
             error);
         // we only want to make sure to purge the outbound buffer for non-retriables, so retriable will be re-queued.
-        if (error.exception() instanceof RetriableException && !(error.exception() instanceof TimeoutException))
+        ApiException exception = error.exception();
+        if (exception instanceof RetriableException && !(exception instanceof TimeoutException))
             testRetriable(commitRequestManager, futures, error);
         else {
             testNonRetriable(futures);


### PR DESCRIPTION
JIRA: [KAFKA-17294](https://issues.apache.org/jira/browse/KAFKA-17294)

The original behavior was implemented to maintain the behavior of the Classic consumer, where the `ConsumerCoordinator` would do the same when handling the `OffsetFetchResponse`. This behavior is being updated for the legacy coordinator as part of [KAFKA-17279](https://issues.apache.org/jira/browse/KAFKA-17279), to retry on all retriable errors.

We should review and update the `CommitRequestManager` to align with this, and retry on all retriable errors, which seems sensible when fetching offsets.

The corresponding PR for classic consumer is #16826 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
