### PR TITLE
KAFKA-17100: GlobalStreamThread#start should not busy-wait

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -469,6 +469,7 @@ public class GlobalStreamThread extends Thread {
         // one could call shutdown() multiple times, so ignore subsequent calls
         // if already shutting down or dead
         setState(PENDING_SHUTDOWN);
+        initializationLatch.countDown();
     }
 
     public Map<MetricName, Metric> consumerMetrics() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -175,7 +175,6 @@ public class GlobalStreamThread extends Thread {
             }
 
             state = newState;
-
         }
 
         if (stateListener != null) {


### PR DESCRIPTION
*More detailed description*
I have replaced the `sleep` method with a `CountDownLatch`. It will await until the latch count reaches zero. The countdown happens in the `initialize` method in a `finally` block.

*Summary of testing strategy*
All the tests in `GlobalStreamThreadTest` pass, indicating that the class's behavior has remained unchanged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
