### PR TITLE
KAFKA-17062: handle dangling "copy_segment_start" state when deleting remote logs

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,7 +39,7 @@
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
               files="core[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="NPathComplexity" files="(ClusterTestExtensions|KafkaApisBuilder|SharePartition).java"/>
-    <suppress checks="NPathComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling" files="(RemoteLogManager|RemoteLogManagerTest).java"/>
+    <suppress checks="NPathComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling|JavaNCSS" files="(RemoteLogManager|RemoteLogManagerTest).java"/>
     <suppress checks="MethodLength" files="RemoteLogManager.java"/>
     <suppress checks="ClassFanOutComplexity" files="RemoteLogManagerTest.java"/>
     <suppress checks="MethodLength"

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1265,10 +1265,7 @@ public class RemoteLogManager implements Closeable {
                         canProcess = false;
                         continue;
                     }
-                    // skip the COPY_SEGMENT_STARTED segments since they might be the dangling segments that failed before
-                    // and blocks the normal segment deletion, ex: it failed `isRemoteSegmentWithinLeaderEpochs` check... etc
-                    if (RemoteLogSegmentState.DELETE_SEGMENT_FINISHED.equals(metadata.state()) ||
-                            RemoteLogSegmentState.COPY_SEGMENT_STARTED.equals(metadata.state())) {
+                    if (RemoteLogSegmentState.DELETE_SEGMENT_FINISHED.equals(metadata.state())) {
                         continue;
                     }
                     if (segmentsToDelete.contains(metadata)) {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -957,9 +957,9 @@ public class RemoteLogManager implements Closeable {
             } catch (RemoteStorageException e) {
                 try {
                     remoteLogStorageManager.deleteLogSegmentData(copySegmentStartedRlsm);
-                    logger.info("Successfully cleaned segment after failing to copy segment");
+                    logger.info("Successfully cleaned segment {} after failing to copy segment", segmentId);
                 } catch (RemoteStorageException e1) {
-                    logger.error("Error while cleaning segment, consider cleaning manually", e1);
+                    logger.error("Error while cleaning segment {}, consider cleaning manually", segmentId, e1);
                 }
                 throw e;
             }


### PR DESCRIPTION
The `COPY_SEGMENT_STARTED` state segments are counted when calculating remote retention size. This causes unexpected retention size breached segment deletion. This PR fixes it by 

1. only counting `COPY_SEGMENT_FINISHED` and `DELETE_SEGMENT_STARTED` state segments when calculating remote log size. 
2. During copy Segment, if we encounter errors, we will delete the segment immediately.
3. Tests added.

Co-authored-by: Guillaume Mallet <>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
