### PR TITLE
KAFKA-17332; Controller always flush and can call resign on observers

### DIFF
--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -235,6 +235,8 @@ class KafkaRaftManager[T](
       time,
       expirationService,
       logContext,
+      // Controllers should always flush the log on replication because they may become voters
+      config.processRoles.contains(ProcessRole.ControllerRole),
       clusterId,
       bootstrapServers,
       localListeners,

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -173,7 +173,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private final Logger logger;
     private final Time time;
     private final int fetchMaxWaitMs;
-    private final boolean alwaysFlush;
+    private final boolean followersAlwaysFlush;
     private final String clusterId;
     private final Endpoints localListeners;
     private final SupportedVersionRange localSupportedKRaftVersion;
@@ -220,6 +220,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      *
      * Note that if the node ID is empty, then the client will behave as a
      * non-participating observer.
+     *
+     * @param followersAlwaysFlush instruct followers to always fsync when appending to the log
      */
     public KafkaRaftClient(
         OptionalInt nodeId,
@@ -230,7 +232,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         Time time,
         ExpirationService expirationService,
         LogContext logContext,
-        boolean alwaysFlush,
+        boolean followersAlwaysFlush,
         String clusterId,
         Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
@@ -248,7 +250,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             time,
             expirationService,
             MAX_FETCH_WAIT_MS,
-            alwaysFlush,
+            followersAlwaysFlush,
             clusterId,
             bootstrapServers,
             localListeners,
@@ -270,7 +272,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         Time time,
         ExpirationService expirationService,
         int fetchMaxWaitMs,
-        boolean alwaysFlush,
+        boolean followersAlwaysFlush,
         String clusterId,
         Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
@@ -294,7 +296,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         this.localListeners = localListeners;
         this.localSupportedKRaftVersion = localSupportedKRaftVersion;
         this.fetchMaxWaitMs = fetchMaxWaitMs;
-        this.alwaysFlush = alwaysFlush;
+        this.followersAlwaysFlush = followersAlwaysFlush;
         this.logger = logContext.logger(KafkaRaftClient.class);
         this.random = random;
         this.quorumConfig = quorumConfig;
@@ -1689,7 +1691,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         Records records
     ) {
         LogAppendInfo info = log.appendAsFollower(records);
-        if (quorum.isVoter() || alwaysFlush) {
+        if (quorum.isVoter() || followersAlwaysFlush) {
             // the leader only requires that voters have flushed their log before sending a Fetch
             // request. Because of reconfiguration some observers (that are getting added to the
             // voter set) need to flush the disk because the leader may assume that they are in the

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -67,7 +67,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testLeaderWritesBootstrapRecords() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -142,7 +142,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testBootstrapCheckpointIsNotReturnedOnFetch() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -172,7 +172,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testLeaderDoesNotBootstrapRecordsWithKraftVersion0() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -220,7 +220,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testFollowerDoesNotRequestLeaderBootstrapSnapshot() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey leader = replicaKey(local.id() + 1, true);
         int epoch = 1;
 
@@ -250,7 +250,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testFollowerReadsKRaftBootstrapRecords() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey leader = replicaKey(local.id() + 1, true);
         ReplicaKey follower = replicaKey(local.id() + 2, true);
         VoterSet voterSet = VoterSetTest.voterSet(Stream.of(local, leader));
@@ -320,7 +320,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testAddVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -399,7 +399,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterInvalidClusterId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -436,7 +436,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterToNotLeader() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -464,7 +464,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithMissingDefaultListener() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -494,7 +494,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithPendingAddVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -550,7 +550,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithoutFencedPreviousLeaders() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -588,7 +588,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithKraftVersion0() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -633,7 +633,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithExistingVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -678,7 +678,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterTimeout() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -750,7 +750,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithApiVersionsFromIncorrectNode() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -810,7 +810,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterInvalidFeatureVersion() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -870,7 +870,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithLaggingNewVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -923,7 +923,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterFailsWhenLosingLeadership() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -972,7 +972,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithMissingDirectoryId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1010,7 +1010,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testRemoveVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1059,7 +1059,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testRemoveVoterIsLeader() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1121,7 +1121,7 @@ public class KafkaRaftClientReconfigTest {
         // Calls to resign should be allowed and not throw an exception
         context.client.resign(epoch);
 
-        // Election timeout is randome numer in [electionTimeoutMs, 2 * electionTimeoutMs)
+        // Election timeout is random numer in [electionTimeoutMs, 2 * electionTimeoutMs)
         context.time.sleep(2 * context.electionTimeoutMs());
         context.client.poll();
 
@@ -1131,7 +1131,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testRemoveVoterInvalidClusterId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1160,7 +1160,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterToNotLeader() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1180,7 +1180,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithPendingRemoveVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1218,7 +1218,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithoutFencedPreviousLeaders() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1240,7 +1240,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithKraftVersion0() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1270,7 +1270,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithNoneVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1300,7 +1300,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithNoneVoterId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1334,7 +1334,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterToEmptyVoterSet() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local));
 
@@ -1352,7 +1352,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterTimedOut() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1396,7 +1396,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterFailsWhenLosingLeadership() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1438,7 +1438,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testAddVoterWithPendingRemoveVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower1 = replicaKey(local.id() + 1, true);
         ReplicaKey follower2 = replicaKey(local.id() + 2, true);
 
@@ -1484,7 +1484,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testRemoveVoterWithPendingAddVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1532,7 +1532,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1590,7 +1590,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testLeaderUpdatesVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1637,7 +1637,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     public void testUpdateVoterInvalidClusterId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1688,7 +1688,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterOldEpoch() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1721,7 +1721,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterNewEpoch() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1754,7 +1754,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterToNotLeader() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1783,7 +1783,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterWithoutFencedPreviousLeaders() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1828,7 +1828,7 @@ public class KafkaRaftClientReconfigTest {
     // KAFKA-16538 is going to allow UpdateVoter RPC when the kraft.version is 0
     @Test
     void testUpdateVoterWithKraftVersion0() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1879,7 +1879,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterWithNoneVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1930,7 +1930,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterWithNoneVoterId() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -1981,7 +1981,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterWithPendingAddVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey follower = replicaKey(local.id() + 1, true);
 
         VoterSet voters = VoterSetTest.voterSet(Stream.of(local, follower));
@@ -2051,7 +2051,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testFollowerSendsUpdateVoter() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey voter1 = replicaKey(local.id() + 1, true);
         ReplicaKey voter2 = replicaKey(local.id() + 2, true);
 
@@ -2123,7 +2123,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testFollowerSendsUpdateVoterWhenDifferent() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey voter1 = replicaKey(local.id() + 1, true);
         ReplicaKey voter2 = replicaKey(local.id() + 2, true);
 
@@ -2167,7 +2167,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testUpdateVoterResponseCausesEpochChange() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         ReplicaKey voter1 = replicaKey(local.id() + 1, true);
         ReplicaKey voter2 = replicaKey(local.id() + 2, true);
 
@@ -2240,7 +2240,7 @@ public class KafkaRaftClientReconfigTest {
 
     @Test
     void testObserverDiscoversLeaderWithUnknownVoters() throws Exception {
-        ReplicaKey local = replicaKey(randomeReplicaId(), true);
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
         InetSocketAddress bootstrapAdddress = InetSocketAddress.createUnresolved("localhost", 1234);
         int epoch = 3;
 
@@ -2280,7 +2280,7 @@ public class KafkaRaftClientReconfigTest {
         assertEquals(expectedKRaftVersion, kRaftVersionRecord.kRaftVersion());
     }
 
-    private int randomeReplicaId() {
+    private int randomReplicaId() {
         return ThreadLocalRandom.current().nextInt(1025);
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -1112,7 +1112,14 @@ public class KafkaRaftClientReconfigTest {
 
         // Expect END_QUORUM_EPOCH requests
         context.pollUntilRequest();
-        context.collectEndQuorumRequests(epoch, new HashSet<>(Arrays.asList(follower1.id(), follower2.id())), Optional.empty());
+        context.collectEndQuorumRequests(
+            epoch,
+            new HashSet<>(Arrays.asList(follower1.id(), follower2.id())),
+            Optional.empty()
+        );
+
+        // Calls to resign should be allowed and not throw an exception
+        context.client.resign(epoch);
 
         // Election timeout is randome numer in [electionTimeoutMs, 2 * electionTimeoutMs)
         context.time.sleep(2 * context.electionTimeoutMs());

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -137,6 +137,8 @@ public final class RaftClientTestContext {
     final Set<Integer> bootstrapIds;
     // Used to determine which RPC request and response to construct
     final boolean kip853Rpc;
+    // Used to determine if the local kraft client was configured to always flush
+    final boolean alwaysFlush;
 
     private final List<RaftResponse.Outbound> sentResponses = new ArrayList<>();
 
@@ -170,6 +172,7 @@ public final class RaftClientTestContext {
         private MemoryPool memoryPool = MemoryPool.NONE;
         private Optional<List<InetSocketAddress>> bootstrapServers = Optional.empty();
         private boolean kip853Rpc = false;
+        private boolean alwaysFlush = false;
         private VoterSet startingVoters = VoterSet.empty();
         private Endpoints localListeners = Endpoints.empty();
         private boolean isStartingVotersStatic = false;
@@ -293,6 +296,11 @@ public final class RaftClientTestContext {
             return this;
         }
 
+        Builder withAlwaysFlush(boolean alwaysFlush) {
+            this.alwaysFlush = alwaysFlush;
+            return this;
+        }
+
         Builder withStaticVoters(Set<Integer> staticVoters) {
             Map<Integer, InetSocketAddress> staticVoterAddressMap = staticVoters
                 .stream()
@@ -407,6 +415,7 @@ public final class RaftClientTestContext {
                 time,
                 new MockExpirationService(time),
                 FETCH_MAX_WAIT_MS,
+                alwaysFlush,
                 clusterId,
                 computedBootstrapServers,
                 localListeners,
@@ -441,6 +450,7 @@ public final class RaftClientTestContext {
                     .boxed()
                     .collect(Collectors.toSet()),
                 kip853Rpc,
+                alwaysFlush,
                 metrics,
                 listener
             );
@@ -468,6 +478,7 @@ public final class RaftClientTestContext {
         VoterSet startingVoters,
         Set<Integer> bootstrapIds,
         boolean kip853Rpc,
+        boolean alwaysFlush,
         Metrics metrics,
         MockListener listener
     ) {
@@ -484,6 +495,7 @@ public final class RaftClientTestContext {
         this.startingVoters = startingVoters;
         this.bootstrapIds = bootstrapIds;
         this.kip853Rpc = kip853Rpc;
+        this.alwaysFlush = alwaysFlush;
         this.metrics = metrics;
         this.listener = listener;
     }
@@ -1531,7 +1543,9 @@ public final class RaftClientTestContext {
         assertEquals(localId.orElse(-1), request.replicaState().replicaId());
 
         // Assert that voters have flushed up to the fetch offset
-        if (localId.isPresent() && startingVoters.voterIds().contains(localId.getAsInt())) {
+        if ((localId.isPresent() && startingVoters.voterIds().contains(localId.getAsInt())) ||
+            alwaysFlush
+        ) {
             assertEquals(
                 log.firstUnflushedOffset(),
                 fetchOffset,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -789,6 +789,7 @@ public class RaftEventSimulationTest {
                 time,
                 new MockExpirationService(time),
                 FETCH_MAX_WAIT_MS,
+                true,
                 clusterId,
                 Collections.emptyList(),
                 endpointsFromId(nodeId, channel.listenerName()),


### PR DESCRIPTION
This change includes two improvements.

When the leader removes itself from the voters set clients of RaftClient may call resign. In those cases the leader is not in the voter set and should not throw an exception.

Controllers that are observers must flush the log on every append because leader may be trying to add them to the voter set. Leader always assume that voters flush their disk before sending a Fetch request.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
