### PR TITLE
KAFKA-17272: [1/2] System test framework for consumer protocol migration

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1710,7 +1710,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 return False
         return True
 
-    def list_consumer_groups(self, node=None, command_config=None):
+    def list_consumer_groups(self, node=None, command_config=None, state=None, type=None):
         """ Get list of consumer groups.
         """
         if node is None:
@@ -1727,6 +1727,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
               (consumer_group_script,
                self.bootstrap_servers(self.security_protocol),
                command_config)
+        if state is not None:
+            cmd += " --state %s" % state
+        if type is not None:
+            cmd += " --type %s" % type
         return self.run_cli_tool(node, cmd)
 
     def describe_consumer_group(self, group, node=None, command_config=None):

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -116,7 +116,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         consumer.start()
         self.await_all_members(consumer)
-        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=90)
+        self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=60)
 
         num_rebalances = consumer.num_rebalances()
         # TODO: make this test work with hard shutdowns, which probably requires
@@ -350,7 +350,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         if fencing_stage == "stable":
             consumer.start()
             self.await_members(consumer, len(consumer.nodes))
-            self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=120)
+            self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=120)
 
             num_rebalances = consumer.num_rebalances()
             conflict_consumer.start()
@@ -417,7 +417,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         consumer.start()
         self.await_all_members(consumer)
-        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=60)
+        self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=60)
         partition_owner = consumer.owner(partition)
 
         # startup the producer and ensure that some records have been written
@@ -482,7 +482,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         producer.start()
         consumer.start()
         self.await_all_members(consumer)
-        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=60)
+        self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=60)
 
         num_rebalances = consumer.num_rebalances()
 

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -116,6 +116,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         consumer.start()
         self.await_all_members(consumer)
+        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=90)
 
         num_rebalances = consumer.num_rebalances()
         # TODO: make this test work with hard shutdowns, which probably requires
@@ -123,10 +124,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
         #       nodes have time to expire
         self.rolling_bounce_brokers(consumer, clean_shutdown=True)
 
-        if group_protocol == consumer_group.classic_group_protocol:
-            unexpected_rebalances = consumer.num_rebalances() - num_rebalances
-            assert unexpected_rebalances == 0, \
-                "Broker rolling bounce caused %d unexpected group rebalances" % unexpected_rebalances
+        unexpected_rebalances = consumer.num_rebalances() - num_rebalances
+        assert unexpected_rebalances == 0, \
+            "Broker rolling bounce caused %d unexpected group rebalances" % unexpected_rebalances
 
         consumer.stop_all()
 
@@ -205,7 +205,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         num_bounces=[5],
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True],
-        group_protocol=consumer_group.classic_group_protocol
+        group_protocol=[consumer_group.classic_group_protocol]
     )
     def test_static_consumer_bounce_with_eager_assignment(self, clean_shutdown, static_membership, bounce_mode, num_bounces, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         """
@@ -350,6 +350,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         if fencing_stage == "stable":
             consumer.start()
             self.await_members(consumer, len(consumer.nodes))
+            self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=120)
 
             num_rebalances = consumer.num_rebalances()
             conflict_consumer.start()
@@ -364,6 +365,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
             else:
                 # Consumer protocol: Existing members should remain active and new conflicting ones should not be able to join.
                 self.await_consumed_messages(consumer)
+                assert num_rebalances == consumer.num_rebalances(), "Static consumers attempt to join with instance id in use should not cause a rebalance"
                 assert len(consumer.joined_nodes()) == len(consumer.nodes)
                 assert len(conflict_consumer.joined_nodes()) == 0
                 
@@ -415,16 +417,8 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         consumer.start()
         self.await_all_members(consumer)
-
-        partition_owner_container = {partition: None}
-        def check_partition_owner(partition_owner_container):
-            partition_owner_container[partition] = consumer.owner(partition)
-            return partition_owner_container[partition] is not None
-
-        wait_until(lambda: check_partition_owner(partition_owner_container),
-                   timeout_sec=self.session_timeout_sec*2+5,
-                   err_msg="Timed out waiting for partition to be assigned.")
-        partition_owner = partition_owner_container[partition]
+        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=60)
+        partition_owner = consumer.owner(partition)
 
         # startup the producer and ensure that some records have been written
         producer.start()
@@ -488,6 +482,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         producer.start()
         consumer.start()
         self.await_all_members(consumer)
+        self.await_all_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_including_session_timeout_sec=60)
 
         num_rebalances = consumer.num_rebalances()
 
@@ -498,10 +493,8 @@ class OffsetValidationTest(VerifiableConsumerTest):
         # ensure that the consumers do some work after the broker failure
         self.await_consumed_messages(consumer, min_messages=1000)
 
-        # verify that there were no rebalances on failover for classic protocol consumer.
-        # Currently, the consumer protocol doesn't support num_rebalances().
-        if group_protocol == consumer_group.classic_group_protocol:
-            assert num_rebalances == consumer.num_rebalances(), "Broker failure should not cause a rebalance"
+        # verify that there were no rebalances on failover.
+        assert num_rebalances == consumer.num_rebalances(), "Broker failure should not cause a rebalance"
 
         consumer.stop_all()
 
@@ -617,7 +610,7 @@ class AssignmentValidationTest(VerifiableConsumerTest):
             consumer.start_node(node)
             self.await_members(consumer, num_started)
             wait_until(lambda: self.valid_assignment(self.TOPIC, self.NUM_PARTITIONS, consumer.current_assignment()),
-                timeout_sec=self.session_timeout_sec*2,
+                timeout_sec=30,
                 err_msg="expected valid assignments of %d partitions when num_started %d: %s" % \
                         (self.NUM_PARTITIONS, num_started, \
                          [(str(node.account), a) for node, a in consumer.current_assignment().items()]))

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -20,8 +20,6 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.verifiable_consumer import VerifiableConsumer
 from kafkatest.services.kafka import TopicPartition
 
-import time
-
 class VerifiableConsumerTest(KafkaTest):
     PRODUCER_REQUEST_TIMEOUT_SEC = 30
 
@@ -89,23 +87,11 @@ class VerifiableConsumerTest(KafkaTest):
     def await_all_members(self, consumer):
         self.await_members(consumer, self.num_consumers)
 
-    def await_valid_assignment(self, topic, num_partitions, consumer, timeout_sec):
-        # Wait until every partition has an owner.
+    def await_all_members_stabilized(self, topic, num_partitions, consumer, timeout_sec):
+        # Wait until the group is in STABLE state and the consumers reconcile to a valid assignment
+        wait_until(lambda: self.group_id in self.kafka.list_consumer_groups(state="stable"),
+                   timeout_sec=timeout_sec,
+                   err_msg="Timed out waiting for group %s to transition to STABLE state." % self.group_id)
         wait_until(lambda: self.valid_assignment(topic, num_partitions, consumer.current_assignment()),
                    timeout_sec=timeout_sec,
                    err_msg="Timeout awaiting for the consumers to reconcile to a valid assignment.")
-        return consumer.current_assignment()
-
-    def stabilized(self, topic, num_partitions, consumer, timeout_sec):
-        # We see the consumer as stabilized if a valid assignment doesn't change after a session timeout.
-        assignment = self.await_valid_assignment(topic, num_partitions, consumer, timeout_sec)
-        time.sleep(consumer.session_timeout_sec)
-        return assignment == self.await_valid_assignment(topic, num_partitions, consumer, timeout_sec)
-
-    def await_all_stabilized(self, topic, num_partitions, consumer, timeout_including_session_timeout_sec):
-        # Wait until the consumer is fully stabilized.
-        assert timeout_including_session_timeout_sec > consumer.session_timeout_sec, \
-            "The stabilization timeout should be larger than the consumer session timeout %d." % consumer.session_timeout_sec
-        wait_until(lambda: self.stabilized(topic, num_partitions, consumer, timeout_including_session_timeout_sec),
-                   timeout_sec=timeout_including_session_timeout_sec,
-                    err_msg="Timeout awaiting for the consumers to stabilize.")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17272

This patch adds the necessary framework for system tests of consumer protocol upgrade/downgrade paths. The change mainly includes
- adding `ConsumerProtocolConsumerEventHandler` for the consumers using the new protocol.
- some other fixes to consumer_test.py with the new framework which fixes
  - [KAFKA-16576](https://issues.apache.org/jira/browse/KAFKA-16576): fixed by getting `partition_owner` after the group is fully stabilized.
  - [KAFKA-17219](https://issues.apache.org/jira/browse/KAFKA-17219): The first issue is the same as KAFKA-16576. The second issue is fixed by taking `num_rebalances` after the group is fully stabilized.
  - [KAFKA-17295](https://issues.apache.org/jira/browse/KAFKA-17295): Same as KAFKA-17219 second issue. Fixed by taking `num_rebalances` after the group is fully stabilized.

A test result of `tests/kafkatest/tests/client` is [here](https://confluent-open-source-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/trunk/2024-08-13--001.54e3cf70-869c-465c-bd7a-2ec0c26b2f05--1723594100--confluentinc--kip-848-migration-system-test-framework-comment-aug12--2388f23da7/report.html).