### PR TITLE
MINOR: Add 3.7.1 to docker_scan action

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.7.0']
+        supported_image_tag: ['latest', '3.7.1']
     steps:
       - name: Run CVE scan
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
We should scan the releases we support. At the moment it's `3.7.1` and `latest` which points to `3.8.0`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
