### PR TITLE
KAFKA-17408: Fix flaky testShouldCountClicksPerRegionWithNamedRepartitionTopic

### DIFF
--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
@@ -97,6 +97,7 @@ class StreamToTableJoinScalaIntegrationTestBase extends StreamToTableJoinTestDat
     p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
     p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer])
+    p.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "20000")
     p
   }
 


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17408

When I ran this test case in my local machine, I found the error is 
```
org.apache.zookeeper.ClientCnxn$SessionTimeoutException: Client session timed out, have not heard from server in 9384ms for session id 0x10010be31470000
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1257)
```
In the Jenkis enviroment, the test result message show that get the empty records, thus I guess it is match in this scenerio
```
org.opentest4j.AssertionFailedError: Condition not met within timeout 60000. Did not receive all [KeyValue(americas, 101), KeyValue(europe, 109), KeyValue(asia, 124)] records from topic output-topic (got [])
```
I consider that add the `session.timeout.ms` can fix this flaky
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
