### PR TITLE
KAFKA-17325: Updated result handling in ShareConsumeRequestManager::commitAsync().

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.clients.consumer.internals.Acknowledgements;
 import org.apache.kafka.common.TopicIdPartition;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ShareAcknowledgementCommitCallbackEvent extends BackgroundEvent {
@@ -27,7 +28,7 @@ public class ShareAcknowledgementCommitCallbackEvent extends BackgroundEvent {
 
     public ShareAcknowledgementCommitCallbackEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_ACKNOWLEDGEMENT_COMMIT_CALLBACK);
-        this.acknowledgementsMap = acknowledgementsMap;
+        this.acknowledgementsMap = new HashMap<>(acknowledgementsMap);
     }
 
     public Map<TopicIdPartition, Acknowledgements> acknowledgementsMap() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class ShareAcknowledgementCommitCallbackEvent extends BackgroundEvent {
 
-    private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
+    private final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
 
     public ShareAcknowledgementCommitCallbackEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_ACKNOWLEDGEMENT_COMMIT_CALLBACK);


### PR DESCRIPTION
*What*
Currently we were not updating the result count when we merged commitAsync() requests into one batch in ShareConsumeRequestManager, so this led to lesser acknowledgements sent to the application thread (ShareConsumerImpl) than expected.
Fix : Now if the acknowledge response came from a commitAsync, then we do not wait for other requests to complete, we always prepare a background event to be sent.

This PR also fixes a bug in ShareConsumeRequestManager, where during the final ShareAcknowledge sent during close(), we also pick up any piggybacked acknowledgements which were waiting to be sent along with ShareFetch.