### PR TITLE
KAFKA-17233: MirrorCheckpointConnector should use batched listConsumerGroupOffsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
@@ -40,7 +40,7 @@ public class ListConsumerGroupOffsetsResult {
 
     final Map<String, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures;
 
-    public ListConsumerGroupOffsetsResult(final Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {
+    ListConsumerGroupOffsetsResult(final Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {
         this.futures = futures.entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().idValue, Entry::getValue));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
@@ -40,7 +40,7 @@ public class ListConsumerGroupOffsetsResult {
 
     final Map<String, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures;
 
-    ListConsumerGroupOffsetsResult(final Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {
+    public ListConsumerGroupOffsetsResult(final Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {
         this.futures = futures.entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().idValue, Entry::getValue));
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -266,8 +266,9 @@ public class MirrorCheckpointConnector extends SourceConnector {
 
     ListConsumerGroupOffsetsResult listConsumerGroupOffsets(List<String> groups)
             throws InterruptedException, ExecutionException {
+        ListConsumerGroupOffsetsSpec groupOffsetsSpec = new ListConsumerGroupOffsetsSpec();
         Map<String, ListConsumerGroupOffsetsSpec> groupSpecs = groups.stream()
-                .collect(Collectors.toMap(group -> group, group -> new ListConsumerGroupOffsetsSpec()));
+                .collect(Collectors.toMap(group -> group, group -> groupOffsetsSpec));
         return adminCall(
                 () -> sourceAdminClient.listConsumerGroupOffsets(groupSpecs),
                 () -> String.format("list offsets for consumer groups %s on %s cluster", groups, config.sourceClusterAlias())

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -17,10 +17,7 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
-import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -48,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -157,13 +157,10 @@ public class MirrorCheckpointConnectorTest {
         doReturn(true).when(connector).shouldReplicateByTopicFilter(anyString());
         doReturn(true).when(connector).shouldReplicateByGroupFilter(anyString());
 
-        Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = new HashMap<>();
-        futures.put(CoordinatorKey.byGroupId("g1"), KafkaFuture.completedFuture(offsets));
-        futures.put(CoordinatorKey.byGroupId("g2"), KafkaFuture.completedFuture(offsets));
-        ListConsumerGroupOffsetsResult offsetsResult = mock(ListConsumerGroupOffsetsResult.class);
-        doReturn(offsetsResult).when(connector).listConsumerGroupOffsets(anyList());
-        doReturn(futures.get(CoordinatorKey.byGroupId("g1"))).when(offsetsResult).partitionsToOffsetAndMetadata("g1");
-        doReturn(futures.get(CoordinatorKey.byGroupId("g2"))).when(offsetsResult).partitionsToOffsetAndMetadata("g2");
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> groupToOffsets = new HashMap<>();
+        groupToOffsets.put("g1", offsets);
+        groupToOffsets.put("g2", offsets);
+        doReturn(groupToOffsets).when(connector).listConsumerGroupOffsets(anyList());
         Set<String> groupFound = connector.findConsumerGroups();
 
         Set<String> expectedGroups = groups.stream().map(ConsumerGroupListing::groupId).collect(Collectors.toSet());
@@ -203,15 +200,11 @@ public class MirrorCheckpointConnectorTest {
         doReturn(true).when(connector).shouldReplicateByGroupFilter("g3");
         doReturn(false).when(connector).shouldReplicateByGroupFilter("g4");
 
-        Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = new HashMap<>();
-        futures.put(CoordinatorKey.byGroupId("g1"), KafkaFuture.completedFuture(offsetsForGroup1));
-        futures.put(CoordinatorKey.byGroupId("g2"), KafkaFuture.completedFuture(offsetsForGroup2));
-        futures.put(CoordinatorKey.byGroupId("g3"), KafkaFuture.completedFuture(offsetsForGroup3));
-        ListConsumerGroupOffsetsResult offsetsResult = mock(ListConsumerGroupOffsetsResult.class);
-        doReturn(offsetsResult).when(connector).listConsumerGroupOffsets(Arrays.asList("g1", "g2", "g3"));
-        doReturn(futures.get(CoordinatorKey.byGroupId("g1"))).when(offsetsResult).partitionsToOffsetAndMetadata("g1");
-        doReturn(futures.get(CoordinatorKey.byGroupId("g2"))).when(offsetsResult).partitionsToOffsetAndMetadata("g2");
-        doReturn(futures.get(CoordinatorKey.byGroupId("g3"))).when(offsetsResult).partitionsToOffsetAndMetadata("g3");
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> groupToOffsets = new HashMap<>();
+        groupToOffsets.put("g1", offsetsForGroup1);
+        groupToOffsets.put("g2", offsetsForGroup2);
+        groupToOffsets.put("g3", offsetsForGroup3);
+        doReturn(groupToOffsets).when(connector).listConsumerGroupOffsets(Arrays.asList("g1", "g2", "g3"));
 
         Set<String> groupFound = connector.findConsumerGroups();
         Set<String> verifiedSet = new HashSet<>();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 
@@ -159,10 +160,10 @@ public class MirrorCheckpointConnectorTest {
         Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = new HashMap<>();
         futures.put(CoordinatorKey.byGroupId("g1"), KafkaFuture.completedFuture(offsets));
         futures.put(CoordinatorKey.byGroupId("g2"), KafkaFuture.completedFuture(offsets));
-        ListConsumerGroupOffsetsResult offsetsResult = new ListConsumerGroupOffsetsResult(futures);
-        offsetsResult = spy(offsetsResult);
+        ListConsumerGroupOffsetsResult offsetsResult = mock(ListConsumerGroupOffsetsResult.class);
         doReturn(offsetsResult).when(connector).listConsumerGroupOffsets(anyList());
         doReturn(futures.get(CoordinatorKey.byGroupId("g1"))).when(offsetsResult).partitionsToOffsetAndMetadata("g1");
+        doReturn(futures.get(CoordinatorKey.byGroupId("g2"))).when(offsetsResult).partitionsToOffsetAndMetadata("g2");
         Set<String> groupFound = connector.findConsumerGroups();
 
         Set<String> expectedGroups = groups.stream().map(ConsumerGroupListing::groupId).collect(Collectors.toSet());
@@ -206,8 +207,7 @@ public class MirrorCheckpointConnectorTest {
         futures.put(CoordinatorKey.byGroupId("g1"), KafkaFuture.completedFuture(offsetsForGroup1));
         futures.put(CoordinatorKey.byGroupId("g2"), KafkaFuture.completedFuture(offsetsForGroup2));
         futures.put(CoordinatorKey.byGroupId("g3"), KafkaFuture.completedFuture(offsetsForGroup3));
-        ListConsumerGroupOffsetsResult offsetsResult = new ListConsumerGroupOffsetsResult(futures);
-        offsetsResult = spy(offsetsResult);
+        ListConsumerGroupOffsetsResult offsetsResult = mock(ListConsumerGroupOffsetsResult.class);
         doReturn(offsetsResult).when(connector).listConsumerGroupOffsets(Arrays.asList("g1", "g2", "g3"));
         doReturn(futures.get(CoordinatorKey.byGroupId("g1"))).when(offsetsResult).partitionsToOffsetAndMetadata("g1");
         doReturn(futures.get(CoordinatorKey.byGroupId("g2"))).when(offsetsResult).partitionsToOffsetAndMetadata("g2");


### PR DESCRIPTION

Of the Admin interface, the listConsumerGroupOffsets by groupSpecs was chosen
because it is the most similar method to the one by groupId. Both methods do
not need to specify options, but create them with the
ListConsumerGroupOffsetsOptions empty constructor and both end up calling
listConsumerGroupOffsets with a created groupSpecs map and default options.

For this reason, the method listConsumerGroupOffsets of class
MirrorCheckpointConnector needed to be changed to adjust itself to the new
method used.

Since all group offsets are now obtained asynchronously, it is necessary to 
modify the for loop in findConsumerGroups: the ListConsumerGroupOffsetsResult
must be obtained outside of the for loop, and for each group it is needed to get
its topic partition and metadata.

To adjust the tests and perform the mock for listConsumerGroupOffsets, it has
needed to create futures to create a ListConsumerGroupOffsetsResult as the
return of listConsumerGroupOffsets. For this reason, the empty constructor has
become public to be accessed inside the test class.

The assertEquals argument order has been fixed as respectively expected and
actual.

The offsetsForGroup4 instance has been removed as listConsumerGroupOffsets could
not return it as part of the result. This is because group "g4" would be
filtered and not be in the filteredGroup that is passed to
listConsumerGroupOffsets.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
