### PR TITLE
KAFKA-17381: Reduce log output from checkstyle task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           gradle-cache-read-only: false
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Compile and validate
-        run: ./gradlew --build-cache --info --scan check -x test
+        run: ./gradlew --build-cache --scan check -x test
 
   test:
     needs: validate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Compile and validate
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
-        run: ./gradlew --build-cache --info --scan check -x test
+        run: ./gradlew --build-cache --scan check -x test
 
   test:
     needs: validate


### PR DESCRIPTION
Reduce checkstyle task output from 5899 lines to 883.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
