### PR TITLE
KAFKA-17318: ConsumerRecord.deliveryCount and remove deprecations

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -32,13 +32,6 @@ public class ConsumerRecord<K, V> {
     public static final long NO_TIMESTAMP = RecordBatch.NO_TIMESTAMP;
     public static final int NULL_SIZE = -1;
 
-    /**
-     * @deprecated checksums are no longer exposed by this class, this constant will be removed in Apache Kafka 4.0
-     *             (deprecated since 3.0).
-     */
-    @Deprecated
-    public static final int NULL_CHECKSUM = -1;
-
     private final String topic;
     private final int partition;
     private final long offset;
@@ -50,6 +43,7 @@ public class ConsumerRecord<K, V> {
     private final K key;
     private final V value;
     private final Optional<Integer> leaderEpoch;
+    private final Optional<Short> deliveryCount;
 
     /**
      * Creates a record to be received from a specified topic and partition (provided for
@@ -72,7 +66,7 @@ public class ConsumerRecord<K, V> {
     }
 
     /**
-     * Creates a record to be received from a specified topic and partition
+     * Creates a record to be received from a specified topic and partition.
      *
      * @param topic The topic this record is received from
      * @param partition The partition of the topic this record is received from
@@ -97,6 +91,38 @@ public class ConsumerRecord<K, V> {
                           V value,
                           Headers headers,
                           Optional<Integer> leaderEpoch) {
+        this(topic, partition, offset, timestamp, timestampType, serializedKeySize, serializedValueSize, key, value,
+            headers, leaderEpoch, Optional.empty());
+    }
+
+    /**
+     * Creates a record to be received from a specified topic and partition.
+     *
+     * @param topic The topic this record is received from
+     * @param partition The partition of the topic this record is received from
+     * @param offset The offset of this record in the corresponding Kafka partition
+     * @param timestamp The timestamp of the record.
+     * @param timestampType The timestamp type
+     * @param serializedKeySize The length of the serialized key
+     * @param serializedValueSize The length of the serialized value
+     * @param key The key of the record, if one exists (null is allowed)
+     * @param value The record contents
+     * @param headers The headers of the record
+     * @param leaderEpoch Optional leader epoch of the record (may be empty for legacy record formats)
+     * @param deliveryCount Optional delivery count of the record (may be empty when deliveries not counted)
+     */
+    public ConsumerRecord(String topic,
+                          int partition,
+                          long offset,
+                          long timestamp,
+                          TimestampType timestampType,
+                          int serializedKeySize,
+                          int serializedValueSize,
+                          K key,
+                          V value,
+                          Headers headers,
+                          Optional<Integer> leaderEpoch,
+                          Optional<Short> deliveryCount) {
         if (topic == null)
             throw new IllegalArgumentException("Topic cannot be null");
         if (headers == null)
@@ -113,106 +139,7 @@ public class ConsumerRecord<K, V> {
         this.value = value;
         this.headers = headers;
         this.leaderEpoch = leaderEpoch;
-    }
-
-    /**
-     * Creates a record to be received from a specified topic and partition (provided for
-     * compatibility with Kafka 0.10 before the message format supported headers).
-     *
-     * @param topic The topic this record is received from
-     * @param partition The partition of the topic this record is received from
-     * @param offset The offset of this record in the corresponding Kafka partition
-     * @param timestamp The timestamp of the record.
-     * @param timestampType The timestamp type
-     * @param serializedKeySize The length of the serialized key
-     * @param serializedValueSize The length of the serialized value
-     * @param key The key of the record, if one exists (null is allowed)
-     * @param value The record contents
-     *
-     * @deprecated use one of the constructors without a `checksum` parameter. This constructor will be removed in
-     *             Apache Kafka 4.0 (deprecated since 3.0).
-     */
-    @Deprecated
-    public ConsumerRecord(String topic,
-                          int partition,
-                          long offset,
-                          long timestamp,
-                          TimestampType timestampType,
-                          long checksum,
-                          int serializedKeySize,
-                          int serializedValueSize,
-                          K key,
-                          V value) {
-        this(topic, partition, offset, timestamp, timestampType, serializedKeySize, serializedValueSize,
-                key, value, new RecordHeaders(), Optional.empty());
-    }
-
-    /**
-     * Creates a record to be received from a specified topic and partition
-     *
-     * @param topic The topic this record is received from
-     * @param partition The partition of the topic this record is received from
-     * @param offset The offset of this record in the corresponding Kafka partition
-     * @param timestamp The timestamp of the record.
-     * @param timestampType The timestamp type
-     * @param serializedKeySize The length of the serialized key
-     * @param serializedValueSize The length of the serialized value
-     * @param key The key of the record, if one exists (null is allowed)
-     * @param value The record contents
-     * @param headers The headers of the record.
-     *
-     * @deprecated use one of the constructors without a `checksum` parameter. This constructor will be removed in
-     *             Apache Kafka 4.0 (deprecated since 3.0).
-     */
-    @Deprecated
-    public ConsumerRecord(String topic,
-                          int partition,
-                          long offset,
-                          long timestamp,
-                          TimestampType timestampType,
-                          Long checksum,
-                          int serializedKeySize,
-                          int serializedValueSize,
-                          K key,
-                          V value,
-                          Headers headers) {
-        this(topic, partition, offset, timestamp, timestampType, serializedKeySize, serializedValueSize,
-                key, value, headers, Optional.empty());
-    }
-
-    /**
-     * Creates a record to be received from a specified topic and partition
-     *
-     * @param topic The topic this record is received from
-     * @param partition The partition of the topic this record is received from
-     * @param offset The offset of this record in the corresponding Kafka partition
-     * @param timestamp The timestamp of the record.
-     * @param timestampType The timestamp type
-     * @param serializedKeySize The length of the serialized key
-     * @param serializedValueSize The length of the serialized value
-     * @param key The key of the record, if one exists (null is allowed)
-     * @param value The record contents
-     * @param headers The headers of the record
-     * @param leaderEpoch Optional leader epoch of the record (may be empty for legacy record formats)
-     *
-     * @deprecated use one of the constructors without a `checksum` parameter. This constructor will be removed in
-     *             Apache Kafka 4.0 (deprecated since 3.0).
-     */
-    @Deprecated
-    public ConsumerRecord(String topic,
-                          int partition,
-                          long offset,
-                          long timestamp,
-                          TimestampType timestampType,
-                          Long checksum,
-                          int serializedKeySize,
-                          int serializedValueSize,
-                          K key,
-                          V value,
-                          Headers headers,
-                          Optional<Integer> leaderEpoch) {
-        this(topic, partition, offset, timestamp, timestampType, serializedKeySize, serializedValueSize, key, value, headers,
-            leaderEpoch);
+        this.deliveryCount = deliveryCount;
     }
 
     /**
@@ -296,6 +223,15 @@ public class ConsumerRecord<K, V> {
         return leaderEpoch;
     }
 
+    /**
+     * Get the delivery count for the record if available
+     *
+     * @return the delivery count or empty when deliveries not counted
+     */
+    public Optional<Short> deliveryCount() {
+        return deliveryCount;
+    }
+
     @Override
     public String toString() {
         return "ConsumerRecord(topic = " + topic
@@ -303,6 +239,7 @@ public class ConsumerRecord<K, V> {
                + ", leaderEpoch = " + leaderEpoch.orElse(null)
                + ", offset = " + offset
                + ", " + timestampType + " = " + timestamp
+               + ", deliveryCount = " + deliveryCount.orElse(null)
                + ", serialized key size = "  + serializedKeySize
                + ", serialized value size = " + serializedValueSize
                + ", headers = " + headers

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -224,7 +224,8 @@ public class ConsumerRecord<K, V> {
     }
 
     /**
-     * Get the delivery count for the record if available
+     * Get the delivery count for the record if available. Deliveries
+     * are counted for records delivered by share groups.
      *
      * @return the delivery count or empty when deliveries not counted
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
@@ -282,7 +282,6 @@ public class ShareCompletedFetch {
     /**
      * Parse the record entry, deserializing the key / value fields if necessary
      */
-    @SuppressWarnings("UnusedParameters")
     <K, V> ConsumerRecord<K, V> parseRecord(final Deserializers<K, V> deserializers,
                                             final TopicIdPartition partition,
                                             final Optional<Integer> leaderEpoch,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
@@ -306,12 +306,11 @@ public class ShareCompletedFetch {
             log.error("Value Deserializers with error: {}", deserializers);
             throw newRecordDeserializationException(RecordDeserializationException.DeserializationExceptionOrigin.VALUE, partition.topicPartition(), timestampType, record, e, headers);
         }
-        // When ConsumerRecord gains the delivery count, add it here
         return new ConsumerRecord<>(partition.topic(), partition.partition(), record.offset(),
                 record.timestamp(), timestampType,
                 keyBytes == null ? ConsumerRecord.NULL_SIZE : keyBytes.remaining(),
                 valueBytes == null ? ConsumerRecord.NULL_SIZE : valueBytes.remaining(),
-                key, value, headers, leaderEpoch);
+                key, value, headers, leaderEpoch, Optional.of(deliveryCount));
     }
 
     private static RecordDeserializationException newRecordDeserializationException(RecordDeserializationException.DeserializationExceptionOrigin origin,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
@@ -48,12 +48,12 @@ public class ConsumerRecordTest {
         assertEquals(ConsumerRecord.NULL_SIZE, record.serializedKeySize());
         assertEquals(ConsumerRecord.NULL_SIZE, record.serializedValueSize());
         assertEquals(Optional.empty(), record.leaderEpoch());
+        assertEquals(Optional.empty(), record.deliveryCount());
         assertEquals(new RecordHeaders(), record.headers());
     }
 
     @Test
-    @Deprecated
-    public void testConstructorsWithChecksum() {
+    public void testLongConstructor() {
         String topic = "topic";
         int partition = 0;
         long offset = 23;
@@ -61,28 +61,13 @@ public class ConsumerRecordTest {
         TimestampType timestampType = TimestampType.CREATE_TIME;
         String key = "key";
         String value = "value";
-        long checksum = 50L;
         int serializedKeySize = 100;
         int serializedValueSize = 1142;
 
-        ConsumerRecord<String, String> record = new ConsumerRecord<>(topic, partition, offset, timestamp, timestampType,
-            checksum, serializedKeySize, serializedValueSize, key, value);
-        assertEquals(topic, record.topic());
-        assertEquals(partition, record.partition());
-        assertEquals(offset, record.offset());
-        assertEquals(key, record.key());
-        assertEquals(value, record.value());
-        assertEquals(timestampType, record.timestampType());
-        assertEquals(timestamp, record.timestamp());
-        assertEquals(serializedKeySize, record.serializedKeySize());
-        assertEquals(serializedValueSize, record.serializedValueSize());
-        assertEquals(Optional.empty(), record.leaderEpoch());
-        assertEquals(new RecordHeaders(), record.headers());
-
         RecordHeaders headers = new RecordHeaders();
         headers.add(new RecordHeader("header key", "header value".getBytes(StandardCharsets.UTF_8)));
-        record = new ConsumerRecord<>(topic, partition, offset, timestamp, timestampType,
-                checksum, serializedKeySize, serializedValueSize, key, value, headers);
+        ConsumerRecord<String, String> record = new ConsumerRecord<>(topic, partition, offset, timestamp, timestampType,
+                serializedKeySize, serializedValueSize, key, value, headers, Optional.empty());
         assertEquals(topic, record.topic());
         assertEquals(partition, record.partition());
         assertEquals(offset, record.offset());
@@ -93,11 +78,13 @@ public class ConsumerRecordTest {
         assertEquals(serializedKeySize, record.serializedKeySize());
         assertEquals(serializedValueSize, record.serializedValueSize());
         assertEquals(Optional.empty(), record.leaderEpoch());
+        assertEquals(Optional.empty(), record.deliveryCount());
         assertEquals(headers, record.headers());
 
         Optional<Integer> leaderEpoch = Optional.of(10);
+        Optional<Short> deliveryCount = Optional.of((short) 1);
         record = new ConsumerRecord<>(topic, partition, offset, timestamp, timestampType,
-                checksum, serializedKeySize, serializedValueSize, key, value, headers, leaderEpoch);
+                serializedKeySize, serializedValueSize, key, value, headers, leaderEpoch, deliveryCount);
         assertEquals(topic, record.topic());
         assertEquals(partition, record.partition());
         assertEquals(offset, record.offset());
@@ -108,7 +95,7 @@ public class ConsumerRecordTest {
         assertEquals(serializedKeySize, record.serializedKeySize());
         assertEquals(serializedValueSize, record.serializedValueSize());
         assertEquals(leaderEpoch, record.leaderEpoch());
+        assertEquals(deliveryCount, record.deliveryCount());
         assertEquals(headers, record.headers());
     }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -84,6 +85,7 @@ public class ShareCompletedFetchTest {
         assertEquals(10, records.size());
         ConsumerRecord<String, String> record = records.get(0);
         assertEquals(10L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
         Acknowledgements acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
 
@@ -92,6 +94,7 @@ public class ShareCompletedFetchTest {
         assertEquals(1, records.size());
         record = records.get(0);
         assertEquals(20L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
         acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
 
@@ -120,6 +123,7 @@ public class ShareCompletedFetchTest {
         assertEquals(10, records.size());
         ConsumerRecord<String, String> record = records.get(0);
         assertEquals(510L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
         Acknowledgements acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
 
@@ -283,9 +287,11 @@ public class ShareCompletedFetchTest {
         // The first offset should be 0
         ConsumerRecord<String, String> record = records.get(0);
         assertEquals(0L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
         // The third offset should be 6
         record = records.get(3);
         assertEquals(6L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
 
         records = completedFetch.fetchRecords(deserializers, 10, true).getInFlightRecords();
         assertEquals(0, records.size());
@@ -316,9 +322,11 @@ public class ShareCompletedFetchTest {
         // The first offset should be 1
         ConsumerRecord<String, String> record = records.get(0);
         assertEquals(1L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
         // The second offset should be 3
         record = records.get(1);
         assertEquals(3L, record.offset());
+        assertEquals(Optional.of((short) 1), record.deliveryCount());
 
         records = completedFetch.fetchRecords(deserializers, 10, true).getInFlightRecords();
         assertEquals(0, records.size());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -400,11 +400,11 @@ public class RecordQueueTest {
             () -> queue.addRawRecords(records)
         );
         assertThat(exception.getMessage(), equalTo("Input record ConsumerRecord(topic = topic, partition = 1, " +
-            "leaderEpoch = null, offset = 1, CreateTime = -1, serialized key size = 0, serialized value size = 0, " +
-            "headers = RecordHeaders(headers = [], isReadOnly = false), key = 1, value = 10) has invalid (negative) " +
-            "timestamp. Possibly because a pre-0.10 producer client was used to write this record to Kafka without " +
-            "embedding a timestamp, or because the input topic was created before upgrading the Kafka cluster to 0.10+. " +
-            "Use a different TimestampExtractor to process this data."));
+            "leaderEpoch = null, offset = 1, CreateTime = -1, deliveryCount = null, serialized key size = 0, " +
+            "serialized value size = 0, headers = RecordHeaders(headers = [], isReadOnly = false), key = 1, value = 10) " +
+            "has invalid (negative) timestamp. Possibly because a pre-0.10 producer client was used to write this record " +
+            "to Kafka without embedding a timestamp, or because the input topic was created before upgrading the Kafka " +
+            "cluster to 0.10+. Use a different TimestampExtractor to process this data."));
     }
 
     @Test


### PR DESCRIPTION
Add the new delivery count to ConsumerRecord as part of KIP-932. Since this is modifying the constructors for this class, I took the opportunity to remove the deprecated constructors which are to be removed in AK 4.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
