### PR TITLE
KAFKA-17355: Update TestFeatureVersion 2 to always be based on MetadataVersion.latestTesting

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/TestFeatureVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/TestFeatureVersion.java
@@ -23,8 +23,8 @@ public enum TestFeatureVersion implements FeatureVersion {
     TEST_0(0, MetadataVersion.MINIMUM_KRAFT_VERSION, Collections.emptyMap()),
     // TEST_1 released right before MV 3.7-IVO was released, and it has no dependencies
     TEST_1(1, MetadataVersion.IBP_3_7_IV0, Collections.emptyMap()),
-    // TEST_2 released right before MV 4.0-IVO was released, and it depends on this metadata version
-    TEST_2(2, MetadataVersion.IBP_4_0_IV0, Collections.singletonMap(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_0_IV0.featureLevel()));
+    // TEST_2 is not yet released and maps to the latest testing version, and it depends on this metadata version
+    TEST_2(2, MetadataVersion.latestTesting(), Collections.singletonMap(MetadataVersion.FEATURE_NAME, MetadataVersion.latestTesting().featureLevel()));
 
     private final short featureLevel;
     private final MetadataVersion metadataVersionMapping;

--- a/server-common/src/test/java/org/apache/kafka/server/common/FeaturesTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/FeaturesTest.java
@@ -123,7 +123,7 @@ public class FeaturesTest {
     @EnumSource(MetadataVersion.class)
     public void testDefaultTestVersion(MetadataVersion metadataVersion) {
         short expectedVersion;
-        if (!metadataVersion.isLessThan(MetadataVersion.IBP_4_0_IV0)) {
+        if (!metadataVersion.isLessThan(MetadataVersion.latestTesting())) {
             expectedVersion = 2;
         } else if (!metadataVersion.isLessThan(MetadataVersion.IBP_3_7_IV0)) {
             expectedVersion = 1;


### PR DESCRIPTION
After some discussion on: https://github.com/apache/kafka/pull/16841#discussion_r1714322320

We decided it is best for test version to always map to MetadataVersion.latestTesting. We should always have one unstable MV (either because there is a feature being worked on OR when we mark the latest version stable we create a new one).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
