### PR TITLE
MINOR: fix clusterInstance waitForTopic sync issue

### DIFF
--- a/core/src/test/java/kafka/test/ClusterInstance.java
+++ b/core/src/test/java/kafka/test/ClusterInstance.java
@@ -200,7 +200,7 @@ public interface ClusterInstance {
     default void waitForTopic(String topic, int partitions) throws InterruptedException {
         // wait for metadata
         TestUtils.waitForCondition(
-            () -> brokers().values().stream().allMatch(broker -> partitions == 0 ?
+            () -> aliveBrokers().values().stream().allMatch(broker -> partitions == 0 ?
                 broker.metadataCache().numPartitions(topic).isEmpty() :
                 broker.metadataCache().numPartitions(topic).contains(partitions)
         ), 60000L, topic + " metadata not propagated after 60000 ms");
@@ -208,7 +208,7 @@ public interface ClusterInstance {
         for (ControllerServer controller : controllers().values()) {
             long controllerOffset = controller.raftManager().replicatedLog().endOffset().offset() - 1;
             TestUtils.waitForCondition(
-                () -> brokers().values().stream().allMatch(broker -> ((BrokerServer) broker).sharedServer().loader().lastAppliedOffset() >= controllerOffset),
+                () -> aliveBrokers().values().stream().allMatch(broker -> ((BrokerServer) broker).sharedServer().loader().lastAppliedOffset() >= controllerOffset),
                 60000L, "Timeout waiting for controller metadata propagating to brokers");
         }
     }

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -252,6 +252,16 @@ public class ClusterTestExtensionsTest {
     }
 
     @ClusterTest(types = {Type.ZK, Type.CO_KRAFT, Type.KRAFT}, brokers = 4)
+    public void testShutdownAndSyncMetadata(ClusterInstance clusterInstance) throws Exception {
+        String topicName = "test";
+        int numPartition = 3;
+        short numReplicas = 3;
+        clusterInstance.createTopic(topicName, numPartition, numReplicas);
+        clusterInstance.shutdownBroker(0);
+        clusterInstance.waitForTopic(topicName, numPartition);
+    }
+
+    @ClusterTest(types = {Type.ZK, Type.CO_KRAFT, Type.KRAFT}, brokers = 4)
     public void testClusterAliveBrokers(ClusterInstance clusterInstance) throws Exception {
         clusterInstance.waitForReadyBrokers();
 


### PR DESCRIPTION
https://github.com/apache/kafka/pull/16323 generate a bug about metadata sync

This test case expose clusterInstance metadata sync bug.
Without this change, the cluster will wait shutdown broker to sync metadata but it already shutdown so the cluster will wait until timeout for `KRaft`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
