### PR TITLE
KAFKA-17331: Throw UnsupportedVersionException if the data in ListOffsetRequest does NOT fit EarliestLocalSpec and LatestTieredSpec.

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -49,6 +49,7 @@
 
   <subpackage name="common">
     <allow class="org.apache.kafka.clients.consumer.ConsumerRecord" exact-match="true" />
+    <allow class="org.apache.kafka.clients.NodeApiVersions" exact-match="true" />
     <allow class="org.apache.kafka.common.message.ApiMessageType" exact-match="true" />
     <disallow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common" exact-match="true" />

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -93,14 +93,18 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
             .stream()
             .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.MAX_TIMESTAMP);
 
+        boolean requireEarliestLocalTimestamp = keys
+                .stream()
+                .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP);
+
         boolean requireTieredStorageTimestamp = keys
             .stream()
-            .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP || offsetTimestampsByPartition.get(key) == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP);
+            .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP);
 
         List<ListOffsetsTopic> topics = new ArrayList<>(topicsByName.values());
 
         return ListOffsetsRequest.Builder
-            .forConsumer(true, options.isolationLevel(), supportsMaxTimestamp, requireTieredStorageTimestamp, topics)
+            .forConsumer(true, options.isolationLevel(), supportsMaxTimestamp, requireEarliestLocalTimestamp, requireTieredStorageTimestamp, topics)
             .setTargetTimes(topics);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -97,9 +97,11 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
             .stream()
             .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP || offsetTimestampsByPartition.get(key) == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP);
 
+        List<ListOffsetsTopic> topics = new ArrayList<>(topicsByName.values());
+
         return ListOffsetsRequest.Builder
-            .forConsumer(true, options.isolationLevel(), supportsMaxTimestamp, requireTieredStorageTimestamp)
-            .setTargetTimes(new ArrayList<>(topicsByName.values()));
+            .forConsumer(true, options.isolationLevel(), supportsMaxTimestamp, requireTieredStorageTimestamp, topics)
+            .setTargetTimes(topics);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -101,14 +101,12 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
             .stream()
             .anyMatch(key -> offsetTimestampsByPartition.get(key) == ListOffsetsRequest.LATEST_TIERED_TIMESTAMP);
 
-        List<ListOffsetsTopic> topics = new ArrayList<>(topicsByName.values());
-
         return ListOffsetsRequest.Builder.forConsumer(true,
                         options.isolationLevel(),
                         supportsMaxTimestamp,
                         requireEarliestLocalTimestamp,
                         requireTieredStorageTimestamp)
-                .setTargetTimes(topics);
+                .setTargetTimes(new ArrayList<>(topicsByName.values()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.internals.AdminApiFuture.SimpleAdminApiFuture;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.Batched;
-import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
@@ -104,28 +103,12 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
 
         List<ListOffsetsTopic> topics = new ArrayList<>(topicsByName.values());
 
-        return getBuilder(options.isolationLevel(),
-                supportsMaxTimestamp,
-                requireEarliestLocalTimestamp,
-                requireTieredStorageTimestamp)
+        return ListOffsetsRequest.Builder.forConsumer(true,
+                        options.isolationLevel(),
+                        supportsMaxTimestamp,
+                        requireEarliestLocalTimestamp,
+                        requireTieredStorageTimestamp)
                 .setTargetTimes(topics);
-    }
-
-    private ListOffsetsRequest.Builder getBuilder(IsolationLevel isolationLevel,
-                                                  boolean requireMaxTimestamp,
-                                                  boolean requireEarliestLocalTimestamp,
-                                                  boolean requireTieredStorageTimestamp) {
-
-        if (requireTieredStorageTimestamp)
-            return ListOffsetsRequest.Builder.forTieredStorageTimestamp(isolationLevel);
-        else if (requireEarliestLocalTimestamp)
-            return ListOffsetsRequest.Builder.forEarliestLocalTimestamp(isolationLevel);
-        else if (requireMaxTimestamp)
-            return ListOffsetsRequest.Builder.forMaxTimestamp(isolationLevel);
-        else if (isolationLevel == IsolationLevel.READ_COMMITTED)
-            return ListOffsetsRequest.Builder.forReadCommitted();
-        else
-            return ListOffsetsRequest.Builder.forRequiredTimestamp();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.internals.AdminApiFuture.SimpleAdminApiFuture;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.Batched;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
@@ -103,9 +104,28 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
 
         List<ListOffsetsTopic> topics = new ArrayList<>(topicsByName.values());
 
-        return ListOffsetsRequest.Builder
-            .forConsumer(true, options.isolationLevel(), supportsMaxTimestamp, requireEarliestLocalTimestamp, requireTieredStorageTimestamp, topics)
-            .setTargetTimes(topics);
+        return getBuilder(options.isolationLevel(),
+                supportsMaxTimestamp,
+                requireEarliestLocalTimestamp,
+                requireTieredStorageTimestamp)
+                .setTargetTimes(topics);
+    }
+
+    private ListOffsetsRequest.Builder getBuilder(IsolationLevel isolationLevel,
+                                                  boolean requireMaxTimestamp,
+                                                  boolean requireEarliestLocalTimestamp,
+                                                  boolean requireTieredStorageTimestamp) {
+
+        if (requireTieredStorageTimestamp)
+            return ListOffsetsRequest.Builder.forTieredStorageTimestamp(isolationLevel);
+        else if (requireEarliestLocalTimestamp)
+            return ListOffsetsRequest.Builder.forEarliestLocalTimestamp(isolationLevel);
+        else if (requireMaxTimestamp)
+            return ListOffsetsRequest.Builder.forMaxTimestamp(isolationLevel);
+        else if (isolationLevel == IsolationLevel.READ_COMMITTED)
+            return ListOffsetsRequest.Builder.forReadCommitted();
+        else
+            return ListOffsetsRequest.Builder.forRequiredTimestamp();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -390,9 +392,10 @@ public class OffsetFetcher {
     private RequestFuture<ListOffsetResult> sendListOffsetRequest(final Node node,
                                                                   final Map<TopicPartition, ListOffsetsPartition> timestampsToSearch,
                                                                   boolean requireTimestamp) {
+        List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch);
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamp, isolationLevel, false, false)
-                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch));
+                .forConsumer(requireTimestamp, isolationLevel, false, false, topics)
+                .setTargetTimes(topics);
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
         return client.send(node, builder)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -393,9 +393,7 @@ public class OffsetFetcher {
                                                                   final Map<TopicPartition, ListOffsetsPartition> timestampsToSearch,
                                                                   boolean requireTimestamp) {
         List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch);
-        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamp, isolationLevel, false, false, false, topics)
-                .setTargetTimes(topics);
+        ListOffsetsRequest.Builder builder = getBuilder(requireTimestamp).setTargetTimes(topics);
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
         return client.send(node, builder)
@@ -407,6 +405,15 @@ public class OffsetFetcher {
                         handleListOffsetResponse(lor, future);
                     }
                 });
+    }
+
+    private ListOffsetsRequest.Builder getBuilder(boolean requireTimestamp) {
+        if (isolationLevel == IsolationLevel.READ_COMMITTED)
+            return  ListOffsetsRequest.Builder.forReadCommitted();
+        else if (requireTimestamp)
+            return  ListOffsetsRequest.Builder.forRequiredTimestamp();
+        else
+            return  ListOffsetsRequest.Builder.defaultBuilder();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -394,7 +394,7 @@ public class OffsetFetcher {
                                                                   boolean requireTimestamp) {
         List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch);
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamp, isolationLevel, false, false, topics)
+                .forConsumer(requireTimestamp, isolationLevel, false, false, false, topics)
                 .setTargetTimes(topics);
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
@@ -44,7 +43,6 @@ import org.slf4j.Logger;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -392,8 +390,9 @@ public class OffsetFetcher {
     private RequestFuture<ListOffsetResult> sendListOffsetRequest(final Node node,
                                                                   final Map<TopicPartition, ListOffsetsPartition> timestampsToSearch,
                                                                   boolean requireTimestamp) {
-        List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch);
-        ListOffsetsRequest.Builder builder = getBuilder(requireTimestamp).setTargetTimes(topics);
+        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
+                .forConsumer(requireTimestamp, isolationLevel)
+                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch));
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
         return client.send(node, builder)
@@ -405,15 +404,6 @@ public class OffsetFetcher {
                         handleListOffsetResponse(lor, future);
                     }
                 });
-    }
-
-    private ListOffsetsRequest.Builder getBuilder(boolean requireTimestamp) {
-        if (isolationLevel == IsolationLevel.READ_COMMITTED)
-            return  ListOffsetsRequest.Builder.forReadCommitted();
-        else if (requireTimestamp)
-            return  ListOffsetsRequest.Builder.forRequiredTimestamp();
-        else
-            return  ListOffsetsRequest.Builder.defaultBuilder();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -338,7 +338,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
         List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(targetTimes);
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamps, isolationLevel, false, false, topics)
+                .forConsumer(requireTimestamps, isolationLevel, false, false, false, topics)
                 .setTargetTimes(topics);
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -336,9 +336,10 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> targetTimes,
             boolean requireTimestamps,
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
+        List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(targetTimes);
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamps, isolationLevel, false, false)
-                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(targetTimes));
+                .forConsumer(requireTimestamps, isolationLevel, false, false, topics)
+                .setTargetTimes(topics);
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,
                 node);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -337,9 +337,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             boolean requireTimestamps,
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
         List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(targetTimes);
-        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamps, isolationLevel, false, false, false, topics)
-                .setTargetTimes(topics);
+        ListOffsetsRequest.Builder builder = getBuilder(requireTimestamps).setTargetTimes(topics);
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,
                 node);
@@ -368,6 +366,15 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             }
         });
         return result;
+    }
+
+    private ListOffsetsRequest.Builder getBuilder(boolean requireTimestamp) {
+        if (isolationLevel == IsolationLevel.READ_COMMITTED)
+            return  ListOffsetsRequest.Builder.forReadCommitted();
+        else if (requireTimestamp)
+            return  ListOffsetsRequest.Builder.forRequiredTimestamp();
+        else
+            return  ListOffsetsRequest.Builder.defaultBuilder();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -336,8 +336,9 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> targetTimes,
             boolean requireTimestamps,
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
-        List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(targetTimes);
-        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder.forConsumer(requireTimestamps, isolationLevel).setTargetTimes(topics);
+        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
+                .forConsumer(requireTimestamps, isolationLevel)
+                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(targetTimes));
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,
                 node);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -337,7 +337,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             boolean requireTimestamps,
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
         List<ListOffsetsRequestData.ListOffsetsTopic> topics = ListOffsetsRequest.toListOffsetsTopics(targetTimes);
-        ListOffsetsRequest.Builder builder = getBuilder(requireTimestamps).setTargetTimes(topics);
+        ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder.forConsumer(requireTimestamps, isolationLevel).setTargetTimes(topics);
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,
                 node);
@@ -366,15 +366,6 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             }
         });
         return result;
-    }
-
-    private ListOffsetsRequest.Builder getBuilder(boolean requireTimestamp) {
-        if (isolationLevel == IsolationLevel.READ_COMMITTED)
-            return  ListOffsetsRequest.Builder.forReadCommitted();
-        else if (requireTimestamp)
-            return  ListOffsetsRequest.Builder.forRequiredTimestamp();
-        else
-            return  ListOffsetsRequest.Builder.defaultBuilder();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -66,12 +66,12 @@ public class ListOffsetsRequest extends AbstractRequest {
         public static Builder forConsumer(boolean requireTimestamp,
                                           IsolationLevel isolationLevel,
                                           boolean requireMaxTimestamp,
-                                          boolean requireEarliestTimestamp,
+                                          boolean requireEarliestLocalTimestamp,
                                           boolean requireTieredStorageTimestamp) {
             short minVersion = 0;
             if (requireTieredStorageTimestamp)
                 minVersion = 9;
-            else if (requireEarliestTimestamp)
+            else if (requireEarliestLocalTimestamp)
                 minVersion = 8;
             else if (requireMaxTimestamp)
                 minVersion = 7;

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -110,7 +110,6 @@ public class ListOffsetsRequest extends AbstractRequest {
         public String toString() {
             return data.toString();
         }
-
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -58,32 +58,32 @@ public class ListOffsetsRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ListOffsetsRequest> {
         private final ListOffsetsRequestData data;
 
+        public static Builder forConsumer(boolean requireTimestamp,
+                                          IsolationLevel isolationLevel) {
+            return forConsumer(requireTimestamp, isolationLevel, false, false, false);
+        }
+
+        public static Builder forConsumer(boolean requireTimestamp,
+                                          IsolationLevel isolationLevel,
+                                          boolean requireMaxTimestamp,
+                                          boolean requireEarliestTimestamp,
+                                          boolean requireTieredStorageTimestamp) {
+            short minVersion = 0;
+            if (requireTieredStorageTimestamp)
+                minVersion = 9;
+            else if (requireEarliestTimestamp)
+                minVersion = 8;
+            else if (requireMaxTimestamp)
+                minVersion = 7;
+            else if (isolationLevel == IsolationLevel.READ_COMMITTED)
+                minVersion = 2;
+            else if (requireTimestamp)
+                minVersion = 1;
+            return new Builder(minVersion, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, isolationLevel);
+        }
+
         public static Builder forReplica(short allowedVersion, int replicaId) {
             return new Builder((short) 0, allowedVersion, replicaId, IsolationLevel.READ_UNCOMMITTED);
-        }
-
-        public static Builder forTieredStorageTimestamp(IsolationLevel isolationLevel) {
-            return new Builder((short) 9, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, isolationLevel);
-        }
-
-        public static Builder forEarliestLocalTimestamp(IsolationLevel isolationLevel) {
-            return new Builder((short) 8, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, isolationLevel);
-        }
-
-        public static Builder forMaxTimestamp(IsolationLevel isolationLevel) {
-            return new Builder((short) 7, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, isolationLevel);
-        }
-
-        public static Builder forReadCommitted() {
-            return new Builder((short) 2, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, IsolationLevel.READ_COMMITTED);
-        }
-
-        public static Builder forRequiredTimestamp() {
-            return new Builder((short) 1, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, IsolationLevel.READ_UNCOMMITTED);
-        }
-
-        public static Builder defaultBuilder() {
-            return new Builder((short) 0, ApiKeys.LIST_OFFSETS.latestVersion(), CONSUMER_REPLICA_ID, IsolationLevel.READ_UNCOMMITTED);
         }
 
         private Builder(short oldestAllowedVersion,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -66,11 +66,14 @@ public class ListOffsetsRequest extends AbstractRequest {
         public static Builder forConsumer(boolean requireTimestamp,
                                           IsolationLevel isolationLevel,
                                           boolean requireMaxTimestamp,
+                                          boolean requireEarliestLocalTimestamp,
                                           boolean requireTieredStorageTimestamp,
                                           List<ListOffsetsTopic> topics) {
             short minVersion = 0;
             if (requireTieredStorageTimestamp)
                 minVersion = 9;
+            else if (requireEarliestLocalTimestamp)
+                minVersion = 8;
             else if (requireMaxTimestamp)
                 minVersion = 7;
             else if (isolationLevel == IsolationLevel.READ_COMMITTED)

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6257,7 +6257,7 @@ public class KafkaAdminClientTest {
             env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.earliestLocal()));
 
             TestUtils.waitForCondition(() -> env.kafkaClient().requests().stream().anyMatch(request ->
-                request.requestBuilder().apiKey().messageType == ApiMessageType.LIST_OFFSETS && request.requestBuilder().oldestAllowedVersion() == 9
+                request.requestBuilder().apiKey().messageType == ApiMessageType.LIST_OFFSETS && request.requestBuilder().oldestAllowedVersion() == 8
             ), "no listOffsets request has the expected oldestAllowedVersion");
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandlerTest.java
@@ -60,6 +60,8 @@ public final class ListOffsetsHandlerTest {
     private final TopicPartition t0p1 = new TopicPartition("t0", 1);
     private final TopicPartition t1p0 = new TopicPartition("t1", 0);
     private final TopicPartition t1p1 = new TopicPartition("t1", 1);
+    private final TopicPartition t2p0 = new TopicPartition("t2", 0);
+    private final TopicPartition t2p1 = new TopicPartition("t2", 1);
 
     private final Node node = new Node(1, "host", 1234);
 
@@ -69,6 +71,8 @@ public final class ListOffsetsHandlerTest {
             put(t0p1, ListOffsetsRequest.EARLIEST_TIMESTAMP);
             put(t1p0, 123L);
             put(t1p1, ListOffsetsRequest.MAX_TIMESTAMP);
+            put(t2p0, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP);
+            put(t2p1, ListOffsetsRequest.LATEST_TIERED_TIMESTAMP);
         }
     };
 
@@ -96,14 +100,14 @@ public final class ListOffsetsHandlerTest {
         ListOffsetsRequest request =
             handler.buildBatchedRequest(node.id(), offsetTimestampsByPartition.keySet()).build();
         List<ListOffsetsTopic> topics = request.topics();
-        assertEquals(2, topics.size());
+        assertEquals(3, topics.size());
         Map<TopicPartition, ListOffsetsPartition> partitions = new HashMap<>();
         for (ListOffsetsTopic topic : topics) {
             for (ListOffsetsPartition partition : topic.partitions()) {
                 partitions.put(new TopicPartition(topic.name(), partition.partitionIndex()), partition);
             }
         }
-        assertEquals(4, partitions.size());
+        assertEquals(6, partitions.size());
         for (Map.Entry<TopicPartition, ListOffsetsPartition> entry : partitions.entrySet()) {
             assertExpectedTimestamp(entry.getKey(), entry.getValue().timestamp());
         }
@@ -126,6 +130,12 @@ public final class ListOffsetsHandlerTest {
 
         builder = readCommittedHandler.buildBatchedRequest(node.id(), mkSet(t0p0, t0p1, t1p0, t1p1));
         assertEquals(7, builder.oldestAllowedVersion());
+
+        builder = readCommittedHandler.buildBatchedRequest(node.id(), mkSet(t0p0, t0p1, t1p0, t1p1, t2p0));
+        assertEquals(8, builder.oldestAllowedVersion());
+
+        builder = readCommittedHandler.buildBatchedRequest(node.id(), mkSet(t0p0, t0p1, t1p0, t1p1, t2p0, t2p1));
+        assertEquals(9, builder.oldestAllowedVersion());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -72,7 +72,12 @@ public class ListOffsetsRequestTest {
                                 new ListOffsetsPartition()
                                     .setPartitionIndex(0))));
             ListOffsetsRequest request = ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false, topics)
+                    .forConsumer(true,
+                            IsolationLevel.READ_COMMITTED,
+                            false,
+                            false,
+                            false,
+                            topics)
                     .setTargetTimes(topics)
                     .build(version);
             ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());
@@ -105,7 +110,12 @@ public class ListOffsetsRequestTest {
                             new ListOffsetsPartition()
                                 .setPartitionIndex(0))));
         ListOffsetsRequest request = ListOffsetsRequest.Builder
-                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+                .forConsumer(true,
+                        IsolationLevel.READ_UNCOMMITTED,
+                        false,
+                        false,
+                        false,
+                        topics)
                 .setTargetTimes(topics)
                 .build((short) 0);
         ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -80,7 +80,7 @@ public class ListOffsetsRequestTest {
                     .setTargetTimes(topics)
                     .build(version);
             ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());
-
+    
             List<ListOffsetsTopicResponse> v = Collections.singletonList(
                     new ListOffsetsTopicResponse()
                         .setName("topic")

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
@@ -75,7 +76,7 @@ public class ListOffsetsRequestTest {
                                 new ListOffsetsPartition()
                                     .setPartitionIndex(0))));
             ListOffsetsRequest request = ListOffsetsRequest.Builder
-                    .forReadCommitted()
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED)
                     .setTargetTimes(topics)
                     .build(version);
             ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());
@@ -108,7 +109,7 @@ public class ListOffsetsRequestTest {
                             new ListOffsetsPartition()
                                 .setPartitionIndex(0))));
         ListOffsetsRequest request = ListOffsetsRequest.Builder
-                .forRequiredTimestamp()
+                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
                 .setTargetTimes(topics)
                 .build((short) 0);
         ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2356,7 +2356,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
+                    .defaultBuilder()
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version == 1) {
@@ -2368,7 +2368,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
+                    .forRequiredTimestamp()
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
@@ -2382,7 +2382,7 @@ public class RequestResponseTest {
                     .setPartitions(singletonList(partition));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false, false, topics)
+                    .forReadCommitted()
                     .setTargetTimes(topics)
                     .build(version);
         } else {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2354,9 +2354,10 @@ public class RequestResponseTest {
                             .setTimestamp(1000000L)
                             .setMaxNumOffsets(10)
                             .setCurrentLeaderEpoch(5)));
+            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false)
-                    .setTargetTimes(singletonList(topic))
+                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+                    .setTargetTimes(topics)
                     .build(version);
         } else if (version == 1) {
             ListOffsetsTopic topic = new ListOffsetsTopic()
@@ -2365,9 +2366,10 @@ public class RequestResponseTest {
                             .setPartitionIndex(0)
                             .setTimestamp(1000000L)
                             .setCurrentLeaderEpoch(5)));
+            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false)
-                    .setTargetTimes(singletonList(topic))
+                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+                    .setTargetTimes(topics)
                     .build(version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
             ListOffsetsPartition partition = new ListOffsetsPartition()
@@ -2378,9 +2380,10 @@ public class RequestResponseTest {
             ListOffsetsTopic topic = new ListOffsetsTopic()
                     .setName("test")
                     .setPartitions(singletonList(partition));
+            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false)
-                    .setTargetTimes(singletonList(topic))
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false, topics)
+                    .setTargetTimes(topics)
                     .build(version);
         } else {
             throw new IllegalArgumentException("Illegal ListOffsetRequest version " + version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2354,10 +2354,9 @@ public class RequestResponseTest {
                             .setTimestamp(1000000L)
                             .setMaxNumOffsets(10)
                             .setCurrentLeaderEpoch(5)));
-            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
                     .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
-                    .setTargetTimes(topics)
+                    .setTargetTimes(singletonList(topic))
                     .build(version);
         } else if (version == 1) {
             ListOffsetsTopic topic = new ListOffsetsTopic()
@@ -2366,10 +2365,9 @@ public class RequestResponseTest {
                             .setPartitionIndex(0)
                             .setTimestamp(1000000L)
                             .setCurrentLeaderEpoch(5)));
-            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
                     .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
-                    .setTargetTimes(topics)
+                    .setTargetTimes(singletonList(topic))
                     .build(version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
             ListOffsetsPartition partition = new ListOffsetsPartition()
@@ -2380,10 +2378,9 @@ public class RequestResponseTest {
             ListOffsetsTopic topic = new ListOffsetsTopic()
                     .setName("test")
                     .setPartitions(singletonList(partition));
-            List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
                     .forConsumer(true, IsolationLevel.READ_COMMITTED)
-                    .setTargetTimes(topics)
+                    .setTargetTimes(singletonList(topic))
                     .build(version);
         } else {
             throw new IllegalArgumentException("Illegal ListOffsetRequest version " + version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2356,7 +2356,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version == 1) {
@@ -2368,7 +2368,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
@@ -2382,7 +2382,7 @@ public class RequestResponseTest {
                     .setPartitions(singletonList(partition));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false, topics)
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false, false, false, topics)
                     .setTargetTimes(topics)
                     .build(version);
         } else {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2356,7 +2356,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .defaultBuilder()
+                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version == 1) {
@@ -2368,7 +2368,7 @@ public class RequestResponseTest {
                             .setCurrentLeaderEpoch(5)));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forRequiredTimestamp()
+                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
                     .setTargetTimes(topics)
                     .build(version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
@@ -2382,7 +2382,7 @@ public class RequestResponseTest {
                     .setPartitions(singletonList(partition));
             List<ListOffsetsTopic> topics = singletonList(topic);
             return ListOffsetsRequest.Builder
-                    .forReadCommitted()
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED)
                     .setTargetTimes(topics)
                     .build(version);
         } else {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -51,7 +51,7 @@ import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern, ResourcePatternFilter, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Utils
-import org.apache.kafka.common.{ElectionType, KafkaException, Node, TopicPartition, Uuid, requests}
+import org.apache.kafka.common.{ElectionType, IsolationLevel, KafkaException, Node, TopicPartition, Uuid, requests}
 import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.security.authorizer.AclEntry.WILDCARD_HOST
@@ -293,7 +293,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
         .setPartitionIndex(tp.partition)
         .setTimestamp(0L)
         .setCurrentLeaderEpoch(27)).asJava)).asJava
-    requests.ListOffsetsRequest.Builder.defaultBuilder()
+    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
       .setTargetTimes(topics)
       .build()
   }

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -293,8 +293,9 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
         .setPartitions(List(new ListOffsetsPartition()
           .setPartitionIndex(tp.partition)
           .setTimestamp(0L)
-          .setCurrentLeaderEpoch(27)).asJava)).asJava)
-      .build()
+          .setCurrentLeaderEpoch(27)).asJava)).asJava
+      ).
+      build()
   }
 
   private def offsetsForLeaderEpochRequest: OffsetsForLeaderEpochRequest = {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -287,14 +287,13 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
   }
 
   private def createListOffsetsRequest = {
-    val topics = List(new ListOffsetsTopic()
-      .setName(tp.topic)
-      .setPartitions(List(new ListOffsetsPartition()
-        .setPartitionIndex(tp.partition)
-        .setTimestamp(0L)
-        .setCurrentLeaderEpoch(27)).asJava)).asJava
     requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
-      .setTargetTimes(topics)
+      .setTargetTimes(List(new ListOffsetsTopic()
+        .setName(tp.topic)
+        .setPartitions(List(new ListOffsetsPartition()
+          .setPartitionIndex(tp.partition)
+          .setTimestamp(0L)
+          .setCurrentLeaderEpoch(27)).asJava)).asJava)
       .build()
   }
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -293,7 +293,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
         .setPartitionIndex(tp.partition)
         .setTimestamp(0L)
         .setCurrentLeaderEpoch(27)).asJava)).asJava
-    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
       .setTargetTimes(topics)
       .build()
   }

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -287,15 +287,15 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
   }
 
   private def createListOffsetsRequest = {
-    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false).setTargetTimes(
-      List(new ListOffsetsTopic()
-        .setName(tp.topic)
-        .setPartitions(List(new ListOffsetsPartition()
-          .setPartitionIndex(tp.partition)
-          .setTimestamp(0L)
-          .setCurrentLeaderEpoch(27)).asJava)).asJava
-      ).
-      build()
+    val topics = List(new ListOffsetsTopic()
+      .setName(tp.topic)
+      .setPartitions(List(new ListOffsetsPartition()
+        .setPartitionIndex(tp.partition)
+        .setTimestamp(0L)
+        .setCurrentLeaderEpoch(27)).asJava)).asJava
+    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+      .setTargetTimes(topics)
+      .build()
   }
 
   private def offsetsForLeaderEpochRequest: OffsetsForLeaderEpochRequest = {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -51,7 +51,7 @@ import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern, ResourcePatternFilter, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Utils
-import org.apache.kafka.common.{ElectionType, IsolationLevel, KafkaException, Node, TopicPartition, Uuid, requests}
+import org.apache.kafka.common.{ElectionType, KafkaException, Node, TopicPartition, Uuid, requests}
 import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.security.authorizer.AclEntry.WILDCARD_HOST
@@ -293,7 +293,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
         .setPartitionIndex(tp.partition)
         .setTimestamp(0L)
         .setCurrentLeaderEpoch(27)).asJava)).asJava
-    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
+    requests.ListOffsetsRequest.Builder.defaultBuilder()
       .setTargetTimes(topics)
       .build()
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4041,7 +4041,7 @@ class KafkaApisTest extends Logging {
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
         .setCurrentLeaderEpoch(currentLeaderEpoch.get)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, targetTimes)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
@@ -10069,7 +10069,7 @@ class KafkaApisTest extends Logging {
       .setPartitions(List(new ListOffsetsPartition()
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, targetTimes)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     kafkaApis = createKafkaApis()

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4041,7 +4041,7 @@ class KafkaApisTest extends Logging {
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
         .setCurrentLeaderEpoch(currentLeaderEpoch.get)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, false, targetTimes)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forRequiredTimestamp()
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
@@ -10069,8 +10069,11 @@ class KafkaApisTest extends Logging {
       .setPartitions(List(new ListOffsetsPartition()
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, false, targetTimes)
-      .setTargetTimes(targetTimes).build()
+    val builder = if (isolationLevel == IsolationLevel.READ_COMMITTED)
+      ListOffsetsRequest.Builder.forReadCommitted()
+    else
+      ListOffsetsRequest.Builder.forRequiredTimestamp()
+    val listOffsetRequest = builder.setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     kafkaApis = createKafkaApis()
     kafkaApis.handleListOffsetRequest(request)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4041,7 +4041,7 @@ class KafkaApisTest extends Logging {
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
         .setCurrentLeaderEpoch(currentLeaderEpoch.get)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forRequiredTimestamp()
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
@@ -10069,11 +10069,8 @@ class KafkaApisTest extends Logging {
       .setPartitions(List(new ListOffsetsPartition()
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)).asJava)).asJava
-    val builder = if (isolationLevel == IsolationLevel.READ_COMMITTED)
-      ListOffsetsRequest.Builder.forReadCommitted()
-    else
-      ListOffsetsRequest.Builder.forRequiredTimestamp()
-    val listOffsetRequest = builder.setTargetTimes(targetTimes).build()
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel)
+      .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     kafkaApis = createKafkaApis()
     kafkaApis.handleListOffsetRequest(request)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4041,7 +4041,7 @@ class KafkaApisTest extends Logging {
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
         .setCurrentLeaderEpoch(currentLeaderEpoch.get)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, targetTimes)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, false, targetTimes)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
@@ -10069,7 +10069,7 @@ class KafkaApisTest extends Logging {
       .setPartitions(List(new ListOffsetsPartition()
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, targetTimes)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false, false, false, targetTimes)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     kafkaApis = createKafkaApis()

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -55,7 +55,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setCurrentLeaderEpoch(0)).asJava)).asJava
 
     val consumerRequest = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
       .setTargetTimes(targetTimes)
       .build()
 
@@ -98,24 +98,28 @@ class ListOffsetsRequestTest extends BaseRequestTest {
   def testListOffsetsRequestOldestVersion(): Unit = {
     val topics: util.List[ListOffsetsTopic] = Nil.asJava
     val consumerRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
 
     val requireTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, topics)
+      .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
 
     val requestCommittedRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_COMMITTED, false, false, topics)
+      .forConsumer(false, IsolationLevel.READ_COMMITTED, false, false, false, topics)
 
     val maxTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, topics)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, false, topics)
+
+    val requireEarliestLocalTimestampRequestBuilder = ListOffsetsRequest.Builder
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, false, topics)
 
     val requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, topics)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true, topics)
 
     assertEquals(0.toShort, consumerRequestBuilder.oldestAllowedVersion())
     assertEquals(1.toShort, requireTimestampRequestBuilder.oldestAllowedVersion())
     assertEquals(2.toShort, requestCommittedRequestBuilder.oldestAllowedVersion())
     assertEquals(7.toShort, maxTimestampRequestBuilder.oldestAllowedVersion())
+    assertEquals(8.toShort, requireEarliestLocalTimestampRequestBuilder.oldestAllowedVersion())
     assertEquals(9.toShort, requireTieredStorageTimestampRequestBuilder.oldestAllowedVersion())
   }
 
@@ -129,7 +133,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       .setName(topic)
       .setPartitions(List(listOffsetPartition).asJava)).asJava
     val request = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
       .setTargetTimes(targetTimes)
       .build()
     assertResponseError(error, brokerId, request)
@@ -173,7 +177,12 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setTimestamp(timestamp)).asJava)).asJava
 
     val builder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+      .forConsumer(false,
+        IsolationLevel.READ_UNCOMMITTED,
+        false,
+        false,
+        false,
+        targetTimes)
       .setTargetTimes(targetTimes)
 
     val request = if (version == -1) builder.build() else builder.build(version)

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -54,7 +54,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setCurrentLeaderEpoch(0)).asJava)).asJava
 
     val consumerRequest = ListOffsetsRequest.Builder
-      .defaultBuilder()
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
       .setTargetTimes(targetTimes)
       .build()
 
@@ -96,22 +96,22 @@ class ListOffsetsRequestTest extends BaseRequestTest {
   @ValueSource(strings = Array("zk", "kraft"))
   def testListOffsetsRequestOldestVersion(): Unit = {
     val consumerRequestBuilder = ListOffsetsRequest.Builder
-      .defaultBuilder()
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
 
     val requireTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forRequiredTimestamp()
+      .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
 
     val requestCommittedRequestBuilder = ListOffsetsRequest.Builder
-      .forReadCommitted()
+      .forConsumer(false, IsolationLevel.READ_COMMITTED)
 
     val maxTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forMaxTimestamp(IsolationLevel.READ_UNCOMMITTED)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, false)
 
     val requireEarliestLocalTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forEarliestLocalTimestamp(IsolationLevel.READ_UNCOMMITTED)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, false)
 
     val requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forTieredStorageTimestamp(IsolationLevel.READ_UNCOMMITTED)
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true)
 
     assertEquals(0.toShort, consumerRequestBuilder.oldestAllowedVersion())
     assertEquals(1.toShort, requireTimestampRequestBuilder.oldestAllowedVersion())
@@ -131,7 +131,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       .setName(topic)
       .setPartitions(List(listOffsetPartition).asJava)).asJava
     val request = ListOffsetsRequest.Builder
-      .defaultBuilder()
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
       .setTargetTimes(targetTimes)
       .build()
     assertResponseError(error, brokerId, request)
@@ -175,7 +175,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setTimestamp(timestamp)).asJava)).asJava
 
     val builder = ListOffsetsRequest.Builder
-      .defaultBuilder()
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
       .setTargetTimes(targetTimes)
 
     val request = if (version == -1) builder.build() else builder.build(version)

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-import java.util
 import java.util.{Optional, Properties}
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
@@ -55,7 +54,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setCurrentLeaderEpoch(0)).asJava)).asJava
 
     val consumerRequest = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
+      .defaultBuilder()
       .setTargetTimes(targetTimes)
       .build()
 
@@ -96,24 +95,23 @@ class ListOffsetsRequestTest extends BaseRequestTest {
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testListOffsetsRequestOldestVersion(): Unit = {
-    val topics: util.List[ListOffsetsTopic] = Nil.asJava
     val consumerRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
+      .defaultBuilder()
 
     val requireTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false, false, false, topics)
+      .forRequiredTimestamp()
 
     val requestCommittedRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_COMMITTED, false, false, false, topics)
+      .forReadCommitted()
 
     val maxTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, false, topics)
+      .forMaxTimestamp(IsolationLevel.READ_UNCOMMITTED)
 
     val requireEarliestLocalTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, false, topics)
+      .forEarliestLocalTimestamp(IsolationLevel.READ_UNCOMMITTED)
 
     val requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true, topics)
+      .forTieredStorageTimestamp(IsolationLevel.READ_UNCOMMITTED)
 
     assertEquals(0.toShort, consumerRequestBuilder.oldestAllowedVersion())
     assertEquals(1.toShort, requireTimestampRequestBuilder.oldestAllowedVersion())
@@ -133,7 +131,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       .setName(topic)
       .setPartitions(List(listOffsetPartition).asJava)).asJava
     val request = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
+      .defaultBuilder()
       .setTargetTimes(targetTimes)
       .build()
     assertResponseError(error, brokerId, request)
@@ -177,12 +175,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
         .setTimestamp(timestamp)).asJava)).asJava
 
     val builder = ListOffsetsRequest.Builder
-      .forConsumer(false,
-        IsolationLevel.READ_UNCOMMITTED,
-        false,
-        false,
-        false,
-        targetTimes)
+      .defaultBuilder()
       .setTargetTimes(targetTimes)
 
     val request = if (version == -1) builder.build() else builder.build(version)

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsParti
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse}
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.{IsolationLevel, TopicPartition}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.storage.internals.log.{LogSegment, LogStartOffsetIncrementReason}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
@@ -61,7 +61,7 @@ class LogOffsetTest extends BaseRequestTest {
   def testGetOffsetsForUnknownTopic(quorum: String): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
     val targetTimes = buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava
-    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
+    val request = ListOffsetsRequest.Builder.defaultBuilder()
       .setTargetTimes(targetTimes).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -60,9 +60,8 @@ class LogOffsetTest extends BaseRequestTest {
   @ValueSource(strings = Array("zk", "kraft"))
   def testGetOffsetsForUnknownTopic(quorum: String): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
-    val targetTimes = buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava
     val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
-      .setTargetTimes(targetTimes).build(0)
+      .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)
   }

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -60,8 +60,9 @@ class LogOffsetTest extends BaseRequestTest {
   @ValueSource(strings = Array("zk", "kraft"))
   def testGetOffsetsForUnknownTopic(quorum: String): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
-    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false)
-      .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava).build(0)
+    val targetTimes = buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava
+    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+      .setTargetTimes(targetTimes).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)
   }

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -61,7 +61,7 @@ class LogOffsetTest extends BaseRequestTest {
   def testGetOffsetsForUnknownTopic(quorum: String): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
     val targetTimes = buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava
-    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
       .setTargetTimes(targetTimes).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsParti
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse}
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.storage.internals.log.{LogSegment, LogStartOffsetIncrementReason}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
@@ -61,7 +61,7 @@ class LogOffsetTest extends BaseRequestTest {
   def testGetOffsetsForUnknownTopic(quorum: String): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
     val targetTimes = buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava
-    val request = ListOffsetsRequest.Builder.defaultBuilder()
+    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
       .setTargetTimes(targetTimes).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -288,8 +288,9 @@ class RequestQuotaTest extends BaseRequestTest {
               .setPartitionIndex(tp.partition)
               .setTimestamp(0L)
               .setCurrentLeaderEpoch(15)).asJava)
-          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false)
-            .setTargetTimes(List(topic).asJava)
+          val targetTimes = List(topic).asJava
+          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+            .setTargetTimes(targetTimes)
 
         case ApiKeys.LEADER_AND_ISR =>
           new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -282,13 +282,14 @@ class RequestQuotaTest extends BaseRequestTest {
           new MetadataRequest.Builder(List(topic).asJava, true)
 
         case ApiKeys.LIST_OFFSETS =>
-          val targetTimes = List(new ListOffsetsTopic()
+          val topic = new ListOffsetsTopic()
             .setName(tp.topic)
             .setPartitions(List(new ListOffsetsPartition()
               .setPartitionIndex(tp.partition)
               .setTimestamp(0L)
-              .setCurrentLeaderEpoch(15)).asJava)).asJava
-          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED).setTargetTimes(targetTimes)
+              .setCurrentLeaderEpoch(15)).asJava)
+          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+            .setTargetTimes(List(topic).asJava)
 
         case ApiKeys.LEADER_AND_ISR =>
           new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -289,7 +289,7 @@ class RequestQuotaTest extends BaseRequestTest {
               .setTimestamp(0L)
               .setCurrentLeaderEpoch(15)).asJava)
           val targetTimes = List(topic).asJava
-          ListOffsetsRequest.Builder.defaultBuilder().setTargetTimes(targetTimes)
+          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED).setTargetTimes(targetTimes)
 
         case ApiKeys.LEADER_AND_ISR =>
           new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -289,8 +289,7 @@ class RequestQuotaTest extends BaseRequestTest {
               .setTimestamp(0L)
               .setCurrentLeaderEpoch(15)).asJava)
           val targetTimes = List(topic).asJava
-          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
-            .setTargetTimes(targetTimes)
+          ListOffsetsRequest.Builder.defaultBuilder().setTargetTimes(targetTimes)
 
         case ApiKeys.LEADER_AND_ISR =>
           new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -289,7 +289,7 @@ class RequestQuotaTest extends BaseRequestTest {
               .setTimestamp(0L)
               .setCurrentLeaderEpoch(15)).asJava)
           val targetTimes = List(topic).asJava
-          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, targetTimes)
+          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, false, targetTimes)
             .setTargetTimes(targetTimes)
 
         case ApiKeys.LEADER_AND_ISR =>

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -282,13 +282,12 @@ class RequestQuotaTest extends BaseRequestTest {
           new MetadataRequest.Builder(List(topic).asJava, true)
 
         case ApiKeys.LIST_OFFSETS =>
-          val topic = new ListOffsetsTopic()
+          val targetTimes = List(new ListOffsetsTopic()
             .setName(tp.topic)
             .setPartitions(List(new ListOffsetsPartition()
               .setPartitionIndex(tp.partition)
               .setTimestamp(0L)
-              .setCurrentLeaderEpoch(15)).asJava)
-          val targetTimes = List(topic).asJava
+              .setCurrentLeaderEpoch(15)).asJava)).asJava
           ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED).setTargetTimes(targetTimes)
 
         case ApiKeys.LEADER_AND_ISR =>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
@@ -19,7 +19,6 @@ package org.apache.kafka.jmh.common;
 
 import kafka.network.RequestConvertToJson;
 
-import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -38,7 +37,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -72,13 +70,7 @@ public class ListOffsetRequestBenchmark {
             }
         }
 
-        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false,
-                        IsolationLevel.READ_UNCOMMITTED,
-                        false,
-                        false,
-                        false,
-                        Collections.emptyList())
-                .build(ApiKeys.LIST_OFFSETS.latestVersion());
+        this.offsetRequest = ListOffsetsRequest.Builder.defaultBuilder().build(ApiKeys.LIST_OFFSETS.latestVersion());
     }
 
     @Benchmark

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
@@ -19,6 +19,7 @@ package org.apache.kafka.jmh.common;
 
 import kafka.network.RequestConvertToJson;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -70,7 +71,8 @@ public class ListOffsetRequestBenchmark {
             }
         }
 
-        this.offsetRequest = ListOffsetsRequest.Builder.defaultBuilder().build(ApiKeys.LIST_OFFSETS.latestVersion());
+        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+                .build(ApiKeys.LIST_OFFSETS.latestVersion());
     }
 
     @Benchmark

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -71,7 +72,11 @@ public class ListOffsetRequestBenchmark {
             }
         }
 
-        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false)
+        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false,
+                        IsolationLevel.READ_UNCOMMITTED,
+                        false,
+                        false,
+                        Collections.emptyList())
                 .build(ApiKeys.LIST_OFFSETS.latestVersion());
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
@@ -76,6 +76,7 @@ public class ListOffsetRequestBenchmark {
                         IsolationLevel.READ_UNCOMMITTED,
                         false,
                         false,
+                        false,
                         Collections.emptyList())
                 .build(ApiKeys.LIST_OFFSETS.latestVersion());
     }


### PR DESCRIPTION
JIRA: [KAFKA-17331](https://issues.apache.org/jira/browse/KAFKA-17331)

Add the version check to client side when building `ListOffsetRequest`  for the specific timestamp:
- the version must be `>=8` if `timestamp=-4L` (`EARLIEST_LOCAL_TIMESTAMP`)
- the version must be `>=9` if `timestamp=-5L` (`LATEST_TIERED_TIMESTAMP`)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
