### PR TITLE
KAFKA-17277: [2/2] Add feature dependency command to the storage and the feature command tool

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.server.config.ReplicationConfigs
 
 import java.util
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.{CollectionHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsScala}
 
 object StorageTool extends Logging {
 
@@ -176,7 +176,7 @@ object StorageTool extends Logging {
     namespace: Namespace,
     printStream: PrintStream
   ): Unit = {
-    val featureArgs = namespace.getList[String]("feature").asScala
+    val featureArgs = Option(namespace.getList[String]("feature")).map(_.asScala.toList).getOrElse(List.empty)
 
     // Iterate over each feature specified with --feature
     if (featureArgs != null) {
@@ -334,7 +334,7 @@ object StorageTool extends Logging {
 
     featureDependenciesParser.addArgument("--feature", "-f")
       .required(true)
-      .help("The features and their versions to look up dependencies for, in feature=level format." +
+      .help("The features and their versions to look up dependencies for, in feature=version format." +
         " For example: `metadata.version=5`."
       )
       .action(append())

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -167,7 +167,7 @@ object StorageTool extends Logging {
       }
     } catch {
       case e: IllegalArgumentException =>
-        throw new TerseFailure(s"Unsupported release version '$releaseVersion'. Supported versions are: " +
+        throw new TerseFailure(s"Unknown release version '$releaseVersion'. Supported versions are: " +
           s"${MetadataVersion.MINIMUM_BOOTSTRAP_VERSION.version} to ${MetadataVersion.LATEST_PRODUCTION.version}")
     }
   }
@@ -195,7 +195,7 @@ object StorageTool extends Logging {
             MetadataVersion.fromFeatureLevel(featureLevel)
           } catch {
             case _: IllegalArgumentException =>
-              throw new TerseFailure(s"Unsupported metadata.version $featureLevel")
+              throw new TerseFailure(s"Unknown metadata.version $featureLevel")
           }
           printStream.printf("%s=%d (%s) has no dependencies.%n", featureName, featureLevel, metadataVersion.version())
         } else {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -197,7 +197,12 @@ object StorageTool extends Logging {
     } else {
       Features.values().find(_.featureName == featureName) match {
         case Some(feature) =>
-          val featureVersion = feature.fromFeatureLevel(featureLevel, true)
+          val featureVersion = try {
+            feature.fromFeatureLevel(featureLevel, true)
+          } catch {
+            case _: IllegalArgumentException =>
+              throw new TerseFailure(s"Feature level $featureLevel is not supported for feature $featureName")
+          }
           val dependencies = featureVersion.dependencies().asScala
 
           if (dependencies.isEmpty) {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -176,10 +176,11 @@ object StorageTool extends Logging {
     namespace: Namespace,
     printStream: PrintStream
   ): Unit = {
-    val featuresArgs = namespace.getList[String]("feature").asScala
+    val featureArgs = namespace.getList[String]("feature").asScala
 
-    if (featuresArgs != null) {
-      for (featureArg <- featuresArgs) {
+    // Iterate over each feature specified with --feature
+    if (featureArgs != null) {
+      for (featureArg <- featureArgs) {
         val Array(featureName, versionStr) = featureArg.split("=")
 
         val featureLevel = try {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -317,7 +317,8 @@ object StorageTool extends Logging {
   private def addFeatureDependenciesParser(subparsers: Subparsers): Unit = {
     val featureDependenciesParser = subparsers.addParser("feature-dependencies")
       .help("Look up dependencies for a given feature version. " +
-        "If the feature is not known or the version not yet defined, an error is thrown")
+        "If the feature is not known or the version not yet defined, an error is thrown. "
+      )
 
     featureDependenciesParser.addArgument("--feature", "-f")
       .required(true)

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -240,7 +240,7 @@ object StorageTool extends Logging {
 
   def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers
-      .newArgumentParser("kafka-storage", /* defaultHelp */ true, /* prefixChars */ "-", /* fromFilePrefix */ "@")
+      .newArgumentParser("kafka-storage", /* defaultHelp */true, /* prefixChars */"-", /* fromFilePrefix */ "@")
       .description("The Kafka storage tool.")
 
     val subparsers = parser.addSubparsers().dest("command")

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.server.config.ReplicationConfigs
 
 import java.util
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.jdk.CollectionConverters._
 
 object StorageTool extends Logging {
 
@@ -193,7 +193,7 @@ object StorageTool extends Logging {
         case _: IllegalArgumentException =>
           throw new TerseFailure(s"Unsupported metadata.version $featureLevel")
       }
-      printStream.printf("%s=%d (%s) has no dependencies.%n", featureName, featureLevel, metadataVersion.version())
+      printStream.print(f"$featureName%s=$featureLevel%d (${metadataVersion.version()}%s) has no dependencies.%n")
     } else {
       Features.values().find(_.featureName == featureName) match {
         case Some(feature) =>
@@ -201,9 +201,9 @@ object StorageTool extends Logging {
           val dependencies = featureVersion.dependencies().asScala
 
           if (dependencies.isEmpty) {
-            printStream.printf("%s=%d has no dependencies.%n", featureName, featureLevel)
+            printStream.print(f"$featureName%s=$featureLevel%d has no dependencies.%n")
           } else {
-            printStream.printf("%s=%d requires:%n", featureName, featureLevel)
+            printStream.print(f"$featureName%s=$featureLevel%d requires:%n")
             for ((depFeature, depLevel) <- dependencies) {
               if (depFeature == MetadataVersion.FEATURE_NAME) {
                 val metadataVersion = MetadataVersion.fromFeatureLevel(depLevel)

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -240,7 +240,7 @@ object StorageTool extends Logging {
 
   def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers
-      .newArgumentParser("kafka-storage", /* defaultHelp */true, /* prefixChars */"-", /* fromFilePrefix */ "@")
+      .newArgumentParser("kafka-storage", /* defaultHelp */ true, /* prefixChars */ "-", /* fromFilePrefix */ "@")
       .description("The Kafka storage tool.")
 
     val subparsers = parser.addSubparsers().dest("command")
@@ -316,11 +316,14 @@ object StorageTool extends Logging {
 
   private def addFeatureDependenciesParser(subparsers: Subparsers): Unit = {
     val featureDependenciesParser = subparsers.addParser("feature-dependencies")
-      .help("Look up dependencies for a given feature version.")
+      .help("Look up dependencies for a given feature version. " +
+        "If the feature is not known or the version not yet defined, an error is thrown")
 
     featureDependenciesParser.addArgument("--feature", "-f")
       .required(true)
-      .help("The feature and version to look up dependencies for, in feature=level format. For example: `metadata.version=5`.")
+      .help("The feature and version to look up dependencies for, in feature=level format." +
+        " For example: `metadata.version=5`."
+      )
       .action(store())
   }
 

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -588,11 +588,11 @@ Found problem:
     properties.putAll(defaultStaticQuorumProperties)
 
     val stream = new ByteArrayOutputStream()
-    val exception = assertThrows(classOf[IllegalArgumentException], () => {
+    val exception = assertThrows(classOf[TerseFailure], () => {
       runFeatureDependenciesCommand(stream, properties, "transaction.version=1000")
     })
 
-    assertEquals("No feature:transaction.version with feature level 1000", exception.getMessage)
+    assertEquals("Feature level 1000 is not supported for feature transaction.version", exception.getMessage)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -512,7 +512,7 @@ Found problem:
       runVersionMappingCommand(stream, "2.9-IV2")
     })
 
-    assertEquals("Unsupported release version '2.9-IV2'." +
+    assertEquals("Unknown release version '2.9-IV2'." +
       " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION.version +
       " to " + MetadataVersion.LATEST_PRODUCTION.version, exception.getMessage
     )
@@ -521,7 +521,7 @@ Found problem:
       runVersionMappingCommand(stream, "invalid")
     })
 
-    assertEquals("Unsupported release version 'invalid'." +
+    assertEquals("Unknown release version 'invalid'." +
       " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION.version +
       " to " + MetadataVersion.LATEST_PRODUCTION.version, exception2.getMessage
     )

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -321,7 +321,7 @@ Found problem:
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream = new ByteArrayOutputStream()
     assertEquals(0, runFormatCommand(stream, properties, Seq("--feature", "metadata.version=20")))
-    assertTrue(stream.toString().contains("3.9-IV0"),
+    assertTrue(stream.toString().contains("4.0-IV0"),
       "Failed to find content in output: " + stream.toString())
   }
 
@@ -534,10 +534,7 @@ Found problem:
   ): Int = {
     val tempDir = TestUtils.tempDir()
     try {
-      val configPathString = new File(tempDir.getAbsolutePath, "feature-dependencies.props").toString
-      PropertiesUtils.writePropertiesFile(properties, configPathString, true)
-
-      val arguments = ListBuffer[String]("feature-dependencies", "--feature", feature, "--config", configPathString)
+      val arguments = ListBuffer[String]("feature-dependencies", "--feature", feature)
       StorageTool.execute(arguments.toArray, new PrintStream(stream))
     } finally {
       Utils.delete(tempDir)

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -195,12 +195,12 @@ public class FeatureCommand {
     private static void addFeatureDependenciesParser(Subparsers subparsers) {
         Subparser featureDependenciesParser = subparsers.addParser("feature-dependencies")
                 .help("Look up dependencies for a given feature version. " +
-                    "If the feature is not known or the version not yet defined, an error is thrown. " +
-                     "Multiple features can be specified. "
+                        "If the feature is not known or the version not yet defined, an error is thrown. " +
+                        "Multiple features can be specified."
                 );
         featureDependenciesParser.addArgument("--feature")
-                .help("The feature and version to look up dependencies for, in feature=level format. " +
-                    "For example: `metadata.version=5`."
+                .help("The feature and version to look up dependencies for, in feature=version format. " +
+                        "For example: `metadata.version=5`."
                 )
                 .required(true)
                 .action(append());

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -40,11 +40,11 @@ import net.sourceforge.argparse4j.inf.Subparsers;
 import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -279,7 +279,7 @@ public class FeatureCommand {
             try {
                 version = MetadataVersion.fromVersionString(metadata);
             } catch (Throwable e) {
-                throw new TerseException("Unsupported metadata.version " + metadata +
+                throw new TerseException("Unknown metadata.version " + metadata +
                         ". Supported metadata.version are " + metadataVersionsToString(
                         MetadataVersion.MINIMUM_BOOTSTRAP_VERSION, MetadataVersion.latestProduction()));
             }
@@ -333,7 +333,7 @@ public class FeatureCommand {
                 System.out.printf("%s=%d%n", feature.featureName(), featureLevel);
             }
         } catch (IllegalArgumentException e) {
-            throw new TerseException("Unsupported release version '" + releaseVersion + "'." +
+            throw new TerseException("Unknown release version '" + releaseVersion + "'." +
                 " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
                 " to " + MetadataVersion.LATEST_PRODUCTION);
         }
@@ -355,7 +355,7 @@ public class FeatureCommand {
                     try {
                         metadataVersion = MetadataVersion.fromFeatureLevel(featureLevel);
                     } catch (IllegalArgumentException e) {
-                        throw new TerseException("Unsupported metadata.version " + featureLevel);
+                        throw new TerseException("Unknown metadata.version " + featureLevel);
                     }
 
                     // Assuming metadata versions do not have dependencies.

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -195,7 +195,7 @@ public class FeatureCommand {
     private static void addFeatureDependenciesParser(Subparsers subparsers) {
         Subparser featureDependenciesParser = subparsers.addParser("feature-dependencies")
                 .help("Look up dependencies for a given feature version. " +
-                    "If the feature is not known or the version not yet defined, an error is thrown"
+                    "If the feature is not known or the version not yet defined, an error is thrown. "
                 );
         featureDependenciesParser.addArgument("--feature")
                 .help("The feature and version to look up dependencies for, in feature=level format. " +

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -119,6 +119,7 @@ public class FeatureCommand {
                     break;
                 case "version-mapping":
                     handleVersionMapping(namespace);
+                    break;
                 case "feature-dependencies":
                     handleFeatureDependencies(namespace);
                     break;
@@ -193,9 +194,13 @@ public class FeatureCommand {
 
     private static void addFeatureDependenciesParser(Subparsers subparsers) {
         Subparser featureDependenciesParser = subparsers.addParser("feature-dependencies")
-                .help("Look up dependencies for a given feature version.");
+                .help("Look up dependencies for a given feature version. " +
+                    "If the feature is not known or the version not yet defined, an error is thrown"
+                );
         featureDependenciesParser.addArgument("--feature")
-                .help("The feature and version to look up dependencies for, in feature=level format. For example: `metadata.version=5`.")
+                .help("The feature and version to look up dependencies for, in feature=level format. " +
+                    "For example: `metadata.version=5`."
+                )
                 .required(true)
                 .action(store());
     }

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -386,7 +386,7 @@ public class FeatureCommandTest {
             FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
-        assertEquals("Unsupported release version '2.9-IV2'." +
+        assertEquals("Unknown release version '2.9-IV2'." +
             " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
             " to " + MetadataVersion.LATEST_PRODUCTION, exception1.getMessage());
 
@@ -396,7 +396,7 @@ public class FeatureCommandTest {
             FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
-        assertEquals("Unsupported release version 'invalid'." +
+        assertEquals("Unknown release version 'invalid'." +
             " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
             " to " + MetadataVersion.LATEST_PRODUCTION, exception2.getMessage());
     }

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -66,12 +66,14 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
+        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
+        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
+                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV1\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 4.0-IV2\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
+                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(3)));
     }
 
     // Use the first MetadataVersion that supports KIP-919
@@ -84,12 +86,14 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
+        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
+        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
+                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 4.0-IV2\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
+                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(3)));
     }
 
     @ClusterTest(types = {Type.ZK}, metadataVersion = MetadataVersion.IBP_3_3_IV1)
@@ -148,7 +152,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. Invalid update version 0 for feature " +
-                "metadata.version. Local controller 3000 only supports versions 1-23", commandOutput);
+                "metadata.version. Local controller 3000 only supports versions 1-24", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),
@@ -340,12 +344,12 @@ public class FeatureCommandTest {
 
         // Check that the metadata version is correctly included in the output
         assertTrue(versionMappingOutput.contains("metadata.version=" + metadataVersion.featureLevel() + " (" + metadataVersion.version() + ")"),
-                "Output did not contain expected Metadata Version: " + versionMappingOutput);
+            "Output did not contain expected Metadata Version: " + versionMappingOutput);
 
         for (Features feature : Features.values()) {
             int featureLevel = feature.defaultValue(metadataVersion);
             assertTrue(versionMappingOutput.contains(feature.featureName() + "=" + featureLevel),
-                    "Output did not contain expected feature mapping: " + versionMappingOutput);
+                "Output did not contain expected feature mapping: " + versionMappingOutput);
         }
     }
 
@@ -364,12 +368,12 @@ public class FeatureCommandTest {
 
         // Check that the metadata version is correctly included in the output
         assertTrue(versionMappingOutput.contains("metadata.version=" + metadataVersion.featureLevel() + " (" + metadataVersion.version() + ")"),
-                "Output did not contain expected Metadata Version: " + versionMappingOutput);
+            "Output did not contain expected Metadata Version: " + versionMappingOutput);
 
         for (Features feature : Features.values()) {
             int featureLevel = feature.defaultValue(metadataVersion);
             assertTrue(versionMappingOutput.contains(feature.featureName() + "=" + featureLevel),
-                    "Output did not contain expected feature mapping: " + versionMappingOutput);
+                "Output did not contain expected feature mapping: " + versionMappingOutput);
         }
     }
 
@@ -379,22 +383,22 @@ public class FeatureCommandTest {
         namespace.put("release_version", "2.9-IV2");
 
         TerseException exception1 = assertThrows(TerseException.class, () ->
-                FeatureCommand.handleVersionMapping(new Namespace(namespace))
+            FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
         assertEquals("Unsupported release version '2.9-IV2'." +
-                " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
-                " to " + MetadataVersion.LATEST_PRODUCTION, exception1.getMessage());
+            " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
+            " to " + MetadataVersion.LATEST_PRODUCTION, exception1.getMessage());
 
         namespace.put("release_version", "invalid");
 
         TerseException exception2 = assertThrows(TerseException.class, () ->
-                FeatureCommand.handleVersionMapping(new Namespace(namespace))
+            FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
         assertEquals("Unsupported release version 'invalid'." +
-                " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
-                " to " + MetadataVersion.LATEST_PRODUCTION, exception2.getMessage());
+            " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
+            " to " + MetadataVersion.LATEST_PRODUCTION, exception2.getMessage());
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -66,14 +66,12 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV2\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(2)));
+                "SupportedMaxVersion: 4.0-IV1\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(1)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
     }
 
     // Use the first MetadataVersion that supports KIP-919
@@ -86,14 +84,12 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().collect(Collectors.toList());
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
+                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV2\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(2)));
+                "SupportedMaxVersion: 4.0-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(1)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
     }
 
     @ClusterTest(types = {Type.ZK}, metadataVersion = MetadataVersion.IBP_3_3_IV1)
@@ -152,7 +148,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. Invalid update version 0 for feature " +
-                "metadata.version. Local controller 3000 only supports versions 1-24", commandOutput);
+                "metadata.version. Local controller 3000 only supports versions 1-23", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),
@@ -344,12 +340,12 @@ public class FeatureCommandTest {
 
         // Check that the metadata version is correctly included in the output
         assertTrue(versionMappingOutput.contains("metadata.version=" + metadataVersion.featureLevel() + " (" + metadataVersion.version() + ")"),
-            "Output did not contain expected Metadata Version: " + versionMappingOutput);
+                "Output did not contain expected Metadata Version: " + versionMappingOutput);
 
         for (Features feature : Features.values()) {
             int featureLevel = feature.defaultValue(metadataVersion);
             assertTrue(versionMappingOutput.contains(feature.featureName() + "=" + featureLevel),
-                "Output did not contain expected feature mapping: " + versionMappingOutput);
+                    "Output did not contain expected feature mapping: " + versionMappingOutput);
         }
     }
 
@@ -363,17 +359,17 @@ public class FeatureCommandTest {
                 throw new RuntimeException(e);
             }
         });
-        
+
         MetadataVersion metadataVersion = MetadataVersion.latestProduction();
 
         // Check that the metadata version is correctly included in the output
         assertTrue(versionMappingOutput.contains("metadata.version=" + metadataVersion.featureLevel() + " (" + metadataVersion.version() + ")"),
-            "Output did not contain expected Metadata Version: " + versionMappingOutput);
+                "Output did not contain expected Metadata Version: " + versionMappingOutput);
 
         for (Features feature : Features.values()) {
             int featureLevel = feature.defaultValue(metadataVersion);
             assertTrue(versionMappingOutput.contains(feature.featureName() + "=" + featureLevel),
-                "Output did not contain expected feature mapping: " + versionMappingOutput);
+                    "Output did not contain expected feature mapping: " + versionMappingOutput);
         }
     }
 
@@ -383,21 +379,101 @@ public class FeatureCommandTest {
         namespace.put("release_version", "2.9-IV2");
 
         TerseException exception1 = assertThrows(TerseException.class, () ->
-            FeatureCommand.handleVersionMapping(new Namespace(namespace))
+                FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
         assertEquals("Unsupported release version '2.9-IV2'." +
-            " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
-            " to " + MetadataVersion.LATEST_PRODUCTION, exception1.getMessage());
+                " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
+                " to " + MetadataVersion.LATEST_PRODUCTION, exception1.getMessage());
 
         namespace.put("release_version", "invalid");
 
         TerseException exception2 = assertThrows(TerseException.class, () ->
-            FeatureCommand.handleVersionMapping(new Namespace(namespace))
+                FeatureCommand.handleVersionMapping(new Namespace(namespace))
         );
 
         assertEquals("Unsupported release version 'invalid'." +
-            " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
-            " to " + MetadataVersion.LATEST_PRODUCTION, exception2.getMessage());
+                " Supported versions are: " + MetadataVersion.MINIMUM_BOOTSTRAP_VERSION +
+                " to " + MetadataVersion.LATEST_PRODUCTION, exception2.getMessage());
+    }
+
+    @Test
+    public void testHandleFeatureDependenciesForFeatureWithDependencies() {
+        Map<String, Object> namespace = new HashMap<>();
+        namespace.put("feature", "test.feature.version=2");
+
+        String output = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                FeatureCommand.handleFeatureDependencies(new Namespace(namespace));
+            } catch (TerseException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        String expectedOutput = String.format(
+            "test.feature.version=2 requires:\n    metadata.version=%d (%s)\n",
+            MetadataVersion.latestTesting().featureLevel(),
+            MetadataVersion.latestTesting().version()
+        );
+
+        assertEquals(expectedOutput.trim(), output.trim());
+    }
+
+    @Test
+    public void testHandleFeatureDependenciesForFeatureWithNoDependencies() {
+        Map<String, Object> namespace = new HashMap<>();
+        namespace.put("feature", "metadata.version=17");
+
+        String output = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                FeatureCommand.handleFeatureDependencies(new Namespace(namespace));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertEquals("metadata.version=17 (3.7-IV2) has no dependencies.", output);
+    }
+
+    @Test
+    public void testHandleFeatureDependenciesForUnknownFeature() {
+        Map<String, Object> namespace = new HashMap<>();
+        namespace.put("feature", "unknown.feature=1");
+
+        Exception exception = assertThrows(
+            TerseException.class,
+            () -> FeatureCommand.handleFeatureDependencies(new Namespace(namespace)
+            ));
+
+        assertEquals("Unknown feature: unknown.feature", exception.getMessage());
+    }
+
+    @Test
+    public void testHandleFeatureDependenciesForFeatureWithUnknownFeatureVersion() {
+        Map<String, Object> namespace = new HashMap<>();
+        namespace.put("feature", "transaction.version=1000");
+
+        Exception exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> FeatureCommand.handleFeatureDependencies(new Namespace(namespace)
+            ));
+
+        assertEquals("No feature:transaction.version with feature level 1000", exception.getMessage());
+    }
+
+    @Test
+    public void testHandleFeatureDependenciesForInvalidVersionFormat() {
+        Map<String, Object> namespace = new HashMap<>();
+        namespace.put("feature", "metadata.version=invalid");
+
+        RuntimeException exception = assertThrows(
+            RuntimeException.class,
+            () -> FeatureCommand.handleFeatureDependencies(new Namespace(namespace))
+        );
+
+        assertEquals(
+            "Can't parse feature=level string metadata.version=invalid: unable to parse invalid as a short.",
+            exception.getMessage()
+        );
     }
 }


### PR DESCRIPTION
This patch belongs to the ongoing efforts of implementing KIP-1022.

Added feature-dependencies command to look up dependencies for a given feature version supplied by --feature flag. If the feature is not known or the version not yet defined, we throw an error.

Examples :
bin/kafka-feature feature-dependencies --feature transaction.version=2
transaction.version=2 requires:
metadata.version=4 (3.3-IV0) (listing any other version dependencies)

bin/kafka-feature feature-dependencies --feature metadata.version=17
metadata.version=17 (3.7-IV2) has no dependencies
