### PR TITLE
MINOR: Fix broken output layout of kafka-consumer-groups.sh

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -156,7 +156,7 @@ public class ConsumerGroupCommand {
     }
 
     static void printOffsetsToReset(Map<String, Map<TopicPartition, OffsetAndMetadata>> groupAssignmentsToReset) {
-        String format = "\n%-30s %-30s %-10s %-15s";
+        String format = "%n%-30s %-30s %-10s %-15s";
         if (!groupAssignmentsToReset.isEmpty())
             System.out.printf(format, "GROUP", "TOPIC", "PARTITION", "NEW-OFFSET");
 
@@ -657,7 +657,7 @@ public class ConsumerGroupCommand {
                     printError("Encounter some unknown error: " + topLevelResult, Optional.empty());
             }
 
-            String format = "\n%-30s %-15s %-15s";
+            String format = "%n%-30s %-15s %-15s";
 
             System.out.printf(format, "TOPIC", "PARTITION", "STATUS");
             partitionLevelResult.entrySet().stream()

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -156,9 +156,9 @@ public class ConsumerGroupCommand {
     }
 
     static void printOffsetsToReset(Map<String, Map<TopicPartition, OffsetAndMetadata>> groupAssignmentsToReset) {
-        String format = "%-30s %-30s %-10s %-15s";
+        String format = "\n%-30s %-30s %-10s %-15s";
         if (!groupAssignmentsToReset.isEmpty())
-            System.out.printf("\n" + format, "GROUP", "TOPIC", "PARTITION", "NEW-OFFSET");
+            System.out.printf(format, "GROUP", "TOPIC", "PARTITION", "NEW-OFFSET");
 
         groupAssignmentsToReset.forEach((groupId, assignment) ->
             assignment.forEach((consumerAssignment, offsetAndMetadata) ->
@@ -167,6 +167,7 @@ public class ConsumerGroupCommand {
                     consumerAssignment.topic(),
                     consumerAssignment.partition(),
                     offsetAndMetadata.offset())));
+        System.out.println();
     }
 
     @SuppressWarnings("ClassFanOutComplexity")
@@ -338,6 +339,7 @@ public class ConsumerGroupCommand {
                                 consumerAssignment.host.orElse(MISSING_COLUMN_VALUE), consumerAssignment.clientId.orElse(MISSING_COLUMN_VALUE)
                             );
                         }
+                        System.out.println();
                     }
                 }
             });
@@ -655,9 +657,9 @@ public class ConsumerGroupCommand {
                     printError("Encounter some unknown error: " + topLevelResult, Optional.empty());
             }
 
-            String format = "%-30s %-15s %-15s";
+            String format = "\n%-30s %-15s %-15s";
 
-            System.out.printf("\n" + format, "TOPIC", "PARTITION", "STATUS");
+            System.out.printf(format, "TOPIC", "PARTITION", "STATUS");
             partitionLevelResult.entrySet().stream()
                 .sorted(Comparator.comparing(e -> e.getKey().topic() + e.getKey().partition()))
                 .forEach(e -> {
@@ -669,6 +671,7 @@ public class ConsumerGroupCommand {
                         error != null ? "Error: :" + error.getMessage() : "Successful"
                     );
                 });
+            System.out.println();
         }
 
         Map<String, ConsumerGroupDescription> describeConsumerGroups(Collection<String> groupIds) throws Exception {


### PR DESCRIPTION
Output format of `kafka-consumer-groups.sh` with `--delete-offsets` or `--reset-offsets` has been broken since line separators are missing.
This PR will fix the problem.

--
Current: 
```
$ kafka-consumer-groups.sh --bootstrap-server localhost:9092 --delete-offsets --topic topic1 --group TestGroup1
Request succeed for deleting offsets with topic topic1 group TestGroup1

TOPIC                          PARTITION       STATUS         topic1                         0               Successful     topic1                         1               Successful     topic1                         2               Successful     topic1                         3               Successful     topic1                         4               Successful     topic1                         5               Successful     topic1                         6               Successful     topic1                         7               Successful     topic1                         8               Successful     topic1                         9               Successful     
```

Expect:
```
$ kafka-consumer-groups.sh --bootstrap-server localhost:9092 --delete-offsets --topic topic1 --group TestGroup1             
Request succeed for deleting offsets with topic topic1 group TestGroup1

TOPIC                          PARTITION       STATUS         
topic1                         0               Successful     
topic1                         1               Successful     
topic1                         2               Successful     
topic1                         3               Successful     
topic1                         4               Successful     
topic1                         5               Successful     
topic1                         6               Successful     
topic1                         7               Successful     
topic1                         8               Successful     
topic1                         9               Successful     
```

--
Current: 
```
$ kafka-consumer-groups.sh --bootstrap-server localhost:9092 --reset-offsets --from-file /tmp/offsets.csv --group TestGroup1 --execute

GROUP                          TOPIC                          PARTITION  NEW-OFFSET     TestGroup1                     topic1                         1          20             TestGroup1                     topic1                         0          10             TestGroup1                     topic1                         3          40             TestGroup1                     topic1                         2          30             TestGroup1                     topic1                         5          60             TestGroup1                     topic1                         4          50             
```

Expect:
```
$ kafka-consumer-groups.sh --bootstrap-server localhost:9092 --reset-offsets --from-file /tmp/offsets.csv --group TestGroup1 --execute

GROUP                          TOPIC                          PARTITION  NEW-OFFSET     
TestGroup1                     topic1                         1          20             
TestGroup1                     topic1                         0          10             
TestGroup1                     topic1                         3          40             
TestGroup1                     topic1                         2          30             
TestGroup1                     topic1                         5          60             
TestGroup1                     topic1                         4          50         
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
