### PR TITLE
KAFKA-17418: Fix the incorrect markdown of junit.py caused by newline character

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -99,6 +99,8 @@ def parse_report(workspace_path, report_path, fp) -> Iterable[TestSuite]:
                 test_case_failed = False
             elif elem.tag == "failure":
                 failure_message = elem.get("message")
+                if failure_message:
+                    failure_message = failure_message.replace('\n', ' ').replace('\r', ' ')
                 failure_class = elem.get("type")
                 failure_stack_trace = elem.text
                 failure = partial_test_case(failure_message, failure_class, failure_stack_trace)

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -101,8 +101,8 @@ def parse_report(workspace_path, report_path, fp) -> Iterable[TestSuite]:
             elif elem.tag == "failure":
                 failure_message = elem.get("message")
                 if failure_message:
-                    failure_message = failure_message.replace('\n', '<br>').replace('\r', '<br>')
                     failure_message = html.escape(failure_message)
+                    failure_message = failure_message.replace('\n', '<br>').replace('\r', '<br>')
                 failure_class = elem.get("type")
                 failure_stack_trace = elem.text
                 failure = partial_test_case(failure_message, failure_class, failure_stack_trace)

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -23,6 +23,7 @@ import os.path
 import sys
 from typing import Tuple, Optional, List, Iterable
 import xml.etree.ElementTree
+import html
 
 
 logger = logging.getLogger()
@@ -100,7 +101,8 @@ def parse_report(workspace_path, report_path, fp) -> Iterable[TestSuite]:
             elif elem.tag == "failure":
                 failure_message = elem.get("message")
                 if failure_message:
-                    failure_message = failure_message.replace('\n', ' ').replace('\r', ' ')
+                    failure_message = failure_message.replace('\n', '<br>').replace('\r', '<br>')
+                    failure_message = html.escape(failure_message)
                 failure_class = elem.get("type")
                 failure_stack_trace = elem.text
                 failure = partial_test_case(failure_message, failure_class, failure_stack_trace)


### PR DESCRIPTION
As title, see https://github.com/apache/kafka/actions/runs/10534117374/jobs/21477070226/summary_raw

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
