### PR TITLE
KAFKA-16330: Remove deprecated methods of TaskId and make deprecated members private

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -21,14 +21,7 @@ import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Objects;
-
-import static org.apache.kafka.streams.processor.internals.assignment.ConsumerProtocolUtils.readTaskIdFrom;
-import static org.apache.kafka.streams.processor.internals.assignment.ConsumerProtocolUtils.writeTaskIdTo;
 
 /**
  * The task ID representation composed as subtopology (aka topicGroupId) plus the assigned partition ID.
@@ -41,10 +34,10 @@ public class TaskId implements Comparable<TaskId> {
 
     /** The ID of the subtopology, aka topicGroupId. */
     @Deprecated
-    public final int topicGroupId;
+    private final int topicGroupId;
     /** The ID of the partition. */
     @Deprecated
-    public final int partition;
+    private final int partition;
 
     /** The namedTopology that this task belongs to, or null if it does not belong to one */
     private final String topologyName;
@@ -112,40 +105,6 @@ public class TaskId implements Comparable<TaskId> {
         } catch (final Exception e) {
             throw new TaskIdFormatException(taskIdStr);
         }
-    }
-
-    /**
-     * @throws IOException if cannot write to output stream
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public void writeTo(final DataOutputStream out, final int version) throws IOException {
-        writeTaskIdTo(this, out, version);
-    }
-
-    /**
-     * @throws IOException if cannot read from input stream
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public static TaskId readFrom(final DataInputStream in, final int version) throws IOException {
-        return readTaskIdFrom(in, version);
-    }
-
-    /**
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public void writeTo(final ByteBuffer buf, final int version) {
-        writeTaskIdTo(this, buf, version);
-    }
-
-    /**
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public static TaskId readFrom(final ByteBuffer buf, final int version) {
-        return readTaskIdFrom(buf, version);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -33,10 +33,8 @@ public class TaskId implements Comparable<TaskId> {
     public static final String NAMED_TOPOLOGY_DELIMITER = "__";
 
     /** The ID of the subtopology, aka topicGroupId. */
-    @Deprecated
     private final int topicGroupId;
     /** The ID of the partition. */
-    @Deprecated
     private final int partition;
 
     /** The namedTopology that this task belongs to, or null if it does not belong to one */


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/KAFKA-16330
- Updated visibility of two params topicGroupId and partition, from public to private
- Removed deprecated methods writeTo, readFrom