### PR TITLE
KAFKA-16534; Implement sending update voter request

### DIFF
--- a/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
+++ b/clients/src/main/resources/common/message/UpdateRaftVoterRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterId", "type": "string", "versions": "0+" },
+    { "name": "ClusterId", "type": "string", "versions": "0+", "nullableVersions": "0+" },
     { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "0+",
       "about": "The current leader epoch of the partition, -1 for unknown leader epoch" },
     { "name": "VoterId", "type": "int32", "versions": "0+",

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -34,7 +34,7 @@ public class FollowerState implements EpochState {
     private final int fetchTimeoutMs;
     private final int epoch;
     private final int leaderId;
-    private final Endpoints endpoints;
+    private final Endpoints leaderEndpoints;
     private final Set<Integer> voters;
     // Used for tracking the expiration of both the Fetch and FetchSnapshot requests
     private final Timer fetchTimer;
@@ -43,6 +43,8 @@ public class FollowerState implements EpochState {
      * Fetch request are paused
      */
     private Optional<RawSnapshotWriter> fetchingSnapshot = Optional.empty();
+    // Used to throttle update voter request and allow for Fetch/FetchSnapshot requests
+    private final Timer updateVoterPeriodTimer;
 
     private final Logger log;
 
@@ -50,7 +52,7 @@ public class FollowerState implements EpochState {
         Time time,
         int epoch,
         int leaderId,
-        Endpoints endpoints,
+        Endpoints leaderEndpoints,
         Set<Integer> voters,
         Optional<LogOffsetMetadata> highWatermark,
         int fetchTimeoutMs,
@@ -59,9 +61,10 @@ public class FollowerState implements EpochState {
         this.fetchTimeoutMs = fetchTimeoutMs;
         this.epoch = epoch;
         this.leaderId = leaderId;
-        this.endpoints = endpoints;
+        this.leaderEndpoints = leaderEndpoints;
         this.voters = voters;
         this.fetchTimer = time.timer(fetchTimeoutMs);
+        this.updateVoterPeriodTimer = time.timer(updateVoterPeriodMs());
         this.highWatermark = highWatermark;
         this.log = logContext.logger(FollowerState.class);
     }
@@ -78,7 +81,7 @@ public class FollowerState implements EpochState {
 
     @Override
     public Endpoints leaderEndpoints() {
-        return endpoints;
+        return leaderEndpoints;
     }
 
     @Override
@@ -96,7 +99,7 @@ public class FollowerState implements EpochState {
     }
 
     public Node leaderNode(ListenerName listener) {
-        return endpoints
+        return leaderEndpoints
             .address(listener)
             .map(address -> new Node(leaderId, address.getHostString(), address.getPort()))
             .orElseThrow(() ->
@@ -105,7 +108,7 @@ public class FollowerState implements EpochState {
                         "Unknown endpoint for leader %d and listener %s, known endpoints are %s",
                         leaderId,
                         listener,
-                        endpoints
+                        leaderEndpoints
                     )
                 )
             );
@@ -124,6 +127,27 @@ public class FollowerState implements EpochState {
     public void overrideFetchTimeout(long currentTimeMs, long timeoutMs) {
         fetchTimer.update(currentTimeMs);
         fetchTimer.reset(timeoutMs);
+    }
+
+    private long updateVoterPeriodMs() {
+        // Allow for a few rounds of fetch request before attempting to update
+        // the voter state
+        return fetchTimeoutMs * 3;
+    }
+
+    public boolean hasUpdateVoterPeriodExpired(long currentTimeMs) {
+        updateVoterPeriodTimer.update(currentTimeMs);
+        return updateVoterPeriodTimer.isExpired();
+    }
+
+    public long remainingUpdateVoterPeriodMs(long currentTimeMs) {
+        updateVoterPeriodTimer.update(currentTimeMs);
+        return updateVoterPeriodTimer.remainingMs();
+    }
+
+    public void resetUpdateVoterPeriod(long currentTimeMs) {
+        updateVoterPeriodTimer.update(currentTimeMs);
+        updateVoterPeriodTimer.reset(updateVoterPeriodMs());
     }
 
     public boolean updateHighWatermark(OptionalLong newHighWatermark) {
@@ -192,12 +216,12 @@ public class FollowerState implements EpochState {
     @Override
     public String toString() {
         return String.format(
-            "FollowerState(fetchTimeoutMs=%d, epoch=%d, leader=%d, endpoints=%s, voters=%s, highWatermark=%s, " +
-            "fetchingSnapshot=%s)",
+            "FollowerState(fetchTimeoutMs=%d, epoch=%d, leader=%d, leaderEndpoints=%s, " +
+            "voters=%s, highWatermark=%s, fetchingSnapshot=%s)",
             fetchTimeoutMs,
             epoch,
             leaderId,
-            endpoints,
+            leaderEndpoints,
             voters,
             highWatermark,
             fetchingSnapshot

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -285,6 +285,14 @@ public class QuorumState {
         return ReplicaKey.of(localIdOrThrow(), localDirectoryId());
     }
 
+    public VoterSet.VoterNode localVoterNodeOrThrow() {
+        return VoterSet.VoterNode.of(
+            localReplicaKeyOrThrow(),
+            localListeners,
+            localSupportedKRaftVersion
+        );
+    }
+
     public int epoch() {
         return state.epoch();
     }
@@ -554,7 +562,6 @@ public class QuorumState {
             candidateState.grantingVoters(),
             accumulator,
             localListeners,
-            localSupportedKRaftVersion,
             fetchTimeoutMs,
             logContext
         );

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -70,6 +70,8 @@ public class RaftUtil {
                 return new FetchSnapshotResponseData().setErrorCode(error.code());
             case API_VERSIONS:
                 return new ApiVersionsResponseData().setErrorCode(error.code());
+            case UPDATE_RAFT_VOTER:
+                return new UpdateRaftVoterResponseData().setErrorCode(error.code());
             default:
                 throw new IllegalArgumentException("Received response for unexpected request type: " + apiKey);
         }

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.apache.kafka.raft.internals.ReplicaKey;
 import org.apache.kafka.raft.internals.VoterSet;
 import org.apache.kafka.raft.internals.VoterSetTest;
-import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.KRaftVersion;
 
 import org.junit.jupiter.api.Test;
@@ -76,7 +75,6 @@ public class LeaderStateTest {
             voters.voterIds(),
             accumulator,
             voters.listeners(localReplicaKey.id()),
-            Features.KRAFT_VERSION.supportedVersionRange(),
             fetchTimeoutMs,
             logContext
         );
@@ -122,7 +120,6 @@ public class LeaderStateTest {
                 Collections.emptySet(),
                 null,
                 Endpoints.empty(),
-                Features.KRAFT_VERSION.supportedVersionRange(),
                 fetchTimeoutMs,
                 logContext
             )


### PR DESCRIPTION
This change implements the KRaft voter sending UpdateVoter request. The UpdateVoter RPC is used to update a voter's listeners and supported kraft versions. The UpdateVoter RPC is sent if the replicated voter set (VotersRecord in the log) doesn't match the local voter's supported kraft versions and controller listeners.

To not starve the Fetch request, the UpdateVoter request is sent at most every 3 fetch timeouts. This is required to make sure that replication is making progress and eventually the voter set in the replicated log matches the local voter configuration.

This change also modifies the semantic for UpdateVoter. Now the UpdateVoter response is sent right after the leader has created the new voter set. This is required so that updating voter can transition from sending UpdateVoter request to sending Fetch request. If the leader waits for the VotersRecord control record to commit before sending the UpdateVoter response, it may never send the UpdateVoter response. This can happen if the leader needs that voter's Fetch request to commit the control record.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
