### PR TITLE
KAFKA-17409: Remove deprecated constructor of RecordMetadata

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
@@ -55,24 +55,6 @@ public final class RecordMetadata {
     }
 
     /**
-     * Creates a new instance with the provided parameters.
-     *
-     * @deprecated use constructor without `checksum` parameter. This constructor will be removed in
-     *             Apache Kafka 4.0 (deprecated since 3.0).
-     */
-    @Deprecated
-    public RecordMetadata(TopicPartition topicPartition, long baseOffset, long batchIndex, long timestamp,
-                          Long checksum, int serializedKeySize, int serializedValueSize) {
-        this(topicPartition, baseOffset, batchIndexToInt(batchIndex), timestamp, serializedKeySize, serializedValueSize);
-    }
-
-    private static int batchIndexToInt(long batchIndex) {
-        if (batchIndex > Integer.MAX_VALUE)
-            throw new IllegalArgumentException("batchIndex is larger than Integer.MAX_VALUE: " + batchIndex);
-        return (int) batchIndex;
-    }
-
-    /**
      * Indicates whether the record metadata includes the offset.
      * @return true if the offset is included in the metadata, false otherwise.
      */

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordMetadataTest.java
@@ -59,33 +59,4 @@ public class RecordMetadataTest {
         assertEquals(keySize, metadata.serializedKeySize());
         assertEquals(valueSize, metadata.serializedValueSize());
     }
-
-    @Test
-    @Deprecated
-    public void testConstructionWithChecksum() {
-        TopicPartition tp = new TopicPartition("foo", 0);
-        long timestamp = 2340234L;
-        long baseOffset = 15L;
-        long batchIndex = 3L;
-        int keySize = 3;
-        int valueSize = 5;
-
-        RecordMetadata metadata = new RecordMetadata(tp, baseOffset, batchIndex, timestamp, null, keySize, valueSize);
-        assertEquals(tp.topic(), metadata.topic());
-        assertEquals(tp.partition(), metadata.partition());
-        assertEquals(timestamp, metadata.timestamp());
-        assertEquals(baseOffset + batchIndex, metadata.offset());
-        assertEquals(keySize, metadata.serializedKeySize());
-        assertEquals(valueSize, metadata.serializedValueSize());
-
-        long checksum = 133424L;
-        metadata = new RecordMetadata(tp, baseOffset, batchIndex, timestamp, checksum, keySize, valueSize);
-        assertEquals(tp.topic(), metadata.topic());
-        assertEquals(tp.partition(), metadata.partition());
-        assertEquals(timestamp, metadata.timestamp());
-        assertEquals(baseOffset + batchIndex, metadata.offset());
-        assertEquals(keySize, metadata.serializedKeySize());
-        assertEquals(valueSize, metadata.serializedValueSize());
-    }
-
 }


### PR DESCRIPTION
As title,
Remove deprecated constructor of `org/apache/kafka/clients/producer/RecordMetadata.java`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
