### PR TITLE
MINOR: Improve error message when Connect's EmbeddedKafkaCluster::verifyClusterReadiness method fails

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -198,7 +198,7 @@ public class EmbeddedKafkaCluster {
                     "The Kafka cluster used in this test was not able to start successfully in time. "
                             + "If no recent changes have altered the behavior of Kafka brokers or clients, and this error "
                             + "is not occurring frequently, it is probably the result of the testing machine being temporarily "
-                            + "and can be safely ignored.",
+                            + "overloaded and can be safely ignored.",
                     e
             );
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -88,6 +88,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Setup an embedded Kafka KRaft cluster (using {@link kafka.testkit.KafkaClusterTestKit} internally) with the
@@ -182,14 +183,24 @@ public class EmbeddedKafkaCluster {
         Map<String, Object> consumerConfig = Collections.singletonMap(GROUP_ID_CONFIG, consumerGroupId);
         String topic = "consumer-warmup-" + consumerGroupId;
 
-        createTopic(topic);
-        produce(topic, "warmup message key", "warmup message value");
+        try {
+            createTopic(topic);
+            produce(topic, "warmup message key", "warmup message value");
 
-        try (Consumer<?, ?> consumer = createConsumerAndSubscribeTo(consumerConfig, topic)) {
-            ConsumerRecords<?, ?> records = consumer.poll(Duration.ofMillis(GROUP_COORDINATOR_AVAILABILITY_DURATION_MS));
-            if (records.isEmpty()) {
-                throw new AssertionError("Failed to verify availability of group coordinator and produce/consume APIs on Kafka cluster in time");
+            try (Consumer<?, ?> consumer = createConsumerAndSubscribeTo(consumerConfig, topic)) {
+                ConsumerRecords<?, ?> records = consumer.poll(Duration.ofMillis(GROUP_COORDINATOR_AVAILABILITY_DURATION_MS));
+                if (records.isEmpty()) {
+                    throw new AssertionError("Failed to verify availability of group coordinator and/or consume APIs on Kafka cluster in time");
+                }
             }
+        } catch (Throwable e) {
+            fail(
+                    "The Kafka cluster used in this test was not able to start successfully in time. "
+                            + "If no recent changes have altered the behavior of Kafka brokers or clients, and this error "
+                            + "is not occurring frequently, it is probably the result of the testing machine being temporarily "
+                            + "and can be safely ignored.",
+                    e
+            );
         }
 
         try (Admin admin = createAdminClient()) {


### PR DESCRIPTION

The embedded Kafka cluster readiness check we added recently for Connect and MM2 integration tests has helped reduce flakiness, but sometimes the check itself fails. This can happen when CI is overloaded and isn't cause for alarm; we can make that clear with our error message so that 1) contributors know that their changes are still safe to merge and 2) people know not to file flaky test tickets when they see these failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
