### PR TITLE
KAFKA-17319: Update latestVersionUnstable of ListOffsetsRequest

### DIFF
--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -39,7 +39,7 @@
   "validVersions": "0-9",
   "deprecatedVersions": "0",
   "flexibleVersions": "6+",
-  "latestVersionUnstable": true,
+  "latestVersionUnstable": false,
   "fields": [
     { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The broker ID of the requester, or -1 if this request is being made by a normal consumer." },


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17319
Due to the  KIP-1005 is completed and on 3.9 released, thus the latestVersionUnstable need to mark to false

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
