### PR TITLE
KAFKA-12827 Remove Deprecated method KafkaStreams#setUncaughtExceptionHandler

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -537,10 +537,6 @@ public class EosIntegrationTest {
             errorInjected.set(true);
             writeInputData(dataAfterFailure);
 
-            waitForCondition(
-                () -> uncaughtException != null, MAX_WAIT_TIME_MS,
-                "Should receive uncaught exception from one StreamThread.");
-
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
             // p-0: ---> 10 rec + C  + 5 rec + C    + 5 rec + C

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -39,7 +39,6 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
@@ -419,7 +418,6 @@ public class EosIntegrationTest {
                 dataBeforeFailure,
                 "The uncommitted records before failure do not match what expected");
 
-            errorInjected.set(true);
             writeInputData(dataAfterFailure);
 
             waitForCondition(
@@ -534,7 +532,6 @@ public class EosIntegrationTest {
                 getMaxPerKey(expectedResultBeforeFailure),
                 "The state store content before failure do not match what expected");
 
-            errorInjected.set(true);
             writeInputData(dataAfterFailure);
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
@@ -1103,16 +1104,16 @@ public class EosIntegrationTest {
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), config);
 
-        streams.setUncaughtExceptionHandler((t, e) -> {
+        streams.setUncaughtExceptionHandler(e -> {
             if (uncaughtException != null ||
-                !(e instanceof StreamsException) ||
-                !e.getCause().getMessage().equals("Injected test exception.")) {
+                    !(e instanceof StreamsException) ||
+                    !e.getCause().getMessage().equals("Injected test exception.")) {
                 e.printStackTrace(System.err);
                 hasUnexpectedError = true;
             }
             uncaughtException = e;
+            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
         });
-
         return streams;
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
@@ -532,7 +533,12 @@ public class EosIntegrationTest {
                 getMaxPerKey(expectedResultBeforeFailure),
                 "The state store content before failure do not match what expected");
 
+            errorInjected.set(true);
             writeInputData(dataAfterFailure);
+
+            waitForCondition(
+                    () -> uncaughtException != null, MAX_WAIT_TIME_MS,
+                    "Should receive uncaught exception from one StreamThread.");
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
@@ -1184,7 +1190,7 @@ public class EosIntegrationTest {
             }
             if (tries >= maxTries) {
                 throw new AssertionError("No committed records in topic " + topic
-                    + ", partition " + partition + " after " + maxTries + " retries.");
+                        + ", partition " + partition + " after " + maxTries + " retries.");
             }
             final long now = System.currentTimeMillis();
             if (now > deadline) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -538,8 +538,8 @@ public class EosIntegrationTest {
             writeInputData(dataAfterFailure);
 
             waitForCondition(
-                    () -> uncaughtException != null, MAX_WAIT_TIME_MS,
-                    "Should receive uncaught exception from one StreamThread.");
+                () -> uncaughtException != null, MAX_WAIT_TIME_MS,
+                "Should receive uncaught exception from one StreamThread.");
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -1108,7 +1108,7 @@ public class EosIntegrationTest {
                 hasUnexpectedError = true;
             }
             uncaughtException = e;
-            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
         });
         return streams;
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -537,6 +537,10 @@ public class EosIntegrationTest {
             errorInjected.set(true);
             writeInputData(dataAfterFailure);
 
+            waitForCondition(
+                () -> uncaughtException != null, MAX_WAIT_TIME_MS,
+                "Should receive uncaught exception from one StreamThread.");
+
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
             // p-0: ---> 10 rec + C  + 5 rec + C    + 5 rec + C
@@ -1102,8 +1106,8 @@ public class EosIntegrationTest {
 
         streams.setUncaughtExceptionHandler(e -> {
             if (uncaughtException != null ||
-                    !(e instanceof StreamsException) ||
-                    !e.getCause().getMessage().equals("Injected test exception.")) {
+                !(e instanceof StreamsException) ||
+                !e.getCause().getMessage().equals("Injected test exception.")) {
                 e.printStackTrace(System.err);
                 hasUnexpectedError = true;
             }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -419,7 +419,7 @@ public class EosIntegrationTest {
                 uncommittedRecords,
                 dataBeforeFailure,
                 "The uncommitted records before failure do not match what expected");
-
+            errorInjected.set(true);
             writeInputData(dataAfterFailure);
 
             waitForCondition(

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -1191,7 +1191,7 @@ public class EosIntegrationTest {
             }
             if (tries >= maxTries) {
                 throw new AssertionError("No committed records in topic " + topic
-                        + ", partition " + partition + " after " + maxTries + " retries.");
+                    + ", partition " + partition + " after " + maxTries + " retries.");
             }
             final long now = System.currentTimeMillis();
             if (now > deadline) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -59,6 +59,7 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestUtils;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -59,7 +59,6 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestUtils;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -1032,14 +1032,14 @@ public class QueryableStateIntegrationTest {
 
         final KeyValue<String, String> hello = KeyValue.pair("hello", "hello");
         IntegrationTestUtils.produceKeyValuesSynchronously(
-                streamThree,
-                Arrays.asList(hello, hello, hello, hello, hello, hello, hello, hello),
-                TestUtils.producerConfig(
-                        CLUSTER.bootstrapServers(),
-                        StringSerializer.class,
-                        StringSerializer.class,
-                        new Properties()),
-                mockTime);
+            streamThree,
+            Arrays.asList(hello, hello, hello, hello, hello, hello, hello, hello),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            mockTime);
 
         final int maxWaitMs = 30000;
 
@@ -1102,53 +1102,53 @@ public class QueryableStateIntegrationTest {
         startApplicationAndWaitUntilRunning(kafkaStreams);
 
         IntegrationTestUtils.produceKeyValuesSynchronously(
-                streamOne,
-                Arrays.asList(
-                        KeyValue.pair("a", "1"),
-                        KeyValue.pair("a", "2"),
-                        KeyValue.pair("b", "3"),
-                        KeyValue.pair("b", "4")),
-                TestUtils.producerConfig(
-                        CLUSTER.bootstrapServers(),
-                        StringSerializer.class,
-                        StringSerializer.class,
-                        new Properties()),
-                mockTime);
+            streamOne,
+            Arrays.asList(
+                KeyValue.pair("a", "1"),
+                KeyValue.pair("a", "2"),
+                KeyValue.pair("b", "3"),
+                KeyValue.pair("b", "4")),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            mockTime);
 
         final int maxWaitMs = 30000;
 
         final ReadOnlyKeyValueStore<String, String> store =
-                IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
+            IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
 
         TestUtils.waitForCondition(
-                () -> "12".equals(store.get("a")) && "34".equals(store.get("b")),
-                maxWaitMs,
-                "wait for agg to be <a,12> and <b,34>");
+            () -> "12".equals(store.get("a")) && "34".equals(store.get("b")),
+            maxWaitMs,
+            "wait for agg to be <a,12> and <b,34>");
 
         IntegrationTestUtils.produceKeyValuesSynchronously(
-                streamOne,
-                Collections.singleton(KeyValue.pair("a", "5")),
-                TestUtils.producerConfig(
-                        CLUSTER.bootstrapServers(),
-                        StringSerializer.class,
-                        StringSerializer.class,
-                        new Properties()),
-                mockTime);
+            streamOne,
+            Collections.singleton(KeyValue.pair("a", "5")),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            mockTime);
 
         final ReadOnlyKeyValueStore<String, String> store2 =
-                IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
+            IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
 
         try {
             TestUtils.waitForCondition(
-                    () -> ("125".equals(store2.get("a"))
-                            || "1225".equals(store2.get("a"))
-                            || "12125".equals(store2.get("a")))
-                            &&
-                            ("34".equals(store2.get("b"))
-                                    || "344".equals(store2.get("b"))
-                                    || "3434".equals(store2.get("b"))),
-                    maxWaitMs,
-                    "wait for agg to be <a,125>||<a,1225>||<a,12125> and <b,34>||<b,344>||<b,3434>");
+                () -> ("125".equals(store2.get("a"))
+                    || "1225".equals(store2.get("a"))
+                    || "12125".equals(store2.get("a")))
+                    &&
+                    ("34".equals(store2.get("b"))
+                        || "344".equals(store2.get("b"))
+                        || "3434".equals(store2.get("b"))),
+                maxWaitMs,
+                "wait for agg to be <a,125>||<a,1225>||<a,12125> and <b,34>||<b,344>||<b,3434>");
         } catch (final Throwable t) {
             throw new RuntimeException("Store content is a: " + store2.get("a") + "; b: " + store2.get("b"), t);
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -1083,17 +1083,17 @@ public class QueryableStateIntegrationTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> input = builder.stream(streamOne);
         input
-                .groupByKey()
-                .reduce((value1, value2) -> {
-                    if (value1.length() > 1) {
-                        if (beforeFailure.compareAndSet(true, false)) {
-                            throw new RuntimeException("Injected test exception");
-                        }
+            .groupByKey()
+            .reduce((value1, value2) -> {
+                if (value1.length() > 1) {
+                    if (beforeFailure.compareAndSet(true, false)) {
+                        throw new RuntimeException("Injected test exception");
                     }
-                    return value1 + value2;
-                }, Materialized.as(storeName))
-                .toStream()
-                .to(outputTopic);
+                }
+                return value1 + value2;
+            }, Materialized.as(storeName))
+            .toStream()
+            .to(outputTopic);
 
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -94,6 +94,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
@@ -102,6 +103,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
+import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.getRunningStreams;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
@@ -1070,6 +1072,87 @@ public class QueryableStateIntegrationTest {
             maxWaitMs,
             "waiting for store " + storeName);
 
+    }
+
+
+    @Test
+    public void shouldAllowToQueryAfterThreadDied() throws Exception {
+        final AtomicBoolean beforeFailure = new AtomicBoolean(true);
+        final AtomicBoolean failed = new AtomicBoolean(false);
+        final String storeName = "store";
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, String> input = builder.stream(streamOne);
+        input
+                .groupByKey()
+                .reduce((value1, value2) -> {
+                    if (value1.length() > 1) {
+                        if (beforeFailure.compareAndSet(true, false)) {
+                            throw new RuntimeException("Injected test exception");
+                        }
+                    }
+                    return value1 + value2;
+                }, Materialized.as(storeName))
+                .toStream()
+                .to(outputTopic);
+
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);
+        kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
+        kafkaStreams.setUncaughtExceptionHandler(exception -> REPLACE_THREAD);
+
+        startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+                streamOne,
+                Arrays.asList(
+                        KeyValue.pair("a", "1"),
+                        KeyValue.pair("a", "2"),
+                        KeyValue.pair("b", "3"),
+                        KeyValue.pair("b", "4")),
+                TestUtils.producerConfig(
+                        CLUSTER.bootstrapServers(),
+                        StringSerializer.class,
+                        StringSerializer.class,
+                        new Properties()),
+                mockTime);
+
+        final int maxWaitMs = 30000;
+
+        final ReadOnlyKeyValueStore<String, String> store =
+                IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
+
+        TestUtils.waitForCondition(
+                () -> "12".equals(store.get("a")) && "34".equals(store.get("b")),
+                maxWaitMs,
+                "wait for agg to be <a,12> and <b,34>");
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+                streamOne,
+                Collections.singleton(KeyValue.pair("a", "5")),
+                TestUtils.producerConfig(
+                        CLUSTER.bootstrapServers(),
+                        StringSerializer.class,
+                        StringSerializer.class,
+                        new Properties()),
+                mockTime);
+
+        final ReadOnlyKeyValueStore<String, String> store2 =
+                IntegrationTestUtils.getStore(storeName, kafkaStreams, keyValueStore());
+
+        try {
+            TestUtils.waitForCondition(
+                    () -> ("125".equals(store2.get("a"))
+                            || "1225".equals(store2.get("a"))
+                            || "12125".equals(store2.get("a")))
+                            &&
+                            ("34".equals(store2.get("b"))
+                                    || "344".equals(store2.get("b"))
+                                    || "3434".equals(store2.get("b"))),
+                    maxWaitMs,
+                    "wait for agg to be <a,125>||<a,1225>||<a,12125> and <b,34>||<b,344>||<b,3434>");
+        } catch (final Throwable t) {
+            throw new RuntimeException("Store content is a: " + store2.get("a") + "; b: " + store2.get("b"), t);
+        }
     }
 
     private void verifyRangeAndAll(final Set<KeyValue<String, Long>> expectedCount,

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -103,7 +103,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
-import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.getRunningStreams;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
@@ -1100,7 +1100,7 @@ public class QueryableStateIntegrationTest {
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
         kafkaStreams.setUncaughtExceptionHandler(exception -> {
             failed.set(true);
-            return SHUTDOWN_CLIENT;
+            return REPLACE_THREAD;
         });
 
         startApplicationAndWaitUntilRunning(kafkaStreams);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -1154,8 +1154,8 @@ public class QueryableStateIntegrationTest {
                     || "12125".equals(store2.get("a")))
                     &&
                     ("34".equals(store2.get("b"))
-                        || "344".equals(store2.get("b"))
-                        || "3434".equals(store2.get("b"))),
+                    || "344".equals(store2.get("b"))
+                    || "3434".equals(store2.get("b"))),
                 maxWaitMs,
                 "wait for agg to be <a,125>||<a,1225>||<a,12125> and <b,34>||<b,344>||<b,3434>");
         } catch (final Throwable t) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -228,7 +228,6 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
         properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 0);
 
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            //kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
             kafkaStreams.setUncaughtExceptionHandler(exception -> REPLACE_THREAD);
 
             startApplicationAndWaitUntilRunning(kafkaStreams);
@@ -339,8 +338,6 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
 
         try (final KafkaStreams kafkaStreams1 = new KafkaStreams(topology, properties);
              final KafkaStreams kafkaStreams2 = new KafkaStreams(topology, properties)) {
-            //kafkaStreams1.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
-            //kafkaStreams2.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
             kafkaStreams1.setUncaughtExceptionHandler(exception -> SHUTDOWN_APPLICATION);
             kafkaStreams2.setUncaughtExceptionHandler(exception -> SHUTDOWN_APPLICATION);
 
@@ -356,8 +353,6 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
     private void testReplaceThreads(final int numThreads) throws Exception {
         properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, numThreads);
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            //kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
-
             final AtomicInteger count = new AtomicInteger();
             kafkaStreams.setUncaughtExceptionHandler(exception -> {
                 if (count.incrementAndGet() == numThreads) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -142,29 +142,8 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
     }
 
     @Test
-    public void shouldShutdownThreadUsingOldHandler() throws Exception {
-        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            final AtomicInteger counter = new AtomicInteger(0);
-            kafkaStreams.setUncaughtExceptionHandler((t, e) -> counter.incrementAndGet());
-
-            startApplicationAndWaitUntilRunning(kafkaStreams);
-            produceMessages(NOW, inputTopic, "A");
-
-            // should call the UncaughtExceptionHandler in current thread
-            TestUtils.waitForCondition(() -> counter.get() == 1, "Handler was called 1st time");
-            // should call the UncaughtExceptionHandler after rebalancing to another thread
-            TestUtils.waitForCondition(() -> counter.get() == 2, DEFAULT_DURATION.toMillis(), "Handler was called 2nd time");
-            // there is no threads running but the client is still in running
-            waitForApplicationState(Collections.singletonList(kafkaStreams), KafkaStreams.State.RUNNING, DEFAULT_DURATION);
-
-            assertThat(processorValueCollector.size(), equalTo(2));
-        }
-    }
-
-    @Test
     public void shouldShutdownClient() throws Exception {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
 
             kafkaStreams.setUncaughtExceptionHandler(exception -> SHUTDOWN_CLIENT);
 
@@ -249,7 +228,7 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
         properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 0);
 
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
+            //kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
             kafkaStreams.setUncaughtExceptionHandler(exception -> REPLACE_THREAD);
 
             startApplicationAndWaitUntilRunning(kafkaStreams);
@@ -360,8 +339,8 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
 
         try (final KafkaStreams kafkaStreams1 = new KafkaStreams(topology, properties);
              final KafkaStreams kafkaStreams2 = new KafkaStreams(topology, properties)) {
-            kafkaStreams1.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
-            kafkaStreams2.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
+            //kafkaStreams1.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
+            //kafkaStreams2.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
             kafkaStreams1.setUncaughtExceptionHandler(exception -> SHUTDOWN_APPLICATION);
             kafkaStreams2.setUncaughtExceptionHandler(exception -> SHUTDOWN_APPLICATION);
 
@@ -377,7 +356,7 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
     private void testReplaceThreads(final int numThreads) throws Exception {
         properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, numThreads);
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
+            //kafkaStreams.setUncaughtExceptionHandler((t, e) -> fail("should not hit old handler"));
 
             final AtomicInteger count = new AtomicInteger();
             kafkaStreams.setUncaughtExceptionHandler(exception -> {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -77,7 +77,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@SuppressWarnings("deprecation") //Need to call the old handler, will remove those calls when the old handler is removed
 @Tag("integration")
 @Timeout(600)
 public class StreamsUncaughtExceptionHandlerIntegrationTest {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -474,10 +474,6 @@ public class KafkaStreams implements AutoCloseable {
         }
     }
 
-    private void defaultStreamsUncaughtExceptionHandler(final Throwable throwable, final boolean skipThreadReplacement) {
-        handleStreamsUncaughtException(throwable, t -> SHUTDOWN_CLIENT, skipThreadReplacement);
-    }
-
     private void replaceStreamThread(final Throwable throwable) {
         if (globalStreamThread != null && Thread.currentThread().getName().equals(globalStreamThread.getName())) {
             log.warn("The global thread cannot be replaced. Reverting to shutting down the client.");
@@ -994,7 +990,7 @@ public class KafkaStreams implements AutoCloseable {
             parseHostInfo(applicationConfigs.getString(StreamsConfig.APPLICATION_SERVER_CONFIG)),
             logContext
         );
-        streamsUncaughtExceptionHandler = this::defaultStreamsUncaughtExceptionHandler;
+        streamsUncaughtExceptionHandler = (throwable, skipThreadReplacement) -> handleStreamsUncaughtException(throwable, t -> SHUTDOWN_CLIENT, skipThreadReplacement);
         delegatingStateRestoreListener = new DelegatingStateRestoreListener();
         delegatingStandbyUpdateListener = new DelegatingStandbyUpdateListener();
 
@@ -1015,7 +1011,7 @@ public class KafkaStreams implements AutoCloseable {
                 time,
                 globalThreadId,
                 delegatingStateRestoreListener,
-                exception -> defaultStreamsUncaughtExceptionHandler(exception, false)
+                exception -> handleStreamsUncaughtException(exception, t -> SHUTDOWN_CLIENT, false)
             );
             globalThreadState = globalStreamThread.state();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -187,7 +187,6 @@ public class KafkaStreams implements AutoCloseable {
     GlobalStreamThread globalStreamThread;
     protected StateDirectory stateDirectory = null;
     private KafkaStreams.StateListener stateListener;
-    private boolean oldHandler;
     private BiConsumer<Throwable, Boolean> streamsUncaughtExceptionHandler;
     private final Object changeThreadCount = new Object();
 
@@ -476,18 +475,7 @@ public class KafkaStreams implements AutoCloseable {
     }
 
     private void defaultStreamsUncaughtExceptionHandler(final Throwable throwable, final boolean skipThreadReplacement) {
-        if (oldHandler) {
-            threads.remove(Thread.currentThread());
-            if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else if (throwable instanceof Error) {
-                throw (Error) throwable;
-            } else {
-                throw new RuntimeException("Unexpected checked exception caught in the uncaught exception handler", throwable);
-            }
-        } else {
-            handleStreamsUncaughtException(throwable, t -> SHUTDOWN_CLIENT, skipThreadReplacement);
-        }
+        handleStreamsUncaughtException(throwable, t -> SHUTDOWN_CLIENT, skipThreadReplacement);
     }
 
     private void replaceStreamThread(final Throwable throwable) {
@@ -513,10 +501,7 @@ public class KafkaStreams implements AutoCloseable {
                                                 final StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler,
                                                 final boolean skipThreadReplacement) {
         final StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse action = streamsUncaughtExceptionHandler.handle(throwable);
-        if (oldHandler) {
-            log.warn("Stream's new uncaught exception handler is set as well as the deprecated old handler." +
-                    "The old handler will be ignored as long as a new handler is set.");
-        }
+
         switch (action) {
             case REPLACE_THREAD:
                 if (!skipThreadReplacement) {
@@ -1009,8 +994,6 @@ public class KafkaStreams implements AutoCloseable {
             parseHostInfo(applicationConfigs.getString(StreamsConfig.APPLICATION_SERVER_CONFIG)),
             logContext
         );
-
-        oldHandler = false;
         streamsUncaughtExceptionHandler = this::defaultStreamsUncaughtExceptionHandler;
         delegatingStateRestoreListener = new DelegatingStateRestoreListener();
         delegatingStandbyUpdateListener = new DelegatingStandbyUpdateListener();

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -432,32 +432,6 @@ public class KafkaStreams implements AutoCloseable {
         }
     }
 
-    /**
-     * Set the handler invoked when an internal {@link StreamsConfig#NUM_STREAM_THREADS_CONFIG stream thread} abruptly
-     * terminates due to an uncaught exception.
-     *
-     * @param uncaughtExceptionHandler the uncaught exception handler for all internal threads; {@code null} deletes the current handler
-     * @throws IllegalStateException if this {@code KafkaStreams} instance has already been started.
-     *
-     * @deprecated Since 2.8.0. Use {@link KafkaStreams#setUncaughtExceptionHandler(StreamsUncaughtExceptionHandler)} instead.
-     *
-     */
-    @Deprecated
-    public void setUncaughtExceptionHandler(final Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
-        synchronized (stateLock) {
-            if (state.hasNotStarted()) {
-                oldHandler = true;
-                processStreamThread(thread -> thread.setUncaughtExceptionHandler(uncaughtExceptionHandler));
-
-                if (globalStreamThread != null) {
-                    globalStreamThread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
-                }
-            } else {
-                throw new IllegalStateException("Can only set UncaughtExceptionHandler before calling start(). " +
-                    "Current state is: " + state);
-            }
-        }
-    }
 
     /**
      * Set the handler invoked when an internal {@link StreamsConfig#NUM_STREAM_THREADS_CONFIG stream thread}
@@ -1403,7 +1377,7 @@ public class KafkaStreams implements AutoCloseable {
      * However, if you have global stores in your topology, this method blocks until all global stores are restored.
      * As a consequence, any fatal exception that happens during processing is by default only logged.
      * If you want to be notified about dying threads, you can
-     * {@link #setUncaughtExceptionHandler(Thread.UncaughtExceptionHandler) register an uncaught exception handler}
+     * {@link #setUncaughtExceptionHandler(StreamsUncaughtExceptionHandler) register an uncaught exception handler}
      * before starting the {@code KafkaStreams} instance.
      * <p>
      * Note, for brokers with version {@code 0.9.x} or lower, the broker version cannot be checked.


### PR DESCRIPTION
- Remove Deprecated method KafkaStreams#setUncaughtExceptionHandler
- Fix test cases.
- https://issues.apache.org/jira/browse/KAFKA-12827 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
