### PR TITLE
KAFKA-17350: Improve share group describe for empty groups

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandTest.java
@@ -49,7 +49,9 @@ import java.util.Set;
 import joptsimple.OptionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -127,6 +129,15 @@ public class ShareGroupCommandTest {
         assertEquals(1, lags.size());
         assertEquals(20, lags.get(new TopicPartition("topic1", 0)));
         service.close();
+    }
+
+    @Test
+    public void testPrintEmptyGroupState() {
+        assertFalse(ShareGroupService.maybePrintEmptyGroupState("group", ShareGroupState.EMPTY, 0));
+        assertFalse(ShareGroupService.maybePrintEmptyGroupState("group", ShareGroupState.DEAD, 0));
+        assertFalse(ShareGroupService.maybePrintEmptyGroupState("group", ShareGroupState.STABLE, 0));
+        assertTrue(ShareGroupService.maybePrintEmptyGroupState("group", ShareGroupState.STABLE, 1));
+        assertTrue(ShareGroupService.maybePrintEmptyGroupState("group", ShareGroupState.UNKNOWN, 1));
     }
 
     @Test


### PR DESCRIPTION
When you use `kafka-share-groups.sh --describe` for an empty group, it prints an empty table consisting of only the table header. `kafka-consumer-groups.sh` summarises the group status to make the output more informative and only prints the table if it contains more than zero rows.

This PR applies this principle across all of the variants of describing share groups which makes the output much nicer where the output would otherwise be strangely empty.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
