### PR TITLE
KAFKA-17373: Add print.epoch to kafka-console-share-consumer.sh/kafka-console-consumer.sh

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -282,7 +282,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(ConsoleConsumer|DefaultMessageFormatter|StreamsResetter|ProducerPerformance|Agent).java"/>
     <suppress checks="BooleanExpressionComplexity"
-              files="StreamsResetter.java"/>
+              files="(StreamsResetter|DefaultMessageFormatter).java"/>
     <suppress checks="NPathComplexity"
               files="(DefaultMessageFormatter|ProducerPerformance|StreamsResetter|Agent|TransactionalMessageCopier|ReplicaVerificationTool).java"/>
     <suppress checks="ImportControl"

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -114,6 +114,7 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                             " print.timestamp=true|false\n" +
                             " print.key=true|false\n" +
                             " print.offset=true|false\n" +
+                            " print.epoch=true|false\n" +
                             " print.partition=true|false\n" +
                             " print.headers=true|false\n" +
                             " print.value=true|false\n" +

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -76,6 +76,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                                 " print.key=true|false\n" +
                                 " print.offset=true|false\n" +
                                 " print.delivery=true|false\n" +
+                                " print.epoch=true|false\n" +
                                 " print.partition=true|false\n" +
                                 " print.headers=true|false\n" +
                                 " print.value=true|false\n" +

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
@@ -134,31 +134,31 @@ class DefaultMessageFormatter implements MessageFormatter {
                 } else {
                     output.print("NO_TIMESTAMP");
                 }
-                writeSeparator(output, anyTrue(printPartition, printOffset, printDelivery, printEpoch, printHeaders, printKey, printValue));
+                writeSeparator(output, printPartition || printOffset || printDelivery || printEpoch || printHeaders || printKey || printValue);
             }
 
             if (printPartition) {
                 output.print("Partition:");
                 output.print(consumerRecord.partition());
-                writeSeparator(output, anyTrue(printOffset, printDelivery, printEpoch, printHeaders, printKey, printValue));
+                writeSeparator(output, printOffset || printDelivery || printEpoch || printHeaders || printKey || printValue);
             }
 
             if (printOffset) {
                 output.print("Offset:");
                 output.print(consumerRecord.offset());
-                writeSeparator(output, anyTrue(printDelivery, printEpoch, printHeaders, printKey, printValue));
+                writeSeparator(output, printDelivery || printEpoch || printHeaders || printKey || printValue);
             }
 
             if (printDelivery) {
                 output.print("Delivery:");
                 output.print(consumerRecord.deliveryCount().map(delivery -> Short.toString(delivery)).orElse("NOT_PRESENT"));
-                writeSeparator(output, anyTrue(printEpoch, printHeaders, printKey, printValue));
+                writeSeparator(output, printEpoch || printHeaders || printKey || printValue);
             }
 
             if (printEpoch) {
                 output.print("Epoch:");
                 output.print(consumerRecord.leaderEpoch().map(epoch -> Integer.toString(epoch)).orElse("NOT_PRESENT"));
-                writeSeparator(output, anyTrue(printHeaders, printKey, printValue));
+                writeSeparator(output, printHeaders || printKey || printValue);
             }
 
             if (printHeaders) {
@@ -190,15 +190,6 @@ class DefaultMessageFormatter implements MessageFormatter {
         } catch (IOException ioe) {
             LOG.error("Unable to write the consumer record to the output", ioe);
         }
-    }
-
-    private boolean anyTrue(boolean... array) {
-        for (boolean element : array) {
-            if (element) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private Map<String, ?> propertiesWithKeyPrefixStripped(String prefix, Map<String, ?> configs) {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
@@ -43,6 +43,7 @@ class DefaultMessageFormatter implements MessageFormatter {
     private boolean printPartition = false;
     private boolean printOffset = false;
     private boolean printDelivery = false;
+    private boolean printEpoch = false;
     private boolean printHeaders = false;
     private byte[] keySeparator = utfBytes("\t");
     private byte[] lineSeparator = utfBytes("\n");
@@ -66,6 +67,9 @@ class DefaultMessageFormatter implements MessageFormatter {
         }
         if (configs.containsKey("print.delivery")) {
             printDelivery = getBoolProperty(configs, "print.delivery");
+        }
+        if (configs.containsKey("print.epoch")) {
+            printEpoch = getBoolProperty(configs, "print.epoch");
         }
         if (configs.containsKey("print.partition")) {
             printPartition = getBoolProperty(configs, "print.partition");
@@ -130,25 +134,31 @@ class DefaultMessageFormatter implements MessageFormatter {
                 } else {
                     output.print("NO_TIMESTAMP");
                 }
-                writeSeparator(output, printPartition || printOffset || printDelivery || printHeaders || printKey || printValue);
+                writeSeparator(output, anyTrue(printPartition, printOffset, printDelivery, printEpoch, printHeaders, printKey, printValue));
             }
 
             if (printPartition) {
                 output.print("Partition:");
                 output.print(consumerRecord.partition());
-                writeSeparator(output, printOffset || printDelivery || printHeaders || printKey || printValue);
+                writeSeparator(output, anyTrue(printOffset, printDelivery, printEpoch, printHeaders, printKey, printValue));
             }
 
             if (printOffset) {
                 output.print("Offset:");
                 output.print(consumerRecord.offset());
-                writeSeparator(output, printDelivery || printHeaders || printKey || printValue);
+                writeSeparator(output, anyTrue(printDelivery, printEpoch, printHeaders, printKey, printValue));
             }
 
             if (printDelivery) {
                 output.print("Delivery:");
                 output.print(consumerRecord.deliveryCount().map(delivery -> Short.toString(delivery)).orElse("NOT_PRESENT"));
-                writeSeparator(output, printHeaders || printKey || printValue);
+                writeSeparator(output, anyTrue(printEpoch, printHeaders, printKey, printValue));
+            }
+
+            if (printEpoch) {
+                output.print("Epoch:");
+                output.print(consumerRecord.leaderEpoch().map(epoch -> Integer.toString(epoch)).orElse("NOT_PRESENT"));
+                writeSeparator(output, anyTrue(printHeaders, printKey, printValue));
             }
 
             if (printHeaders) {
@@ -180,6 +190,15 @@ class DefaultMessageFormatter implements MessageFormatter {
         } catch (IOException ioe) {
             LOG.error("Unable to write the consumer record to the output", ioe);
         }
+    }
+
+    private boolean anyTrue(boolean... array) {
+        for (boolean element : array) {
+            if (element) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Map<String, ?> propertiesWithKeyPrefixStripped(String prefix, Map<String, ?> configs) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/DefaultMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/DefaultMessageFormatterTest.java
@@ -83,28 +83,40 @@ public class DefaultMessageFormatterTest {
         formatter.writeTo(record, new PrintStream(out));
         assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tDelivery:NOT_PRESENT\tNO_HEADERS\tkey\tvalue\n", out.toString());
 
+        configs.put("print.epoch", "true");
+        formatter.configure(configs);
+        out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+        assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tDelivery:NOT_PRESENT\tEpoch:NOT_PRESENT\tNO_HEADERS\tkey\tvalue\n", out.toString());
+
         RecordHeaders headers = new RecordHeaders();
         headers.add("h1", "v1".getBytes());
         headers.add("h2", "v2".getBytes());
         record = new ConsumerRecord<>("topic", 0, 123, 123L, TimestampType.CREATE_TIME, -1, -1, "key".getBytes(), "value".getBytes(),
-                headers, Optional.empty(), Optional.of((short) 1));
+                headers, Optional.of(58), Optional.of((short) 1));
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:1\th1:v1,h2:v2\tkey\tvalue\n", out.toString());
+        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:1\tEpoch:58\th1:v1,h2:v2\tkey\tvalue\n", out.toString());
 
         configs.put("print.value", "false");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:1\th1:v1,h2:v2\tkey\n", out.toString());
+        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:1\tEpoch:58\th1:v1,h2:v2\tkey\n", out.toString());
 
         configs.put("key.separator", "<sep>");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:1<sep>h1:v1,h2:v2<sep>key\n", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:1<sep>Epoch:58<sep>h1:v1,h2:v2<sep>key\n", out.toString());
 
         configs.put("print.delivery", "false");
+        formatter.configure(configs);
+        out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Epoch:58<sep>h1:v1,h2:v2<sep>key\n", out.toString());
+
+        configs.put("print.epoch", "false");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));


### PR DESCRIPTION
As title, setting `print.epoch=true` can show the `ConsumerRecord#leaderEpoch`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
