### PR TITLE
MINOR add tags for Gradle build scans

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -34,11 +34,11 @@ develocity {
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
         if (System.getenv("JENKINS_URL")) {
-          tag "jenkins"
-        else if (System.getenv("GITHUB_ACTIONS")) {
-          tag "github"
-        else {
-          tag "local"
+            tag "jenkins"
+        } else if (System.getenv("GITHUB_ACTIONS")) {
+            tag "github"
+        } else {
+            tag "local"
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,13 @@ develocity {
             // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
+        if (System.getenv("JENKINS_URL")) {
+          tag "jenkins"
+        else if (System.getenv("GITHUB_ACTIONS")) {
+          tag "github"
+        else {
+          tag "local"
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,9 +33,9 @@ develocity {
             // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
-        if (System.getenv("JENKINS_URL")) {
+        if (isJenkins) {
             tag "jenkins"
-        } else if (System.getenv("GITHUB_ACTIONS")) {
+        } else if (isGithubActions) {
             tag "github"
         } else {
             tag "local"


### PR DESCRIPTION
This adds three tags for the Gradle build scans: jenkins, github, and local. Adding these tags will allow us to more easily differentiate build scan statistics based on the origin of the build.