### PR TITLE
KAFKA-12829: Remove deprecated StreamsBuilder#addGlobalStore of old Processor API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -33,8 +33,6 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.processor.internals.ProcessorAdapter;
-import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
 import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -520,52 +518,6 @@ public class StreamsBuilder {
     public synchronized StreamsBuilder addStateStore(final StoreBuilder<?> builder) {
         Objects.requireNonNull(builder, "builder can't be null");
         internalStreamsBuilder.addStateStore(new StoreBuilderWrapper(builder));
-        return this;
-    }
-
-    /**
-     * Adds a global {@link StateStore} to the topology.
-     * The {@link StateStore} sources its data from all partitions of the provided input topic.
-     * There will be exactly one instance of this {@link StateStore} per Kafka Streams instance.
-     * <p>
-     * A {@link SourceNode} with the provided sourceName will be added to consume the data arriving from the partitions
-     * of the input topic.
-     * <p>
-     * The provided {@link org.apache.kafka.streams.processor.ProcessorSupplier} will be used to create an {@link ProcessorNode} that will receive all
-     * records forwarded from the {@link SourceNode}.
-     * This {@link ProcessorNode} should be used to keep the {@link StateStore} up-to-date.
-     * The default {@link TimestampExtractor} as specified in the {@link StreamsConfig config} is used.
-     * <p>
-     * It is not required to connect a global store to {@link org.apache.kafka.streams.processor.api.Processor Processors},
-     * {@link org.apache.kafka.streams.kstream.Transformer Transformers},
-     * or {@link org.apache.kafka.streams.kstream.ValueTransformer ValueTransformer}; those have read-only access to all global stores by default.
-     * <p>
-     * The supplier should always generate a new instance each time {@link  ProcessorSupplier#get()} gets called. Creating
-     * a single {@link Processor} object and returning the same object reference in {@link ProcessorSupplier#get()} would be
-     * a violation of the supplier pattern and leads to runtime exceptions.
-     *
-     * @param storeBuilder          user defined {@link StoreBuilder}; can't be {@code null}
-     * @param topic                 the topic to source the data from
-     * @param consumed              the instance of {@link Consumed} used to define optional parameters; can't be {@code null}
-     * @param stateUpdateSupplier   the instance of {@link org.apache.kafka.streams.processor.ProcessorSupplier}
-     * @return itself
-     * @throws TopologyException if the processor of state is already registered
-     * @deprecated Since 2.7.0; use {@link #addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)} instead.
-     */
-    @Deprecated
-    public synchronized <K, V> StreamsBuilder addGlobalStore(final StoreBuilder<?> storeBuilder,
-                                                             final String topic,
-                                                             final Consumed<K, V> consumed,
-                                                             final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
-        Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
-        Objects.requireNonNull(consumed, "consumed can't be null");
-        internalStreamsBuilder.addGlobalStore(
-            new StoreBuilderWrapper(storeBuilder),
-            topic,
-            new ConsumedInternal<>(consumed),
-            () -> ProcessorAdapter.adapt(stateUpdateSupplier.get()),
-            true
-        );
         return this;
     }
 

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/StreamsBuilder.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/StreamsBuilder.scala
@@ -20,7 +20,7 @@ import java.util.Properties
 import java.util.regex.Pattern
 
 import org.apache.kafka.streams.kstream.GlobalKTable
-import org.apache.kafka.streams.processor.{ProcessorSupplier, StateStore}
+import org.apache.kafka.streams.processor.StateStore
 import org.apache.kafka.streams.state.StoreBuilder
 import org.apache.kafka.streams.{StreamsBuilder => StreamsBuilderJ, Topology}
 import org.apache.kafka.streams.scala.kstream.{Consumed, KStream, KTable, Materialized}
@@ -163,27 +163,6 @@ class StreamsBuilder(inner: StreamsBuilderJ = new StreamsBuilderJ) {
    * @see `org.apache.kafka.streams.StreamsBuilder#addStateStore`
    */
   def addStateStore(builder: StoreBuilder[_ <: StateStore]): StreamsBuilderJ = inner.addStateStore(builder)
-
-  /**
-   * Adds a global `StateStore` to the topology. Global stores should not be added to `Processor`, `Transformer`,
-   * or `ValueTransformer` (in contrast to regular stores).
-   * <p>
-   * It is not required to connect a global store to `Processor`, `Transformer`, or `ValueTransformer`;
-   * those have read-only access to all global stores by default.
-   *
-   * @see `org.apache.kafka.streams.StreamsBuilder#addGlobalStore`
-   */
-  @deprecated(
-    "Use #addGlobalStore(StoreBuilder, String, Consumed, org.apache.kafka.streams.processor.api.ProcessorSupplier) instead.",
-    "2.7.0"
-  )
-  def addGlobalStore[K, V](
-    storeBuilder: StoreBuilder[_ <: StateStore],
-    topic: String,
-    consumed: Consumed[K, V],
-    stateUpdateSupplier: ProcessorSupplier[K, V]
-  ): StreamsBuilderJ =
-    inner.addGlobalStore(storeBuilder, topic, consumed, stateUpdateSupplier)
 
   /**
    * Adds a global `StateStore` to the topology. Global stores should not be added to `Processor`, `Transformer`,


### PR DESCRIPTION
KAFKA-12829: Remove deprecated StreamsBuilder#addGlobalStore of old Processor API

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
