### PR TITLE
KAFKA-17447: Changed fetch queue processing to reduce the no. of locking and unlocking activity

### DIFF
--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1022,7 +1022,7 @@ public class SharePartitionManagerTest {
             .build();
 
         doAnswer(invocation -> {
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
@@ -1225,35 +1225,35 @@ public class SharePartitionManagerTest {
             assertEquals(4, sp1.nextFetchOffset());
             assertEquals(10, sp2.nextFetchOffset());
             assertEquals(20, sp3.nextFetchOffset());
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).doAnswer(invocation -> {
             assertEquals(15, sp0.nextFetchOffset());
             assertEquals(1, sp1.nextFetchOffset());
             assertEquals(25, sp2.nextFetchOffset());
             assertEquals(15, sp3.nextFetchOffset());
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).doAnswer(invocation -> {
             assertEquals(6, sp0.nextFetchOffset());
             assertEquals(18, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(23, sp3.nextFetchOffset());
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).doAnswer(invocation -> {
             assertEquals(30, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).doAnswer(invocation -> {
             assertEquals(25, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
+            releaseFetchQueueAndPartitionsLock(sharePartitionManager, groupId, partitionMaxBytes.keySet());
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
@@ -1922,6 +1922,11 @@ public class SharePartitionManagerTest {
                 actualValidPartitions.add(topicIdPartition));
         assertEquals(expectedErroneousSet, actualErroneousPartitions);
         assertEquals(expectedValidSet, actualValidPartitions);
+    }
+
+    private void releaseFetchQueueAndPartitionsLock(SharePartitionManager sharePartitionManager, String groupId, Set<TopicIdPartition> topicIdPartitions) {
+        topicIdPartitions.forEach(tp -> sharePartitionManager.sharePartition(groupId, tp).releaseFetchLock());
+        sharePartitionManager.releaseProcessFetchQueueLock();
     }
 
     private static class SharePartitionManagerBuilder {


### PR DESCRIPTION
### About
For the share groups fetch request processing, we have an recursive approach of dealing with individual fetch requests. While  it works fine with less no. of records (< 1,000,000) and lesser sharing (< 5 share consumers), it seems that some requests are getting stuck when we increase the load and try to increase the throughput. I've replaced this approach by removing the unlocking and locking of fetch queue in between entries. This had reduced the complexity and also removes the reliability issue on increasing the load.

### Testing
The code has been tested with the help of unit tests.