### PR TITLE
KAFKA-17327: Add support of group in kafka-configs.sh

### DIFF
--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -131,6 +131,7 @@
     <allow pkg="kafka.server"/>
     <allow pkg="kafka.zk"/>
     <allow pkg="org.apache.kafka.clients.admin"/>
+    <allow pkg="org.apache.kafka.coordinator.group"/>
     <allow pkg="org.apache.kafka.metadata.authorizer"/>
     <allow pkg="org.apache.kafka.security"/>
     <allow pkg="org.apache.kafka.server"/>

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -92,6 +92,7 @@ public class MockAdminClient extends AdminClient {
     private final List<Map<String, String>> brokerConfigs;
     private final Map<String, Map<String, String>> clientMetricsConfigs;
     private final Map<String, Map<String, String>> groupConfigs;
+    private final Map<String, String> defaultGroupConfigs;
 
     private Node controller;
     private int timeoutNextRequests = 0;
@@ -245,6 +246,7 @@ public class MockAdminClient extends AdminClient {
         this.brokerConfigs = new ArrayList<>();
         this.clientMetricsConfigs = new HashMap<>();
         this.groupConfigs = new HashMap<>();
+        this.defaultGroupConfigs = generateDefaultGroupConfigs();
         for (int i = 0; i < brokers.size(); i++) {
             final Map<String, String> config = new HashMap<>();
             config.put("default.replication.factor", String.valueOf(defaultReplicationFactor));
@@ -833,7 +835,9 @@ public class MockAdminClient extends AdminClient {
                 if (resourceName.isEmpty()) {
                     throw new InvalidRequestException("Empty resource name");
                 }
-                return toConfigObject(groupConfigs.get(resourceName));
+                Map<String, String> groupConfig = groupConfigs.getOrDefault(resourceName, new HashMap<>());
+                defaultGroupConfigs.forEach(groupConfig::putIfAbsent);
+                return toConfigObject(groupConfig);
             }
             default:
                 throw new UnsupportedOperationException("Not implemented yet");
@@ -1470,5 +1474,12 @@ public class MockAdminClient extends AdminClient {
 
     public synchronized Node broker(int index) {
         return brokers.get(index);
+    }
+
+    private Map<String, String> generateDefaultGroupConfigs() {
+        Map<String, String> defaultGroupConfigs = new HashMap<>();
+        defaultGroupConfigs.put("consumer.session.timeout.ms", "45000");
+        defaultGroupConfigs.put("consumer.heartbeat.interval.ms", "5000");
+        return defaultGroupConfigs;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -123,6 +123,7 @@ public class MockAdminClient extends AdminClient {
         private Map<String, Short> featureLevels = Collections.emptyMap();
         private Map<String, Short> minSupportedFeatureLevels = Collections.emptyMap();
         private Map<String, Short> maxSupportedFeatureLevels = Collections.emptyMap();
+        private Map<String, String> defaultGroupConfigs = Collections.emptyMap();
 
         @SuppressWarnings("this-escape")
         public Builder() {
@@ -193,6 +194,11 @@ public class MockAdminClient extends AdminClient {
             return this;
         }
 
+        public Builder defaultGroupConfigs(Map<String, String> defaultGroupConfigs) {
+            this.defaultGroupConfigs = defaultGroupConfigs;
+            return this;
+        }
+
         public MockAdminClient build() {
             return new MockAdminClient(brokers,
                 controller == null ? brokers.get(0) : controller,
@@ -203,7 +209,8 @@ public class MockAdminClient extends AdminClient {
                 usingRaftController,
                 featureLevels,
                 minSupportedFeatureLevels,
-                maxSupportedFeatureLevels);
+                maxSupportedFeatureLevels,
+                defaultGroupConfigs);
         }
     }
 
@@ -221,6 +228,7 @@ public class MockAdminClient extends AdminClient {
             false,
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             Collections.emptyMap());
     }
 
@@ -235,7 +243,8 @@ public class MockAdminClient extends AdminClient {
         boolean usingRaftController,
         Map<String, Short> featureLevels,
         Map<String, Short> minSupportedFeatureLevels,
-        Map<String, Short> maxSupportedFeatureLevels
+        Map<String, Short> maxSupportedFeatureLevels,
+        Map<String, String> defaultGroupConfigs
     ) {
         this.brokers = brokers;
         controller(controller);
@@ -246,7 +255,7 @@ public class MockAdminClient extends AdminClient {
         this.brokerConfigs = new ArrayList<>();
         this.clientMetricsConfigs = new HashMap<>();
         this.groupConfigs = new HashMap<>();
-        this.defaultGroupConfigs = generateDefaultGroupConfigs();
+        this.defaultGroupConfigs = new HashMap<>(defaultGroupConfigs);
         for (int i = 0; i < brokers.size(); i++) {
             final Map<String, String> config = new HashMap<>();
             config.put("default.replication.factor", String.valueOf(defaultReplicationFactor));
@@ -1474,12 +1483,5 @@ public class MockAdminClient extends AdminClient {
 
     public synchronized Node broker(int index) {
         return brokers.get(index);
-    }
-
-    private Map<String, String> generateDefaultGroupConfigs() {
-        Map<String, String> defaultGroupConfigs = new HashMap<>();
-        defaultGroupConfigs.put("consumer.session.timeout.ms", "45000");
-        defaultGroupConfigs.put("consumer.heartbeat.interval.ms", "5000");
-        return defaultGroupConfigs;
     }
 }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -25,7 +25,8 @@ import kafka.server.{DynamicBrokerConfig, DynamicConfig, KafkaConfig}
 import kafka.utils.Implicits._
 import kafka.utils.Logging
 import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasOptions, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeClusterOptions, DescribeConfigsOptions, ListTopicsOptions, ScramCredentialInfo, UserScramCredentialDeletion, UserScramCredentialUpsertion, Config => JConfig, ScramMechanism => PublicScramMechanism}
+import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasOptions, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeClusterOptions, DescribeConfigsOptions, ListConsumerGroupsOptions, ListTopicsOptions, ScramCredentialInfo, UserScramCredentialDeletion, UserScramCredentialUpsertion, Config => JConfig, ScramMechanism => PublicScramMechanism}
+import org.apache.kafka.common.GroupType
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.errors.InvalidConfigurationException
@@ -45,7 +46,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection._
 
 /**
- * This script can be used to change configs for topics/clients/users/brokers/ips/client-metrics dynamically
+ * This script can be used to change configs for topics/clients/users/brokers/ips/client-metrics/groups dynamically
  * An entity described or altered by the command may be one of:
  * <ul>
  *     <li> topic: --topic <topic> OR --entity-type topics --entity-name <topic>
@@ -57,6 +58,7 @@ import scala.collection._
  *     <li> broker-logger: --broker-logger <broker-id> OR --entity-type broker-loggers --entity-name <broker-id>
  *     <li> ip: --ip <ip> OR --entity-type ips --entity-name <ip>
  *     <li> client-metrics: --client-metrics <name> OR --entity-type client-metrics --entity-name <name>
+ *     <li> group: --group <group> OR --entiry-type groups --entity-name <group>
  * </ul>
  * --entity-type <users|clients|brokers|ips> --entity-default may be specified in place of --entity-type <users|clients|brokers|ips> --entity-name <entityName>
  * when describing or altering default configuration for users, clients, brokers, or ips, respectively.
@@ -78,7 +80,7 @@ object ConfigCommand extends Logging {
 
   val BrokerDefaultEntityName = ""
   val BrokerLoggerConfigType = "broker-loggers"
-  private val BrokerSupportedConfigTypes = ConfigType.ALL.asScala :+ BrokerLoggerConfigType :+ ConfigType.CLIENT_METRICS
+  private val BrokerSupportedConfigTypes = ConfigType.ALL.asScala :+ BrokerLoggerConfigType :+ ConfigType.CLIENT_METRICS :+ ConfigType.GROUP
   private val ZkSupportedConfigTypes = Seq(ConfigType.USER, ConfigType.BROKER)
   private val DefaultScramIterations = 4096
 
@@ -86,7 +88,8 @@ object ConfigCommand extends Logging {
     try {
       val opts = new ConfigCommandOptions(args)
 
-      CommandLineUtils.maybePrintHelpOrVersion(opts, "This tool helps to manipulate and describe entity config for a topic, client, user, broker, ip or client-metrics")
+      CommandLineUtils.maybePrintHelpOrVersion(opts,
+        "This tool helps to manipulate and describe entity config for a topic, client, user, broker, ip, client-metrics or group")
 
       opts.checkArgs()
 
@@ -366,20 +369,7 @@ object ConfigCommand extends Logging {
 
     entityTypeHead match {
       case ConfigType.TOPIC =>
-        val oldConfig = getResourceConfig(adminClient, entityTypeHead, entityNameHead, includeSynonyms = false, describeAll = false)
-          .map { entry => (entry.name, entry) }.toMap
-
-        // fail the command if any of the configs to be deleted does not exist
-        val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
-        if (invalidConfigs.nonEmpty)
-          throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
-
-        val configResource = new ConfigResource(ConfigResource.Type.TOPIC, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
-        val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
-          ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
-        ).asJavaCollection
-        adminClient.incrementalAlterConfigs(Map(configResource -> alterEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
+        alterResourceConfig(adminClient, entityTypeHead, entityNameHead, configsToBeDeleted, configsToBeAdded, ConfigResource.Type.TOPIC)
 
       case ConfigType.BROKER =>
         val oldConfig = getResourceConfig(adminClient, entityTypeHead, entityNameHead, includeSynonyms = false, describeAll = false)
@@ -455,20 +445,11 @@ object ConfigCommand extends Logging {
           throw new IllegalArgumentException(s"Only connection quota configs can be added for '${ConfigType.IP}' using --bootstrap-server. Unexpected config names: ${unknownConfigs.mkString(",")}")
         alterQuotaConfigs(adminClient, entityTypes, entityNames, configsToBeAddedMap, configsToBeDeleted)
       case ConfigType.CLIENT_METRICS =>
-        val oldConfig = getResourceConfig(adminClient, entityTypeHead, entityNameHead, includeSynonyms = false, describeAll = false)
-          .map { entry => (entry.name, entry) }.toMap
+        alterResourceConfig(adminClient, entityTypeHead, entityNameHead, configsToBeDeleted, configsToBeAdded, ConfigResource.Type.CLIENT_METRICS)
 
-        // fail the command if any of the configs to be deleted does not exist
-        val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
-        if (invalidConfigs.nonEmpty)
-          throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
+      case ConfigType.GROUP =>
+        alterResourceConfig(adminClient, entityTypeHead, entityNameHead, configsToBeDeleted, configsToBeAdded, ConfigResource.Type.GROUP)
 
-        val configResource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, entityNameHead)
-        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
-        val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
-          ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
-          ).asJavaCollection
-        adminClient.incrementalAlterConfigs(Map(configResource -> alterEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
       case _ => throw new IllegalArgumentException(s"Unsupported entity type: $entityTypeHead")
     }
 
@@ -542,7 +523,7 @@ object ConfigCommand extends Logging {
     val describeAll = opts.options.has(opts.allOpt)
 
     entityTypes.head match {
-      case ConfigType.TOPIC | ConfigType.BROKER | BrokerLoggerConfigType | ConfigType.CLIENT_METRICS =>
+      case ConfigType.TOPIC | ConfigType.BROKER | BrokerLoggerConfigType | ConfigType.CLIENT_METRICS | ConfigType.GROUP =>
         describeResourceConfig(adminClient, entityTypes.head, entityNames.headOption, describeAll)
       case ConfigType.USER | ConfigType.CLIENT =>
         describeClientQuotaAndUserScramCredentialConfigs(adminClient, entityTypes, entityNames)
@@ -562,6 +543,8 @@ object ConfigCommand extends Logging {
           adminClient.describeCluster(new DescribeClusterOptions()).nodes().get().asScala.map(_.idString).toSeq :+ BrokerDefaultEntityName
         case ConfigType.CLIENT_METRICS =>
           adminClient.listClientMetricsResources().all().get().asScala.map(_.name).toSeq
+        case ConfigType.GROUP =>
+          adminClient.listConsumerGroups(new ListConsumerGroupsOptions().withTypes(Seq(GroupType.CONSUMER).toSet.asJava)).all.get.asScala.map(_.groupId).toSeq
         case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
       })
 
@@ -578,6 +561,23 @@ object ConfigCommand extends Logging {
         println(s"  ${entry.name}=${entry.value} sensitive=${entry.isSensitive} synonyms={$synonyms}")
       }
     }
+  }
+
+  private def alterResourceConfig(adminClient: Admin, entityTypeHead: String, entityNameHead: String, configsToBeDeleted: Seq[String], configsToBeAdded: Map[String, ConfigEntry], resourceType: ConfigResource.Type): Unit = {
+    val oldConfig = getResourceConfig(adminClient, entityTypeHead, entityNameHead, includeSynonyms = false, describeAll = false)
+      .map { entry => (entry.name, entry) }.toMap
+
+    // fail the command if any of the configs to be deleted does not exist
+    val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
+    if (invalidConfigs.nonEmpty)
+      throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
+
+    val configResource = new ConfigResource(resourceType, entityNameHead)
+    val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+    val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
+      ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
+      ).asJavaCollection
+    adminClient.incrementalAlterConfigs(Map(configResource -> alterEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
   }
 
   private def getResourceConfig(adminClient: Admin, entityType: String, entityName: String, includeSynonyms: Boolean, describeAll: Boolean) = {
@@ -604,6 +604,8 @@ object ConfigCommand extends Logging {
         (ConfigResource.Type.BROKER_LOGGER, None)
       case ConfigType.CLIENT_METRICS =>
         (ConfigResource.Type.CLIENT_METRICS, Some(ConfigEntry.ConfigSource.DYNAMIC_CLIENT_METRICS_CONFIG))
+      case ConfigType.GROUP =>
+        (ConfigResource.Type.GROUP, Some(ConfigEntry.ConfigSource.DYNAMIC_GROUP_CONFIG))
       case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
     }
 
@@ -819,10 +821,10 @@ object ConfigCommand extends Logging {
     val describeOpt: OptionSpecBuilder = parser.accepts("describe", "List configs for the given entity.")
     val allOpt: OptionSpecBuilder = parser.accepts("all", "List all configs for the given topic, broker, or broker-logger entity (includes static configuration when the entity type is brokers)")
 
-    val entityType: OptionSpec[String] = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers/broker-loggers/ips/client-metrics)")
+    val entityType: OptionSpec[String] = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers/broker-loggers/ips/client-metrics/groups)")
       .withRequiredArg
       .ofType(classOf[String])
-    val entityName: OptionSpec[String] = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id/ip/client metrics)")
+    val entityName: OptionSpec[String] = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id/ip/client metrics/group name)")
       .withRequiredArg
       .ofType(classOf[String])
     private val entityDefault: OptionSpecBuilder = parser.accepts("entity-default", "Default entity name for clients/users/brokers/ips (applies to corresponding entity type in command line)")
@@ -835,6 +837,7 @@ object ConfigCommand extends Logging {
       "For entity-type '" + ConfigType.CLIENT + "': " + DynamicConfig.Client.names.asScala.toSeq.sorted.map("\t" + _).mkString(nl, nl, nl) +
       "For entity-type '" + ConfigType.IP + "': " + DynamicConfig.Ip.names.asScala.toSeq.sorted.map("\t" + _).mkString(nl, nl, nl) +
       "For entity-type '" + ConfigType.CLIENT_METRICS + "': " + DynamicConfig.ClientMetrics.names.asScala.toSeq.sorted.map("\t" + _).mkString(nl, nl, nl) +
+      "For entity-type '" + ConfigType.GROUP + "': " + DynamicConfig.Group.names.asScala.toSeq.sorted.map("\t" + _).mkString(nl, nl, nl) +
       s"Entity types '${ConfigType.USER}' and '${ConfigType.CLIENT}' may be specified together to update config for clients of a specific user.")
       .withRequiredArg
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -824,7 +824,7 @@ object ConfigCommand extends Logging {
     val entityType: OptionSpec[String] = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers/broker-loggers/ips/client-metrics/groups)")
       .withRequiredArg
       .ofType(classOf[String])
-    val entityName: OptionSpec[String] = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id/ip/client metrics/group name)")
+    val entityName: OptionSpec[String] = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id/ip/client metrics/group id)")
       .withRequiredArg
       .ofType(classOf[String])
     private val entityDefault: OptionSpecBuilder = parser.accepts("entity-default", "Default entity name for clients/users/brokers/ips (applies to corresponding entity type in command line)")
@@ -871,7 +871,7 @@ object ConfigCommand extends Logging {
     val ip: OptionSpec[String] = parser.accepts("ip", "The IP address.")
       .withRequiredArg
       .ofType(classOf[String])
-    val group: OptionSpec[String] = parser.accepts("group", "The group's name.")
+    val group: OptionSpec[String] = parser.accepts("group", "The group's ID.")
       .withRequiredArg
       .ofType(classOf[String])
     val zkTlsConfigFile: OptionSpec[String] = parser.accepts("zk-tls-config-file",

--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -22,6 +22,7 @@ import kafka.server.DynamicBrokerConfig.AllDynamicConfigs
 import java.net.{InetAddress, UnknownHostException}
 import java.util.Properties
 import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.coordinator.group.GroupConfig
 import org.apache.kafka.server.config.{QuotaConfigs, ZooKeeperInternals}
 
 import java.util
@@ -75,7 +76,7 @@ object DynamicConfig {
   }
 
   object Ip {
-    private val ipConfigs = QuotaConfigs.ipConfigs()
+    private val ipConfigs = QuotaConfigs.ipConfigs
 
     def configKeys: util.Map[String, ConfigDef.ConfigKey] = ipConfigs.configKeys
 
@@ -101,9 +102,15 @@ object DynamicConfig {
     def names: util.Set[String] = clientConfigs.names
   }
 
+  object Group {
+    private val groupConfigs = GroupConfig.configDef()
+
+    def names: util.Set[String] = groupConfigs.names
+  }
+
   private def validate(configDef: ConfigDef, props: Properties, customPropsAllowed: Boolean) = {
     // Validate Names
-    val names = configDef.names()
+    val names = configDef.names
     val propKeys = props.keySet.asScala.map(_.asInstanceOf[String])
     if (!customPropsAllowed) {
       val unknownKeys = propKeys.filterNot(names.contains(_))

--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -124,6 +124,12 @@ public class ConfigCommandIntegrationTest {
                 "--entity-name", "group",
                 "--alter", "--add-config", "consumer.session.timeout.ms=50000")),
             errOut -> assertTrue(errOut.contains("Invalid entity type groups, the entity type must be one of users, brokers with a --zookeeper argument"), errOut));
+
+        // Test for the --group alias
+        assertNonZeroStatusExit(Stream.concat(quorumArgs(), Stream.of(
+                "--group", "group",
+                "--alter", "--add-config", "consumer.session.timeout.ms=50000")),
+            errOut -> assertTrue(errOut.contains("Invalid entity type groups, the entity type must be one of users, brokers with a --zookeeper argument"), errOut));
     }
 
     @ClusterTest(types = {Type.CO_KRAFT, Type.KRAFT})
@@ -144,7 +150,13 @@ public class ConfigCommandIntegrationTest {
             "--entity-name", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
         String message = captureStandardMsg(run(command));
+        assertTrue(StringUtils.isBlank(message), message);
 
+        // Test for the --group alias
+        command = Stream.concat(quorumArgs(), Stream.of(
+            "--group", "group",
+            "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
+        message = captureStandardMsg(run(command));
         assertTrue(StringUtils.isBlank(message), message);
     }
 
@@ -284,7 +296,14 @@ public class ConfigCommandIntegrationTest {
     })
     public void testGroupConfigUpdateUsingKraft() throws Exception {
         alterOpts = asList("--bootstrap-server", cluster.bootstrapServers(), "--entity-type", "groups", "--alter");
+        verifyGroupConfigUpdate();
 
+        // Test for the --group alias
+        alterOpts = asList("--bootstrap-server", cluster.bootstrapServers(), "--group", "--alter");
+        verifyGroupConfigUpdate();
+    }
+
+    private void verifyGroupConfigUpdate() throws Exception {
         try (Admin client = cluster.createAdminClient()) {
             // Add config
             Map<String, String> configs = new HashMap<>();

--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -63,6 +63,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_CIPHER_ALGORITHM_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_ITERATIONS_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_KEYFACTORY_ALGORITHM_CONFIG;
@@ -291,8 +293,8 @@ public class ConfigCommandIntegrationTest {
     }
 
     @ClusterTest(types = {Type.KRAFT, Type.CO_KRAFT}, serverProperties = {
-        @ClusterConfigProperty(key = "group.coordinator.new.enable", value = "true"),
-        @ClusterConfigProperty(key = "group.coordinator.rebalance.protocols", value = "classic,consumer"),
+        @ClusterConfigProperty(key = NEW_GROUP_COORDINATOR_ENABLE_CONFIG, value = "true"),
+        @ClusterConfigProperty(key = GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer"),
     })
     public void testGroupConfigUpdateUsingKraft() throws Exception {
         alterOpts = asList("--bootstrap-server", cluster.bootstrapServers(), "--entity-type", "groups", "--alter");

--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -63,8 +63,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.NEW_GROUP_COORDINATOR_ENABLE_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_CIPHER_ALGORITHM_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_ITERATIONS_CONFIG;
 import static org.apache.kafka.security.PasswordEncoderConfigs.PASSWORD_ENCODER_KEYFACTORY_ALGORITHM_CONFIG;
@@ -143,7 +141,7 @@ public class ConfigCommandIntegrationTest {
     public void testNullStatusOnKraftCommandAlterGroup() {
         Stream<String> command = Stream.concat(quorumArgs(), Stream.of(
             "--entity-type", "groups",
-            "--entity-name", "admin",
+            "--entity-name", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
         String message = captureStandardMsg(run(command));
 
@@ -281,8 +279,8 @@ public class ConfigCommandIntegrationTest {
     }
 
     @ClusterTest(types = {Type.KRAFT, Type.CO_KRAFT}, serverProperties = {
-        @ClusterConfigProperty(key = NEW_GROUP_COORDINATOR_ENABLE_CONFIG, value = "true"),
-        @ClusterConfigProperty(key = GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer"),
+        @ClusterConfigProperty(key = "group.coordinator.new.enable", value = "true"),
+        @ClusterConfigProperty(key = "group.coordinator.rebalance.protocols", value = "classic,consumer"),
     })
     public void testGroupConfigUpdateUsingKraft() throws Exception {
         alterOpts = asList("--bootstrap-server", cluster.bootstrapServers(), "--entity-type", "groups", "--alter");

--- a/core/src/test/java/kafka/admin/ConfigCommandTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandTest.java
@@ -128,6 +128,13 @@ public class ConfigCommandTest {
     }
 
     @Test
+    public void shouldExitWithNonZeroStatusOnZkCommandWithGroupsEntity() {
+        assertNonZeroStatusExit(toArray(ZOOKEEPER_BOOTSTRAP, Arrays.asList(
+            "--entity-type", "groups",
+            "--describe")));
+    }
+
+    @Test
     public void shouldExitWithNonZeroStatusAlterUserQuotaWithoutEntityName() {
         assertNonZeroStatusExit(toArray(BROKER_BOOTSTRAP, Arrays.asList(
             "--entity-type", "users",
@@ -259,6 +266,21 @@ public class ConfigCommandTest {
     @Test
     public void shouldParseArgumentsForIpEntityTypeWithControllerBootstrap() {
         testArgumentParse(CONTROLLER_BOOTSTRAP, "ips");
+    }
+
+    @Test
+    public void shouldFailParseArgumentsForGroupEntityTypeUsingZookeeper() {
+        assertThrows(IllegalArgumentException.class, () -> testArgumentParse(ZOOKEEPER_BOOTSTRAP, "groups"));
+    }
+
+    @Test
+    public void shouldParseArgumentsForGroupEntityTypeWithBrokerBootstrap() {
+        testArgumentParse(BROKER_BOOTSTRAP, "groups");
+    }
+
+    @Test
+    public void shouldParseArgumentsForGroupEntityTypeWithControllerBootstrap() {
+        testArgumentParse(CONTROLLER_BOOTSTRAP, "groups");
     }
 
     public void testArgumentParse(List<String> bootstrapArguments, String entityType) {
@@ -437,18 +459,21 @@ public class ConfigCommandTest {
         if (!zkConfig) {
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.TOPIC), Collections.singletonList("A"), connectOpts, "--entity-type", "topics", "--entity-name", "A");
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.IP), Collections.singletonList("1.2.3.4"), connectOpts, "--entity-name", "1.2.3.4", "--entity-type", "ips");
+            testExpectedEntityTypeNames(Collections.singletonList(ConfigType.GROUP), Collections.singletonList("A"), connectOpts, "--entity-type", "groups", "--entity-name", "A");
             testExpectedEntityTypeNames(Arrays.asList(ConfigType.USER, ConfigType.CLIENT), Arrays.asList("A", ""), connectOpts,
                 "--entity-type", "users", "--entity-type", "clients", "--entity-name", "A", "--entity-default");
             testExpectedEntityTypeNames(Arrays.asList(ConfigType.USER, ConfigType.CLIENT), Arrays.asList("", "B"), connectOpts,
                 "--entity-default", "--entity-name", "B", "--entity-type", "users", "--entity-type", "clients");
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.TOPIC), Collections.singletonList("A"), connectOpts, "--topic", "A");
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.IP), Collections.singletonList("1.2.3.4"), connectOpts, "--ip", "1.2.3.4");
+            testExpectedEntityTypeNames(Collections.singletonList(ConfigType.GROUP), Collections.singletonList("A"), connectOpts, "--group", "A");
             testExpectedEntityTypeNames(Arrays.asList(ConfigType.CLIENT, ConfigType.USER), Arrays.asList("B", "A"), connectOpts, "--client", "B", "--user", "A");
             testExpectedEntityTypeNames(Arrays.asList(ConfigType.CLIENT, ConfigType.USER), Arrays.asList("B", ""), connectOpts, "--client", "B", "--user-defaults");
             testExpectedEntityTypeNames(Arrays.asList(ConfigType.CLIENT, ConfigType.USER), Collections.singletonList("A"), connectOpts,
                 "--entity-type", "clients", "--entity-type", "users", "--entity-name", "A");
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.TOPIC), Collections.emptyList(), connectOpts, "--entity-type", "topics");
             testExpectedEntityTypeNames(Collections.singletonList(ConfigType.IP), Collections.emptyList(), connectOpts, "--entity-type", "ips");
+            testExpectedEntityTypeNames(Collections.singletonList(ConfigType.GROUP), Collections.emptyList(), connectOpts, "--entity-type", "groups");
         }
 
         testExpectedEntityTypeNames(Collections.singletonList(ConfigType.BROKER), Collections.singletonList("0"), connectOpts, "--entity-name", "0", "--entity-type", "brokers");

--- a/core/src/test/scala/unit/kafka/server/metadata/ZkConfigRepositoryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/ZkConfigRepositoryTest.scala
@@ -53,5 +53,7 @@ class ZkConfigRepositoryTest {
       assertThrows(classOf[IllegalArgumentException], () => zkConfigRepository.config(new ConfigResource(value, value.toString))))
     // Validate exception for CLIENT_METRICS.
     assertThrows(classOf[InvalidRequestException], () => zkConfigRepository.config(new ConfigResource(Type.CLIENT_METRICS, Type.CLIENT_METRICS.toString)))
+    // Validate exception for GROUP.
+    assertThrows(classOf[InvalidRequestException], () => zkConfigRepository.config(new ConfigResource(Type.GROUP, Type.GROUP.toString)))
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -66,6 +66,10 @@ public class GroupConfig extends AbstractConfig {
         this.consumerHeartbeatIntervalMs = getInt(CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG);
     }
 
+    public static ConfigDef configDef() {
+        return CONFIG;
+    }
+
     public static Optional<Type> configType(String configName) {
         return Optional.ofNullable(CONFIG.configKeys().get(configName)).map(c -> c.type);
     }


### PR DESCRIPTION
The PR adds support of alter/describe configs for group in kafka-configs.sh.
