### PR TITLE
KAFKA-17399: Apply LambdaValidator to code base

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1584,16 +1584,8 @@ public class ConfigDef {
      */
     private static Validator embeddedValidator(final String keyPrefix, final Validator base) {
         if (base == null) return null;
-        return new Validator() {
-            public void ensureValid(String name, Object value) {
-                base.ensureValid(name.substring(keyPrefix.length()), value);
-            }
-
-            @Override
-            public String toString() {
-                return base.toString();
-            }
-        };
+        return ConfigDef.LambdaValidator.with(
+            (name, value) -> base.ensureValid(name.substring(keyPrefix.length()), value), base::toString);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -52,22 +52,14 @@ public enum CompressionType {
 
         @Override
         public ConfigDef.Validator levelValidator() {
-            return new ConfigDef.Validator() {
-                @Override
-                public void ensureValid(String name, Object o) {
-                    if (o == null)
-                        throw new ConfigException(name, null, "Value must be non-null");
-                    int level = ((Number) o).intValue();
-                    if (level > MAX_LEVEL || (level < MIN_LEVEL && level != DEFAULT_LEVEL)) {
-                        throw new ConfigException(name, o, "Value must be between " + MIN_LEVEL + " and " + MAX_LEVEL + " or equal to " + DEFAULT_LEVEL);
-                    }
+            return ConfigDef.LambdaValidator.with((name, value) -> {
+                if (value == null)
+                    throw new ConfigException(name, null, "Value must be non-null");
+                int level = ((Number) value).intValue();
+                if (level > MAX_LEVEL || (level < MIN_LEVEL && level != DEFAULT_LEVEL)) {
+                    throw new ConfigException(name, value, "Value must be between " + MIN_LEVEL + " and " + MAX_LEVEL + " or equal to " + DEFAULT_LEVEL);
                 }
-
-                @Override
-                public String toString() {
-                    return "[" + MIN_LEVEL + ",...," + MAX_LEVEL + "] or " + DEFAULT_LEVEL;
-                }
-            };
+            }, () -> "[" + MIN_LEVEL + ",...," + MAX_LEVEL + "] or " + DEFAULT_LEVEL);
         }
     },
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -231,6 +231,7 @@ public class ConnectorConfig extends AbstractConfig {
     private static ConfigDef.CompositeValidator aliasValidator(String kind) {
         return ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), ConfigDef.LambdaValidator.with(
             (name, value) -> {
+                @SuppressWarnings("unchecked")
                 final List<String> aliases = (List<String>) value;
                 if (aliases.size() > new HashSet<>(aliases).size()) {
                     throw new ConfigException(name, value, "Duplicate alias provided.");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -229,21 +229,14 @@ public class ConnectorConfig extends AbstractConfig {
     }
 
     private static ConfigDef.CompositeValidator aliasValidator(String kind) {
-        return ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.Validator() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void ensureValid(String name, Object value) {
+        return ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), ConfigDef.LambdaValidator.with(
+            (name, value) -> {
                 final List<String> aliases = (List<String>) value;
                 if (aliases.size() > new HashSet<>(aliases).size()) {
                     throw new ConfigException(name, value, "Duplicate alias provided.");
                 }
-            }
-
-            @Override
-            public String toString() {
-                return "unique " + kind + " aliases";
-            }
-        });
+            },
+            () -> "unique " + kind + " aliases"));
     }
 
     public ConnectorConfig(Plugins plugins) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -71,22 +71,15 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public void ensureValid(String name, Object valueObject) {
+            .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.LambdaValidator.with(
+                    (name, valueObject) -> {
                         List<String> value = (List<String>) valueObject;
                         if (value == null || value.isEmpty()) {
                             throw new ConfigException("Must specify at least one field to cast.");
                         }
                         parseFieldTypes(value);
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>";
-                    }
-            },
+                    },
+                    () -> "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>"),
             ConfigDef.Importance.HIGH,
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -73,6 +73,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.LambdaValidator.with(
                     (name, valueObject) -> {
+                        @SuppressWarnings("unchecked")
                         List<String> value = (List<String>) valueObject;
                         if (value == null || value.isEmpty()) {
                             throw new ConfigException("Must specify at least one field to cast.");

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
@@ -68,7 +68,11 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
                     "Deprecated. Use " + ConfigName.INCLUDE + " instead.")
             .define(ConfigName.RENAME, ConfigDef.Type.LIST, Collections.emptyList(),
                 ConfigDef.LambdaValidator.with(
-                    (name, value) -> parseRenameMappings((List<String>) value),
+                    (name, value) -> {
+                        @SuppressWarnings("unchecked")
+                        List<String> valueList = (List<String>) value;
+                        parseRenameMappings(valueList);
+                    },
                     () -> "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>"),
                 ConfigDef.Importance.MEDIUM, "Field rename mappings.")
             .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
@@ -66,18 +66,11 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
                     "Fields to include. If specified, only these fields will be used.")
             .define("whitelist", ConfigDef.Type.LIST, null, Importance.LOW,
                     "Deprecated. Use " + ConfigName.INCLUDE + " instead.")
-            .define(ConfigName.RENAME, ConfigDef.Type.LIST, Collections.emptyList(), new ConfigDef.Validator() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public void ensureValid(String name, Object value) {
-                    parseRenameMappings((List<String>) value);
-                }
-
-                @Override
-                public String toString() {
-                    return "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>";
-                }
-            }, ConfigDef.Importance.MEDIUM, "Field rename mappings.")
+            .define(ConfigName.RENAME, ConfigDef.Type.LIST, Collections.emptyList(),
+                ConfigDef.LambdaValidator.with(
+                    (name, value) -> parseRenameMappings((List<String>) value),
+                    () -> "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>"),
+                ConfigDef.Importance.MEDIUM, "Field rename mappings.")
             .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1003,17 +1003,9 @@ public class StreamsConfig extends AbstractConfig {
             .define(TOPOLOGY_OPTIMIZATION_CONFIG,
                     Type.STRING,
                     NO_OPTIMIZATION,
-                    new ConfigDef.Validator() {
-                        @Override
-                        public void ensureValid(final String name, final Object value) {
-                            verifyTopologyOptimizationConfigs((String) value);
-                        }
-
-                        @Override
-                        public String toString() {
-                            return TOPOLOGY_OPTIMIZATION_CONFIGS.toString();
-                        }
-                    },
+                    ConfigDef.LambdaValidator.with(
+                        (name, value) -> verifyTopologyOptimizationConfigs((String) value),
+                        TOPOLOGY_OPTIMIZATION_CONFIGS::toString),
                     Importance.MEDIUM,
                     TOPOLOGY_OPTIMIZATION_DOC)
 


### PR DESCRIPTION
There are many validator impl used to offer the custom `toString`. However, the impl is a bit ugly so we should consider decorating them by `LambdaValidator`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
