### PR TITLE
MINOR: Fix visibility for classes exposed outside of their scope

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -692,7 +692,7 @@ public class LeaderState<T> implements EpochState {
         }
     }
 
-    static class ReplicaState implements Comparable<ReplicaState> {
+    public static class ReplicaState implements Comparable<ReplicaState> {
         private ReplicaKey replicaKey;
         private Endpoints listeners;
         private Optional<LogOffsetMetadata> endOffset;

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestSender.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
  * Responsible for managing the connection state and sending request when the connection is
  * available.
  */
-interface RequestSender {
+public interface RequestSender {
     /**
      * The name of the listener used for sending request.
      *


### PR DESCRIPTION
These 2 classes are package protected but they are part of the public API of public methods. To have clean APIs we should make this consistent.

- static class `ReplicaState` is exposed in `RaftUtil.singletonDescribeQuorumResponse` method which is public
- `RequestSender` is implemented by a public class and it's exposed in the public constructor of `AddVoterHandler`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
