### PR TITLE
KAFKA-17371: Flaky test in DefaultTaskExecutorTest.shouldUnassignTaskWhenRequired

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
+import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,6 @@ import java.util.Collections;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -230,7 +230,9 @@ public class DefaultTaskExecutorTest {
         taskExecutor.start();
 
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
-        assertNotNull(taskExecutor.currentTask());
+        TestUtils.waitForCondition(() -> taskExecutor.currentTask() != null,
+                VERIFICATION_TIMEOUT,
+                "Task reassign take too much time");
 
         final KafkaFuture<StreamTask> future = taskExecutor.unassign();
 


### PR DESCRIPTION
JIRA: [KAFKA-17371](https://issues.apache.org/jira/browse/KAFKA-17371)
> The root cause of the failure is that `currentTask = taskManager.assignNextTask(DefaultTaskExecutor.this);` is not an atomic operation. This means that calling `taskManager.assignNextTask` will unblock the `verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);` statement in the test method.
If `assertNotNull(taskExecutor.currentTask());` is executed before the assignment `currentTaks = [...]` the test will fail.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
