### PR TITLE
KAFKA-17432: Fix threads alive after shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -32,8 +32,6 @@ import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 import org.slf4j.Logger;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -73,8 +71,6 @@ public class DefaultTaskExecutor implements TaskExecutor {
                     log.debug("Releasing task {} due to shutdown.", currentTask.id());
                     unassignCurrentTask();
                 }
-
-                shutdownGate.countDown();
 
                 final KafkaFutureImpl<StreamTask> taskReleaseFuture;
                 if ((taskReleaseFuture = taskReleaseRequested.getAndSet(null)) != null) {
@@ -223,7 +219,6 @@ public class DefaultTaskExecutor implements TaskExecutor {
 
     private StreamTask currentTask = null;
     private TaskExecutorThread taskExecutorThread = null;
-    private CountDownLatch shutdownGate;
 
     public DefaultTaskExecutor(final TaskManager taskManager,
                                final String name,
@@ -247,13 +242,12 @@ public class DefaultTaskExecutor implements TaskExecutor {
         if (taskExecutorThread == null) {
             taskExecutorThread = new TaskExecutorThread(name);
             taskExecutorThread.start();
-            shutdownGate = new CountDownLatch(1);
         }
     }
 
     @Override
     public boolean isRunning() {
-        return taskExecutorThread != null && taskExecutorThread.isAlive() && shutdownGate.getCount() != 0;
+        return taskExecutorThread != null && taskExecutorThread.isAlive();
     }
 
     @Override
@@ -267,7 +261,8 @@ public class DefaultTaskExecutor implements TaskExecutor {
     public void awaitShutdown(final Duration timeout) {
         if (taskExecutorThread != null) {
             try {
-                if (!shutdownGate.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                taskExecutorThread.join(timeout.toMillis());
+                if (taskExecutorThread.isAlive()) {
                     throw new StreamsException("State updater thread did not shutdown within the timeout");
                 }
                 taskExecutorThread = null;
@@ -290,7 +285,7 @@ public class DefaultTaskExecutor implements TaskExecutor {
             if (!taskExecutorThread.taskReleaseRequested.compareAndSet(null, future)) {
                 throw new IllegalStateException("There was already a task release request registered");
             }
-            if (shutdownGate.getCount() == 0) {
+            if (!taskExecutorThread.isAlive()) {
                 log.debug("Completing future, because task executor was just shut down");
                 future.complete(null);
             } else {


### PR DESCRIPTION
We currently use a `CountDownLatch` to signal when a thread has
completed shutdown to the blocking `shutdown` method. However, this
latch triggers _before_ the thread has fully exited.

Dependent on the OS thread scheduling, it's possible that this thread
will still be "alive" after the latch has unblocked the `shutdown`
method.

In practice, this is mostly a problem for `StreamThreadTest`, which now
checks that there are no `TaskExecutor` or `StateUpdater` threads
immediately after shutting them down.

Sometimes, after shutdown returns, we find that these threads are still
"alive", usually completing execution of the "thread shutdown" log
message, or even the `Thread#exit` JVM method that's invoked to clean up
threads just before they exit. This causes sporadic test failures, even
though these threads did indeed shutdown correctly.

Instead of using a `CountDownLatch`, let's just await the thread to exit
directly, using `Thread#join`. Just as before, we set a timeout, and if
the Thread is still alive after the timeout, we throw a
`StreamsException`, maintaining the contract of the `shutdown` method.

There should be no measurable impact on production code here. This will
mostly just improve the reliability of tests that require these threads
have fully exited after calling `shutdown`.
