### PR TITLE
MINOR fix for opt-in flag for Github build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 11 ]
-    if: ${{ inputs.github-actions-opt-in }}
+    if: ${{ inputs.github-actions-opt-in == 'true' }}
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
When we switched to using a reusable workflow with `workflow_call` and `uses`, it broke the GH opt-in flag. The input is defined as a string and its "truthiness" does not work as expected. This patch changes to using an explicit conditional