### PR TITLE
KAFKA-16379: Coordinator event queue, processing, flush, purgatory time histograms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1424,6 +1424,7 @@ project(':group-coordinator') {
     implementation libs.jacksonJDK8Datatypes
     implementation libs.slf4jApi
     implementation libs.metrics
+    implementation libs.hdrHistogram
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output

--- a/checkstyle/import-control-group-coordinator.xml
+++ b/checkstyle/import-control-group-coordinator.xml
@@ -72,6 +72,7 @@
             <allow pkg="org.apache.kafka.coordinator.common.runtime" />
             <subpackage name="metrics">
                 <allow pkg="com.yammer.metrics"/>
+                <allow pkg="org.HdrHistogram" />
                 <allow pkg="org.apache.kafka.common.metrics" />
                 <allow pkg="org.apache.kafka.server.metrics" />
             </subpackage>

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -68,6 +68,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorWriteEvent.NOT_QUEUED;
+
 /**
  * The CoordinatorRuntime provides a framework to implement coordinators such as the group coordinator
  * or the transaction coordinator.
@@ -741,6 +743,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private void flushCurrentBatch() {
             if (currentBatch != null) {
                 try {
+                    long flushStartMs = time.milliseconds();
                     // Write the records to the log and update the last written offset.
                     long offset = partitionWriter.append(
                         tp,
@@ -769,6 +772,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     for (DeferredEvent event : currentBatch.deferredEvents) {
                         deferredEventQueue.add(offset, event);
                     }
+                    runtimeMetrics.recordFlushTime(time.milliseconds() - flushStartMs);
 
                     // Free up the current batch.
                     freeCurrentBatch();
@@ -1071,6 +1075,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     result
                 );
 
+                long flushStartMs = time.milliseconds();
                 long offset = partitionWriter.append(
                     tp,
                     VerificationGuard.SENTINEL,
@@ -1084,6 +1089,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         )
                     )
                 );
+                runtimeMetrics.recordFlushTime(time.milliseconds() - flushStartMs);
                 coordinator.updateLastWrittenOffset(offset);
 
                 deferredEventQueue.add(offset, event);
@@ -1143,6 +1149,12 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param <T> The type of the response.
      */
     class CoordinatorWriteEvent<T> implements CoordinatorEvent, DeferredEvent {
+
+        /**
+         * Indicates that the event was not appended to the deferred event queue.
+         */
+        public static final long NOT_QUEUED = -1L;
+
         /**
          * The topic partition that this write event is applied to.
          */
@@ -1206,6 +1218,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private final long createdTimeMs;
 
         /**
+         * The time the event was added to the deferred queue.
+         */
+        private long deferredEventQueuedTimestamp;
+
+        /**
          * Constructor.
          *
          * @param name                  The operation name.
@@ -1263,6 +1280,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             this.future = new CompletableFuture<>();
             this.createdTimeMs = time.milliseconds();
             this.writeTimeout = writeTimeout;
+            this.deferredEventQueuedTimestamp = NOT_QUEUED;
         }
 
         /**
@@ -1300,6 +1318,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     if (!future.isDone()) {
                         operationTimeout = new OperationTimeout(tp, this, writeTimeout.toMillis());
                         timer.add(operationTimeout);
+
+                        // Only update when this event was appended to the deferred queue.
+                        deferredEventQueuedTimestamp = time.milliseconds();
                     }
                 });
             } catch (Throwable t) {
@@ -1315,6 +1336,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          */
         @Override
         public void complete(Throwable exception) {
+            final long purgatoryTimeMs = time.milliseconds() - deferredEventQueuedTimestamp;
             CompletableFuture<Void> appendFuture = result != null ? result.appendFuture() : null;
 
             if (exception == null) {
@@ -1328,6 +1350,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             if (operationTimeout != null) {
                 operationTimeout.cancel();
                 operationTimeout = null;
+            }
+
+            if (deferredEventQueuedTimestamp != NOT_QUEUED) {
+                // Only record the purgatory time if the event was deferred.
+                runtimeMetrics.recordEventPurgatoryTime(purgatoryTimeMs);
             }
         }
 
@@ -1531,6 +1558,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          */
         private final long createdTimeMs;
 
+        /**
+         * The time the records were appended to the log.
+         */
+        private long deferredEventQueuedTimestamp;
+
         CoordinatorCompleteTransactionEvent(
             String name,
             TopicPartition tp,
@@ -1549,6 +1581,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             this.writeTimeout = writeTimeout;
             this.future = new CompletableFuture<>();
             this.createdTimeMs = time.milliseconds();
+            this.deferredEventQueuedTimestamp = NOT_QUEUED;
         }
 
         /**
@@ -1578,6 +1611,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     if (!future.isDone()) {
                         operationTimeout = new OperationTimeout(tp, this, writeTimeout.toMillis());
                         timer.add(operationTimeout);
+
+                        // Only update when this event was appended to the deferred queue.
+                        deferredEventQueuedTimestamp = time.milliseconds();
                     }
                 });
             } catch (Throwable t) {
@@ -1593,6 +1629,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          */
         @Override
         public void complete(Throwable exception) {
+            final long purgatoryTimeMs = time.milliseconds() - deferredEventQueuedTimestamp;
             if (exception == null) {
                 future.complete(null);
             } else {
@@ -1602,6 +1639,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             if (operationTimeout != null) {
                 operationTimeout.cancel();
                 operationTimeout = null;
+            }
+
+            if (deferredEventQueuedTimestamp != NOT_QUEUED) {
+                // Only record the purgatory time if the event was deferred.
+                runtimeMetrics.recordEventPurgatoryTime(purgatoryTimeMs);
             }
         }
 
@@ -1708,7 +1750,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      */
     class HighWatermarkListener implements PartitionWriter.Listener {
 
-        private static final long NO_OFFSET = -1L;
+        static final long NO_OFFSET = -1L;
 
         /**
          * The atomic long is used to store the last and unprocessed high watermark

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -750,6 +750,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         currentBatch.verificationGuard,
                         currentBatch.builder.build()
                     );
+                    runtimeMetrics.recordFlushTime(time.milliseconds() - flushStartMs);
                     coordinator.updateLastWrittenOffset(offset);
 
                     if (offset != currentBatch.nextOffset) {
@@ -772,7 +773,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     for (DeferredEvent event : currentBatch.deferredEvents) {
                         deferredEventQueue.add(offset, event);
                     }
-                    runtimeMetrics.recordFlushTime(time.milliseconds() - flushStartMs);
 
                     // Free up the current batch.
                     freeCurrentBatch();

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -51,7 +51,21 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
      *
      * @param durationMs The event processing time.
      */
-    void recordEventQueueProcessingTime(long durationMs);
+    void recordEventProcessingTime(long durationMs);
+
+    /**
+     * Record the event purgatory time.
+     *
+     * @param durationMs    The time the event was completed.
+     */
+    void recordEventPurgatoryTime(long durationMs);
+
+    /**
+     * Record the flush time.
+     *
+     * @param durationMs The flush time in milliseconds.
+     */
+    void recordFlushTime(long durationMs);
 
     /**
      * Record the thread idle time.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
@@ -145,7 +145,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                         long dequeuedTimeMs = time.milliseconds();
                         metrics.recordEventQueueTime(dequeuedTimeMs - event.createdTimeMs());
                         event.run();
-                        metrics.recordEventQueueProcessingTime(time.milliseconds() - dequeuedTimeMs);
+                        metrics.recordEventProcessingTime(time.milliseconds() - dequeuedTimeMs);
                     } catch (Throwable t) {
                         log.error("Failed to run event {} due to: {}.", event, t.getMessage(), t);
                         event.complete(t);

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -101,6 +101,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("checkstyle:JavaNCSS")
 public class CoordinatorRuntimeTest {
     private static final TopicPartition TP = new TopicPartition("__consumer_offsets", 0);
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMillis(5);

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -81,6 +82,7 @@ import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.Coo
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState.FAILED;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState.INITIAL;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState.LOADING;
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.HighWatermarkListener.NO_OFFSET;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.MIN_BUFFER_SIZE;
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -224,24 +226,26 @@ public class CoordinatorRuntimeTest {
      * An in-memory partition writer that accepts a maximum number of writes.
      */
     private static class MockPartitionWriter extends InMemoryPartitionWriter {
+        private final Time time;
         private final int maxWrites;
         private final boolean failEndMarker;
         private final AtomicInteger writeCount = new AtomicInteger(0);
 
         public MockPartitionWriter() {
-            this(Integer.MAX_VALUE, false);
+            this(new MockTime(), Integer.MAX_VALUE, false);
         }
 
         public MockPartitionWriter(int maxWrites) {
-            this(maxWrites, false);
+            this(new MockTime(), maxWrites, false);
         }
 
         public MockPartitionWriter(boolean failEndMarker) {
-            this(Integer.MAX_VALUE, failEndMarker);
+            this(new MockTime(), Integer.MAX_VALUE, failEndMarker);
         }
 
-        public MockPartitionWriter(int maxWrites, boolean failEndMarker) {
+        public MockPartitionWriter(Time time, int maxWrites, boolean failEndMarker) {
             super(false);
+            this.time = time;
             this.maxWrites = maxWrites;
             this.failEndMarker = failEndMarker;
         }
@@ -271,6 +275,7 @@ public class CoordinatorRuntimeTest {
             if (failEndMarker && batch.firstBatch().isControlBatch())
                 throw new KafkaException("Couldn't write end marker.");
 
+            time.sleep(10);
             return super.append(tp, verificationGuard, batch);
         }
     }
@@ -4125,6 +4130,201 @@ public class CoordinatorRuntimeTest {
         assertEquals(Collections.singletonList(0L), ctx.coordinator.snapshotRegistry().epochsList());
         assertEquals(Collections.emptyList(), ctx.coordinator.coordinator().fullRecords());
         assertEquals(Collections.emptyList(), writer.entries(TP));
+    }
+
+    @Test
+    public void testRecordFlushTime() throws Exception {
+        MockTimer timer = new MockTimer();
+
+        // Writer sleeps for 10ms before appending records.
+        MockPartitionWriter writer = new MockPartitionWriter(timer.time(), Integer.MAX_VALUE, false);
+        CoordinatorRuntimeMetrics runtimeMetrics = mock(CoordinatorRuntimeMetrics.class);
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
+                .withCoordinatorRuntimeMetrics(runtimeMetrics)
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(new StringSerializer())
+                .withAppendLingerMs(10)
+                .build();
+
+        // Schedule the loading.
+        runtime.scheduleLoadOperation(TP, 10);
+
+        // Verify the initial state.
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        assertNull(ctx.currentBatch);
+
+        // Get the max batch size.
+        int maxBatchSize = writer.config(TP).maxMessageSize();
+
+        // Create records with a quarter of the max batch size each. Keep in mind that
+        // each batch has a header so it is not possible to have those four records
+        // in one single batch.
+        List<String> records = Stream.of('1', '2', '3', '4').map(c -> {
+            char[] payload = new char[maxBatchSize / 4];
+            Arrays.fill(payload, c);
+            return new String(payload);
+        }).collect(Collectors.toList());
+
+        // Write #1 with two records.
+        long firstBatchTimestamp = timer.time().milliseconds();
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+            state -> new CoordinatorResult<>(records.subList(0, 2), "response1")
+        );
+
+        // A batch has been created.
+        assertNotNull(ctx.currentBatch);
+
+        // Write #2 with one record.
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+            state -> new CoordinatorResult<>(records.subList(2, 3), "response2")
+        );
+
+        // Verify the state. Records are replayed but no batch written.
+        assertEquals(Collections.emptyList(), writer.entries(TP));
+        verify(runtimeMetrics, times(0)).recordFlushTime(10);
+
+        // Write #3 with one record. This one cannot go into the existing batch
+        // so the existing batch should be flushed and a new one should be created.
+        long secondBatchTimestamp = timer.time().milliseconds();
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(50),
+            state -> new CoordinatorResult<>(records.subList(3, 4), "response3")
+        );
+
+        // Verify the state. Records are replayed. The previous batch
+        // got flushed with all the records but the new one from #3.
+        assertEquals(3L, ctx.coordinator.lastWrittenOffset());
+        assertEquals(0L, ctx.coordinator.lastCommittedOffset());
+        assertEquals(Arrays.asList(
+            new MockCoordinatorShard.RecordAndMetadata(0, records.get(0)),
+            new MockCoordinatorShard.RecordAndMetadata(1, records.get(1)),
+            new MockCoordinatorShard.RecordAndMetadata(2, records.get(2)),
+            new MockCoordinatorShard.RecordAndMetadata(3, records.get(3))
+        ), ctx.coordinator.coordinator().fullRecords());
+        assertEquals(Collections.singletonList(
+            records(firstBatchTimestamp, records.subList(0, 3))
+        ), writer.entries(TP));
+        verify(runtimeMetrics, times(1)).recordFlushTime(10);
+
+        // Advance past the linger time.
+        timer.advanceClock(11);
+
+        // Verify the state. The pending batch is flushed.
+        assertEquals(4L, ctx.coordinator.lastWrittenOffset());
+        assertEquals(0L, ctx.coordinator.lastCommittedOffset());
+        assertEquals(Arrays.asList(
+            new MockCoordinatorShard.RecordAndMetadata(0, records.get(0)),
+            new MockCoordinatorShard.RecordAndMetadata(1, records.get(1)),
+            new MockCoordinatorShard.RecordAndMetadata(2, records.get(2)),
+            new MockCoordinatorShard.RecordAndMetadata(3, records.get(3))
+        ), ctx.coordinator.coordinator().fullRecords());
+        assertEquals(Arrays.asList(
+            records(secondBatchTimestamp, records.subList(0, 3)),
+            records(secondBatchTimestamp, records.subList(3, 4))
+        ), writer.entries(TP));
+        verify(runtimeMetrics, times(2)).recordFlushTime(10);
+
+        // Commit and verify that writes are completed.
+        writer.commit(TP);
+        assertTrue(write1.isDone());
+        assertTrue(write2.isDone());
+        assertTrue(write3.isDone());
+        assertEquals(4L, ctx.coordinator.lastCommittedOffset());
+        assertEquals("response1", write1.get(5, TimeUnit.SECONDS));
+        assertEquals("response2", write2.get(5, TimeUnit.SECONDS));
+        assertEquals("response3", write3.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testRecordEventPurgatoryTime() throws Exception {
+        Duration writeTimeout = Duration.ofMillis(1000);
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = new MockPartitionWriter();
+        ManualEventProcessor processor = new ManualEventProcessor();
+        CoordinatorRuntimeMetrics runtimeMetrics = mock(CoordinatorRuntimeMetrics.class);
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(writeTimeout)
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(processor)
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
+                .withCoordinatorRuntimeMetrics(runtimeMetrics)
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(new StringSerializer())
+                .build();
+
+        // Loads the coordinator. Poll once to execute the load operation and once
+        // to complete the load.
+        runtime.scheduleLoadOperation(TP, 10);
+        processor.poll();
+        processor.poll();
+
+        // write#1 will be committed and update the high watermark. Record time spent in purgatory.
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, writeTimeout,
+            state -> new CoordinatorResult<>(Collections.singletonList("record1"), "response1")
+        );
+        // write#2 will time out sitting in the purgatory. Record time spent in purgatory.
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, writeTimeout,
+            state -> new CoordinatorResult<>(Collections.singletonList("record2"), "response2")
+        );
+        // write#3 will error while appending. Does not spend time in purgatory.
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, writeTimeout,
+            state -> {
+                throw new KafkaException("write#3 failed.");
+            });
+
+        processor.poll();
+        processor.poll();
+        processor.poll();
+
+        // Confirm we do not record purgatory time for write#3.
+        assertTrue(write3.isCompletedExceptionally());
+        verify(runtimeMetrics, times(0)).recordEventPurgatoryTime(0L);
+
+        // Records have been written to the log.
+        long writeTimestamp = timer.time().milliseconds();
+        assertEquals(Arrays.asList(
+            records(writeTimestamp, "record1"),
+            records(writeTimestamp, "record2")
+        ), writer.entries(TP));
+
+        // There is no pending high watermark.
+        assertEquals(NO_OFFSET, runtime.contextOrThrow(TP).highWatermarklistener.lastHighWatermark());
+
+        // Advance the clock then commit records from write#1.
+        timer.advanceClock(700);
+        writer.commit(TP, 1);
+
+        // We should still have one pending event and the pending high watermark should be updated.
+        assertEquals(1, processor.size());
+        assertEquals(1, runtime.contextOrThrow(TP).highWatermarklistener.lastHighWatermark());
+
+        // Poll once to process the high watermark update and complete the writes.
+        processor.poll();
+        long purgatoryTimeMs = timer.time().milliseconds() - writeTimestamp;
+
+        // Advance the clock past write timeout. write#2 has now timed out.
+        timer.advanceClock(300 + 1);
+        processor.poll();
+
+        assertEquals(NO_OFFSET, runtime.contextOrThrow(TP).highWatermarklistener.lastHighWatermark());
+        assertEquals(1, runtime.contextOrThrow(TP).coordinator.lastCommittedOffset());
+        assertTrue(write1.isDone());
+        assertTrue(write2.isCompletedExceptionally());
+        verify(runtimeMetrics, times(1)).recordEventPurgatoryTime(purgatoryTimeMs);
+        verify(runtimeMetrics, times(1)).recordEventPurgatoryTime(writeTimeout.toMillis() + 1);
     }
 
     private static <S extends CoordinatorShard<U>, U> ArgumentMatcher<CoordinatorPlayback<U>> coordinatorMatcher(

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessorTest.java
@@ -446,7 +446,7 @@ public class MultiThreadedEventProcessorTest {
             // e1 poll time
             verify(mockRuntimeMetrics, times(1)).recordEventQueueTime(500L);
             // e1 processing time + e2 enqueue time
-            verify(mockRuntimeMetrics, times(1)).recordEventQueueProcessingTime(7000L);
+            verify(mockRuntimeMetrics, times(1)).recordEventProcessingTime(7000L);
 
             // Second event (e2)
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -161,7 +161,8 @@ versions += [
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4",
-  junitPlatform: "1.10.2"
+  junitPlatform: "1.10.2",
+  hdrHistogram: "2.2.2"
 ]
 
 libs += [
@@ -259,5 +260,6 @@ libs += [
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
   zstd: "com.github.luben:zstd-jni:$versions.zstd",
-  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient"
+  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient",
+  hdrHistogram: "org.hdrhistogram:HdrHistogram:$versions.hdrHistogram"
 ]

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/HdrHistogram.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/HdrHistogram.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+import org.HdrHistogram.ValueRecorder;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * <p>A wrapper on top of the HdrHistogram API. It handles writing to the histogram by delegating
+ * to an internal {@link ValueRecorder} implementation, and reading from the histogram by
+ * efficiently implementing the retrieval of up-to-date histogram data.
+ *
+ * <p>Note that all APIs expect a timestamp which is used by the histogram to discard decaying data
+ * and determine when the snapshot from which the histogram metrics are calculated should be
+ * refreshed.
+ */
+public final class HdrHistogram {
+
+    private static final long DEFAULT_MAX_SNAPSHOT_AGE_MS = 1000L;
+
+    /**
+     * The duration (in millis) after which the latest histogram snapshot is considered outdated and
+     * subsequent calls to {@link #latestHistogram(long)} will result in the snapshot being recreated.
+     */
+    private final long maxSnapshotAgeMs;
+
+    /**
+     * The internal HdrHistogram data structure used to:
+     * <ul>
+     *   <li>ingest data;</li>
+     *   <li>get a {@link Histogram} of the latest ingested data;</li>
+     * </ul>
+     */
+    private final Recorder recorder;
+
+    /**
+     * The latest snapshot of the internal HdrHistogram. Automatically updated by
+     * {@link #latestHistogram(long)} if older than {@link #maxSnapshotAgeMs}.
+     */
+    private final AtomicReference<Timestamped<Histogram>> timestampedHistogramSnapshot;
+
+    public HdrHistogram(
+        long highestTrackableValue,
+        int numberOfSignificantValueDigits
+    ) {
+        this(DEFAULT_MAX_SNAPSHOT_AGE_MS, highestTrackableValue, numberOfSignificantValueDigits);
+    }
+
+    HdrHistogram(
+        long maxSnapshotAgeMs,
+        long highestTrackableValue,
+        int numberOfSignificantValueDigits
+    ) {
+        this.maxSnapshotAgeMs = maxSnapshotAgeMs;
+        recorder = new Recorder(highestTrackableValue, numberOfSignificantValueDigits);
+        this.timestampedHistogramSnapshot = new AtomicReference<>(new Timestamped<>(0, null));
+    }
+
+    private Histogram latestHistogram(long now) {
+        Timestamped<Histogram> latest = timestampedHistogramSnapshot.get();
+        while (now - latest.timestamp > maxSnapshotAgeMs) {
+            Histogram currentSnapshot = recorder.getIntervalHistogram();
+            boolean updatedLatest = timestampedHistogramSnapshot.compareAndSet(
+                latest, new Timestamped<>(now, currentSnapshot));
+
+            latest = timestampedHistogramSnapshot.get();
+            if (updatedLatest) {
+                break;
+            }
+        }
+        return latest.value;
+    }
+
+    /**
+     * Writes to the histogram. Will throw {@link ArrayIndexOutOfBoundsException} if the histogram's
+     * highestTrackableValue is lower than the value being recorded.
+     *
+     * @param value The value to be recorded. Cannot be negative.
+     */
+    public void record(long value) {
+        recorder.recordValue(value);
+    }
+
+    /**
+     * @param now An externally provided timestamp expected to be in milliseconds.
+     * @return The total number of updates recorded by the histogram, i.e. the number of times
+     * {@link #record(long)} has been called.
+     */
+    public long count(long now) {
+        return latestHistogram(now).getTotalCount();
+    }
+
+    /**
+     * @param now An externally provided timestamp expected to be in milliseconds.
+     * @return The maximum value recorded by the histogram.
+     */
+    public long max(long now) {
+        return latestHistogram(now).getMaxValue();
+    }
+
+    /**
+     * Reads percentile data from the histogram.
+     *
+     * @param now        An externally provided timestamp expected to be in milliseconds.
+     * @param percentile The percentile for which a value is going to be retrieved. Expected to be
+     *                   between 0.0 and 100.0.
+     * @return The histogram value for the given percentile.
+     */
+    public double measurePercentile(long now, double percentile) {
+        return latestHistogram(now).getValueAtPercentile(percentile);
+    }
+
+    /**
+     * A simple tuple of a timestamp and a value. Can be used updating a value and recording the
+     * timestamp of the update in a single atomic operation.
+     */
+    private static final class Timestamped<T> {
+
+        private final long timestamp;
+        private final T value;
+
+        private Timestamped(long timestamp, T value) {
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+    }
+
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/KafkaMetricHistogram.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/KafkaMetricHistogram.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.CompoundStat;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.stats.Percentiles;
+import org.apache.kafka.common.utils.Utils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A compound stat providing various metrics based on an internally maintained {@link HdrHistogram}.
+ * It should be more performant, more precise, and much more flexible regarding concurrent usage
+ * compared to either the most commonly used in the Kafka codebase Yammer histograms or the existing
+ * Kafka Metrics alternatives like {@link Percentiles}.
+ */
+public final class KafkaMetricHistogram implements CompoundStat {
+
+    /**
+     * The number of significant digits used for the histogram.
+     */
+    public static final int NUM_SIG_FIGS = 3;
+
+    /**
+     * Max latency value.
+     */
+    public static final long MAX_LATENCY_MS = Duration.ofMinutes(1).toMillis();
+
+    /**
+     * Suffix used for the histogram's max value.
+     */
+    private static final String MAX_NAME = "max";
+
+    /**
+     * Set list of percentiles we will provide metrics for.
+     */
+    private static final Map<Double, String> PERCENTILE_NAMES =
+        Utils.mkMap(
+            Utils.mkEntry(50.0, "p50"),
+            Utils.mkEntry(95.0, "p95"),
+            Utils.mkEntry(99.0, "p99"),
+            Utils.mkEntry(99.9, "p999")
+        );
+
+    /**
+     * Factory for creating a {@link MetricName} based on a metric name with suffix.
+     */
+    private final Function<String, MetricName> metricNameFactory;
+    private final HdrHistogram hdrHistogram;
+
+    /**
+     * Creates a new histogram with the purpose of tracking latency values. As such, the histogram
+     * allows concurrent reads and writes and 3-digit precision across its range (higher precision significantly
+     * increases the memory footprint of the histogram and is rarely needed).
+     *
+     * @param metricNameFactory A factory for creating a {@link MetricName} based on a metric name
+     *                          string.
+     * @return A new {@link KafkaMetricHistogram} with the configured properties.
+     */
+    public static KafkaMetricHistogram newLatencyHistogram(
+        Function<String, MetricName> metricNameFactory
+    ) {
+        return new KafkaMetricHistogram(
+            metricNameFactory,
+            MAX_LATENCY_MS,
+            NUM_SIG_FIGS);
+    }
+
+    /**
+     * Creates a new histogram with the purpose of tracking latency values. As such, the histogram
+     * allows concurrent reads and writes and 3-digit precision across its range (higher precision significantly
+     * increases the memory footprint of the histogram and is rarely needed).
+     *
+     * @param metricNameFactory              A factory for creating a {@link MetricName} based on a metric name
+     *                                          string.
+     * @param highestTrackableValue          The maximum trackable value for the histogram, e.g. something
+     *                                          with some safety margin above the configured request timeout for
+     *                                          request latencies.
+     * @param numberOfSignificantValueDigits The number of significant digits used.
+     */
+    private KafkaMetricHistogram(
+        Function<String, MetricName> metricNameFactory,
+        long highestTrackableValue,
+        int numberOfSignificantValueDigits
+    ) {
+        this.metricNameFactory = metricNameFactory;
+        this.hdrHistogram = new HdrHistogram(highestTrackableValue, numberOfSignificantValueDigits);
+    }
+
+    @Override
+    public List<NamedMeasurable> stats() {
+        List<NamedMeasurable> stats = new ArrayList<>();
+        stats.add(new NamedMeasurable(
+            metricNameFactory.apply(MAX_NAME),
+            (config, now) -> hdrHistogram.max(now)));
+        PERCENTILE_NAMES
+            .entrySet()
+            .stream()
+            .map(e -> new NamedMeasurable(
+                metricNameFactory.apply(e.getValue()),
+                (config, now) -> hdrHistogram.measurePercentile(now, e.getKey())))
+            .forEachOrdered(stats::add);
+        return stats;
+    }
+
+    @Override
+    public void record(MetricConfig config, double value, long timeMs) {
+        hdrHistogram.record((long) value);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -51,30 +51,30 @@ public class GroupCoordinatorRuntimeMetricsTest {
             kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "loading"),
             kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "active"),
             kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "failed"),
-            metrics.metricName("event-queue-size", METRICS_GROUP),
-            metrics.metricName("partition-load-time-max", METRICS_GROUP),
-            metrics.metricName("partition-load-time-avg", METRICS_GROUP),
-            metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP),
-            metrics.metricName("event-queue-time-ms-max", METRICS_GROUP),
-            metrics.metricName("event-queue-time-ms-p50", METRICS_GROUP),
-            metrics.metricName("event-queue-time-ms-p95", METRICS_GROUP),
-            metrics.metricName("event-queue-time-ms-p99", METRICS_GROUP),
-            metrics.metricName("event-queue-time-ms-p999", METRICS_GROUP),
-            metrics.metricName("event-processing-time-ms-max", METRICS_GROUP),
-            metrics.metricName("event-processing-time-ms-p50", METRICS_GROUP),
-            metrics.metricName("event-processing-time-ms-p95", METRICS_GROUP),
-            metrics.metricName("event-processing-time-ms-p99", METRICS_GROUP),
-            metrics.metricName("event-processing-time-ms-p999", METRICS_GROUP),
-            metrics.metricName("event-purgatory-time-ms-max", METRICS_GROUP),
-            metrics.metricName("event-purgatory-time-ms-p50", METRICS_GROUP),
-            metrics.metricName("event-purgatory-time-ms-p95", METRICS_GROUP),
-            metrics.metricName("event-purgatory-time-ms-p99", METRICS_GROUP),
-            metrics.metricName("event-purgatory-time-ms-p999", METRICS_GROUP),
-            metrics.metricName("batch-flush-time-ms-max", METRICS_GROUP),
-            metrics.metricName("batch-flush-time-ms-p50", METRICS_GROUP),
-            metrics.metricName("batch-flush-time-ms-p95", METRICS_GROUP),
-            metrics.metricName("batch-flush-time-ms-p99", METRICS_GROUP),
-            metrics.metricName("batch-flush-time-ms-p999", METRICS_GROUP)
+            kafkaMetricName(metrics, "event-queue-size"),
+            kafkaMetricName(metrics, "partition-load-time-max"),
+            kafkaMetricName(metrics, "partition-load-time-avg"),
+            kafkaMetricName(metrics, "thread-idle-ratio-avg"),
+            kafkaMetricName(metrics, "event-queue-time-ms-max"),
+            kafkaMetricName(metrics, "event-queue-time-ms-p50"),
+            kafkaMetricName(metrics, "event-queue-time-ms-p95"),
+            kafkaMetricName(metrics, "event-queue-time-ms-p99"),
+            kafkaMetricName(metrics, "event-queue-time-ms-p999"),
+            kafkaMetricName(metrics, "event-processing-time-ms-max"),
+            kafkaMetricName(metrics, "event-processing-time-ms-p50"),
+            kafkaMetricName(metrics, "event-processing-time-ms-p95"),
+            kafkaMetricName(metrics, "event-processing-time-ms-p99"),
+            kafkaMetricName(metrics, "event-processing-time-ms-p999"),
+            kafkaMetricName(metrics, "event-purgatory-time-ms-max"),
+            kafkaMetricName(metrics, "event-purgatory-time-ms-p50"),
+            kafkaMetricName(metrics, "event-purgatory-time-ms-p95"),
+            kafkaMetricName(metrics, "event-purgatory-time-ms-p99"),
+            kafkaMetricName(metrics, "event-purgatory-time-ms-p999"),
+            kafkaMetricName(metrics, "batch-flush-time-ms-max"),
+            kafkaMetricName(metrics, "batch-flush-time-ms-p50"),
+            kafkaMetricName(metrics, "batch-flush-time-ms-p95"),
+            kafkaMetricName(metrics, "batch-flush-time-ms-p99"),
+            kafkaMetricName(metrics, "batch-flush-time-ms-p999")
         ));
 
         try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
@@ -118,14 +118,12 @@ public class GroupCoordinatorRuntimeMetricsTest {
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 1000);
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 2000);
 
-            org.apache.kafka.common.MetricName metricName = metrics.metricName(
-                "partition-load-time-avg", METRICS_GROUP);
+            org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "partition-load-time-avg");
 
             KafkaMetric metric = metrics.metrics().get(metricName);
             assertEquals(1500.0, metric.metricValue());
 
-            metricName = metrics.metricName(
-                "partition-load-time-max", METRICS_GROUP);
+            metricName = kafkaMetricName(metrics, "partition-load-time-max");
             metric = metrics.metrics().get(metricName);
             assertEquals(2000.0, metric.metricValue());
         }
@@ -139,8 +137,7 @@ public class GroupCoordinatorRuntimeMetricsTest {
         GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics);
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleTime((i + 1) * 1000L));
 
-        org.apache.kafka.common.MetricName metricName = metrics.metricName(
-            "thread-idle-ratio-avg", METRICS_GROUP);
+        org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "thread-idle-ratio-avg");
         KafkaMetric metric = metrics.metrics().get(metricName);
         assertEquals(6 / 30.0, metric.metricValue()); // 'total_ms / window_ms'
     }
@@ -185,23 +182,23 @@ public class GroupCoordinatorRuntimeMetricsTest {
             }
         });
 
-        MetricName metricName = metrics.metricName(metricNamePrefix + "-max", METRICS_GROUP);
+        MetricName metricName = kafkaMetricName(metrics, metricNamePrefix + "-max");
         KafkaMetric metric = metrics.metrics().get(metricName);
         assertEquals(1000.0, metric.metricValue());
 
-        metricName = metrics.metricName(metricNamePrefix + "-p50", METRICS_GROUP);
+        metricName = kafkaMetricName(metrics, metricNamePrefix + "-p50");
         metric = metrics.metrics().get(metricName);
         assertEquals(500.0, metric.metricValue());
 
-        metricName = metrics.metricName(metricNamePrefix + "-p95", METRICS_GROUP);
+        metricName = kafkaMetricName(metrics, metricNamePrefix + "-p95");
         metric = metrics.metrics().get(metricName);
         assertEquals(950.0, metric.metricValue());
 
-        metricName = metrics.metricName(metricNamePrefix + "-p99", METRICS_GROUP);
+        metricName = kafkaMetricName(metrics, metricNamePrefix + "-p99");
         metric = metrics.metrics().get(metricName);
         assertEquals(990.0, metric.metricValue());
 
-        metricName = metrics.metricName(metricNamePrefix + "-p999", METRICS_GROUP);
+        metricName = kafkaMetricName(metrics, metricNamePrefix + "-p999");
         metric = metrics.metrics().get(metricName);
         assertEquals(999.0, metric.metricValue());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -24,11 +24,17 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.BATCH_FLUSH_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.EVENT_PROCESSING_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.EVENT_PURGATORY_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.EVENT_QUEUE_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.METRICS_GROUP;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.NUM_PARTITIONS_METRIC_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +54,27 @@ public class GroupCoordinatorRuntimeMetricsTest {
             metrics.metricName("event-queue-size", METRICS_GROUP),
             metrics.metricName("partition-load-time-max", METRICS_GROUP),
             metrics.metricName("partition-load-time-avg", METRICS_GROUP),
-            metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP)
+            metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP),
+            metrics.metricName("event-queue-time-ms-max", METRICS_GROUP),
+            metrics.metricName("event-queue-time-ms-p50", METRICS_GROUP),
+            metrics.metricName("event-queue-time-ms-p95", METRICS_GROUP),
+            metrics.metricName("event-queue-time-ms-p99", METRICS_GROUP),
+            metrics.metricName("event-queue-time-ms-p999", METRICS_GROUP),
+            metrics.metricName("event-processing-time-ms-max", METRICS_GROUP),
+            metrics.metricName("event-processing-time-ms-p50", METRICS_GROUP),
+            metrics.metricName("event-processing-time-ms-p95", METRICS_GROUP),
+            metrics.metricName("event-processing-time-ms-p99", METRICS_GROUP),
+            metrics.metricName("event-processing-time-ms-p999", METRICS_GROUP),
+            metrics.metricName("event-purgatory-time-ms-max", METRICS_GROUP),
+            metrics.metricName("event-purgatory-time-ms-p50", METRICS_GROUP),
+            metrics.metricName("event-purgatory-time-ms-p95", METRICS_GROUP),
+            metrics.metricName("event-purgatory-time-ms-p99", METRICS_GROUP),
+            metrics.metricName("event-purgatory-time-ms-p999", METRICS_GROUP),
+            metrics.metricName("batch-flush-time-ms-max", METRICS_GROUP),
+            metrics.metricName("batch-flush-time-ms-p50", METRICS_GROUP),
+            metrics.metricName("batch-flush-time-ms-p95", METRICS_GROUP),
+            metrics.metricName("batch-flush-time-ms-p99", METRICS_GROUP),
+            metrics.metricName("batch-flush-time-ms-p999", METRICS_GROUP)
         ));
 
         try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
@@ -56,7 +82,10 @@ public class GroupCoordinatorRuntimeMetricsTest {
             expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
 
-        expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
+        expectedMetrics.forEach(metricName -> assertFalse(
+            metrics.metrics().containsKey(metricName),
+            "metrics did not expect to contain metricName: " + metricName + " after closing."
+        ));
     }
 
     @Test
@@ -127,13 +156,58 @@ public class GroupCoordinatorRuntimeMetricsTest {
         }
     }
 
-    private static void assertMetricGauge(Metrics metrics, org.apache.kafka.common.MetricName metricName, long count) {
-        assertEquals(count, (long) metrics.metric(metricName).metricValue());
+    @ParameterizedTest
+    @ValueSource(strings = {
+        EVENT_QUEUE_TIME_METRIC_NAME,
+        EVENT_PROCESSING_TIME_METRIC_NAME,
+        EVENT_PURGATORY_TIME_METRIC_NAME,
+        BATCH_FLUSH_TIME_METRIC_NAME
+    })
+    public void testHistogramMetrics(String metricNamePrefix) {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+
+        GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics);
+
+        IntStream.range(1, 1001).forEach(i -> {
+            switch (metricNamePrefix) {
+                case EVENT_QUEUE_TIME_METRIC_NAME:
+                    runtimeMetrics.recordEventQueueTime(i);
+                    break;
+                case EVENT_PROCESSING_TIME_METRIC_NAME:
+                    runtimeMetrics.recordEventProcessingTime(i);
+                    break;
+                case EVENT_PURGATORY_TIME_METRIC_NAME:
+                    runtimeMetrics.recordEventPurgatoryTime(i);
+                    break;
+                case BATCH_FLUSH_TIME_METRIC_NAME:
+                    runtimeMetrics.recordFlushTime(i);
+            }
+        });
+
+        MetricName metricName = metrics.metricName(metricNamePrefix + "-max", METRICS_GROUP);
+        KafkaMetric metric = metrics.metrics().get(metricName);
+        assertEquals(1000.0, metric.metricValue());
+
+        metricName = metrics.metricName(metricNamePrefix + "-p50", METRICS_GROUP);
+        metric = metrics.metrics().get(metricName);
+        assertEquals(500.0, metric.metricValue());
+
+        metricName = metrics.metricName(metricNamePrefix + "-p95", METRICS_GROUP);
+        metric = metrics.metrics().get(metricName);
+        assertEquals(950.0, metric.metricValue());
+
+        metricName = metrics.metricName(metricNamePrefix + "-p99", METRICS_GROUP);
+        metric = metrics.metrics().get(metricName);
+        assertEquals(990.0, metric.metricValue());
+
+        metricName = metrics.metricName(metricNamePrefix + "-p999", METRICS_GROUP);
+        metric = metrics.metrics().get(metricName);
+        assertEquals(999.0, metric.metricValue());
     }
 
-    private static com.yammer.metrics.core.MetricName yammerMetricName(String type, String name) {
-        String mBeanName = String.format("kafka.coordinator.group:type=%s,name=%s", type, name);
-        return new com.yammer.metrics.core.MetricName("kafka.coordinator.group", type, name, null, mBeanName);
+    private static void assertMetricGauge(Metrics metrics, org.apache.kafka.common.MetricName metricName, long count) {
+        assertEquals(count, (long) metrics.metric(metricName).metricValue());
     }
 
     private static MetricName kafkaMetricName(Metrics metrics, String name, String... keyValue) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/HdrHistogramTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/HdrHistogramTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HdrHistogramTest {
+
+    private static final double[] QUANTILES = new double[]{0.5, 0.75, 0.95, 0.98, 0.99, 0.999};
+
+    private static final long MAX_VALUE = TimeUnit.MINUTES.toMillis(1L);
+    private static final long REGULAR_VALUE = 100L;
+    private static final int NUM_SIGNIFICANT_DIGITS = 3;
+
+    @Test
+    public void testHdrVsYammerUniform() {
+        List<Long> samples = new ArrayList<>();
+        for (long i = 0; i <= MAX_VALUE; i++) { // 60k iterations with the current constants
+            samples.add(i);
+        }
+        testHdrHistogramVsYammerHistogram(samples, "uniform");
+    }
+
+    @Test
+    public void testHdrVsYammerNormal() {
+        List<Long> samples = new ArrayList<>();
+        for (long i = 0; i <= MAX_VALUE; i++) { // 60k iterations with the current constants
+            samples.add(ThreadLocalRandom.current().nextLong(MAX_VALUE));
+        }
+        testHdrHistogramVsYammerHistogram(samples, "normal");
+    }
+
+    @Test
+    public void testHdrVsYammerBimodal() {
+        List<Long> samples = new ArrayList<>();
+        for (long i = 0; i <= MAX_VALUE; i++) { // 60k iterations with the current constants
+            if (i % 500 == 0) {
+                // generate a tail-like latency value, and do it once in every 500 iterations, so that the
+                // p999 value is expected to reflect it
+                samples.add(ThreadLocalRandom.current().nextLong(MAX_VALUE));
+            } else {
+                // generate a normal latency value
+                samples.add(ThreadLocalRandom.current().nextLong(REGULAR_VALUE));
+            }
+        }
+        testHdrHistogramVsYammerHistogram(samples, "bimodal");
+    }
+
+    private void testHdrHistogramVsYammerHistogram(List<Long> samples, String distributionLabel) {
+        HdrHistogram hdrHistogram = new HdrHistogram(MAX_VALUE, NUM_SIGNIFICANT_DIGITS);
+        Histogram yammerHistogram = new MetricsRegistry().newHistogram(new MetricName("", "", ""),
+            true);
+
+        Collections.sort(samples);
+        double[] expectedQuantileValues = new double[QUANTILES.length];
+        for (int i = 0; i < QUANTILES.length; i++) {
+            int quantileIndex = (int) (Math.ceil(samples.size() * QUANTILES[i])) - 1;
+            expectedQuantileValues[i] = samples.get(quantileIndex);
+        }
+        Collections.shuffle(samples);
+
+        for (long sample : samples) {
+            hdrHistogram.record(sample);
+            yammerHistogram.update(sample);
+        }
+
+        System.out.printf("Testing HdrHistogram vs Yammer histogram for %s distribution%n",
+            distributionLabel);
+        long now = System.currentTimeMillis();
+        int numYammerWins = 0;
+        for (int i = 0; i < QUANTILES.length; i++) {
+            double quantile = QUANTILES[i];
+            double hdrHistogramValue = hdrHistogram.measurePercentile(now, quantile * 100);
+            double yammerHistogramValue = yammerHistogram.getSnapshot().getValue(quantile);
+            double expectedValue = expectedQuantileValues[i];
+            System.out.printf(
+                "Values for quantile %f: HdrHistogram: %f, Yammer histogram: %f, Expected: %f%n",
+                quantile, hdrHistogramValue, yammerHistogramValue, expectedValue);
+            if (Math.abs(expectedValue - hdrHistogramValue) > Math.abs(
+                expectedValue - yammerHistogramValue)) {
+                numYammerWins++;
+            }
+        }
+        System.out.printf("HdrHistogram was more accurate: %d out of %d times%n",
+            QUANTILES.length - numYammerWins, QUANTILES.length);
+        assertTrue(numYammerWins <= QUANTILES.length / 2);
+    }
+
+    @Test
+    public void testCount() throws Exception {
+        int numUpdates = 100_000;
+        HdrHistogram hdrHistogram = new HdrHistogram(
+            MAX_VALUE, NUM_SIGNIFICANT_DIGITS);
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        for (int i = 0; i < numUpdates; i++) {
+            executorService.submit(() -> hdrHistogram.record(1L));
+        }
+        executorService.shutdown();
+        assertTrue(executorService.awaitTermination(1L, TimeUnit.SECONDS));
+        assertEquals(numUpdates, hdrHistogram.count(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testMax() throws Exception {
+        int numSignificantDigits = 5;
+        int numUpdates = 30_000;
+        double expectedMax = 0.0;
+        long[] values = new long[numUpdates];
+        for (int i = 0; i < numUpdates; i++) {
+            long value = ThreadLocalRandom.current().nextLong(MAX_VALUE);
+            values[i] = value;
+            expectedMax = Math.max(expectedMax, value);
+        }
+
+        HdrHistogram hdrHistogram = new HdrHistogram(MAX_VALUE, numSignificantDigits);
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        for (int i = 0; i < numUpdates; i++) {
+            final long value = values[i];
+            executorService.submit(() -> hdrHistogram.record(value));
+        }
+        executorService.shutdown();
+        assertTrue(executorService.awaitTermination(1L, TimeUnit.SECONDS));
+
+        double histogramMax = hdrHistogram.max(System.currentTimeMillis());
+        assertEquals(expectedMax, histogramMax);
+    }
+
+    @Test
+    public void testHistogramDataReset() {
+        long maxSnapshotAgeMs = 10L;
+        HdrHistogram hdrHistogram = new HdrHistogram(maxSnapshotAgeMs, MAX_VALUE, 3);
+        int numEventsInFirstCycle = 1000;
+        for (int i = 0; i < numEventsInFirstCycle; i++) {
+            hdrHistogram.record(i);
+        }
+        long now = System.currentTimeMillis();
+        assertEquals(numEventsInFirstCycle, hdrHistogram.count(now));
+        int numEventsInSecondCycle = 2000;
+        for (int i = 0; i < numEventsInSecondCycle; i++) {
+            hdrHistogram.record(i);
+        }
+        assertEquals(numEventsInFirstCycle, hdrHistogram.count(now));
+        assertEquals(numEventsInFirstCycle, hdrHistogram.count(now + maxSnapshotAgeMs));
+        assertEquals(numEventsInSecondCycle, hdrHistogram.count(now + 1 + maxSnapshotAgeMs));
+    }
+}


### PR DESCRIPTION
The HdrHistogram wrapper implementation (HdrHistogram, KafkaMetricHistogram) was authored by @dimitarndimitrov  

This patch introduces a wrapper around [HdrHistogram](https://github.com/HdrHistogram/HdrHistogram) to use for group coordinator histograms, event queue time, event processing time, flush time, and purgatory time.

Note that the wrapper refreshes histogram snapshots on a query/read basis - it does not refresh the snapshot if metrics(max, p99, etc) are never queried. The implication is that if we collect metrics at, say every 60s, then the first query will contain 60s worth of data whereas the subsequent queries will generate a new snapshot

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
