### PR TITLE
MINOR: Separate GH workflows for PRs and trunk

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: "Gradle Setup"
+description: "Setup Java and Gradle"
+inputs:
+  java-version:
+    description: "Java version to use"
+    default: "17"
+  gradle-cache-read-only:
+    description: "Should the Gradle cache be read-only?"
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      env:
+        GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+      with:
+        gradle-version: wrapper
+        develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+        cache-read-only: ${{ inputs.gradle-cache-read-only }}
+        # Cache downloaded JDKs in addition to the default directories.
+        gradle-home-cache-includes: |
+          caches
+          notifications
+          jdks
+        cache-cleanup: on-success

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -25,6 +25,9 @@ inputs:
   gradle-cache-read-only:
     description: "Should the Gradle cache be read-only?"
     default: "true"
+  develocity-access-key:
+    description: "Optional access key for uploading build scans to Develocity"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -39,7 +42,7 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
       with:
         gradle-version: wrapper
-        develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+        develocity-access-key: ${{ inputs.develocity-access-key }}
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         # Cache downloaded JDKs in addition to the default directories.
         gradle-home-cache-includes: |

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -28,10 +28,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Public Pull Requests
+name: CI
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  push:
     branches:
       - 'trunk'
-    paths-ignore:
-      - '.github/*'
-      - '.asf.yaml'
-
-permissions:
-  # all other permissions are set to none
-  contents: read
-  pull-requests: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false  # Let each trunk commit finish a build
 
 jobs:
   validate:
@@ -40,14 +30,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 21]
+        java: [8, 11, 17, 21]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
-      - name: Checkout code		# Checkout the PR's code
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -56,15 +44,18 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        env:
+          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
         with:
           gradle-version: wrapper
-          cache-read-only: true
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+          cache-read-only: false
           # Cache downloaded JDKs in addition to the default directories.
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           cache-cleanup: on-success
+          cache-overwrite-existing: true
       - name: Compile and validate
-        run: ./gradlew --build-cache --info check -x test
-
+        run: ./gradlew --build-cache --info --scan check -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           gradle-cache-read-only: false
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Compile and validate
         run: ./gradlew --build-cache --info --scan check -x test
 
@@ -63,6 +64,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           gradle-cache-read-only: false
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Test
         timeout-minutes: 180  # 3 hours
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         java: [8, 11, 17, 21]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
@@ -50,6 +54,10 @@ jobs:
         java: [ 11, 17 ]
     name: JUnit tests Java ${{ matrix.java }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,29 +33,33 @@ jobs:
         java: [8, 11, 17, 21]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        env:
-          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+        uses: ./.github/actions/setup-gradle
         with:
-          gradle-version: wrapper
-          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
-          cache-read-only: false
-          # Cache downloaded JDKs in addition to the default directories.
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-cleanup: on-success
-          cache-overwrite-existing: true
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: false
       - name: Compile and validate
         run: ./gradlew --build-cache --info --scan check -x test
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 11, 17 ]
+    name: JUnit tests Java ${{ matrix.java }}
+    steps:
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: false
+      - name: Test
+        timeout-minutes: 180  # 3 hours
+        run: |
+          ./gradlew --build-cache --scan --continue \
+          -PtestLoggingEvents=started,passed,skipped,failed \
+          -PignoreFailures=true -PmaxParallelForks=2 \
+          -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
+          test

--- a/.github/workflows/fork-pr.yml
+++ b/.github/workflows/fork-pr.yml
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Public Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: 'gh-*'
+    paths-ignore:
+      - '.github/*'
+      - '.asf.yaml'
+
+permissions:
+  # all other permissions are set to none
+  contents: read
+  pull-requests: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 21]
+    name: Compile and Check Java ${{ matrix.java }}
+    steps:
+      - name: Checkout code		# Checkout the PR's code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+          # Cache downloaded JDKs in addition to the default directories.
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          cache-cleanup: on-success
+      - name: Compile and validate
+        run: ./gradlew --build-cache --info check -x test
+

--- a/.github/workflows/fork-pr.yml
+++ b/.github/workflows/fork-pr.yml
@@ -18,7 +18,8 @@ name: Public Pull Requests
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-    branches: 'gh-*'
+    branches:
+      - 'trunk'
     paths-ignore:
       - '.github/*'
       - '.asf.yaml'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,10 @@ jobs:
         java: [ 8, 11, 17, 21 ]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
@@ -53,6 +57,10 @@ jobs:
     if: contains(github.ref, 'gh-')  # For now, only run tests on "gh-*" PRs
     name: JUnit tests Java ${{ matrix.java }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 11, 17 ]
-    if: contains(github.ref, 'gh-')  # For now, only run tests on "gh-*" PRs
+    if: contains(github.head_ref, 'gh-')  # For now, only run tests on "gh-*" PRs
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           gradle-cache-read-only: true
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Compile and validate
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         run: ./gradlew --build-cache --info --scan check -x test
@@ -66,6 +67,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           gradle-cache-read-only: true
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Test
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         timeout-minutes: 180  # 3 hours

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,19 +49,16 @@ jobs:
           GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
         with:
           gradle-version: wrapper
-          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
           # Only write to the cache from trunk
-          #cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
-          cache-read-only: false
+          cache-read-only: true
           # Cache downloaded JDKs in addition to the default directories.
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           cache-cleanup: on-success
-          cache-overwrite-existing: true
       - name: Compile and validate
-        run: ./gradlew --build-cache --info --scan check -x test
+        run: ./gradlew --build-cache --info check -x test
 
   test:
     needs: validate
@@ -70,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 11, 17 ]
-    if: contains(github.ref, 'gh-')
+    if: contains(github.ref, 'gh-')  # For now, only run tests on "gh-*" PRs
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code
@@ -88,17 +85,15 @@ jobs:
           GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
         with:
           gradle-version: wrapper
+          # Only PRs from apache/kafka will publish build scans. Include this temporarily to generate some data.
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
-          # Only write to the cache from trunk
-          #cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
-          cache-read-only: false
+          cache-read-only: true
           # Cache downloaded JDKs in addition to the default directories.
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           cache-cleanup: on-success
-          cache-overwrite-existing: true
       - name: Test
         timeout-minutes: 180  # 3 hours
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,6 +97,7 @@ jobs:
           cache-cleanup: on-success
           cache-overwrite-existing: true
       - name: Test
+        timeout-minutes: 180  # 3 hours
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,10 @@ on:
     types: [opened, synchronize, reopened]
     branches: 'gh-*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 21]
+        java: [ 8, 11, 17, 21 ]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
       - name: Setup Gradle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,31 +34,14 @@ jobs:
         java: [8, 21]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        env:
-          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+        uses: ./.github/actions/setup-gradle
         with:
-          gradle-version: wrapper
-          # Only write to the cache from trunk
-          cache-read-only: true
-          # Cache downloaded JDKs in addition to the default directories.
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-cleanup: on-success
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: true
       - name: Compile and validate
-        run: ./gradlew --build-cache --info check -x test
+        # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
+        run: ./gradlew --build-cache --info --scan check -x test
 
   test:
     needs: validate
@@ -70,31 +53,13 @@ jobs:
     if: contains(github.ref, 'gh-')  # For now, only run tests on "gh-*" PRs
     name: JUnit tests Java ${{ matrix.java }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        env:
-          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+        uses: ./.github/actions/setup-gradle
         with:
-          gradle-version: wrapper
-          # Only PRs from apache/kafka will publish build scans. Include this temporarily to generate some data.
-          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
-          cache-read-only: true
-          # Cache downloaded JDKs in addition to the default directories.
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-cleanup: on-success
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: true
       - name: Test
+        # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         timeout-minutes: 180  # 3 hours
         run: |
           ./gradlew --build-cache --scan --continue \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,10 +19,6 @@ on:
   push:
     branches: 'gh-*'
 
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: 'gh-*'
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,10 @@
 name: Pull Requests
 
 on:
-  push:
-    branches: 'gh-*'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'trunk'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -68,6 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 11, 17 ]
+    if: contains(github.ref, 'gh-')
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Github has different behavior for PRs within apache/kafka and those from public forks. For security reasons, ASF Infra disallows forks to trigger workflows using the `pull_request` event (as this would expose repository secrets). Instead, we can use the `pull_request_target` event which triggers when a fork creates a PR. This event will cause the workflow to run using the code of the PR target (i.e., trunk).

Per the ASF Infra policy https://infra.apache.org/github-actions-policy.html, we must take care not to inject secrets into `pull_request_target` workflows. For this reason, I've created a separate "Public Pull Requests" workflow that does not public Develocity build scans.

For now the new fork workflow just does a compile check.