### PR TITLE
KAFKA-17086: docs(ops.html): add missing Java 21

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, and Java 17 are supported.
+  Java 8, Java 11, Java 17, and Java 21 are supported.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.


### PR DESCRIPTION

in [6.6 Java Version](https://kafka.apache.org/documentation.html#java)

> Java 8, Java 11, and Java 17 are supported.

we forget to add Java 21 is missing, so I add it back in this PR

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)