### PR TITLE
KAFKA-17151: Remove waitForCondition when detecting thread leak

### DIFF
--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -226,21 +226,12 @@ public class KafkaClusterTestKit implements AutoCloseable {
             Map<Integer, ControllerServer> controllers = new HashMap<>();
             Map<Integer, BrokerServer> brokers = new HashMap<>();
             Map<Integer, SharedServer> jointServers = new HashMap<>();
-            /*
-              Number of threads = Total number of brokers + Total number of controllers + Total number of Raft Managers
-                                = Total number of brokers + Total number of controllers * 2
-                                  (Raft Manager per broker/controller)
-             */
-            int numOfExecutorThreads = (nodes.brokerNodes().size() + nodes.controllerNodes().size()) * 2;
-            ExecutorService executorService = null;
             ControllerQuorumVotersFutureManager connectFutureManager =
                 new ControllerQuorumVotersFutureManager(nodes.controllerNodes().size());
             File baseDirectory = null;
 
             try {
                 baseDirectory = new File(nodes.baseDirectory());
-                executorService = Executors.newFixedThreadPool(numOfExecutorThreads,
-                    ThreadUtils.createThreadFactory("kafka-cluster-test-kit-executor-%d", false));
                 for (TestKitNode node : nodes.controllerNodes().values()) {
                     setupNodeDirectories(baseDirectory, node.metadataDirectory(), Collections.emptyList());
                     SharedServer sharedServer = new SharedServer(
@@ -297,9 +288,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
                     brokers.put(node.id(), broker);
                 }
             } catch (Exception e) {
-                if (executorService != null) {
-                    ThreadUtils.shutdownExecutorServiceQuietly(executorService, 5, TimeUnit.MINUTES);
-                }
                 for (BrokerServer brokerServer : brokers.values()) {
                     brokerServer.shutdown();
                 }
@@ -312,7 +300,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 }
                 throw e;
             }
-            return new KafkaClusterTestKit(executorService,
+            return new KafkaClusterTestKit(
                     nodes,
                     controllers,
                     brokers,
@@ -352,7 +340,9 @@ public class KafkaClusterTestKit implements AutoCloseable {
         }
     }
 
+    private static final String KAFKA_CLUSTER_THREAD_PREFIX = "kafka-cluster-test-kit-";
     private final ExecutorService executorService;
+    private final KafkaClusterThreadFactory threadFactory = new KafkaClusterThreadFactory(KAFKA_CLUSTER_THREAD_PREFIX);
     private final TestKitNodes nodes;
     private final Map<Integer, ControllerServer> controllers;
     private final Map<Integer, BrokerServer> brokers;
@@ -361,7 +351,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
     private final SimpleFaultHandlerFactory faultHandlerFactory;
 
     private KafkaClusterTestKit(
-        ExecutorService executorService,
         TestKitNodes nodes,
         Map<Integer, ControllerServer> controllers,
         Map<Integer, BrokerServer> brokers,
@@ -369,7 +358,13 @@ public class KafkaClusterTestKit implements AutoCloseable {
         File baseDirectory,
         SimpleFaultHandlerFactory faultHandlerFactory
     ) {
-        this.executorService = executorService;
+        /*
+          Number of threads = Total number of brokers + Total number of controllers + Total number of Raft Managers
+                            = Total number of brokers + Total number of controllers * 2
+                              (Raft Manager per broker/controller)
+        */
+        int numOfExecutorThreads = (nodes.brokerNodes().size() + nodes.controllerNodes().size()) * 2;
+        this.executorService = Executors.newFixedThreadPool(numOfExecutorThreads, threadFactory);
         this.nodes = nodes;
         this.controllers = controllers;
         this.brokers = brokers;
@@ -642,6 +637,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         } finally {
             ThreadUtils.shutdownExecutorServiceQuietly(executorService, 5, TimeUnit.MINUTES);
         }
+        waitForAllThreads();
         faultHandlerFactory.fatalFaultHandler().maybeRethrowFirstException();
         faultHandlerFactory.nonFatalFaultHandler().maybeRethrowFirstException();
     }
@@ -653,5 +649,11 @@ public class KafkaClusterTestKit implements AutoCloseable {
             entry.getValue().get();
             log.debug("{} successfully shut down.", entry.getKey());
         }
+    }
+
+    private void waitForAllThreads() throws InterruptedException {
+        TestUtils.waitForCondition(() -> Thread.getAllStackTraces().keySet()
+                    .stream().noneMatch(t -> threadFactory.getThreadIds().contains(t.getId())),
+                "Failed to wait for all threads to shut down.");
     }
 }

--- a/core/src/test/java/kafka/testkit/KafkaClusterThreadFactory.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterThreadFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.testkit;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class KafkaClusterThreadFactory implements ThreadFactory {
+    private final String prefix;
+    private final Set<Long> threadIds = ConcurrentHashMap.newKeySet();
+    private final AtomicLong threadEpoch = new AtomicLong(0);
+
+    KafkaClusterThreadFactory(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        String threadName = prefix + threadEpoch.addAndGet(1);
+        Thread thread = new Thread(r, threadName);
+
+        threadIds.add(thread.getId());
+        return thread;
+    }
+
+    public Set<Long> getThreadIds() {
+        return threadIds;
+    }
+}

--- a/core/src/test/java/kafka/testkit/KafkaClusterThreadFactoryTest.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterThreadFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.testkit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaClusterThreadFactoryTest {
+    @Test
+    public void testGetThreadIds() {
+        String testThreadFactoryPrefix = "test-thread-factory-";
+        KafkaClusterThreadFactory testThreadFactory = new KafkaClusterThreadFactory(testThreadFactoryPrefix);
+        Thread firstThread = testThreadFactory.newThread(() -> { });
+        assertTrue(firstThread.getName().startsWith(testThreadFactoryPrefix));
+
+        Thread secondThread = testThreadFactory.newThread(() -> { });
+        assertNotEquals(firstThread.getName(), secondThread.getName());
+
+        assertTrue(testThreadFactory.getThreadIds().contains(firstThread.getId()));
+        assertTrue(testThreadFactory.getThreadIds().contains(secondThread.getId()));
+    }
+}


### PR DESCRIPTION
This is testing for GitHub Action CI.

https://github.com/apache/kafka/pull/16661

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
