### PR TITLE
KAFKA-17300: add document for new tiered storage feature in v3.9.0.

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4316,7 +4316,26 @@ $ bin/kafka-topics.sh --create --topic tieredTopic --bootstrap-server localhost:
 
 <pre><code class="language-bash">$ bin/kafka-console-consumer.sh --topic tieredTopic --from-beginning --max-messages 1 --bootstrap-server localhost:9092 --property print.offset=true</code></pre>
 
-<p>Please note, if you want to disable tiered storage at the cluster level, you should delete the tiered storage enabled topics explicitly.
+<p>If you want to disable tiered storage at the topic level to let the remote logs become read-only and no more local logs copied to the remote storage,
+  you can set <code>remote.storage.enable=true,remote.log.copy.disable=true</code> to the topic.</p>
+
+<p>Note: You also need to set <code>local.retention.ms</code> and <code>local.retention.bytes</code> to the same value as
+  <code>retention.ms</code> and <code>retention.bytes</code>, or set to "-2". This is because after disabling remote log copy,
+  the local retention policies will not be applied anymore, and that might confuse users and cause unexpected disk full.
+</p>
+
+<pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 \
+   --alter --entity-type topics --entity-name tieredTopic \
+   --add-config 'remote.storage.enable=true,remote.log.copy.disable=true,local.retention.ms=-2,local.retention.bytes=-2'</code></pre>
+
+<p>If you want to completely disable tiered storage at the topic level with all remote logs deleted,
+  you can set <code>remote.storage.enable=false,remote.log.delete.on.disable=true</code> to the topic.</p>
+
+  <pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 \
+   --alter --entity-type topics --entity-name tieredTopic \
+   --add-config 'remote.storage.enable=false,remote.log.delete.on.disable=true'</code></pre>
+
+<p>You can also re-enable tiered storage feature at the topic level. Please note, if you want to disable tiered storage at the cluster level, you should delete the tiered storage enabled topics explicitly.
   Attempting to disable tiered storage at the cluster level without deleting the topics using tiered storage will result in an exception during startup.</p>
 
 <pre><code class="language-bash">$ bin/kafka-topics.sh --delete --topic tieredTopic --bootstrap-server localhost:9092</code></pre>
@@ -4327,9 +4346,7 @@ $ bin/kafka-topics.sh --create --topic tieredTopic --bootstrap-server localhost:
 
 <p>While the early access release of Tiered Storage offers the opportunity to try out this new feature, it is important to be aware of the following limitations:
 <ul>
-  <li>No support for clusters with multiple log directories (i.e. JBOD feature)</li>
   <li>No support for compacted topics</li>
-  <li>Cannot disable tiered storage at the topic level</li>
   <li>Deleting tiered storage enabled topics is required before disabling tiered storage at the broker level</li>
   <li>Admin actions related to tiered storage feature are only supported on clients from version 3.0 onwards</li>
 </ul>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4203,6 +4203,8 @@ listeners=CONTROLLER://:9093
   Please check <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-405%3A+Kafka+Tiered+Storage">KIP-405</a> for more information.
 </p>
 
+<p><b>Note: Tiered storage is considered as an early access feature, and is not recommended for use in production environments</b></p>
+
 <h4 class="anchor-heading"><a id="tiered_storage_config" class="anchor-link"></a><a href="#tiered_storage_config">Configuration</a></h4>
 
 <h5 class="anchor-heading"><a id="tiered_storage_config_broker" class="anchor-link"></a><a href="#tiered_storage_config_broker">Broker Configurations</a></h5>
@@ -4344,12 +4346,15 @@ $ bin/kafka-topics.sh --create --topic tieredTopic --bootstrap-server localhost:
 
 <h4 class="anchor-heading"><a id="tiered_storage_limitation" class="anchor-link"></a><a href="#tiered_storage_limitation">Limitations</a></h4>
 
-<p>It is important to be aware of the following limitations of the tiered storage feature:
+<p>While the early access release of Tiered Storage offers the opportunity to try out this new feature, it is important to be aware of the following limitations:
 <ul>
   <li>No support for compacted topics</li>
   <li>Deleting tiered storage enabled topics is required before disabling tiered storage at the broker level</li>
   <li>Admin actions related to tiered storage feature are only supported on clients from version 3.0 onwards</li>
 </ul>
+
+<p>For more information, please check <a href="https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Tiered+Storage+Early+Access+Release+Notes">Tiered Storage Early Access Release Note</a>.
+</p>
 
 </script>
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4203,8 +4203,6 @@ listeners=CONTROLLER://:9093
   Please check <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-405%3A+Kafka+Tiered+Storage">KIP-405</a> for more information.
 </p>
 
-<p><b>Note: Tiered storage is considered as an early access feature, and is not recommended for use in production environments</b></p>
-
 <h4 class="anchor-heading"><a id="tiered_storage_config" class="anchor-link"></a><a href="#tiered_storage_config">Configuration</a></h4>
 
 <h5 class="anchor-heading"><a id="tiered_storage_config_broker" class="anchor-link"></a><a href="#tiered_storage_config_broker">Broker Configurations</a></h5>
@@ -4346,16 +4344,12 @@ $ bin/kafka-topics.sh --create --topic tieredTopic --bootstrap-server localhost:
 
 <h4 class="anchor-heading"><a id="tiered_storage_limitation" class="anchor-link"></a><a href="#tiered_storage_limitation">Limitations</a></h4>
 
-<p>While the early access release of Tiered Storage offers the opportunity to try out this new feature, it is important to be aware of the following limitations:
+<p>It is important to be aware of the following limitations of the tiered storage feature:
 <ul>
   <li>No support for compacted topics</li>
   <li>Deleting tiered storage enabled topics is required before disabling tiered storage at the broker level</li>
   <li>Admin actions related to tiered storage feature are only supported on clients from version 3.0 onwards</li>
 </ul>
-
-<p>For more information, please check <a href="https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Tiered+Storage+Early+Access+Release+Notes">Tiered Storage Early Access Release Note</a>.
-</p>
-
 
 </script>
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4316,7 +4316,9 @@ $ bin/kafka-topics.sh --create --topic tieredTopic --bootstrap-server localhost:
 
 <pre><code class="language-bash">$ bin/kafka-console-consumer.sh --topic tieredTopic --from-beginning --max-messages 1 --bootstrap-server localhost:9092 --property print.offset=true</code></pre>
 
-<p>If you want to disable tiered storage at the topic level to let the remote logs become read-only and no more local logs copied to the remote storage,
+<p>In KRaft mode, you can disable tiered storage at the topic level, to make the remote logs as read-only logs, or completely delete all remote logs.</p>
+
+<p>If you want to let the remote logs become read-only and no more local logs copied to the remote storage,
   you can set <code>remote.storage.enable=true,remote.log.copy.disable=true</code> to the topic.</p>
 
 <p>Note: You also need to set <code>local.retention.ms</code> and <code>local.retention.bytes</code> to the same value as

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,6 +28,8 @@
             For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
 	    This is a known issue for version 3.8.0 as well.
         </li>
+        <li>Tiered storage feature can be dynamically disabled and then re-enabled on topic level.
+            See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-950%3A++Tiered+Storage+Disablement">KIP-950</a> for more details.</li>
     </ul>
 
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,8 +28,11 @@
             For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
 	    This is a known issue for version 3.8.0 as well.
         </li>
-        <li>In KRaft, the tiered storage feature can be dynamically disabled and then re-enabled on topic level.
+        <li>In KRaft mode, the tiered storage feature can be dynamically disabled and then re-enabled on topic level.
             See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-950%3A++Tiered+Storage+Disablement">KIP-950</a> for more details.</li>
+        <li>Tiered storage quota is implemented. Users can set an "upper bound" on the rate at which logs are copied/read to/from the remote storage.
+            See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-956+Tiered+Storage+Quotas">KIP-956</a> for more details.</li>
+        <li>Tiered storage is a general availability feature now.</li>
     </ul>
 
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,7 +28,7 @@
             For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
 	    This is a known issue for version 3.8.0 as well.
         </li>
-        <li>Tiered storage feature can be dynamically disabled and then re-enabled on topic level.
+        <li>In KRaft, the tiered storage feature can be dynamically disabled and then re-enabled on topic level.
             See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-950%3A++Tiered+Storage+Disablement">KIP-950</a> for more details.</li>
     </ul>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -32,7 +32,6 @@
             See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-950%3A++Tiered+Storage+Disablement">KIP-950</a> for more details.</li>
         <li>Tiered storage quota is implemented. Users can set an "upper bound" on the rate at which logs are copied/read to/from the remote storage.
             See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-956+Tiered+Storage+Quotas">KIP-956</a> for more details.</li>
-        <li>Tiered storage is a general availability feature now.</li>
     </ul>
 
 <h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>


### PR DESCRIPTION
1. Added document for disabling tiered storage at topic level
2. Added a notable change item in v3.9.0 for tiered storage quota.

The updated doc for "disabling tiered storage at topic level" looks like this:
![image](https://github.com/user-attachments/assets/2be2d6d0-a1af-476d-ada2-0e8122b2887f)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
