### PR TITLE
MINOR increase develocity expiry to 4 hours

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -43,6 +43,7 @@ runs:
       with:
         gradle-version: wrapper
         develocity-access-key: ${{ inputs.develocity-access-key }}
+        develocity-token-expiry: "4"
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         # Cache downloaded JDKs in addition to the default directories.
         gradle-home-cache-includes: |

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -43,7 +43,7 @@ runs:
       with:
         gradle-version: wrapper
         develocity-access-key: ${{ inputs.develocity-access-key }}
-        develocity-token-expiry: "4"
+        develocity-token-expiry: 4
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         # Cache downloaded JDKs in addition to the default directories.
         gradle-home-cache-includes: |


### PR DESCRIPTION
We are using short-lived access tokens for ge.apache.org. The default expiry time is 2 hours which is not long enough for some of our CI workflows. This patch increases the expiry to 4 hours. This gives us some buffer beyond our CI timeout of 3 hours.