### PR TITLE
KAFKA-17315: Fix the behavior of delegation tokens that expire immediately upon creation in KRaft mode

### DIFF
--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -67,6 +67,7 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
       this.serverConfig.setProperty(AclAuthorizer.SuperUsersProp, kafkaPrincipal.toString)
     }
 
+    // Enable delegationTokenControlManager
     serverConfig.setProperty(DelegationTokenManagerConfigs.DELEGATION_TOKEN_SECRET_KEY_CONFIG, "123")
     serverConfig.setProperty(DelegationTokenManagerConfigs.DELEGATION_TOKEN_MAX_LIFETIME_CONFIG, "5000")
 
@@ -538,7 +539,10 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     // Test expiring the token immediately
     val token1 = client.createDelegationToken(createDelegationTokenOptions).delegationToken().get()
     val expireTokeOptions = new ExpireDelegationTokenOptions()
-    val token1ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(token1.hmac(), expireTokeOptions.expiryTimePeriodMs(-1)).expiryTimestamp().get())
+    val token1ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(
+      token1.hmac(),
+      expireTokeOptions.expiryTimePeriodMs(-1)).expiryTimestamp().get()
+    )
     assertTrue(token1ExpireTime < System.currentTimeMillis())
 
     // Test expiring the expired token
@@ -552,7 +556,10 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
     // Test shortening the expiryTimestamp
     val token3 = client.createDelegationToken(createDelegationTokenOptions).delegationToken().get()
-    val token3ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(token3.hmac(), expireTokeOptions.expiryTimePeriodMs(1000)).expiryTimestamp().get())
+    val token3ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(
+      token3.hmac(),
+      expireTokeOptions.expiryTimePeriodMs(1000)).expiryTimestamp().get()
+    )
     assertTrue(token3ExpireTime < token3.tokenInfo().expiryTimestamp())
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -526,7 +526,7 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
-  def testExpireDelegationToken(): Unit = {
+  def testExpireDelegationToken(quorum: String): Unit = {
     client = createAdminClient
     val createDelegationTokenOptions = new CreateDelegationTokenOptions()
 
@@ -539,6 +539,8 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     // Test expiring the token immediately
     val token1 = client.createDelegationToken(createDelegationTokenOptions).delegationToken().get()
     val expireTokeOptions = new ExpireDelegationTokenOptions()
+    // wait for broker sync
+    Thread.sleep(500)
     val token1ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(
       token1.hmac(),
       expireTokeOptions.expiryTimePeriodMs(-1)).expiryTimestamp().get()
@@ -556,6 +558,8 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
     // Test shortening the expiryTimestamp
     val token3 = client.createDelegationToken(createDelegationTokenOptions).delegationToken().get()
+    // wait for broker sync
+    Thread.sleep(500)
     val token3ExpireTime = assertDoesNotThrow(() => client.expireDelegationToken(
       token3.hmac(),
       expireTokeOptions.expiryTimePeriodMs(1000)).expiryTimestamp().get()

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -302,10 +302,6 @@ public class DelegationTokenControlManager {
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_NOT_FOUND.code()));
         }
 
-        if (myTokenInformation.maxTimestamp() < now || myTokenInformation.expiryTimestamp() < now) {
-            return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_EXPIRED.code()));
-        }
-
         if (!allowedToRenew(myTokenInformation, context.principal())) {
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_OWNER_MISMATCH.code()));
         }
@@ -313,9 +309,11 @@ public class DelegationTokenControlManager {
         if (requestData.expiryTimePeriodMs() < 0) { // expire immediately
             responseData
                 .setErrorCode(NONE.code())
-                .setExpiryTimestampMs(time.milliseconds());
+                .setExpiryTimestampMs(now);
             records.add(new ApiMessageAndVersion(new RemoveDelegationTokenRecord().
                 setTokenId(myTokenInformation.tokenId()), (short) 0));
+        } else if (myTokenInformation.maxTimestamp() < now || myTokenInformation.expiryTimestamp() < now) {
+            responseData.setErrorCode(DELEGATION_TOKEN_EXPIRED.code());
         } else {
             long expiryTimestamp = Math.min(myTokenInformation.maxTimestamp(),
                 now + requestData.expiryTimePeriodMs());

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -313,7 +313,7 @@ public class DelegationTokenControlManager {
         if (requestData.expiryTimePeriodMs() < 0) { // expire immediately
             responseData
                 .setErrorCode(NONE.code())
-                .setExpiryTimestampMs(requestData.expiryTimePeriodMs());
+                .setExpiryTimestampMs(time.milliseconds());
             records.add(new ApiMessageAndVersion(new RemoveDelegationTokenRecord().
                 setTokenId(myTokenInformation.tokenId()), (short) 0));
         } else {


### PR DESCRIPTION
JIRA: [KAFKA-17315](https://issues.apache.org/jira/browse/KAFKA-17315)

The behavior of expiring delegation token are different in zk and kraft, this PR aim to align them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
