### PR TITLE
KAFKA-17377: Consider using defaultApiTimeoutMs in AsyncKafkaConsumer#unsubscribe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1478,7 +1478,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         acquireAndEnsureOpen();
         try {
             fetchBuffer.retainAll(Collections.emptySet());
-            Timer timer = time.timer(Long.MAX_VALUE);
+            Timer timer = time.timer(defaultApiTimeoutMs);
             UnsubscribeEvent unsubscribeEvent = new UnsubscribeEvent(calculateDeadlineMs(timer));
             applicationEventHandler.add(unsubscribeEvent);
             log.info("Unsubscribing all topics or patterns and assigned partitions {}",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1475,7 +1475,12 @@ public class AsyncKafkaConsumerTest {
 
         assertTrue(consumer.subscription().isEmpty());
         assertTrue(consumer.assignment().isEmpty());
-        verify(applicationEventHandler).add(ArgumentMatchers.isA(UnsubscribeEvent.class));
+        ArgumentCaptor<UnsubscribeEvent> eventCaptor = ArgumentCaptor.forClass(UnsubscribeEvent.class);
+        verify(applicationEventHandler).add(eventCaptor.capture());
+
+        // check the deadline is set to the default API timeout
+        long deadline = time.milliseconds() + (int) ConsumerConfig.configDef().defaultValues().get(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+        assertTrue(eventCaptor.getValue().deadlineMs() <= deadline);
     }
 
     @Test


### PR DESCRIPTION
Followup from https://github.com/apache/kafka/pull/16673#discussion_r1717009724

The `AsyncKafkaConsumer#unsubscribe` uses `Long.MAX_VALUE` to calculate deadline. However, most of `AsyncKafkaConsumer` operations use [default.api.timeout.ms](https://kafka.apache.org/documentation/#consumerconfigs_default.api.timeout.ms) if users don't specify a timeout. In [design document](https://cwiki.apache.org/confluence/display/KAFKA/Java+client+Consumer+timeouts#JavaclientConsumertimeouts-DefaultTimeouts), it also mentions that using `default.api.timeout.ms` as default timeout.

The `AsyncKafkaConsumer#unsubscribe` uses `processBackgroundEvents` to wait for callbacks and a response to the leave group request, so this PR ensures that the api call is bounded by the `default.api.timeout.ms`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
