### PR TITLE
MINOR: Github build enable Gradle cache and add checkstyle annotations 

### DIFF
--- a/.github/scripts/checkstyle.py
+++ b/.github/scripts/checkstyle.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
     See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message
     """
-    if not os.getenv("GITHUB"):
+    if not os.getenv("GITHUB_WORKSPACE"):
         print("This script is intended to by run by GitHub Actions.")
         exit(1)
     

--- a/.github/scripts/checkstyle.py
+++ b/.github/scripts/checkstyle.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from glob import glob
+import logging
+import os
+import os.path
+import sys
+from typing import Tuple, Optional
+import xml.etree.ElementTree
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stderr)
+handler.setLevel(logging.DEBUG)
+logger.addHandler(handler)
+
+
+def get_env(key: str) -> str:
+    value = os.getenv(key)
+    logger.debug(f"Read env {key}: {value}")
+
+def get_url(filename: str, line: Optional[int]) -> str:
+    """
+    filename will be a full path like:
+
+    /Users/davidarthur/Code/Apache/kafka/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+    
+    or on Github, 
+
+    /home/runner/work/apache/kafka/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+
+    we just want the relative part in the source tree.
+    """
+
+    github_repo_path = get_env("GITHUB_WORKSPACE") # e.g., /home/runner/work/apache/kafka
+    rel_path = os.path.relpath(filename, github_repo_path)
+    repo = get_env("GITHUB_REPOSITORY") # apache/kafka
+    branch = get_env("GITHUB_BASE_REF") # my-branch
+
+    url = f"https://github.com/{repo}/blob/{branch}/{rel_path}"
+    if line is not None:
+        return f"{url}#L{line}"
+    else:
+        return url
+
+
+def parse_report(fp) -> Tuple[int, int]:
+    stack = []
+    errors = []
+    file_count = 0
+    error_count = 0
+    for (event, elem) in xml.etree.ElementTree.iterparse(fp, events=["start", "end"]):
+        if event == "start":
+            stack.append(elem)   
+            if elem.tag == "file":
+                file_count += 1
+                errors.clear()
+            if elem.tag == "error":
+                logger.debug(f"Found checkstyle error: {elem.attrib}")
+                errors.append(elem)
+                error_count += 1
+        else:
+            # end
+            if elem.tag == "file" and len(errors) > 0:
+                filename = os.path.basename(elem.get("name"))
+                logger.debug(f"Printing errors for: {elem.attrib}")
+                for error in errors:
+                    url = get_url(elem.get("name"), error.get("line"))
+                    print(f"|[{filename}]({url})|{error.get('message')}|")
+            stack.pop()
+    return file_count, error_count
+
+
+if __name__ == "__main__":
+    if not os.getenv("GITHUB"):
+        print("This script is intended to by run by GitHub Actions.")
+        exit(1)
+    
+    reports = glob(pathname="**/checkstyle/*.xml", recursive=True)
+    logger.debug(f"Found {len(reports)} checkstyle reports")
+    total_file_count = 0
+    total_error_count = 0
+
+    print("## Checkstyle summary")
+    print("|----|----|")
+    for report in reports:
+        with open(report, "r") as fp:
+            logger.debug(f"Parsing report file: {report}")
+            file_count, error_count = parse_report(fp)
+            if error_count == 1:
+                logger.debug(f"Checked {file_count} files from {report} and found 1 error")
+            else:
+                logger.debug(f"Checked {file_count} files from {report} and found {error_count} errors")
+            total_file_count += file_count
+            total_error_count += error_count
+    print("|----|----|")
+

--- a/.github/scripts/checkstyle.py
+++ b/.github/scripts/checkstyle.py
@@ -32,6 +32,8 @@ logger.addHandler(handler)
 def get_env(key: str) -> str:
     value = os.getenv(key)
     logger.debug(f"Read env {key}: {value}")
+    return value
+
 
 def get_url(filename: str, line: Optional[int]) -> str:
     """
@@ -80,7 +82,7 @@ def parse_report(fp) -> Tuple[int, int]:
                 logger.debug(f"Printing errors for: {elem.attrib}")
                 for error in errors:
                     url = get_url(elem.get("name"), error.get("line"))
-                    print(f"|[{filename}]({url})|{error.get('message')}|")
+                    print(f"| [{filename}]({url}) | {error.get('severity')} | ❌ {error.get('message')} |")
             stack.pop()
     return file_count, error_count
 
@@ -96,7 +98,8 @@ if __name__ == "__main__":
     total_error_count = 0
 
     print("## Checkstyle summary")
-    print("|----|----|")
+    print("| File | Severity | Message | ")
+    print("| ---- | -------- | ------- |")
     for report in reports:
         with open(report, "r") as fp:
             logger.debug(f"Parsing report file: {report}")
@@ -107,5 +110,5 @@ if __name__ == "__main__":
                 logger.debug(f"Checked {file_count} files from {report} and found {error_count} errors")
             total_file_count += file_count
             total_error_count += error_count
-    print("|----|----|")
-
+    if total_error_count == 0:
+        print(f"| - | - | ✅ Checked {total_file_count} files, no errors")

--- a/.github/scripts/checkstyle.py
+++ b/.github/scripts/checkstyle.py
@@ -87,7 +87,8 @@ def parse_report(fp) -> Tuple[int, int]:
                     col = error.get("column")
                     severity = error.get("severity")
                     message = error.get('message')
-                    print(f"::notice file={rel_path},line={line},col={col}::{message}")
+                    title = f"Checkstyle {severity}"
+                    print(f"::notice file={rel_path},line={line},col={col},title={title}::{message}")
             stack.pop()
     return file_count, error_count
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,12 +52,12 @@ jobs:
         run: ./gradlew --build-cache --info --scan check -x test
       - name: Parse checkstyle
         if: always()
-        run: python .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
+        run: python .github/scripts/checkstyle.py
         env:
           GITHUB: 1
           GITHUB_WORKSPACE: ${{ github.workspace }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BRANCH: ${{ github.ref_name }}
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,8 +69,6 @@ jobs:
         env:
           GITHUB: 1
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_BRANCH: ${{ github.ref_name }}
 
   test:
     needs: validate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 21, 8, 11, 17 ]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
             **/build/**/*.html
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
-        if: ${{ failure() && matrix.java == '21' }}
+        if: ${{ failure() && matrix.java == '21' }}  # Avoid duplicate annotations, only process java 21
         run: python .github/scripts/checkstyle.py
         env:
           GITHUB: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,14 +50,6 @@ jobs:
       - name: Compile and validate
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         run: ./gradlew --build-cache --info --scan check -x test
-      - name: Parse checkstyle
-        if: always()
-        run: python .github/scripts/checkstyle.py
-        env:
-          GITHUB: 1
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_BRANCH: ${{ github.ref_name }}
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -65,6 +57,15 @@ jobs:
           name: check-reports-${{ matrix.java }}
           path: |
             **/build/**/*.html
+          if-no-files-found: ignore
+      - name: Annotate checkstyle errors
+        if: ${{ failure() && matrix.java == '21' }}
+        run: python .github/scripts/checkstyle.py
+        env:
+          GITHUB: 1
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_BRANCH: ${{ github.ref_name }}
 
   test:
     needs: validate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
@@ -49,7 +52,7 @@ jobs:
         run: ./gradlew --build-cache --info --scan check -x test
       - name: Parse checkstyle
         if: always()
-        run: .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
+        run: python .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,8 @@ jobs:
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
         # Avoid duplicate annotations, only run on java 21
-        if: ${{ failure() && matrix.java == '21' }}
+        # For now, limit to "gh-" PRs
+        if: ${{ contains(github.head_ref, 'gh-') && failure() && matrix.java == '21' }}
         run: python .github/scripts/checkstyle.py
         env:
           GITHUB: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Compile and validate
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         run: ./gradlew --build-cache --info --scan check -x test
+      - name: Parse checkstyle
+        run: .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
       - name: Archive check reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,8 +48,13 @@ jobs:
           gradle-cache-read-only: true
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Compile and validate
-        # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
-        run: ./gradlew --build-cache --info --scan check -x test
+        # Gradle flags
+        # --build-cache:  Let Gradle restore the build cache
+        # --info:         For now, we'll generate lots of logs while setting up the GH Actions
+        # --scan:         Attempt to publish build scans in PRs. This will only work on PRs from apache/kafka, not public forks.
+        # spotlessCheck:  Skip spotless. While it is faster than checkstyle, it does not produce a report
+        #                 which makes it a bit less useful when running on CI.
+        run: ./gradlew --build-cache --info --scan check -x test -x spotlessCheck
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -59,7 +64,8 @@ jobs:
             **/build/**/*.html
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
-        if: ${{ failure() && matrix.java == '21' }}  # Avoid duplicate annotations, only process java 21
+        # Avoid duplicate annotations, only run on java 21
+        if: ${{ failure() && matrix.java == '21' }}
         run: python .github/scripts/checkstyle.py
         env:
           GITHUB: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 8, 11, 17 ]
+        java: [ 21, 17, 11, 8 ]
     name: Compile and Check Java ${{ matrix.java }}
     steps:
       - name: Checkout code
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 11 ]
     if: contains(github.head_ref, 'gh-')  # For now, only run tests on "gh-*" PRs
     name: JUnit tests Java ${{ matrix.java }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Parse checkstyle
         if: always()
         run: python .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB: 1
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,6 @@ jobs:
         if: ${{ contains(github.head_ref, 'gh-') && failure() && matrix.java == '21' }}
         run: python .github/scripts/checkstyle.py
         env:
-          GITHUB: 1
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Compile and validate
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         run: ./gradlew --build-cache --info --scan check -x test
+      - name: Archive check reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: check-reports-${{ matrix.java }}
+          path: |
+            **/build/**/*.html
 
   test:
     needs: validate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,8 +48,10 @@ jobs:
         # Publish build scans for now. This will only work on PRs from apache/kafka, not public forks.
         run: ./gradlew --build-cache --info --scan check -x test
       - name: Parse checkstyle
+        if: always()
         run: .github/scripts/checkstyle.py >> $GITHUB_STEP_SUMMARY
       - name: Archive check reports
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: check-reports-${{ matrix.java }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,9 +52,7 @@ jobs:
         # --build-cache:  Let Gradle restore the build cache
         # --info:         For now, we'll generate lots of logs while setting up the GH Actions
         # --scan:         Attempt to publish build scans in PRs. This will only work on PRs from apache/kafka, not public forks.
-        # spotlessCheck:  Skip spotless. While it is faster than checkstyle, it does not produce a report
-        #                 which makes it a bit less useful when running on CI.
-        run: ./gradlew --build-cache --info --scan check -x test -x spotlessCheck
+        run: ./gradlew --build-cache --info --scan check -x test
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -144,7 +144,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -144,6 +144,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ develocity {
 
 buildCache {
     local {
-        enabled = !isCI
+        enabled = !isJenkins
     }
 
     remote(develocity.buildCache) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,8 @@ develocity {
 
 buildCache {
     local {
+        // This allows the build cache to be used locally or on GitHub Actions.
+        // Using the cache on GH should be safe since each job is run on a new VM
         enabled = !isJenkins
     }
 


### PR DESCRIPTION
Passing --build-cache to gradlew is not enough, we also need to have the build cache enabled in settings.gradle. Once on trunk, this should allow the build-cache to get cached by GitHub. Hopefully this allows actual Gradle build graph, task outputs, and compiled classes to get cached for faster builds.