### PR TITLE
Migrate from Gradle Enterprise Gradle Plugin to Develocity Gradle Plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,21 +14,20 @@
 // limitations under the License.
 
 plugins {
-    id 'com.gradle.enterprise' version '3.14.1'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.1'
+    id 'com.gradle.develocity' version '3.17.6'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
 
-gradleEnterprise {
+develocity {
     server = "https://ge.apache.org"
+    projectId = "kafka"
     buildScan {
-        capture { taskInputFiles = true }
         uploadInBackground = !isCI
-        publishAlways()
-        publishIfAuthenticated()
+        publishing.onlyIf { it.authenticated }
         obfuscation {
             // This obfuscates the IP addresses of the build machine in the build scan.
             // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -42,7 +41,7 @@ buildCache {
         enabled = !isCI
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = false
     }
 }


### PR DESCRIPTION
This change migrates Kafka to use the Develocity Gradle Plugin. The existing Gradle Enterprise Gradle Plugin will no longer be supported when ge.apache.org is updated to 2024.3.

These changes will not functionally change how build scans are published to ge.apache.org.

This will resolve https://issues.apache.org/jira/browse/KAFKA-17352

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
