### PR TITLE
Add missing class for ZSTD in native docker image

### DIFF
--- a/docker/native/native-image-configs/jni-config.json
+++ b/docker/native/native-image-configs/jni-config.json
@@ -10,6 +10,10 @@
   "fields":[{"name":"dstPos"}, {"name":"srcPos"}]
 },
 {
+  "name":"com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+  "fields":[{"name":"dstPos"}, {"name":"srcPos"}]
+},
+{
   "name":"com.sun.management.internal.DiagnosticCommandArgumentInfo",
   "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.lang.String","java.lang.String","boolean","boolean","boolean","int"] }]
 },


### PR DESCRIPTION
Using the native docker image, we faced issues when trying to create a topic that has `compression_type=zstd".

That basically threw the following error, which was only disappeared when we tried to disable the compression on the topic.
```
ERROR [ReplicaManager broker=1] Error processing append operation on partition <topic_name>-<partition_number> (kafka.server.ReplicaManager)
java.lang.NoSuchFieldError: com.github.luben.zstd.ZstdOutputStreamNoFinalizer.dstPos
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions$Support.getFieldID(JNIFunctions.java:1357)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions.GetFieldID(JNIFunctions.java:449)
	at com.github.luben.zstd.ZstdOutputStreamNoFinalizer.resetCStream(Native Method)
	at com.github.luben.zstd.ZstdOutputStreamNoFinalizer.close(ZstdOutputStreamNoFinalizer.java:423)
	at com.github.luben.zstd.ZstdOutputStreamNoFinalizer.close(ZstdOutputStreamNoFinalizer.java:405)
	at java.base@21.0.2/java.io.FilterOutputStream.close(FilterOutputStream.java:193)
	at java.base@21.0.2/java.io.FilterOutputStream.close(FilterOutputStream.java:193)
```

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
