### PR TITLE
KAFKA-17426; Check node directory id for KRaft

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -81,6 +81,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaRaftClientTest {
+    @Test
+    public void testNodeDirectoryId() {
+        int localId = randomReplicaId();
+        assertThrows(
+            IllegalArgumentException.class,
+            new RaftClientTestContext.Builder(localId, Uuid.ZERO_UUID)::build
+        );
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })


### PR DESCRIPTION
The log metadata directory must be a non-zero uuid when instantiating KafkaRaftClient 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
