### PR TITLE
KAFKA-16993: Flaky test shouldInvokeUserDefinedGlobalStateRestoreListener

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -664,7 +664,7 @@ public class RestoreIntegrationTest {
         }
 
         boolean awaitUntilRestorationSuspends() throws InterruptedException {
-            return awaitLatchWithTimeout(onRestoreSuspendedLatch);
+            return onRestoreEndLatch.getCount() == 1 || awaitLatchWithTimeout(onRestoreSuspendedLatch);
         }
 
         boolean awaitUntilRestorationEnds() throws InterruptedException {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -580,7 +580,7 @@ public class RestoreIntegrationTest {
         validateReceivedMessages(sampleData, outputTopic);
 
         // Close kafkaStreams1 (with cleanup) and start it again to force the restoration of the state.
-        kafkaStreams.close(Duration.ofMillis(30_000L));
+        kafkaStreams.close(Duration.ofMillis(5000L));
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfigurations);
 
         final TestStateRestoreListener kafkaStreams1StateRestoreListener = new TestStateRestoreListener("ks1", RESTORATION_DELAY);
@@ -637,12 +637,12 @@ public class RestoreIntegrationTest {
                                            final StateRestoreListener stateRestoreListener,
                                            final Map<String, Object> extraConfiguration) {
         final Properties streamsConfiguration = props(mkObjectProperties(extraConfiguration));
-        final KafkaStreams kstreams = new KafkaStreams(streamsBuilder.build(), streamsConfiguration);
+        final KafkaStreams kafkaStreams = new KafkaStreams(streamsBuilder.build(), streamsConfiguration);
 
-        kstreams.setGlobalStateRestoreListener(stateRestoreListener);
-        kstreams.start();
+        kafkaStreams.setGlobalStateRestoreListener(stateRestoreListener);
+        kafkaStreams.start();
 
-        return kstreams;
+        return kafkaStreams;
     }
 
     private static final class TestStateRestoreListener implements StateRestoreListener {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -581,7 +581,7 @@ public class RestoreIntegrationTest {
 
         // Close kafkaStreams1 (with cleanup) and start it again to force the restoration of the state.
         kafkaStreams.close(Duration.ofMillis(5000L));
-        kafkaStreams.cleanUp();
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfigurations);
 
         final TestStateRestoreListener kafkaStreams1StateRestoreListener = new TestStateRestoreListener("ks1", RESTORATION_DELAY);
         kafkaStreams = startKafkaStreams(builder, kafkaStreams1StateRestoreListener, kafkaStreams1Configuration);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -546,6 +546,8 @@ public class RestoreIntegrationTest {
 
     @Test
     public void shouldInvokeUserDefinedGlobalStateRestoreListener() throws Exception {
+
+        
         final String inputTopic = "inputTopic";
         final String outputTopic = "outputTopic";
         CLUSTER.createTopic(inputTopic, 5, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -648,7 +648,6 @@ public class RestoreIntegrationTest {
 
         private final CountDownLatch onRestoreStartLatch = new CountDownLatch(1);
         private final CountDownLatch onRestoreEndLatch = new CountDownLatch(1);
-        private final CountDownLatch onRestoreSuspendedLatch = new CountDownLatch(1);
         private final CountDownLatch onBatchRestoredLatch = new CountDownLatch(1);
         private final AtomicInteger suspendedCounter = new AtomicInteger(0);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -580,7 +580,7 @@ public class RestoreIntegrationTest {
         validateReceivedMessages(sampleData, outputTopic);
 
         // Close kafkaStreams1 (with cleanup) and start it again to force the restoration of the state.
-        kafkaStreams.close(Duration.ofMillis(5000L));
+        kafkaStreams.close(Duration.ofMillis(30_000L));
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfigurations);
 
         final TestStateRestoreListener kafkaStreams1StateRestoreListener = new TestStateRestoreListener("ks1", RESTORATION_DELAY);
@@ -637,12 +637,12 @@ public class RestoreIntegrationTest {
                                            final StateRestoreListener stateRestoreListener,
                                            final Map<String, Object> extraConfiguration) {
         final Properties streamsConfiguration = props(mkObjectProperties(extraConfiguration));
-        final KafkaStreams kafkaStreams = new KafkaStreams(streamsBuilder.build(), streamsConfiguration);
+        final KafkaStreams kstreams = new KafkaStreams(streamsBuilder.build(), streamsConfiguration);
 
-        kafkaStreams.setGlobalStateRestoreListener(stateRestoreListener);
-        kafkaStreams.start();
+        kstreams.setGlobalStateRestoreListener(stateRestoreListener);
+        kstreams.start();
 
-        return kafkaStreams;
+        return kstreams;
     }
 
     private static final class TestStateRestoreListener implements StateRestoreListener {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -546,8 +546,6 @@ public class RestoreIntegrationTest {
 
     @Test
     public void shouldInvokeUserDefinedGlobalStateRestoreListener() throws Exception {
-
-        
         final String inputTopic = "inputTopic";
         final String outputTopic = "outputTopic";
         CLUSTER.createTopic(inputTopic, 5, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -569,7 +569,7 @@ public class RestoreIntegrationTest {
                .toStream()
                .to(outputTopic);
 
-        final List<KeyValue<Integer, Integer>> sampleData = IntStream.range(0, 100)
+        final List<KeyValue<Integer, Integer>> sampleData = IntStream.range(0, 1000)
                                                                      .mapToObj(i -> new KeyValue<>(i, i))
                                                                      .collect(Collectors.toList());
 
@@ -581,7 +581,7 @@ public class RestoreIntegrationTest {
 
         // Close kafkaStreams1 (with cleanup) and start it again to force the restoration of the state.
         kafkaStreams.close(Duration.ofMillis(5000L));
-        IntegrationTestUtils.purgeLocalStreamsState(streamsConfigurations);
+        kafkaStreams.cleanUp();
 
         final TestStateRestoreListener kafkaStreams1StateRestoreListener = new TestStateRestoreListener("ks1", RESTORATION_DELAY);
         kafkaStreams = startKafkaStreams(builder, kafkaStreams1StateRestoreListener, kafkaStreams1Configuration);
@@ -664,7 +664,7 @@ public class RestoreIntegrationTest {
         }
 
         boolean awaitUntilRestorationSuspends() throws InterruptedException {
-            return onRestoreEndLatch.getCount() == 1 || awaitLatchWithTimeout(onRestoreSuspendedLatch);
+            return awaitLatchWithTimeout(onRestoreSuspendedLatch);
         }
 
         boolean awaitUntilRestorationEnds() throws InterruptedException {


### PR DESCRIPTION
 Increased the number of records while decreasing the restore batch size to ensure the restoration does not complete before the second Kafka Streams instance starts up.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
