### PR TITLE
KAFKA-17297: testHandleEndQuorumRequest fails, Due to the same id makes voter became candidate, thus epoch plus one

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1249,7 +1249,7 @@ public class KafkaRaftClientTest {
     @ValueSource(booleans = { true, false })
     public void testHandleEndQuorumRequest(boolean withKip853Rpc) throws Exception {
         int localId = randomReplicaId();
-        int oldLeaderId = randomReplicaId() + 1;
+        int oldLeaderId = localId + 1;
         int leaderEpoch = 2;
         Set<Integer> voters = Utils.mkSet(localId, oldLeaderId);
 


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17297
In old code `leaderId` and `oldLeaderId` all use `randomReplicaId()`, thus it will be flaky when `leaderId` is equals `oldLeaderId`. When `KafkaRaftClient` initialize it will find `leaderId` and `oldLeaderId`, so it will tansfer to candidate, and the leaderEpoch will be + 1
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
