### PR TITLE
KAFKA-17277: [1/2] Add version mapping command to the storage tool and feature command tool

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -154,11 +154,11 @@ object StorageTool extends Logging {
       val metadataVersion = MetadataVersion.fromVersionString(releaseVersion)
 
       val metadataVersionLevel = metadataVersion.featureLevel()
-      printStream.printf("metadata.version=%d (%s)  ", metadataVersionLevel, releaseVersion)
+      printStream.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion) // New line after this output
 
       for (feature <- Features.values()) {
         val featureLevel = feature.defaultValue(metadataVersion)
-        printStream.printf("%s=%d  ", feature.featureName, featureLevel)
+        printStream.printf("%s=%d%n", feature.featureName, featureLevel) // New line for each feature
       }
     } catch {
       case e: IllegalArgumentException =>
@@ -211,6 +211,8 @@ object StorageTool extends Logging {
     val formatParser = subparsers.addParser("format")
       .help("Format the Kafka log directories on this node.")
 
+    addConfigArguments(formatParser)
+
     formatParser.addArgument("--cluster-id", "-t")
       .action(store())
       .required(true)
@@ -243,14 +245,12 @@ object StorageTool extends Logging {
       .help("The initial controllers, as a comma-separated list of id@hostname:port:directory. The same values must be used to format all nodes. For example:\n" +
         "0@example.com:8082:JEXY6aqzQY-32P5TStzaFg,1@example.com:8083:MvDxzVmcRsaTz33bUuRU6A,2@example.com:8084:07R5amHmR32VDA6jHkGbTA\n")
       .action(store())
-
-    addConfigArguments(formatParser)
   }
 
   private def addVersionMappingParser(subparsers: Subparsers): Unit = {
     val versionMappingParser = subparsers.addParser("version-mapping")
       .help("Look up the corresponding features for a given metadata version. " +
-        "Using the command with no  --release-version  argument will return the mapping for " +
+        "Using the command with no --release-version  argument will return the mapping for " +
         "the latest stable metadata version"
       )
 
@@ -258,8 +258,6 @@ object StorageTool extends Logging {
       .action(store())
       .help(s"The release version to use for the corresponding feature mapping. The minimum is " +
         s"${MetadataVersion.IBP_3_0_IV0}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
-
-    addConfigArguments(versionMappingParser)
   }
 
   private def addRandomUuidParser(subparsers: Subparsers): Unit = {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -187,7 +187,7 @@ object StorageTool extends Logging {
 
   def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers
-      .newArgumentParser("kafka-storage", true, "-", "@")
+      .newArgumentParser("kafka-storage", /* defaultHelp */true, /* prefixChars */"-", /* fromFilePrefix */ "@")
       .description("The Kafka storage tool.")
 
     val subparsers = parser.addSubparsers().dest("command")
@@ -204,7 +204,7 @@ object StorageTool extends Logging {
     val infoParser = subparsers.addParser("info")
       .help("Get information about the Kafka log directories on this node.")
 
-    addCommonArguments(infoParser)
+    addConfigArguments(infoParser)
   }
 
   private def addFormatParser(subparsers: Subparsers): Unit = {
@@ -244,7 +244,7 @@ object StorageTool extends Logging {
         "0@example.com:8082:JEXY6aqzQY-32P5TStzaFg,1@example.com:8083:MvDxzVmcRsaTz33bUuRU6A,2@example.com:8084:07R5amHmR32VDA6jHkGbTA\n")
       .action(store())
 
-    addCommonArguments(formatParser)
+    addConfigArguments(formatParser)
   }
 
   private def addVersionMappingParser(subparsers: Subparsers): Unit = {
@@ -259,7 +259,7 @@ object StorageTool extends Logging {
       .help(s"The release version to use for the corresponding feature mapping. The minimum is " +
         s"${MetadataVersion.IBP_3_0_IV0}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
 
-    addCommonArguments(versionMappingParser)
+    addConfigArguments(versionMappingParser)
   }
 
   private def addRandomUuidParser(subparsers: Subparsers): Unit = {
@@ -267,7 +267,7 @@ object StorageTool extends Logging {
       .help("Print a random UUID.")
   }
 
-  private def addCommonArguments(parser: Subparser): Unit = {
+  private def addConfigArguments(parser: Subparser): Unit = {
     parser.addArgument("--config", "-c")
       .action(store())
       .required(true)

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -154,11 +154,11 @@ object StorageTool extends Logging {
       val metadataVersion = MetadataVersion.fromVersionString(releaseVersion)
 
       val metadataVersionLevel = metadataVersion.featureLevel()
-      printStream.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion) // New line after this output
+      printStream.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion)
 
       for (feature <- Features.values()) {
         val featureLevel = feature.defaultValue(metadataVersion)
-        printStream.printf("%s=%d%n", feature.featureName, featureLevel) // New line for each feature
+        printStream.printf("%s=%d%n", feature.featureName, featureLevel)
       }
     } catch {
       case e: IllegalArgumentException =>

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -154,11 +154,11 @@ object StorageTool extends Logging {
       val metadataVersion = MetadataVersion.fromVersionString(releaseVersion)
 
       val metadataVersionLevel = metadataVersion.featureLevel()
-      printStream.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion)
+      printStream.print(f"metadata.version=$metadataVersionLevel%d ($releaseVersion%s)%n")
 
       for (feature <- Features.values()) {
         val featureLevel = feature.defaultValue(metadataVersion)
-        printStream.printf("%s=%d%n", feature.featureName, featureLevel)
+        printStream.print(f"${feature.featureName}%s=$featureLevel%d%n")
       }
     } catch {
       case e: IllegalArgumentException =>

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package kafka.tools
 
 import kafka.server.KafkaConfig
@@ -24,11 +23,11 @@ import java.nio.file.{Files, Paths}
 import kafka.utils.Logging
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments.{append, store, storeTrue}
-import net.sourceforge.argparse4j.inf.{ArgumentParserException, Namespace}
+import net.sourceforge.argparse4j.inf.{ArgumentParserException, Namespace, Subparser, Subparsers}
 import net.sourceforge.argparse4j.internal.HelpScreenException
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.{Exit, Utils}
-import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.common.{Features, MetadataVersion}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.metadata.storage.{Formatter, FormatterException}
 import org.apache.kafka.raft.DynamicVoters
@@ -87,9 +86,14 @@ object StorageTool extends Logging {
         runFormatCommand(namespace, config.get, printStream)
         0
 
+      case "version-mapping" =>
+        runVersionMappingCommand(namespace, printStream)
+        0
+
       case "random-uuid" =>
         printStream.println(Uuid.randomUuid)
         0
+
       case _ =>
         throw new RuntimeException(s"Unknown command $command")
     }
@@ -134,6 +138,35 @@ object StorageTool extends Logging {
     formatter.run()
   }
 
+  /**
+   * Maps the given release version to the corresponding metadata version
+   * and prints the corresponding feature names and versions.
+   *
+   * @param namespace       Arguments containing the release version.
+   * @param printStream     The print stream to output the version mapping.
+   */
+  def runVersionMappingCommand(
+    namespace: Namespace,
+    printStream: PrintStream
+  ): Unit = {
+    val releaseVersion = Option(namespace.getString("release_version")).getOrElse(MetadataVersion.LATEST_PRODUCTION.toString)
+    try {
+      val metadataVersion = MetadataVersion.fromVersionString(releaseVersion)
+
+      val metadataVersionLevel = metadataVersion.featureLevel()
+      printStream.printf("metadata.version=%d (%s)  ", metadataVersionLevel, releaseVersion)
+
+      for (feature <- Features.values()) {
+        val featureLevel = feature.defaultValue(metadataVersion)
+        printStream.printf("%s=%d  ", feature.featureName, featureLevel)
+      }
+    } catch {
+      case e: IllegalArgumentException =>
+        throw new TerseFailure(s"Unsupported release version '$releaseVersion'. Supported versions are: " +
+          s"${MetadataVersion.MINIMUM_BOOTSTRAP_VERSION.version} to ${MetadataVersion.LATEST_PRODUCTION.version}")
+    }
+  }
+
   def createStandaloneDynamicVoters(
     config: KafkaConfig
   ): DynamicVoters = {
@@ -153,50 +186,89 @@ object StorageTool extends Logging {
   }
 
   def parseArguments(args: Array[String]): Namespace = {
-    val parser = ArgumentParsers.
-      newArgumentParser("kafka-storage", /* defaultHelp */ true, /* prefixChars */ "-", /* fromFilePrefix */ "@").
-      description("The Kafka storage tool.")
+    val parser = ArgumentParsers
+      .newArgumentParser("kafka-storage", true, "-", "@")
+      .description("The Kafka storage tool.")
 
     val subparsers = parser.addSubparsers().dest("command")
 
-    val infoParser = subparsers.addParser("info").
-      help("Get information about the Kafka log directories on this node.")
-    val formatParser = subparsers.addParser("format").
-      help("Format the Kafka log directories on this node.")
-    subparsers.addParser("random-uuid").help("Print a random UUID.")
-    List(infoParser, formatParser).foreach(parser => {
-      parser.addArgument("--config", "-c").
-        action(store()).
-        required(true).
-        help("The Kafka configuration file to use.")
-    })
-    formatParser.addArgument("--cluster-id", "-t").
-      action(store()).
-      required(true).
-      help("The cluster ID to use.")
-    formatParser.addArgument("--add-scram", "-S").
-      action(append()).
-      help("""A SCRAM_CREDENTIAL to add to the __cluster_metadata log e.g.
+    addInfoParser(subparsers)
+    addFormatParser(subparsers)
+    addVersionMappingParser(subparsers)
+    addRandomUuidParser(subparsers)
+
+    parser.parseArgs(args)
+  }
+
+  private def addInfoParser(subparsers: Subparsers): Unit = {
+    val infoParser = subparsers.addParser("info")
+      .help("Get information about the Kafka log directories on this node.")
+
+    addCommonArguments(infoParser)
+  }
+
+  private def addFormatParser(subparsers: Subparsers): Unit = {
+    val formatParser = subparsers.addParser("format")
+      .help("Format the Kafka log directories on this node.")
+
+    formatParser.addArgument("--cluster-id", "-t")
+      .action(store())
+      .required(true)
+      .help("The cluster ID to use.")
+
+    formatParser.addArgument("--add-scram", "-S")
+      .action(append())
+      .help("""A SCRAM_CREDENTIAL to add to the __cluster_metadata log e.g.
               |'SCRAM-SHA-256=[name=alice,password=alice-secret]'
               |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
-    formatParser.addArgument("--ignore-formatted", "-g").
-      action(storeTrue())
-    formatParser.addArgument("--release-version", "-r").
-      action(store()).
-      help(s"The release version to use for the initial feature settings. The minimum is " +
+
+    formatParser.addArgument("--ignore-formatted", "-g")
+      .action(storeTrue())
+
+    formatParser.addArgument("--release-version", "-r")
+      .action(store())
+      .help(s"The release version to use for the initial feature settings. The minimum is " +
         s"${MetadataVersion.IBP_3_0_IV0}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
-    formatParser.addArgument("--feature", "-f").
-      help("The setting to use for a specific feature, in feature=level format. For example: `kraft.version=1`.").
-      action(append())
+
+    formatParser.addArgument("--feature", "-f")
+      .help("The setting to use for a specific feature, in feature=level format. For example: `kraft.version=1`.")
+      .action(append())
+
     val reconfigurableQuorumOptions = formatParser.addMutuallyExclusiveGroup()
-    reconfigurableQuorumOptions.addArgument("--standalone", "-s").
-      help("Used to initialize a single-node quorum controller quorum.").
-      action(storeTrue())
-    reconfigurableQuorumOptions.addArgument("--initial-controllers", "-I").
-      help("The initial controllers, as a comma-separated list of id@hostname:port:directory. The same values must be used to format all nodes. For example:\n" +
-        "0@example.com:8082:JEXY6aqzQY-32P5TStzaFg,1@example.com:8083:MvDxzVmcRsaTz33bUuRU6A,2@example.com:8084:07R5amHmR32VDA6jHkGbTA\n").
-      action(store())
-    parser.parseArgs(args)
+    reconfigurableQuorumOptions.addArgument("--standalone", "-s")
+      .help("Used to initialize a single-node quorum controller quorum.")
+      .action(storeTrue())
+
+    reconfigurableQuorumOptions.addArgument("--initial-controllers", "-I")
+      .help("The initial controllers, as a comma-separated list of id@hostname:port:directory. The same values must be used to format all nodes. For example:\n" +
+        "0@example.com:8082:JEXY6aqzQY-32P5TStzaFg,1@example.com:8083:MvDxzVmcRsaTz33bUuRU6A,2@example.com:8084:07R5amHmR32VDA6jHkGbTA\n")
+      .action(store())
+
+    addCommonArguments(formatParser)
+  }
+
+  private def addVersionMappingParser(subparsers: Subparsers): Unit = {
+    val versionMappingParser = subparsers.addParser("version-mapping")
+      .help("Get the feature mapping for a given metadata version.")
+
+    versionMappingParser.addArgument("--release-version", "-r")
+      .action(store())
+      .help(s"The release version to use for the initial feature settings. The minimum is " +
+        s"${MetadataVersion.IBP_3_0_IV0}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
+
+    addCommonArguments(versionMappingParser)
+  }
+
+  private def addRandomUuidParser(subparsers: Subparsers): Unit = {
+    subparsers.addParser("random-uuid")
+      .help("Print a random UUID.")
+  }
+
+  private def addCommonArguments(parser: Subparser): Unit = {
+    parser.addArgument("--config", "-c")
+      .action(store())
+      .required(true)
+      .help("The Kafka configuration file to use.")
   }
 
   def configToLogDirectories(config: KafkaConfig): Seq[String] = {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -140,7 +140,7 @@ object StorageTool extends Logging {
 
   /**
    * Maps the given release version to the corresponding metadata version
-   * and prints the corresponding feature names and versions.
+   * and prints the corresponding features.
    *
    * @param namespace       Arguments containing the release version.
    * @param printStream     The print stream to output the version mapping.
@@ -249,11 +249,14 @@ object StorageTool extends Logging {
 
   private def addVersionMappingParser(subparsers: Subparsers): Unit = {
     val versionMappingParser = subparsers.addParser("version-mapping")
-      .help("Get the feature mapping for a given metadata version.")
+      .help("Look up the corresponding features for a given metadata version. " +
+        "Using the command with no  --release-version  argument will return the mapping for " +
+        "the latest stable metadata version"
+      )
 
     versionMappingParser.addArgument("--release-version", "-r")
       .action(store())
-      .help(s"The release version to use for the initial feature settings. The minimum is " +
+      .help(s"The release version to use for the corresponding feature mapping. The minimum is " +
         s"${MetadataVersion.IBP_3_0_IV0}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
 
     addCommonArguments(versionMappingParser)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -464,16 +464,18 @@ Found problem:
     assertEquals(0, runVersionMappingCommand(stream, "3.3-IV3"))
 
     val output = stream.toString()
-    assertTrue(output.contains("metadata.version=7 (3.3-IV3)"),
-      s"Output did not contain expected Metadata Version: $output")
-    assertTrue(output.contains("kraft.version=0"),
-      s"Output did not contain expected feature mapping: $output")
-    assertTrue(output.contains("test.feature.version=0"),
-      s"Output did not contain expected feature mapping: $output")
-    assertTrue(output.contains("transaction.version=0"),
-      s"Output did not contain expected feature mapping: $output")
-    assertTrue(output.contains("group.version=0"),
-      s"Output did not contain expected feature mapping: $output")
+    val metadataVersion = MetadataVersion.IBP_3_3_IV3
+    // Check that the metadata version is correctly included in the output
+    assertTrue(output.contains(s"metadata.version=${metadataVersion.featureLevel()} (${metadataVersion.version()})"),
+      s"Output did not contain expected Metadata Version: $output"
+    )
+
+    for (feature <- Features.values()) {
+      val featureLevel = feature.defaultValue(metadataVersion)
+      assertTrue(output.contains(s"${feature.featureName()}=$featureLevel"),
+        s"Output did not contain expected feature mapping: $output"
+      )
+    }
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -472,6 +472,8 @@ Found problem:
       s"Output did not contain expected feature mapping: $output")
     assertTrue(output.contains("transaction.version=0"),
       s"Output did not contain expected feature mapping: $output")
+    assertTrue(output.contains("group.version=0"),
+      s"Output did not contain expected feature mapping: $output")
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -436,15 +436,10 @@ Found problem:
 
   private def runVersionMappingCommand(
     stream: ByteArrayOutputStream,
-    properties: Properties,
     releaseVersion: String
   ): Int = {
     val tempDir = TestUtils.tempDir()
     try {
-      // Write the properties to a temporary file
-      val configPathString = new File(tempDir.getAbsolutePath, "version-mapping.props").toString
-      PropertiesUtils.writePropertiesFile(properties, configPathString, true)
-
       // Prepare the arguments list
       val arguments = ListBuffer[String]("version-mapping")
 
@@ -453,9 +448,6 @@ Found problem:
         arguments += "--release-version"
         arguments += releaseVersion
       }
-
-      arguments += "--config"
-      arguments += configPathString
 
       // Execute the StorageTool with the arguments
       StorageTool.execute(arguments.toArray, new PrintStream(stream))
@@ -467,12 +459,9 @@ Found problem:
 
   @Test
   def testVersionMappingWithValidReleaseVersion(): Unit = {
-    val properties = new Properties()
-    properties.putAll(defaultStaticQuorumProperties)
-
     val stream = new ByteArrayOutputStream()
     // Test with a valid release version
-    assertEquals(0, runVersionMappingCommand(stream, properties, "3.3-IV3"))
+    assertEquals(0, runVersionMappingCommand(stream, "3.3-IV3"))
 
     val output = stream.toString()
     assertTrue(output.contains("metadata.version=7 (3.3-IV3)"),
@@ -491,7 +480,7 @@ Found problem:
     properties.putAll(defaultStaticQuorumProperties)
 
     val stream = new ByteArrayOutputStream()
-    assertEquals(0, runVersionMappingCommand(stream, properties, null))
+    assertEquals(0, runVersionMappingCommand(stream, null))
 
     val output = stream.toString
     val metadataVersion = MetadataVersion.latestProduction()
@@ -516,7 +505,7 @@ Found problem:
     val stream = new ByteArrayOutputStream()
     // Test with an invalid release version
     val exception = assertThrows(classOf[TerseFailure], () => {
-      runVersionMappingCommand(stream, properties, "2.9-IV2")
+      runVersionMappingCommand(stream, "2.9-IV2")
     })
 
     assertEquals("Unsupported release version '2.9-IV2'." +
@@ -525,7 +514,7 @@ Found problem:
     )
 
     val exception2 = assertThrows(classOf[TerseFailure], () => {
-      runVersionMappingCommand(stream, properties, "invalid")
+      runVersionMappingCommand(stream, "invalid")
     })
 
     assertEquals("Unsupported release version 'invalid'." +

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.admin.Admin;
@@ -25,6 +24,7 @@ import org.apache.kafka.clients.admin.UpdateFeaturesOptions;
 import org.apache.kafka.clients.admin.UpdateFeaturesResult;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.common.Features;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.util.CommandLineUtils;
 
@@ -90,6 +90,7 @@ public class FeatureCommand {
         addUpgradeParser(subparsers);
         addDowngradeParser(subparsers);
         addDisableParser(subparsers);
+        addVersionMappingParser(subparsers);
 
         Namespace namespace = parser.parseArgsOrFail(args);
         String command = namespace.getString("command");
@@ -113,6 +114,9 @@ public class FeatureCommand {
                     break;
                 case "disable":
                     handleDisable(namespace, adminClient);
+                    break;
+                case "version-mapping":
+                    handleVersionMapping(namespace);
                     break;
                 default:
                     throw new TerseException("Unknown command " + command);
@@ -169,6 +173,15 @@ public class FeatureCommand {
         downgradeParser.addArgument("--dry-run")
                 .help("Perform a dry-run of this disable operation.")
                 .action(storeTrue());
+    }
+
+    private static void addVersionMappingParser(Subparsers subparsers) {
+        Subparser versionMappingParser = subparsers.addParser("version-mapping")
+                .help("Look up the corresponding features and their versions for a given release version. If no release version is specified the default stable version is used");
+        versionMappingParser.addArgument("--release-version")
+                .help("The release version to use for the initial feature settings. The minimum is " +
+                        MetadataVersion.IBP_3_0_IV0 + "; the default is " + MetadataVersion.LATEST_PRODUCTION)
+                .action(store());
     }
 
     static String levelToString(String feature, short level) {
@@ -280,6 +293,32 @@ public class FeatureCommand {
         }
 
         update("disable", adminClient, updates, namespace.getBoolean("dry_run"));
+    }
+
+    static void handleVersionMapping(Namespace namespace) throws TerseException {
+        // Get the release version from the command-line arguments or default to the latest stable version
+        String releaseVersion = Optional.ofNullable(namespace.getString("release_version"))
+            .orElseGet(() -> {
+                String latestVersion = MetadataVersion.latestProduction().version();
+                System.out.println("No release version provided. Defaulting to the latest stable version: " + latestVersion);
+                return latestVersion;
+            });
+
+        try {
+            MetadataVersion version = MetadataVersion.fromVersionString(releaseVersion);
+
+            short metadataVersionLevel = version.featureLevel();
+            System.out.printf("metadata.version=%d (%s)  ", metadataVersionLevel, releaseVersion);
+
+            for (Features feature : Features.values()) {
+                short featureLevel = feature.defaultValue(version);
+                System.out.printf("%s=%d  ", feature.featureName(), featureLevel);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new TerseException("Unsupported release.version " + releaseVersion +
+                    ". Supported release.version are " + metadataVersionsToString(
+                    MetadataVersion.MINIMUM_BOOTSTRAP_VERSION, MetadataVersion.latestProduction()));
+        }
     }
 
     private static void update(String op, Admin admin, Map<String, FeatureUpdate> updates, Boolean dryRun) throws TerseException {

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -314,9 +314,9 @@ public class FeatureCommand {
                 System.out.printf("%s=%d%n", feature.featureName(), featureLevel);
             }
         } catch (IllegalArgumentException e) {
-            throw new TerseException("Unsupported release.version " + releaseVersion +
-                ". Supported release.version are " + metadataVersionsToString(
-                MetadataVersion.MINIMUM_BOOTSTRAP_VERSION, MetadataVersion.latestProduction()));
+            throw new TerseException("Unsupported release version '" + releaseVersion + "'." +
+                " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
+                " to " + MetadataVersion.LATEST_PRODUCTION);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -177,9 +177,12 @@ public class FeatureCommand {
 
     private static void addVersionMappingParser(Subparsers subparsers) {
         Subparser versionMappingParser = subparsers.addParser("version-mapping")
-                .help("Look up the corresponding features and their versions for a given release version. If no release version is specified the default stable version is used");
+                .help("Look up the corresponding features for a given metadata version. " +
+                        "Using the command with no  --release-version  argument will return the mapping for " +
+                        "the latest stable metadata version"
+                );
         versionMappingParser.addArgument("--release-version")
-                .help("The release version to use for the feature version mapping. The minimum is " +
+                .help("The release version to use for the corresponding feature mapping. The minimum is " +
                         MetadataVersion.IBP_3_0_IV0 + "; the default is " + MetadataVersion.LATEST_PRODUCTION)
                 .action(store());
     }

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -307,11 +307,11 @@ public class FeatureCommand {
             MetadataVersion version = MetadataVersion.fromVersionString(releaseVersion);
 
             short metadataVersionLevel = version.featureLevel();
-            System.out.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion); // New line after this output
+            System.out.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion);
 
             for (Features feature : Features.values()) {
                 short featureLevel = feature.defaultValue(version);
-                System.out.printf("%s=%d%n", feature.featureName(), featureLevel); // New line for each feature
+                System.out.printf("%s=%d%n", feature.featureName(), featureLevel);
             }
         } catch (IllegalArgumentException e) {
             throw new TerseException("Unsupported release.version " + releaseVersion +

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -178,7 +178,7 @@ public class FeatureCommand {
     private static void addVersionMappingParser(Subparsers subparsers) {
         Subparser versionMappingParser = subparsers.addParser("version-mapping")
                 .help("Look up the corresponding features for a given metadata version. " +
-                        "Using the command with no  --release-version  argument will return the mapping for " +
+                        "Using the command with no --release-version  argument will return the mapping for " +
                         "the latest stable metadata version"
                 );
         versionMappingParser.addArgument("--release-version")
@@ -301,26 +301,22 @@ public class FeatureCommand {
     static void handleVersionMapping(Namespace namespace) throws TerseException {
         // Get the release version from the command-line arguments or default to the latest stable version
         String releaseVersion = Optional.ofNullable(namespace.getString("release_version"))
-            .orElseGet(() -> {
-                String latestVersion = MetadataVersion.latestProduction().version();
-                System.out.println("No release version provided. Defaulting to the latest stable version: " + latestVersion);
-                return latestVersion;
-            });
+           .orElseGet(() -> MetadataVersion.latestProduction().version());
 
         try {
             MetadataVersion version = MetadataVersion.fromVersionString(releaseVersion);
 
             short metadataVersionLevel = version.featureLevel();
-            System.out.printf("metadata.version=%d (%s)  ", metadataVersionLevel, releaseVersion);
+            System.out.printf("metadata.version=%d (%s)%n", metadataVersionLevel, releaseVersion); // New line after this output
 
             for (Features feature : Features.values()) {
                 short featureLevel = feature.defaultValue(version);
-                System.out.printf("%s=%d  ", feature.featureName(), featureLevel);
+                System.out.printf("%s=%d%n", feature.featureName(), featureLevel); // New line for each feature
             }
         } catch (IllegalArgumentException e) {
             throw new TerseException("Unsupported release.version " + releaseVersion +
-                    ". Supported release.version are " + metadataVersionsToString(
-                    MetadataVersion.MINIMUM_BOOTSTRAP_VERSION, MetadataVersion.latestProduction()));
+                ". Supported release.version are " + metadataVersionsToString(
+                MetadataVersion.MINIMUM_BOOTSTRAP_VERSION, MetadataVersion.latestProduction()));
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -179,7 +179,7 @@ public class FeatureCommand {
         Subparser versionMappingParser = subparsers.addParser("version-mapping")
                 .help("Look up the corresponding features and their versions for a given release version. If no release version is specified the default stable version is used");
         versionMappingParser.addArgument("--release-version")
-                .help("The release version to use for the initial feature settings. The minimum is " +
+                .help("The release version to use for the feature version mapping. The minimum is " +
                         MetadataVersion.IBP_3_0_IV0 + "; the default is " + MetadataVersion.LATEST_PRODUCTION)
                 .action(store());
     }

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -301,7 +301,7 @@ public class FeatureCommand {
     static void handleVersionMapping(Namespace namespace) throws TerseException {
         // Get the release version from the command-line arguments or default to the latest stable version
         String releaseVersion = Optional.ofNullable(namespace.getString("release_version"))
-           .orElseGet(() -> MetadataVersion.latestProduction().version());
+            .orElseGet(() -> MetadataVersion.latestProduction().version());
 
         try {
             MetadataVersion version = MetadataVersion.fromVersionString(releaseVersion);

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -355,7 +355,7 @@ public class FeatureCommandTest {
 
         assertTrue(versionMappingOutput.contains("metadata.version=22 (4.0-IV0)"));
         assertTrue(versionMappingOutput.contains("kraft.version=1"));
-        assertTrue(versionMappingOutput.contains("test.feature.version=2"));
+        assertTrue(versionMappingOutput.contains("test.feature.version=1"));
         assertTrue(versionMappingOutput.contains("transaction.version=2"));
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -340,11 +340,17 @@ public class FeatureCommandTest {
             }
         });
 
-        assertTrue(versionMappingOutput.contains("metadata.version=7 (3.3-IV3)"));
-        assertTrue(versionMappingOutput.contains("kraft.version=0"));
-        assertTrue(versionMappingOutput.contains("test.feature.version=0"));
-        assertTrue(versionMappingOutput.contains("transaction.version=0"));
-        assertTrue(versionMappingOutput.contains("group.version=0"));
+        MetadataVersion metadataVersion = MetadataVersion.IBP_3_3_IV3;
+
+        // Check that the metadata version is correctly included in the output
+        assertTrue(versionMappingOutput.contains("metadata.version=" + metadataVersion.featureLevel() + " (" + metadataVersion.version() + ")"),
+            "Output did not contain expected Metadata Version: " + versionMappingOutput);
+
+        for (Features feature : Features.values()) {
+            int featureLevel = feature.defaultValue(metadataVersion);
+            assertTrue(versionMappingOutput.contains(feature.featureName() + "=" + featureLevel),
+                "Output did not contain expected feature mapping: " + versionMappingOutput);
+        }
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -369,7 +369,6 @@ public class FeatureCommandTest {
                 throw new RuntimeException(e);
             }
         });
-        assertTrue(versionMappingOutput.contains("No release version provided. Defaulting to the latest stable version"));
         assertTrue(versionMappingOutput.contains("metadata.version=21 (3.9-IV0)"));
         assertTrue(versionMappingOutput.contains("kraft.version=1"));
         assertTrue(versionMappingOutput.contains("test.feature.version=1"));


### PR DESCRIPTION
As a part of KIP-1022 the following has been implemented in this patch:

1. A version-mapping command to to look up the corresponding features for a given metadata version. Using the command with no --release-version argument will return the mapping for the latest stable metadata version.
2. This command has been added to the FeatureCommand Tool and the Storage Tool.
3. The storage tools parsing method has been made more modular similar to the feature command tool
