### PR TITLE
KAFKA-17293: New consumer HeartbeatRequestManager should rediscover disconnected coordinator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -307,6 +307,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         resetHeartbeatState();
         membershipManager().onHeartbeatFailure(exception instanceof RetriableException);
         if (exception instanceof RetriableException) {
+            coordinatorRequestManager.handleCoordinatorDisconnect(exception, responseTimeMs);
             String message = String.format("%s failed because of the retriable exception. Will retry in %s ms: %s",
                 heartbeatRequestName(),
                 heartbeatRequestState.remainingBackoffMs(responseTimeMs),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -130,8 +130,6 @@ public class CoordinatorRequestManager implements RequestManager {
      * attempt to discover a new coordinator. For any other exception type, no action is performed.
      *
      * @param exception     The exception to handle, which was received as part of a request response.
-     *                      If this is an instance of {@link DisconnectException}, the coordinator is marked as unknown.
-     *                      For other types of exceptions, no action is performed.
      * @param currentTimeMs The current time in milliseconds.
      */
     public void handleCoordinatorDisconnect(Throwable exception, long currentTimeMs) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -127,11 +127,12 @@ public class CoordinatorRequestManager implements RequestManager {
      * Handles the disconnection of the current coordinator.
      * This method checks if the given exception is an instance of {@link DisconnectException}.
      * If so, it marks the coordinator as unknown, indicating that the client should
-     * attempt to discover a new coordinator.
+     * attempt to discover a new coordinator. For any other exception type, no action is performed.
      *
-     * @param exception     The exception that caused the coordinator to be marked as unknown.
-     *                      This is expected to be an instance of {@link DisconnectException}.
-     * @param currentTimeMs the current time in ms.
+     * @param exception     The exception to handle, which was received as part of a request response.
+     *                      If this is an instance of {@link DisconnectException}, the coordinator is marked as unknown.
+     *                      For other types of exceptions, no action is performed.
+     * @param currentTimeMs The current time in milliseconds.
      */
     public void handleCoordinatorDisconnect(Throwable exception, long currentTimeMs) {
         if (exception instanceof DisconnectException) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
@@ -120,6 +121,22 @@ public class CoordinatorRequestManager implements RequestManager {
                 onFailedResponse(unsentRequest.handler().completionTimeMs(), throwable);
             }
         });
+    }
+
+    /**
+     * Handles the disconnection of the current coordinator.
+     * This method checks if the given exception is an instance of {@link DisconnectException}.
+     * If so, it marks the coordinator as unknown, indicating that the client should
+     * attempt to discover a new coordinator.
+     *
+     * @param exception     The exception that caused the coordinator to be marked as unknown.
+     *                      This is expected to be an instance of {@link DisconnectException}.
+     * @param currentTimeMs the current time in ms.
+     */
+    public void handleCoordinatorDisconnect(Throwable exception, long currentTimeMs) {
+        if (exception instanceof DisconnectException) {
+            markCoordinatorUnknown(exception.getMessage(), currentTimeMs);
+        }
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -459,7 +459,7 @@ public class CommitRequestManagerTest {
         // Commit should mark the coordinator unknown and fail with RetriableCommitFailedException.
         assertTrue(commitResult.isDone());
         assertFutureThrows(commitResult, RetriableCommitFailedException.class);
-        assertCoordinatorDisconnect();
+        assertCoordinatorDisconnectOnDisconnect();
     }
 
     @Test
@@ -752,7 +752,7 @@ public class CommitRequestManagerTest {
         // Request not completed just yet
         assertFalse(result.isDone());
         if (shouldRediscoverCoordinator) {
-            assertCoordinatorDisconnect();
+            assertCoordinatorDisconnectOnCoordinatorError();
         }
 
         // Request should be retried with backoff.
@@ -782,7 +782,7 @@ public class CommitRequestManagerTest {
 
         // Request not completed just yet, but should have marked the coordinator unknown
         assertFalse(result.isDone());
-        assertCoordinatorDisconnect();
+        assertCoordinatorDisconnectOnDisconnect();
 
         time.sleep(retryBackoffMs);
         when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
@@ -922,7 +922,11 @@ public class CommitRequestManagerTest {
         assertRetryBackOff(commitRequestManager, retryBackoffMs);
     }
 
-    private void assertCoordinatorDisconnect() {
+    private void assertCoordinatorDisconnectOnDisconnect() {
+        verify(coordinatorRequestManager).handleCoordinatorDisconnect(any(), anyLong());
+    }
+
+    private void assertCoordinatorDisconnectOnCoordinatorError() {
         verify(coordinatorRequestManager).markCoordinatorUnknown(any(), anyLong());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -459,7 +459,7 @@ public class CommitRequestManagerTest {
         // Commit should mark the coordinator unknown and fail with RetriableCommitFailedException.
         assertTrue(commitResult.isDone());
         assertFutureThrows(commitResult, RetriableCommitFailedException.class);
-        assertCoordinatorDisconnectOnDisconnect();
+        assertCoordinatorDisconnectHandling();
     }
 
     @Test
@@ -782,7 +782,7 @@ public class CommitRequestManagerTest {
 
         // Request not completed just yet, but should have marked the coordinator unknown
         assertFalse(result.isDone());
-        assertCoordinatorDisconnectOnDisconnect();
+        assertCoordinatorDisconnectHandling();
 
         time.sleep(retryBackoffMs);
         when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
@@ -922,7 +922,7 @@ public class CommitRequestManagerTest {
         assertRetryBackOff(commitRequestManager, retryBackoffMs);
     }
 
-    private void assertCoordinatorDisconnectOnDisconnect() {
+    private void assertCoordinatorDisconnectHandling() {
         verify(coordinatorRequestManager).handleCoordinatorDisconnect(any(), anyLong());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -391,18 +391,20 @@ public class ConsumerHeartbeatRequestManagerTest {
         result.unsentRequests.get(0).handler().onFailure(time.milliseconds(), DisconnectException.INSTANCE);
         verify(membershipManager).onHeartbeatFailure(true);
         // Ensure that the coordinatorManager rediscovers the coordinator
-        verify(coordinatorRequestManager).markCoordinatorUnknown(any(), anyLong());
+        verify(coordinatorRequestManager).handleCoordinatorDisconnect(any(), anyLong());
         verify(backgroundEventHandler, never()).add(any());
 
-        // Assure the manager will backoff on disconnect
         time.sleep(DEFAULT_RETRY_BACKOFF_MS - 1);
         result = heartbeatRequestManager.poll(time.milliseconds());
-        assertEquals(0, result.unsentRequests.size());
+        assertEquals(0,
+                result.unsentRequests.size(),
+                "No request should be generated before the backoff expires");
 
-        // Assure that the backoff time has been exceeded
         time.sleep(1);
         result = heartbeatRequestManager.poll(time.milliseconds());
-        assertEquals(1, result.unsentRequests.size());
+        assertEquals(1,
+                result.unsentRequests.size(),
+                "A new request should be generated after the backoff expires");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -383,7 +383,6 @@ public class ConsumerHeartbeatRequestManagerTest {
 
     @Test
     public void testDisconnect() {
-        // The initial heartbeatInterval is set to 0
         createHeartbeatRequestStateWithZeroHeartbeatInterval();
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
@@ -396,15 +395,11 @@ public class ConsumerHeartbeatRequestManagerTest {
 
         time.sleep(DEFAULT_RETRY_BACKOFF_MS - 1);
         result = heartbeatRequestManager.poll(time.milliseconds());
-        assertEquals(0,
-                result.unsentRequests.size(),
-                "No request should be generated before the backoff expires");
+        assertEquals(0, result.unsentRequests.size(), "No request should be generated before the backoff expires");
 
         time.sleep(1);
         result = heartbeatRequestManager.poll(time.milliseconds());
-        assertEquals(1,
-                result.unsentRequests.size(),
-                "A new request should be generated after the backoff expires");
+        assertEquals(1, result.unsentRequests.size(), "A new request should be generated after the backoff expires");
     }
 
     @Test


### PR DESCRIPTION
JIRA: [KAFKA-17293](https://issues.apache.org/jira/browse/KAFKA-17293)

Ensure that the new consumer will rediscover the coordinator on disconnect and send heartbeats to the correct coordinator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
