### PR TITLE
KAFKA-12989: MockClient should respect the request matcher passed to prepareUnsupportedVersionResponse

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -250,15 +250,16 @@ public class MockClient implements KafkaClient {
                 short version = nodeApiVersions.latestUsableVersion(request.apiKey(), builder.oldestAllowedVersion(),
                         builder.latestAllowedVersion());
 
+
+                AbstractRequest abstractRequest = request.requestBuilder().build(version);
+                if (!futureResp.requestMatcher.matches(abstractRequest))
+                    throw new IllegalStateException("Request matcher did not match next-in-line request "
+                            + abstractRequest + " with prepared response " + futureResp.responseBody);
+
                 UnsupportedVersionException unsupportedVersionException = null;
                 if (futureResp.isUnsupportedRequest) {
                     unsupportedVersionException = new UnsupportedVersionException(
                             "Api " + request.apiKey() + " with version " + version);
-                } else {
-                    AbstractRequest abstractRequest = request.requestBuilder().build(version);
-                    if (!futureResp.requestMatcher.matches(abstractRequest))
-                        throw new IllegalStateException("Request matcher did not match next-in-line request "
-                                + abstractRequest + " with prepared response " + futureResp.responseBody);
                 }
 
                 ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -876,7 +876,9 @@ public class TransactionManagerTest {
         client.prepareUnsupportedVersionResponse(body -> {
             FindCoordinatorRequest findCoordinatorRequest = (FindCoordinatorRequest) body;
             assertEquals(CoordinatorType.forId(findCoordinatorRequest.data().keyType()), CoordinatorType.TRANSACTION);
-            assertEquals(findCoordinatorRequest.data().key(), transactionalId);
+            assertTrue(findCoordinatorRequest.data().key().isEmpty());
+            assertEquals(1, findCoordinatorRequest.data().coordinatorKeys().size());
+            assertTrue(findCoordinatorRequest.data().coordinatorKeys().contains(transactionalId));
             return true;
         });
 

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -171,7 +171,8 @@ class ForwardingManagerTest {
 
     Mockito.when(controllerNodeProvider.getControllerInfo()).thenReturn(controllerInfo)
 
-    client.prepareUnsupportedVersionResponse(req => req.apiKey == requestHeader.apiKey)
+    val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
+    client.prepareUnsupportedVersionResponse(isEnvelopeRequest)
 
     val response = new AtomicReference[AbstractResponse]()
     forwardingManager.forwardRequest(request, res => res.foreach(response.set))


### PR DESCRIPTION
The MockClient#send doesn't respect matcher for unsupported request. ~Currently, I prefer to remove matcher. All related test cases can pass. We can see whether add matcher back for unsupported request in the future.~

Updated `MockClient#send` to run request matcher first.

```java
                UnsupportedVersionException unsupportedVersionException = null;
                if (futureResp.isUnsupportedRequest) {
                    unsupportedVersionException = new UnsupportedVersionException(
                            "Api " + request.apiKey() + " with version " + version);
                } else {
                    AbstractRequest abstractRequest = request.requestBuilder().build(version);
                    if (!futureResp.requestMatcher.matches(abstractRequest))
                        throw new IllegalStateException("Request matcher did not match next-in-line request "
                                + abstractRequest + " with prepared response " + futureResp.responseBody);
                }

                ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
                        request.createdTimeMs(), time.milliseconds(), futureResp.disconnected,
                        unsupportedVersionException, null, futureResp.responseBody);
                responses.add(resp);
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
