### PR TITLE
KAFKA-17317: Validate and maybe trigger downgrade after static member replacement

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1052,7 +1052,7 @@ public class GroupMetadataManager {
      * @return A boolean indicating whether it's valid to online downgrade the consumer group.
      */
     private boolean validateOnlineDowngrade(ConsumerGroup consumerGroup) {
-        if (!consumerGroup.allMembersUseClassic()) {
+        if (!consumerGroup.allMembersUseClassicProtocol()) {
             return false;
         } else if (consumerGroup.isEmpty()) {
             log.debug("Skip downgrading the consumer group {} to classic group because it's empty.",
@@ -1063,6 +1063,32 @@ public class GroupMetadataManager {
                 consumerGroup.groupId());
             return false;
         } else if (consumerGroup.numMembers() > classicGroupMaxSize) {
+            log.info("Cannot downgrade consumer group {} to classic group because its group size is greater than classic group max size.",
+                consumerGroup.groupId());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates the online downgrade if a consumer member is fenced from the consumer group.
+     *
+     * @param consumerGroup The ConsumerGroup.
+     * @param memberId      The fenced member id.
+     * @return A boolean indicating whether it's valid to online downgrade the consumer group.
+     */
+    private boolean validateOnlineDowngradeWithFencedMember(ConsumerGroup consumerGroup, String memberId) {
+        if (!consumerGroup.allMembersUseClassicProtocolExcept(memberId)) {
+            return false;
+        } else if (consumerGroup.numMembers() <= 1) {
+            log.debug("Skip downgrading the consumer group {} to classic group because it's empty.",
+                consumerGroup.groupId());
+            return false;
+        } else if (!consumerGroupMigrationPolicy.isDowngradeEnabled()) {
+            log.info("Cannot downgrade consumer group {} to classic group because the online downgrade is disabled.",
+                consumerGroup.groupId());
+            return false;
+        } else if (consumerGroup.numMembers() - 1 > classicGroupMaxSize) {
             log.info("Cannot downgrade consumer group {} to classic group because its group size is greater than classic group max size.",
                 consumerGroup.groupId());
             return false;
@@ -1129,10 +1155,7 @@ public class GroupMetadataManager {
 
         classicGroup.allMembers().forEach(member -> rescheduleClassicGroupMemberHeartbeat(classicGroup, member));
 
-        // Trigger a rebalance if group is not stable.
-        if (!STABLE.toString().equals(consumerGroup.stateAsString())) {
-            prepareRebalance(classicGroup, String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId()));
-        }
+        prepareRebalance(classicGroup, String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId()));
 
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.exceptionally(__ -> {
@@ -2068,7 +2091,7 @@ public class GroupMetadataManager {
 
                 // Maybe downgrade the consumer group if the last member using the
                 // consumer protocol is replaced by the joining member.
-                scheduleConsumerGroupDowngradeTimeout(groupId);
+                scheduleConsumerGroupDowngradeTimeout(group);
             }
         });
 
@@ -2763,16 +2786,18 @@ public class GroupMetadataManager {
             records.add(newConsumerGroupSubscriptionMetadataRecord(group.groupId(), subscriptionMetadata));
         }
 
-        // We bump the group epoch.
-        int groupEpoch = group.groupEpoch() + 1;
-        records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch));
+        // We bump the group epoch if the group doesn't need a downgrade.
+        if (!validateOnlineDowngradeWithFencedMember(group, member.memberId())) {
+            int groupEpoch = group.groupEpoch() + 1;
+            records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch));
+        }
 
         cancelTimers(group.groupId(), member.memberId());
 
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.whenComplete((__, t) -> {
             if (t == null) {
-                scheduleConsumerGroupDowngradeTimeout(group.groupId());
+                scheduleConsumerGroupDowngradeTimeout(group);
             }
         });
 
@@ -3154,24 +3179,19 @@ public class GroupMetadataManager {
     /**
      * Maybe schedules the downgrade timeout for the consumer group.
      *
-     * @param groupId The group id to downgrade.
+     * @param consumerGroup The group to downgrade.
      */
     private void scheduleConsumerGroupDowngradeTimeout(
-        String groupId
+        ConsumerGroup consumerGroup
     ) {
-        try {
-            ConsumerGroup consumerGroup = consumerGroup(groupId);
-            if (validateOnlineDowngrade(consumerGroup)) {
-                timer.scheduleIfAbsent(
-                    consumerGroupDowngradeKey(groupId),
-                    0,
-                    TimeUnit.MILLISECONDS,
-                    true,
-                    () -> consumerGroupDowngradeOperation(groupId)
-                );
-            }
-        } catch (GroupIdNotFoundException e) {
-            log.debug("Cannot schedule the downgrade timeout {} because the group doesn't exist or it's not a consumer group.");
+        if (validateOnlineDowngrade(consumerGroup)) {
+            timer.scheduleIfAbsent(
+                consumerGroupDowngradeKey(consumerGroup.groupId()),
+                0,
+                TimeUnit.MILLISECONDS,
+                true,
+                () -> consumerGroupDowngradeOperation(consumerGroup.groupId())
+            );
         }
     }
 
@@ -3740,7 +3760,7 @@ public class GroupMetadataManager {
                             );
                         }
                     });
-                    scheduleConsumerGroupDowngradeTimeout(groupId);
+                    scheduleConsumerGroupDowngradeTimeout(consumerGroup);
                     break;
 
                 case CLASSIC:

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1085,7 +1085,7 @@ public class GroupMetadataManager {
                 return convertToClassicGroup(consumerGroup);
             }
         } catch (GroupIdNotFoundException e) {
-            log.info("Cannot downgrade group {} because the group doesn't exist or it's not a consumer group.");
+            log.debug("Cannot downgrade group {} because the group doesn't exist or it's not a consumer group.");
         }
         return new CoordinatorResult<>(Collections.emptyList());
     }
@@ -1128,14 +1128,18 @@ public class GroupMetadataManager {
         metrics.onClassicGroupStateTransition(null, classicGroup.currentState());
 
         classicGroup.allMembers().forEach(member -> rescheduleClassicGroupMemberHeartbeat(classicGroup, member));
-        prepareRebalance(classicGroup, String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId()));
+
+        // Trigger a rebalance if group is not stable.
+        if (!STABLE.toString().equals(consumerGroup.stateAsString())) {
+            prepareRebalance(classicGroup, String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId()));
+        }
 
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.exceptionally(__ -> {
             metrics.onClassicGroupStateTransition(classicGroup.currentState(), null);
             return null;
         });
-        return new CoordinatorResult<>(records, null, appendFuture, false);
+        return new CoordinatorResult<>(records, appendFuture, false);
     }
 
     /**
@@ -3148,20 +3152,27 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Schedules the downgrade timeout for the consumer group.
+     * Maybe schedules the downgrade timeout for the consumer group.
      *
      * @param groupId The group id to downgrade.
      */
     private void scheduleConsumerGroupDowngradeTimeout(
         String groupId
     ) {
-        timer.schedule(
-            consumerGroupDowngradeKey(groupId),
-            0,
-            TimeUnit.MILLISECONDS,
-            true,
-            () -> consumerGroupDowngradeOperation(groupId)
-        );
+        try {
+            ConsumerGroup consumerGroup = consumerGroup(groupId);
+            if (validateOnlineDowngrade(consumerGroup)) {
+                timer.scheduleIfAbsent(
+                    consumerGroupDowngradeKey(groupId),
+                    0,
+                    TimeUnit.MILLISECONDS,
+                    true,
+                    () -> consumerGroupDowngradeOperation(groupId)
+                );
+            }
+        } catch (GroupIdNotFoundException e) {
+            log.debug("Cannot schedule the downgrade timeout {} because the group doesn't exist or it's not a consumer group.");
+        }
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1046,16 +1046,15 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Validates the online downgrade if a consumer member is fenced from the consumer group.
+     * Validates whether the group id is eligible for an online downgrade.
      *
-     * @param consumerGroup The ConsumerGroup.
-     * @param memberId      The fenced member id.
+     * @param consumerGroup The group to downgrade.
      * @return A boolean indicating whether it's valid to online downgrade the consumer group.
      */
-    private boolean validateOnlineDowngrade(ConsumerGroup consumerGroup, String memberId) {
-        if (!consumerGroup.allMembersUseClassicProtocolExcept(memberId)) {
+    private boolean validateOnlineDowngrade(ConsumerGroup consumerGroup) {
+        if (!consumerGroup.allMembersUseClassic()) {
             return false;
-        } else if (consumerGroup.numMembers() <= 1) {
+        } else if (consumerGroup.isEmpty()) {
             log.debug("Skip downgrading the consumer group {} to classic group because it's empty.",
                 consumerGroup.groupId());
             return false;
@@ -1063,7 +1062,7 @@ public class GroupMetadataManager {
             log.info("Cannot downgrade consumer group {} to classic group because the online downgrade is disabled.",
                 consumerGroup.groupId());
             return false;
-        } else if (consumerGroup.numMembers() - 1 > classicGroupMaxSize) {
+        } else if (consumerGroup.numMembers() > classicGroupMaxSize) {
             log.info("Cannot downgrade consumer group {} to classic group because its group size is greater than classic group max size.",
                 consumerGroup.groupId());
             return false;
@@ -1072,17 +1071,33 @@ public class GroupMetadataManager {
     }
 
     /**
+     * Maybe downgrade the consumer group to a classic group if it's valid for online downgrade.
+     *
+     * @param groupId   The group id.
+     * @return The CoordinatorResult to be applied.
+     */
+    private <T> CoordinatorResult<T, CoordinatorRecord> consumerGroupDowngradeOperation(
+        String groupId
+    ) {
+        try {
+            ConsumerGroup consumerGroup = consumerGroup(groupId);
+            if (validateOnlineDowngrade(consumerGroup)) {
+                return convertToClassicGroup(consumerGroup);
+            }
+        } catch (GroupIdNotFoundException e) {
+            log.info("Cannot downgrade group {} because the group doesn't exist or it's not a consumer group.");
+        }
+        return new CoordinatorResult<>(Collections.emptyList());
+    }
+
+    /**
      * Creates a ClassicGroup corresponding to the given ConsumerGroup.
      *
      * @param consumerGroup     The converted ConsumerGroup.
-     * @param leavingMemberId   The leaving member that triggers the downgrade validation.
-     * @param response          The response of the returned CoordinatorResult.
      * @return A CoordinatorResult.
      */
     private <T> CoordinatorResult<T, CoordinatorRecord> convertToClassicGroup(
-        ConsumerGroup consumerGroup,
-        String leavingMemberId,
-        T response
+        ConsumerGroup consumerGroup
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
         consumerGroup.createGroupTombstoneRecords(records);
@@ -1091,7 +1106,6 @@ public class GroupMetadataManager {
         try {
             classicGroup = ClassicGroup.fromConsumerGroup(
                 consumerGroup,
-                leavingMemberId,
                 logContext,
                 time,
                 metrics,
@@ -1121,7 +1135,7 @@ public class GroupMetadataManager {
             metrics.onClassicGroupStateTransition(classicGroup.currentState(), null);
             return null;
         });
-        return new CoordinatorResult<>(records, response, appendFuture, false);
+        return new CoordinatorResult<>(records, null, appendFuture, false);
     }
 
     /**
@@ -2047,6 +2061,10 @@ public class GroupMetadataManager {
                 scheduleConsumerGroupSyncTimeout(groupId, response.memberId(), request.rebalanceTimeoutMs());
 
                 responseFuture.complete(response);
+
+                // Maybe downgrade the consumer group if the last member using the
+                // consumer protocol is replaced by the joining member.
+                scheduleConsumerGroupDowngradeTimeout(groupId);
             }
         });
 
@@ -2725,33 +2743,36 @@ public class GroupMetadataManager {
         ConsumerGroupMember member,
         T response
     ) {
-        if (validateOnlineDowngrade(group, member.memberId())) {
-            return convertToClassicGroup(group, member.memberId(), response);
-        } else {
-            List<CoordinatorRecord> records = new ArrayList<>();
-            removeMember(records, group.groupId(), member.memberId());
+        List<CoordinatorRecord> records = new ArrayList<>();
+        removeMember(records, group.groupId(), member.memberId());
 
-            // We update the subscription metadata without the leaving member.
-            Map<String, TopicMetadata> subscriptionMetadata = group.computeSubscriptionMetadata(
-                group.computeSubscribedTopicNames(member, null),
-                metadataImage.topics(),
-                metadataImage.cluster()
-            );
+        // We update the subscription metadata without the leaving member.
+        Map<String, TopicMetadata> subscriptionMetadata = group.computeSubscriptionMetadata(
+            group.computeSubscribedTopicNames(member, null),
+            metadataImage.topics(),
+            metadataImage.cluster()
+        );
 
-            if (!subscriptionMetadata.equals(group.subscriptionMetadata())) {
-                log.info("[GroupId {}] Computed new subscription metadata: {}.",
-                    group.groupId(), subscriptionMetadata);
-                records.add(newConsumerGroupSubscriptionMetadataRecord(group.groupId(), subscriptionMetadata));
-            }
-
-            // We bump the group epoch.
-            int groupEpoch = group.groupEpoch() + 1;
-            records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch));
-
-            cancelTimers(group.groupId(), member.memberId());
-
-            return new CoordinatorResult<>(records, response);
+        if (!subscriptionMetadata.equals(group.subscriptionMetadata())) {
+            log.info("[GroupId {}] Computed new subscription metadata: {}.",
+                group.groupId(), subscriptionMetadata);
+            records.add(newConsumerGroupSubscriptionMetadataRecord(group.groupId(), subscriptionMetadata));
         }
+
+        // We bump the group epoch.
+        int groupEpoch = group.groupEpoch() + 1;
+        records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch));
+
+        cancelTimers(group.groupId(), member.memberId());
+
+        CompletableFuture<Void> appendFuture = new CompletableFuture<>();
+        appendFuture.whenComplete((__, t) -> {
+            if (t == null) {
+                scheduleConsumerGroupDowngradeTimeout(group.groupId());
+            }
+        });
+
+        return new CoordinatorResult<>(records, response, appendFuture, true);
     }
 
     /**
@@ -3124,6 +3145,23 @@ public class GroupMetadataManager {
         String memberId
     ) {
         timer.cancel(consumerGroupSyncKey(groupId, memberId));
+    }
+
+    /**
+     * Schedules the downgrade timeout for the consumer group.
+     *
+     * @param groupId The group id to downgrade.
+     */
+    private void scheduleConsumerGroupDowngradeTimeout(
+        String groupId
+    ) {
+        timer.schedule(
+            consumerGroupDowngradeKey(groupId),
+            0,
+            TimeUnit.MILLISECONDS,
+            true,
+            () -> consumerGroupDowngradeOperation(groupId)
+        );
     }
 
     /**
@@ -3691,6 +3729,7 @@ public class GroupMetadataManager {
                             );
                         }
                     });
+                    scheduleConsumerGroupDowngradeTimeout(groupId);
                     break;
 
                 case CLASSIC:
@@ -5984,5 +6023,18 @@ public class GroupMetadataManager {
      */
     static String consumerGroupSyncKey(String groupId, String memberId) {
         return "sync-" + groupId + "-" + memberId;
+    }
+
+    /**
+     * Generate a consumer group downgrade key for the timer.
+     *
+     * Package private for testing.
+     *
+     * @param groupId   The group id.
+     *
+     * @return the downgrade key.
+     */
+    static String consumerGroupDowngradeKey(String groupId) {
+        return "downgrade-" + groupId;
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1356,11 +1356,8 @@ public class ClassicGroup implements Group {
 
     /**
      * Convert the given ConsumerGroup to a corresponding ClassicGroup.
-     * The member with leavingMemberId will not be converted to the new ClassicGroup as it's the last
-     * member using new consumer protocol that left and triggered the downgrade.
      *
      * @param consumerGroup                 The converted ConsumerGroup.
-     * @param leavingMemberId               The member that will not be converted in the ClassicGroup.
      * @param logContext                    The logContext to create the ClassicGroup.
      * @param time                          The time to create the ClassicGroup.
      * @param metadataImage                 The MetadataImage.
@@ -1368,7 +1365,6 @@ public class ClassicGroup implements Group {
      */
     public static ClassicGroup fromConsumerGroup(
         ConsumerGroup consumerGroup,
-        String leavingMemberId,
         LogContext logContext,
         Time time,
         GroupCoordinatorMetricsShard metrics,
@@ -1387,23 +1383,21 @@ public class ClassicGroup implements Group {
             Optional.of(time.milliseconds())
         );
 
-        consumerGroup.members().forEach((memberId, member) -> {
-            if (!memberId.equals(leavingMemberId)) {
-                classicGroup.add(
-                    new ClassicGroupMember(
-                        memberId,
-                        Optional.ofNullable(member.instanceId()),
-                        member.clientId(),
-                        member.clientHost(),
-                        member.rebalanceTimeoutMs(),
-                        member.classicProtocolSessionTimeout().get(),
-                        ConsumerProtocol.PROTOCOL_TYPE,
-                        member.supportedJoinGroupRequestProtocols(),
-                        null
-                    )
-                );
-            }
-        });
+        consumerGroup.members().forEach((memberId, member) ->
+            classicGroup.add(
+                new ClassicGroupMember(
+                    memberId,
+                    Optional.ofNullable(member.instanceId()),
+                    member.clientId(),
+                    member.clientHost(),
+                    member.rebalanceTimeoutMs(),
+                    member.classicProtocolSessionTimeout().get(),
+                    ConsumerProtocol.PROTOCOL_TYPE,
+                    member.supportedJoinGroupRequestProtocols(),
+                    null
+                )
+            )
+        );
 
         classicGroup.setProtocolName(Optional.of(classicGroup.selectProtocol()));
         classicGroup.setSubscribedTopics(classicGroup.computeSubscribedTopics());
@@ -1456,6 +1450,13 @@ public class ClassicGroup implements Group {
                 targetState.validPreviousStates() + " states before moving to " + targetState +
                 " state. Instead it is in " + state + " state.");
         }
+    }
+
+    /**
+     * For testing only.
+     */
+    public void setLeaderId(Optional<String> leaderId) {
+        this.leaderId = leaderId;
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -912,8 +912,19 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @return A boolean indicating whether all the members use the classic protocol.
      */
-    public boolean allMembersUseClassic() {
+    public boolean allMembersUseClassicProtocol() {
         return numClassicProtocolMembers() == members().size();
+    }
+
+    /**
+     * Checks whether all the members use the classic protocol except the given member.
+     *
+     * @param memberId The member to remove.
+     * @return A boolean indicating whether all the members use the classic protocol.
+     */
+    public boolean allMembersUseClassicProtocolExcept(String memberId) {
+        return numClassicProtocolMembers() == members().size() - 1 &&
+            !getOrMaybeCreateMember(memberId, false).useClassicProtocol();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -908,14 +908,12 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     }
 
     /**
-     * Checks whether all the members use the classic protocol except the given member.
+     * Checks whether all the members use the classic protocol.
      *
-     * @param memberId The member to remove.
      * @return A boolean indicating whether all the members use the classic protocol.
      */
-    public boolean allMembersUseClassicProtocolExcept(String memberId) {
-        return numClassicProtocolMembers() == members().size() - 1 &&
-            !getOrMaybeCreateMember(memberId, false).useClassicProtocol();
+    public boolean allMembersUseClassic() {
+        return numClassicProtocolMembers() == members().size();
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -11156,15 +11156,10 @@ public class GroupMetadataManagerTest {
             classicGroupHeartbeatKey(groupId, memberId1)
         );
         assertNotNull(heartbeatTimeout);
-        // The new rebalance has a groupJoin timeout.
-        ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
-            classicGroupJoinKey(groupId)
-        );
-        assertNotNull(groupJoinTimeout);
 
-        // A new rebalance is triggered.
+        // No rebalance is triggered.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
+        assertTrue(classicGroup.isInState(STABLE));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -10891,7 +10891,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            11,
+            10,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -10925,7 +10925,7 @@ public class GroupMetadataManagerTest {
         );
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.
@@ -11043,7 +11043,6 @@ public class GroupMetadataManagerTest {
         }));
 
         context.commit();
-        ConsumerGroup consumerGroup = context.groupMetadataManager.consumerGroup(groupId);
 
         // A new member using classic protocol with the same instance id joins, scheduling the downgrade.
         JoinGroupRequestData joinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
@@ -11161,10 +11160,11 @@ public class GroupMetadataManagerTest {
         ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
             classicGroupJoinKey(groupId)
         );
+        assertNotNull(groupJoinTimeout);
 
-        // No rebalance is triggered. The group is stable.
+        // A new rebalance is triggered.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(STABLE));
+        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
     }
 
     @Test
@@ -11296,7 +11296,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            11,
+            10,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11330,7 +11330,7 @@ public class GroupMetadataManagerTest {
 
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.
@@ -11506,7 +11506,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            12,
+            11,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11540,7 +11540,7 @@ public class GroupMetadataManagerTest {
         );
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.RECONCILING, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -94,6 +94,7 @@ import org.apache.kafka.server.common.MetadataVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.AssertionFailedError;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,6 +106,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -131,6 +133,7 @@ import static org.apache.kafka.coordinator.group.GroupMetadataManager.appendGrou
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupHeartbeatKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupJoinKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupSyncKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupDowngradeKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupJoinKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupRebalanceTimeoutKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.groupSessionTimeoutKey;
@@ -3121,25 +3124,34 @@ public class GroupMetadataManagerTest {
         List<ExpiredTimeout<Void, CoordinatorRecord>> timeouts = context.sleep(45000 + 1);
 
         // Verify the expired timeout.
+        assertEquals(1, timeouts.size());
+        ExpiredTimeout<Void, CoordinatorRecord> timeout = timeouts.get(0);
+        assertEquals(groupSessionTimeoutKey(groupId, memberId), timeout.key);
         assertEquals(
-            Collections.singletonList(new ExpiredTimeout<Void, CoordinatorRecord>(
-                groupSessionTimeoutKey(groupId, memberId),
-                new CoordinatorResult<>(
-                    Arrays.asList(
-                        GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, Collections.emptyMap()),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2)
-                    )
-                )
-            )),
-            timeouts
+            Arrays.asList(
+                GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, Collections.emptyMap()),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2)
+            ),
+            timeout.result.records()
         );
 
-        // Verify that there are no timers.
+        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
+        context.assertDowngradeTimeout(groupId);
+
+        // The downgrade is not triggered.
+        assertEquals(
+            new ExpiredTimeout<Void, CoordinatorRecord>(
+                consumerGroupDowngradeKey(groupId),
+                new CoordinatorResult<>(Collections.emptyList())
+            ),
+            context.sleep(0).get(0)
+        );
     }
 
     @Test
@@ -3202,25 +3214,34 @@ public class GroupMetadataManagerTest {
         List<ExpiredTimeout<Void, CoordinatorRecord>> timeouts = context.sleep(45000 + 1);
 
         // Verify the expired timeout.
+        assertEquals(1, timeouts.size());
+        ExpiredTimeout<Void, CoordinatorRecord> timeout = timeouts.get(0);
+        assertEquals(groupSessionTimeoutKey(groupId, memberId), timeout.key);
         assertEquals(
-            Collections.singletonList(new ExpiredTimeout<Void, CoordinatorRecord>(
-                groupSessionTimeoutKey(groupId, memberId),
-                new CoordinatorResult<>(
-                    Arrays.asList(
-                        GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, Collections.emptyMap()),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2)
-                    )
-                )
-            )),
-            timeouts
+            Arrays.asList(
+                GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
+                GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, Collections.emptyMap()),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2)
+            ),
+            timeout.result.records()
         );
 
-        // Verify that there are no timers.
+        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
+        context.assertDowngradeTimeout(groupId);
+
+        // The downgrade is not triggered.
+        assertEquals(
+            new ExpiredTimeout<Void, CoordinatorRecord>(
+                consumerGroupDowngradeKey(groupId),
+                new CoordinatorResult<>(Collections.emptyList())
+            ),
+            context.sleep(0).get(0)
+        );
     }
 
     @Test
@@ -3499,24 +3520,33 @@ public class GroupMetadataManagerTest {
         List<ExpiredTimeout<Void, CoordinatorRecord>> timeouts = context.sleep(10000 + 1);
 
         // Verify the expired timeout.
+        assertEquals(1, timeouts.size());
+        ExpiredTimeout<Void, CoordinatorRecord> timeout = timeouts.get(0);
+        assertEquals(consumerGroupRebalanceTimeoutKey(groupId, memberId1), timeout.key);
         assertEquals(
-            Collections.singletonList(new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupRebalanceTimeoutKey(groupId, memberId1),
-                new CoordinatorResult<>(
-                    Arrays.asList(
-                        GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId1),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId1),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3)
-                    )
-                )
-            )),
-            timeouts
+            Arrays.asList(
+                GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId1),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId1),
+                GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3)
+            ),
+            timeout.result.records()
         );
 
-        // Verify that there are no timers.
+        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId1);
         context.assertNoRebalanceTimeout(groupId, memberId1);
+        context.assertDowngradeTimeout(groupId);
+
+        // The downgrade is not triggered.
+        assertEquals(
+            new ExpiredTimeout<Void, CoordinatorRecord>(
+                consumerGroupDowngradeKey(groupId),
+                new CoordinatorResult<>(Collections.emptyList())
+            ),
+            context.sleep(0).get(0)
+        );
     }
 
     @Test
@@ -3570,6 +3600,9 @@ public class GroupMetadataManagerTest {
 
         // foo-1 should also have a revocation timeout in place.
         assertNotNull(context.timer.timeout(consumerGroupRebalanceTimeoutKey("foo", "foo-1")));
+
+        // The group has a downgrade timeout scheduled.
+        assertNotNull(context.timer.timeout(consumerGroupDowngradeKey("foo")));
     }
 
     @Test
@@ -10854,7 +10887,7 @@ public class GroupMetadataManagerTest {
         context.commit();
         ConsumerGroup consumerGroup = context.groupMetadataManager.consumerGroup(groupId);
 
-        // Member 2 leaves the consumer group, triggering the downgrade.
+        // Member 2 leaves the consumer group, scheduling the downgrade.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
@@ -10864,6 +10897,11 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
+        // Simulate a successful write to the log. The downgrade operation is scheduled.
+        context.commit();
+        result.appendFuture().complete(null);
+        ExpiredTimeout<Void, CoordinatorRecord> downgradeTimeout = context.sleep(0).get(0);
+        assertEquals(consumerGroupDowngradeKey(groupId), downgradeTimeout.key);
 
         byte[] assignment = Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
             new TopicPartition(fooTopicName, 0),
@@ -10873,6 +10911,197 @@ public class GroupMetadataManagerTest {
             new TopicPartition(barTopicName, 1)
         ))));
         Map<String, byte[]> assignments = Collections.singletonMap(memberId1, assignment);
+
+        ClassicGroup expectedClassicGroup = new ClassicGroup(
+            new LogContext(),
+            groupId,
+            STABLE,
+            context.time,
+            context.metrics,
+            11,
+            Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
+            Optional.of("range"),
+            Optional.of(memberId1),
+            Optional.of(context.time.milliseconds())
+        );
+        expectedClassicGroup.add(
+            new ClassicGroupMember(
+                memberId1,
+                Optional.ofNullable(member1.instanceId()),
+                member1.clientId(),
+                member1.clientHost(),
+                member1.rebalanceTimeoutMs(),
+                member1.classicProtocolSessionTimeout().get(),
+                ConsumerProtocol.PROTOCOL_TYPE,
+                member1.supportedJoinGroupRequestProtocols(),
+                assignment
+            )
+        );
+
+        List<CoordinatorRecord> expectedRecords = Arrays.asList(
+            GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId1),
+
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId1),
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentEpochTombstoneRecord(groupId),
+
+            GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
+            GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataTombstoneRecord(groupId),
+            GroupCoordinatorRecordHelpers.newConsumerGroupEpochTombstoneRecord(groupId),
+
+            GroupCoordinatorRecordHelpers.newGroupMetadataRecord(expectedClassicGroup, assignments, MetadataVersion.latestTesting())
+        );
+        assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
+
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
+
+        // The new classic member 1 has a heartbeat timeout.
+        ScheduledTimeout<Void, CoordinatorRecord> heartbeatTimeout = context.timer.timeout(
+            classicGroupHeartbeatKey(groupId, memberId1)
+        );
+        assertNotNull(heartbeatTimeout);
+        // The new rebalance has a groupJoin timeout.
+        ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
+            classicGroupJoinKey(groupId)
+        );
+        assertNotNull(groupJoinTimeout);
+
+        // A new rebalance is triggered.
+        ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
+        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
+
+        // Simulate a failed conversion.
+        downgradeTimeout.result.appendFuture().completeExceptionally(new NotLeaderOrFollowerException());
+        context.rollback();
+
+        // The group is reverted back to the consumer group.
+        assertEquals(consumerGroup, context.groupMetadataManager.consumerGroup(groupId));
+        verify(context.metrics, times(1)).onClassicGroupStateTransition(PREPARING_REBALANCE, null);
+    }
+
+    @Test
+    public void testLastStaticConsumerProtocolMemberReplacedByClassicProtocolMember() throws ExecutionException, InterruptedException {
+        String groupId = "group-id";
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String instanceId = "instance-id";
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        List<ConsumerGroupMemberMetadataValue.ClassicProtocol> protocols = Collections.singletonList(
+            new ConsumerGroupMemberMetadataValue.ClassicProtocol()
+                .setName("range")
+                .setMetadata(Utils.toArray(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                    Arrays.asList(fooTopicName, barTopicName),
+                    null,
+                    Arrays.asList(
+                        new TopicPartition(fooTopicName, 0),
+                        new TopicPartition(fooTopicName, 1),
+                        new TopicPartition(fooTopicName, 2),
+                        new TopicPartition(barTopicName, 0),
+                        new TopicPartition(barTopicName, 1)
+                    )
+                ))))
+        );
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder(memberId1)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setRebalanceTimeoutMs(45000)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(5000)
+                    .setSupportedProtocols(protocols)
+            )
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2),
+                mkTopicAssignment(barTopicId, 0, 1)))
+            .build();
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
+            .setInstanceId(instanceId)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(Collections.singletonList("foo"))
+            .setServerAssignorName("range")
+            .setRebalanceTimeoutMs(45000)
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5)))
+            .build();
+
+        // Consumer group with two members.
+        // Member 1 uses the classic protocol and static member 2 uses the consumer protocol.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConsumerGroupMigrationPolicy(ConsumerGroupMigrationPolicy.DOWNGRADE)
+            .withConsumerGroupAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 2)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member1)
+                .withMember(member2)
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
+            {
+                put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
+                put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 2, mkMapOfPartitionRacks(2)));
+            }
+        }));
+
+        context.commit();
+        ConsumerGroup consumerGroup = context.groupMetadataManager.consumerGroup(groupId);
+
+        // A new member using classic protocol with the same instance id joins, scheduling the downgrade.
+        JoinGroupRequestData joinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withGroupInstanceId(instanceId)
+            .withProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+        GroupMetadataManagerTestContext.JoinResult result = context.sendClassicGroupJoin(joinRequest);
+        result.appendFuture.complete(null);
+        memberId2 = result.joinFuture.get().memberId();
+
+        ExpiredTimeout<Void, CoordinatorRecord> downgradeTimeout = context.sleep(0).get(0);
+        assertEquals(consumerGroupDowngradeKey(groupId), downgradeTimeout.key);
+
+        byte[] assignment1 = Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
+            new TopicPartition(fooTopicName, 0),
+            new TopicPartition(fooTopicName, 1),
+            new TopicPartition(fooTopicName, 2),
+            new TopicPartition(barTopicName, 0),
+            new TopicPartition(barTopicName, 1)
+        ))));
+        byte[] assignment2 = Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
+            new TopicPartition(fooTopicName, 3),
+            new TopicPartition(fooTopicName, 4),
+            new TopicPartition(fooTopicName, 5)
+        ))));
+        Map<String, byte[]> assignments = new HashMap<>();
+        assignments.put(memberId1, assignment1);
+        assignments.put(memberId2, assignment2);
 
         ClassicGroup expectedClassicGroup = new ClassicGroup(
             new LogContext(),
@@ -10896,7 +11125,20 @@ public class GroupMetadataManagerTest {
                 member1.classicProtocolSessionTimeout().get(),
                 ConsumerProtocol.PROTOCOL_TYPE,
                 member1.supportedJoinGroupRequestProtocols(),
-                assignment
+                assignment1
+            )
+        );
+        expectedClassicGroup.add(
+            new ClassicGroupMember(
+                memberId2,
+                Optional.ofNullable(member2.instanceId()),
+                DEFAULT_CLIENT_ID,
+                DEFAULT_CLIENT_ADDRESS.toString(),
+                joinRequest.rebalanceTimeoutMs(),
+                joinRequest.sessionTimeoutMs(),
+                joinRequest.protocolType(),
+                joinRequest.protocols(),
+                assignment2
             )
         );
 
@@ -10916,11 +11158,23 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newGroupMetadataRecord(expectedClassicGroup, assignments, MetadataVersion.latestTesting())
         );
 
-        assertUnorderedListEquals(expectedRecords.subList(0, 2), result.records().subList(0, 2));
-        assertUnorderedListEquals(expectedRecords.subList(2, 4), result.records().subList(2, 4));
-        assertRecordEquals(expectedRecords.get(4), result.records().get(4));
-        assertUnorderedListEquals(expectedRecords.subList(5, 7), result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 10), result.records().subList(7, 10));
+        assertEquals(expectedRecords.size(), downgradeTimeout.result.records().size());
+        assertUnorderedListEquals(expectedRecords.subList(0, 2), downgradeTimeout.result.records().subList(0, 2));
+        assertUnorderedListEquals(expectedRecords.subList(2, 4), downgradeTimeout.result.records().subList(2, 4));
+        assertRecordEquals(expectedRecords.get(4), downgradeTimeout.result.records().get(4));
+        assertUnorderedListEquals(expectedRecords.subList(5, 7), downgradeTimeout.result.records().subList(5, 7));
+        assertRecordsEquals(expectedRecords.subList(7, 9), downgradeTimeout.result.records().subList(7, 9));
+
+        // Leader can be either member 1 or member 2.
+        try {
+            assertRecordEquals(expectedRecords.get(9), downgradeTimeout.result.records().get(9));
+        } catch (AssertionFailedError e) {
+            expectedClassicGroup.setLeaderId(Optional.of(memberId2));
+            assertRecordEquals(
+                GroupCoordinatorRecordHelpers.newGroupMetadataRecord(expectedClassicGroup, assignments, MetadataVersion.latestTesting()),
+                downgradeTimeout.result.records().get(9)
+            );
+        }
 
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
@@ -10939,14 +11193,6 @@ public class GroupMetadataManagerTest {
         // A new rebalance is triggered.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
         assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
-
-        // Simulate a failed write to the log.
-        result.appendFuture().completeExceptionally(new NotLeaderOrFollowerException());
-        context.rollback();
-
-        // The group is reverted back to the consumer group.
-        assertEquals(consumerGroup, context.groupMetadataManager.consumerGroup(groupId));
-        verify(context.metrics, times(1)).onClassicGroupStateTransition(PREPARING_REBALANCE, null);
     }
 
     @Test
@@ -11054,9 +11300,14 @@ public class GroupMetadataManagerTest {
         context.assertSessionTimeout(groupId, memberId2, 45000);
 
         // Advance time past the session timeout.
-        // Member 2 should be fenced from the group, thus triggering the downgrade.
-        ExpiredTimeout<Void, CoordinatorRecord> timeout = context.sleep(45000 + 1).get(0);
-        assertEquals(groupSessionTimeoutKey(groupId, memberId2), timeout.key);
+        // Member 2 should be fenced from the group.
+        ExpiredTimeout<Void, CoordinatorRecord> sessionTimeout = context.sleep(45000 + 1).get(0);
+        assertEquals(groupSessionTimeoutKey(groupId, memberId2), sessionTimeout.key);
+
+        // Simulate a successful write to the log. The downgrade operation is scheduled.
+        sessionTimeout.result.appendFuture().complete(null);
+        ExpiredTimeout<Void, CoordinatorRecord> downgradeTimeout = context.sleep(0).get(0);
+        assertEquals(consumerGroupDowngradeKey(groupId), downgradeTimeout.key);
 
         byte[] assignment = Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
             new TopicPartition(fooTopicName, 0),
@@ -11073,7 +11324,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            10,
+            11,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11094,27 +11345,20 @@ public class GroupMetadataManagerTest {
         );
         List<CoordinatorRecord> expectedRecords = Arrays.asList(
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId2),
 
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId2),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentEpochTombstoneRecord(groupId),
 
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId2),
             GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataTombstoneRecord(groupId),
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochTombstoneRecord(groupId),
 
             GroupCoordinatorRecordHelpers.newGroupMetadataRecord(expectedClassicGroup, assignments, MetadataVersion.latestTesting())
         );
 
-        assertUnorderedListEquals(expectedRecords.subList(0, 2), timeout.result.records().subList(0, 2));
-        assertUnorderedListEquals(expectedRecords.subList(2, 4), timeout.result.records().subList(2, 4));
-        assertRecordEquals(expectedRecords.get(4), timeout.result.records().get(4));
-        assertUnorderedListEquals(expectedRecords.subList(5, 7), timeout.result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 10), timeout.result.records().subList(7, 10));
+        assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.
@@ -11244,8 +11488,9 @@ public class GroupMetadataManagerTest {
             }
         ));
 
-        // Member 2 heartbeats with a different subscribedTopicNames. The assignor computes a new assignment
-        // where member 2 will need to revoke topic partition bar-2 thus transitions to the REVOKING state.
+        // Member 2 heartbeats with a different subscribedTopicNames. A rebalance is triggered and the
+        // group epoch is bumped to 11. The assignor computes a new assignment where member 2 will need
+        // to revoke topic partition bar-2 thus transitions to the REVOKING state.
         context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
@@ -11266,9 +11511,13 @@ public class GroupMetadataManagerTest {
         context.assertRebalanceTimeout(groupId, memberId2, 30000);
 
         // Advance time past the session timeout.
-        // Member 2 should be fenced from the group, thus triggering the downgrade.
-        ExpiredTimeout<Void, CoordinatorRecord> timeout = context.sleep(30000 + 1).get(0);
-        assertEquals(consumerGroupRebalanceTimeoutKey(groupId, memberId2), timeout.key);
+        // Member 2 should be fenced from the group.
+        ExpiredTimeout<Void, CoordinatorRecord> rebalanceTimeout = context.sleep(30000 + 1).get(0);
+
+        // Simulate a successful write to the log. The downgrade operation is scheduled.
+        rebalanceTimeout.result.appendFuture().complete(null);
+        ExpiredTimeout<Void, CoordinatorRecord> downgradeTimeout = context.sleep(0).get(0);
+        assertEquals(consumerGroupDowngradeKey(groupId), downgradeTimeout.key);
 
         byte[] assignment = Utils.toArray(ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(Arrays.asList(
             new TopicPartition(fooTopicName, 0),
@@ -11285,7 +11534,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            11,
+            12,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11307,27 +11556,19 @@ public class GroupMetadataManagerTest {
 
         List<CoordinatorRecord> expectedRecords = Arrays.asList(
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId2),
 
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId2),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentEpochTombstoneRecord(groupId),
 
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
-            GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId2),
             GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataTombstoneRecord(groupId),
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochTombstoneRecord(groupId),
 
             GroupCoordinatorRecordHelpers.newGroupMetadataRecord(expectedClassicGroup, assignments, MetadataVersion.latestTesting())
         );
+        assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        assertUnorderedListEquals(expectedRecords.subList(0, 2), timeout.result.records().subList(0, 2));
-        assertUnorderedListEquals(expectedRecords.subList(2, 4), timeout.result.records().subList(2, 4));
-        assertRecordEquals(expectedRecords.get(4), timeout.result.records().get(4));
-        assertUnorderedListEquals(expectedRecords.subList(5, 7), timeout.result.records().subList(5, 7));
-        assertRecordsEquals(expectedRecords.subList(7, 10), timeout.result.records().subList(7, 10));
-
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.RECONCILING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -3138,20 +3138,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3228,20 +3219,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3533,20 +3515,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId1);
         context.assertNoRebalanceTimeout(groupId, memberId1);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3601,8 +3574,8 @@ public class GroupMetadataManagerTest {
         // foo-1 should also have a revocation timeout in place.
         assertNotNull(context.timer.timeout(consumerGroupRebalanceTimeoutKey("foo", "foo-1")));
 
-        // The group has a downgrade timeout scheduled.
-        assertNotNull(context.timer.timeout(consumerGroupDowngradeKey("foo")));
+        // No downgrade timeout is scheduled.
+        assertNull(context.timer.timeout(consumerGroupDowngradeKey("foo")));
     }
 
     @Test
@@ -11188,11 +11161,10 @@ public class GroupMetadataManagerTest {
         ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
             classicGroupJoinKey(groupId)
         );
-        assertNotNull(groupJoinTimeout);
 
-        // A new rebalance is triggered.
+        // No rebalance is triggered. The group is stable.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
+        assertTrue(classicGroup.isInState(STABLE));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -111,6 +111,7 @@ import static org.apache.kafka.coordinator.group.Assertions.assertSyncGroupRespo
 import static org.apache.kafka.coordinator.group.GroupConfigManagerTest.createConfigManager;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.EMPTY_RESULT;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupHeartbeatKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupDowngradeKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupJoinKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupRebalanceTimeoutKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupSyncKey;
@@ -749,6 +750,16 @@ public class GroupMetadataManagerTestContext {
         MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
             timer.timeout(consumerGroupSyncKey(groupId, memberId));
         assertNull(timeout);
+    }
+
+    public MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> assertDowngradeTimeout(
+        String groupId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
+            timer.timeout(consumerGroupDowngradeKey(groupId));
+        assertNotNull(timeout);
+        assertEquals(time.milliseconds(), timeout.deadlineMs);
+        return timeout;
     }
 
     ClassicGroup createClassicGroup(String groupId) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -762,6 +762,15 @@ public class GroupMetadataManagerTestContext {
         return timeout;
     }
 
+    public MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> assertNoDowngradeTimeout(
+        String groupId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
+            timer.timeout(consumerGroupDowngradeKey(groupId));
+        assertNull(timeout);
+        return timeout;
+    }
+
     ClassicGroup createClassicGroup(String groupId) {
         return groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, true);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1410,14 +1410,16 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member1);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertTrue(consumerGroup.allMembersUseClassic());
+        assertTrue(consumerGroup.allMembersUseClassicProtocol());
+        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept(member1.memberId()));
 
         // The group has member 1 (using the classic protocol) and member 2 (using the consumer protocol).
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member-2")
             .build();
         consumerGroup.updateMember(member2);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassic());
+        assertFalse(consumerGroup.allMembersUseClassicProtocol());
+        assertTrue(consumerGroup.allMembersUseClassicProtocolExcept(member2.memberId()));
 
         // The group has member 2 (using the consumer protocol) and member 3 (using the consumer protocol).
         consumerGroup.removeMember(member1.memberId());
@@ -1425,12 +1427,13 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member3);
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassic());
+        assertFalse(consumerGroup.allMembersUseClassicProtocol());
+        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept(member2.memberId()));
 
         // The group is empty.
         consumerGroup.removeMember(member2.memberId());
         consumerGroup.removeMember(member3.memberId());
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertTrue(consumerGroup.allMembersUseClassic());
+        assertTrue(consumerGroup.allMembersUseClassicProtocol());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1410,14 +1410,14 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member1);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
+        assertTrue(consumerGroup.allMembersUseClassic());
 
         // The group has member 1 (using the classic protocol) and member 2 (using the consumer protocol).
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member-2")
             .build();
         consumerGroup.updateMember(member2);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept("member-1"));
-        assertTrue(consumerGroup.allMembersUseClassicProtocolExcept("member-2"));
+        assertFalse(consumerGroup.allMembersUseClassic());
 
         // The group has member 2 (using the consumer protocol) and member 3 (using the consumer protocol).
         consumerGroup.removeMember(member1.memberId());
@@ -1425,15 +1425,12 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member3);
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept("member-2"));
+        assertFalse(consumerGroup.allMembersUseClassic());
 
-        // The group has member 2 (using the classic protocol).
+        // The group is empty.
         consumerGroup.removeMember(member2.memberId());
-        member2 = new ConsumerGroupMember.Builder("member-2")
-            .setClassicMemberMetadata(new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(protocols))
-            .build();
-        consumerGroup.updateMember(member2);
-        assertEquals(1, consumerGroup.numClassicProtocolMembers());
+        consumerGroup.removeMember(member3.memberId());
+        assertEquals(0, consumerGroup.numClassicProtocolMembers());
+        assertTrue(consumerGroup.allMembersUseClassic());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17317
This patch makes the online downgrade trigger asynchronous by scheduling a timer to downgrade the group in the appendFuture of the coordinator result. This also fixes the bug discovered in the system test, where the group can't be downgraded when the last static member using the consumer protocol is replaced by a classic member with the same instance id.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
