### PR TITLE
KAFKA-17422: Adding copySegmentLatch countdown after expiration task is over

### DIFF
--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2133,6 +2133,7 @@ public class RemoteLogManagerTest {
                 // wait until copy thread has started copying segment data
                 copySegmentDataLatch.await();
                 expirationTask.cleanupExpiredRemoteLogSegments();
+                copyLogSegmentLatch.countDown();
             } catch (RemoteStorageException | ExecutionException | InterruptedException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
The given test took 5 seconds as the logic was waiting completely for 5 seconds for the expiration task to be completed. 

**Fix**
1. After the expiration task complete , manually called copySegmentLatch.countDown().