### PR TITLE
MINOR: fix HTML for topology.optimization config

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1003,7 +1003,17 @@ public class StreamsConfig extends AbstractConfig {
             .define(TOPOLOGY_OPTIMIZATION_CONFIG,
                     Type.STRING,
                     NO_OPTIMIZATION,
-                    (name, value) -> verifyTopologyOptimizationConfigs((String) value),
+                    new ConfigDef.Validator() {
+                        @Override
+                        public void ensureValid(final String name, final Object value) {
+                            verifyTopologyOptimizationConfigs((String) value);
+                        }
+
+                        @Override
+                        public String toString() {
+                            return TOPOLOGY_OPTIMIZATION_CONFIGS.toString();
+                        }
+                    },
                     Importance.MEDIUM,
                     TOPOLOGY_OPTIMIZATION_DOC)
 


### PR DESCRIPTION
The HTML rendering broke via https://issues.apache.org/jira/browse/KAFKA-14209 in 3.4 release. The currently shown value is some garbage `org.apache.kafka.streams.StreamsConfig$$Lambda$20/0x0000000800c0cf18@b1bc7ed`

cf https://kafka.apache.org/documentation/#streamsconfigs_topology.optimization

Verified the fix via running `StreamsConfig#main()` locally.