### PR TITLE
KAFKA-17312: Fix tests shouldForwardAllDbOptionsCalls and shouldOverwriteAllOptionsMethods in RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -108,6 +108,10 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             add("notifyAll");
             add("toString");
             add("getOptionStringFromProps");
+            add("maxBackgroundCompactions");
+            add("setMaxBackgroundCompactions");
+            add("maxBackgroundFlushes");
+            add("setMaxBackgroundFlushes");
             addAll(walRelatedMethods);
         }
     };


### PR DESCRIPTION
Add deprecated methods to `ignoreMethods`. Related `RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter` methods are removed by https://github.com/apache/kafka/pull/16813.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
