### PR TITLE
MINOR: typo in the lz4java exception handling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockInputStream.java
@@ -302,7 +302,7 @@ public final class Lz4BlockInputStream extends InputStream {
         try {
             DECOMPRESSOR.decompress(nonZeroOffsetBuffer, 0, compressedLength, dest, 0, source.length);
         } catch (Exception e) {
-            throw new RuntimeException("Kafka has detected detected a buggy lz4-java library (< 1.4.x) on the classpath."
+            throw new RuntimeException("Kafka has detected a buggy lz4-java library (< 1.4.x) on the classpath."
                                        + " If you are using Kafka client libraries, make sure your application does not"
                                        + " accidentally override the version provided by Kafka or include multiple versions"
                                        + " of the library on the classpath. The lz4-java version on the classpath should"


### PR DESCRIPTION
There is simple typo in the `Lz4BlockInputStream` class.

Should not inflict any changes in behaviour nor in the tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
