### PR TITLE
KAFKA-17454: Fix failed transactions_mixed_versions_test.py when running with 3.2

### DIFF
--- a/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
+++ b/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
@@ -199,6 +199,8 @@ class TransactionsMixedVersionsTest(Test):
         self.kafka.logs["kafka_data_1"]["collect_default"] = True
         self.kafka.logs["kafka_data_2"]["collect_default"] = True
         self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = False if old_kafka_version == str(LATEST_3_2) else True
+        # The 3.2.3 release does not include KAFKA-14259, which will cause an exception when writing debug messages.
+        # Therefore, changing the log level to INFO can avoid triggering the bug.
         self.kafka.log_level = "INFO" if old_kafka_version == str(LATEST_3_2) else "DEBUG"
 
         self.setup_topics()

--- a/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
+++ b/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
@@ -199,6 +199,7 @@ class TransactionsMixedVersionsTest(Test):
         self.kafka.logs["kafka_data_1"]["collect_default"] = True
         self.kafka.logs["kafka_data_2"]["collect_default"] = True
         self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = False if old_kafka_version == str(LATEST_3_2) else True
+        self.kafka.log_level = "INFO" if old_kafka_version == str(LATEST_3_2) else "DEBUG"
 
         self.setup_topics()
         self.kafka.start()


### PR DESCRIPTION
JIRA: [KAFKA-17454](https://issues.apache.org/jira/browse/KAFKA-17454)

> 3.2.3 release does not include [KAFKA-14259](https://issues.apache.org/jira/browse/KAFKA-14259), so it will produce exception (shown below) when log level is DEBUG. Hence, we should change the log level from DEBUG to INFO for 3.2.3
for example: add `self.kafka.log_level = "INFO"`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
