### PR TITLE
MINOR: Clean should delete generated sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,11 @@ allprojects {
     else
       options.links "https://docs.oracle.com/javase/8/docs/api/"
   }
+
+  clean {
+    delete "${projectDir}/src/generated"
+    delete "${projectDir}/src/generated-test"
+  }
 }
 
 def determineCommitId() {


### PR DESCRIPTION
Recently I changed branches, and had a local build failure because generated code depended on some other class which was not present/not being regenerated. This did not resolve by running `./gradlew clean`.

It appears that processMessages defines an output directory for the purposes of caching, but Gradle does not automatically include the outputs for cleaning, and requires projects explicitly specify that they should be cleaned up.

This is a broad "clean" statement for all projects, regardless of whether they use generated sources or not. This will clean up generated sources which may have been generated in the past, in addition to the projects actively generating sources.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
