### PR TITLE
KAFKA-17264 add validation for new RPC input parameters

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2073,12 +2073,38 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             );
         }
 
+        if (data.timeoutMs() < 0) {
+            return completedFuture(
+                new AddRaftVoterResponseData()
+                    .setErrorCode(Errors.INVALID_REQUEST.code())
+                    .setErrorMessage(
+                        String.format(
+                            "Add voter request contains an invalid timeout: \"%d\" it must be non-negative",
+                            data.timeoutMs()
+                        )
+                    )
+            );
+        }
+
         Optional<ReplicaKey> newVoter = RaftUtil.addVoterRequestVoterKey(data);
         if (!newVoter.isPresent() || !newVoter.get().directoryId().isPresent()) {
             return completedFuture(
                 new AddRaftVoterResponseData()
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("Add voter request didn't include a valid voter")
+            );
+        }
+
+        AddRaftVoterRequestData.ListenerCollection listeners = data.listeners();
+        boolean containsInvalidListener = listeners.stream().anyMatch(listener ->
+                listener.name().isEmpty() || listener.port() < 0 || listener.port() > 65535 || listener.host().isEmpty()
+        );
+
+        if (containsInvalidListener) {
+            return completedFuture(
+                new AddRaftVoterResponseData()
+                        .setErrorCode(Errors.INVALID_REQUEST.code())
+                        .setErrorMessage("Add voter request contains invalid listener")
             );
         }
 
@@ -2203,6 +2229,22 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         Optional<ReplicaKey> voter = RaftUtil.updateVoterRequestVoterKey(data);
         if (!voter.isPresent() || !voter.get().directoryId().isPresent()) {
+            return completedFuture(
+                RaftUtil.updateVoterResponse(
+                    Errors.INVALID_REQUEST,
+                    requestMetadata.listenerName(),
+                    quorum.leaderAndEpoch(),
+                    quorum.leaderEndpoints()
+                )
+            );
+        }
+
+        UpdateRaftVoterRequestData.ListenerCollection listeners = data.listeners();
+        boolean containsInvalidListener = listeners.stream().anyMatch(listener ->
+                listener.name().isEmpty() || listener.port() < 0 || listener.port() > 65535 || listener.host().isEmpty()
+        );
+
+        if (containsInvalidListener) {
             return completedFuture(
                 RaftUtil.updateVoterResponse(
                     Errors.INVALID_REQUEST,

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -527,6 +527,19 @@ public class RaftUtil {
     }
 
     public static AddRaftVoterRequestData addVoterRequest(
+            String clusterId,
+            ReplicaKey voter,
+            Endpoints listeners
+    ) {
+        return new AddRaftVoterRequestData()
+                .setClusterId(clusterId)
+                .setTimeoutMs(Integer.MAX_VALUE)
+                .setVoterId(voter.id())
+                .setVoterDirectoryId(voter.directoryId().orElse(ReplicaKey.NO_DIRECTORY_ID))
+                .setListeners(listeners.buildTestAddVoterRequest());
+    }
+
+    public static AddRaftVoterRequestData addVoterRequest(
         String clusterId,
         int timeoutMs,
         ReplicaKey voter,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -1698,6 +1698,17 @@ public final class RaftClientTestContext {
     }
 
     AddRaftVoterRequestData addVoterRequest(
+            ReplicaKey voter,
+            Endpoints endpoints
+    ) {
+        return addVoterRequest(
+                clusterId,
+                voter,
+                endpoints
+        );
+    }
+
+    AddRaftVoterRequestData addVoterRequest(
         int timeoutMs,
         ReplicaKey voter,
         Endpoints endpoints
@@ -1707,6 +1718,18 @@ public final class RaftClientTestContext {
             timeoutMs,
             voter,
             endpoints
+        );
+    }
+
+    AddRaftVoterRequestData addVoterRequest(
+            String clusterId,
+            ReplicaKey voter,
+            Endpoints endpoints
+    ) {
+        return RaftUtil.addVoterRequest(
+                clusterId,
+                voter,
+                endpoints
         );
     }
 


### PR DESCRIPTION
The new RPC requests, such as `AddVoter#request`, `RemoveVoter#request`, and `UpdateVoter#request`, should include validation for `Listener` and `timeOut` fields during processing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
