### PR TITLE
KAFKA-17457 Don't allow ZK migration to start without transactions

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -418,7 +418,14 @@ class KafkaServer(
         kafkaController.startup()
 
         if (config.migrationEnabled) {
-          logger.info("Starting up additional components for ZooKeeper migration")
+          if (config.interBrokerProtocolVersion.isMetadataTransactionSupported) {
+            logger.info("Starting up additional components for ZooKeeper migration")
+          } else {
+            logger.error("Caution! Starting up additional components for ZooKeeper migration without metadata transactions. " +
+              "The controller will not allow the migration to begin. If a migration is in progress, it will be able to " +
+              "continue, but without the fault tolerance afforded by metadata transactions."
+            )
+          }
           lifecycleManager = new BrokerLifecycleManager(config,
             time,
             s"zk-broker-${config.nodeId}-",

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -418,10 +418,9 @@ class KafkaServer(
         kafkaController.startup()
 
         if (config.migrationEnabled) {
-          if (config.interBrokerProtocolVersion.isMetadataTransactionSupported) {
-            logger.info("Starting up additional components for ZooKeeper migration")
-          } else {
-            logger.error("Caution! Starting up additional components for ZooKeeper migration without metadata transactions. " +
+          logger.info("Starting up additional components for ZooKeeper migration")
+          if (!config.interBrokerProtocolVersion.isMetadataTransactionSupported) {
+            logger.error("Caution! Enabled ZooKeeper migration without metadata transactions support. " +
               "The controller will not allow the migration to begin. If a migration is in progress, it will be able to " +
               "continue, but without the fault tolerance afforded by metadata transactions."
             )

--- a/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
@@ -45,7 +45,7 @@ import scala.jdk.CollectionConverters._
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class KafkaServerKRaftRegistrationTest {
 
-  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0, serverProperties = Array(
+  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_6_IV1, serverProperties = Array(
     new ClusterConfigProperty(key = "inter.broker.listener.name", value = "EXTERNAL"),
     new ClusterConfigProperty(key = "listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
     new ClusterConfigProperty(key = "advertised.listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
@@ -57,7 +57,7 @@ class KafkaServerKRaftRegistrationTest {
     // Bootstrap the ZK cluster ID into KRaft
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_4_IV0).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
@@ -99,7 +99,7 @@ class KafkaServerKRaftRegistrationTest {
     val clusterId = zkCluster.clusterId()
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_4_IV0).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -65,8 +65,6 @@ import scala.jdk.CollectionConverters._
 object ZkMigrationIntegrationTest {
   def zkClustersForAllMigrationVersions(): java.util.List[ClusterConfig] = {
     Seq(
-      MetadataVersion.IBP_3_4_IV0,
-      MetadataVersion.IBP_3_5_IV2,
       MetadataVersion.IBP_3_6_IV2,
       MetadataVersion.IBP_3_7_IV0,
       MetadataVersion.IBP_3_7_IV1,

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -65,6 +65,7 @@ import scala.jdk.CollectionConverters._
 object ZkMigrationIntegrationTest {
   def zkClustersForAllMigrationVersions(): java.util.List[ClusterConfig] = {
     Seq(
+      MetadataVersion.IBP_3_6_IV1,
       MetadataVersion.IBP_3_6_IV2,
       MetadataVersion.IBP_3_7_IV0,
       MetadataVersion.IBP_3_7_IV1,
@@ -113,7 +114,7 @@ class ZkMigrationIntegrationTest {
 
   @ClusterTest(
     brokers = 3, types = Array(Type.ZK), autoStart = AutoStart.YES,
-    metadataVersion = MetadataVersion.IBP_3_4_IV0,
+    metadataVersion = MetadataVersion.IBP_3_6_IV1,
     serverProperties = Array(
       new ClusterConfigProperty(key="authorizer.class.name", value="kafka.security.authorizer.AclAuthorizer"),
       new ClusterConfigProperty(key="super.users", value="User:ANONYMOUS")
@@ -156,7 +157,7 @@ class ZkMigrationIntegrationTest {
 
   @ClusterTest(
     brokers = 3, types = Array(Type.ZK), autoStart = AutoStart.YES,
-    metadataVersion = MetadataVersion.IBP_3_4_IV0,
+    metadataVersion = MetadataVersion.IBP_3_6_IV1,
     serverProperties = Array(
       new ClusterConfigProperty(key = "authorizer.class.name", value = "kafka.security.authorizer.AclAuthorizer"),
       new ClusterConfigProperty(key = "super.users", value = "User:ANONYMOUS"),
@@ -171,7 +172,7 @@ class ZkMigrationIntegrationTest {
     val clusterId = zkCluster.clusterId()
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_4_IV0).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
@@ -218,7 +219,7 @@ class ZkMigrationIntegrationTest {
    * and modifies data using AdminClient. The ZkMigrationClient is then used to read the metadata from ZK
    * as would happen during a migration. The generated records are then verified.
    */
-  @ClusterTest(brokers = 3, types = Array(Type.ZK), metadataVersion = MetadataVersion.IBP_3_4_IV0)
+  @ClusterTest(brokers = 3, types = Array(Type.ZK), metadataVersion = MetadataVersion.IBP_3_6_IV1)
   def testMigrate(clusterInstance: ClusterInstance): Unit = {
     val admin = clusterInstance.createAdminClient()
     val newTopics = new util.ArrayList[NewTopic]()
@@ -428,7 +429,7 @@ class ZkMigrationIntegrationTest {
   }
 
   // SCRAM and Quota are intermixed. Test SCRAM Only here
-  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_5_IV2, serverProperties = Array(
+  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_6_IV1, serverProperties = Array(
     new ClusterConfigProperty(key = "inter.broker.listener.name", value = "EXTERNAL"),
     new ClusterConfigProperty(key = "listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
     new ClusterConfigProperty(key = "advertised.listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
@@ -445,7 +446,7 @@ class ZkMigrationIntegrationTest {
     val clusterId = zkCluster.clusterId()
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_5_IV2).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
@@ -664,7 +665,7 @@ class ZkMigrationIntegrationTest {
   }
 
   // SCRAM and Quota are intermixed. Test both here
-  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_5_IV2, serverProperties = Array(
+  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_6_IV1, serverProperties = Array(
     new ClusterConfigProperty(key = "inter.broker.listener.name", value = "EXTERNAL"),
     new ClusterConfigProperty(key = "listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
     new ClusterConfigProperty(key = "advertised.listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
@@ -681,7 +682,7 @@ class ZkMigrationIntegrationTest {
     val clusterId = zkCluster.clusterId()
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_5_IV2).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
@@ -729,7 +730,7 @@ class ZkMigrationIntegrationTest {
     }
   }
 
-  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0, serverProperties = Array(
+  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_6_IV1, serverProperties = Array(
     new ClusterConfigProperty(key = "inter.broker.listener.name", value = "EXTERNAL"),
     new ClusterConfigProperty(key = "listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
     new ClusterConfigProperty(key = "advertised.listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
@@ -745,7 +746,7 @@ class ZkMigrationIntegrationTest {
     val clusterId = zkCluster.clusterId()
     val kraftCluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
-        setBootstrapMetadataVersion(MetadataVersion.IBP_3_4_IV0).
+        setBootstrapMetadataVersion(MetadataVersion.IBP_3_6_IV1).
         setClusterId(clusterId).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
@@ -892,7 +893,7 @@ class ZkMigrationIntegrationTest {
     }
   }
 
-  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0, serverProperties = Array(
+  @ClusterTest(types = Array(Type.ZK), brokers = 3, metadataVersion = MetadataVersion.IBP_3_6_IV1, serverProperties = Array(
     new ClusterConfigProperty(key = "inter.broker.listener.name", value = "EXTERNAL"),
     new ClusterConfigProperty(key = "listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),
     new ClusterConfigProperty(key = "advertised.listeners", value = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"),

--- a/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
@@ -205,7 +205,7 @@ class BrokerRegistrationRequestTest {
     types = Array(Type.KRAFT),
     brokers = 1,
     controllers = 1,
-    metadataVersion = MetadataVersion.IBP_3_4_IV0,
+    metadataVersion = MetadataVersion.IBP_3_6_IV1,
     autoStart = AutoStart.NO,
     serverProperties = Array(new ClusterConfigProperty(key = "zookeeper.metadata.migration.enable", value = "true")))
   def testRegisterZkWithKRaftMigrationEnabled(clusterInstance: ClusterInstance): Unit = {
@@ -218,6 +218,10 @@ class BrokerRegistrationRequestTest {
 
       assertEquals(
         Errors.NONE,
+        registerBroker(channelManager, clusterId, 100, Some(1), Some((MetadataVersion.IBP_3_4_IV0, MetadataVersion.IBP_3_6_IV1))))
+
+      assertEquals(
+        Errors.UNSUPPORTED_VERSION,
         registerBroker(channelManager, clusterId, 100, Some(1), Some((MetadataVersion.IBP_3_4_IV0, MetadataVersion.IBP_3_4_IV0))))
 
       assertEquals(

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -88,7 +88,8 @@ public class ActivationRecordsGenerator {
         // initialization, etc.
         records.addAll(bootstrapMetadata.records());
 
-        if (metadataVersion.isMigrationSupported()) {
+        // In 3.9, we moved the minimum MV for migrations to 3.6. For empty logs, we only allow the newer 3.6 MV
+        if (metadataVersion.isMetadataTransactionSupported()) {
             if (zkMigrationEnabled) {
                 logMessageBuilder.append("Putting the controller into pre-migration mode. No metadata updates " +
                     "will be allowed until the ZK metadata has been migrated. ");
@@ -107,6 +108,7 @@ public class ActivationRecordsGenerator {
 
         activationMessageConsumer.accept(logMessageBuilder.toString().trim());
         if (metadataVersion.isMetadataTransactionSupported()) {
+            // End marker for bootstrap records
             records.add(new ApiMessageAndVersion(new EndTransactionRecord(), (short) 0));
             return ControllerResult.of(records, null);
         } else {
@@ -149,6 +151,7 @@ public class ActivationRecordsGenerator {
                 .append(". ");
         }
 
+        // In 3.9, we moved the minimum MV for migrations to 3.6. For non-empty logs, we allow the older 3.4 MV
         if (zkMigrationEnabled && !metadataVersion.isMigrationSupported()) {
             throw new RuntimeException("Should not have ZK migrations enabled on a cluster running " +
                 "metadata.version " + featureControl.metadataVersion());

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -1385,18 +1385,18 @@ public class QuorumControllerTest {
     @Test
     public void testBootstrapZkMigrationRecord() throws Exception {
         assertEquals(ZkMigrationState.PRE_MIGRATION,
-            checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_4_IV0, true));
+            checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_6_IV1, true));
+
+        assertEquals(ZkMigrationState.NONE,
+            checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_6_IV1, false));
 
         assertEquals(ZkMigrationState.NONE,
             checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_4_IV0, false));
 
-        assertEquals(ZkMigrationState.NONE,
-            checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_3_IV0, false));
-
         assertEquals(
-            "The bootstrap metadata.version 3.3-IV0 does not support ZK migrations. Cannot continue with ZK migrations enabled.",
+            "The bootstrap metadata.version 3.4-IV0 does not support ZK migrations. Cannot continue with ZK migrations enabled.",
             assertThrows(FaultHandlerException.class, () ->
-                checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_3_IV0, true)).getCause().getMessage()
+                checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_4_IV0, true)).getCause().getMessage()
         );
     }
 
@@ -1499,9 +1499,10 @@ public class QuorumControllerTest {
     public void testActivationRecords34() {
         FeatureControlManager featureControl;
 
-        featureControl = getActivationRecords(MetadataVersion.IBP_3_4_IV0, Optional.empty(), true);
-        assertEquals(MetadataVersion.IBP_3_4_IV0, featureControl.metadataVersion());
-        assertEquals(ZkMigrationState.PRE_MIGRATION, featureControl.zkMigrationState());
+        assertEquals(
+            "The bootstrap metadata.version 3.4-IV0 does not support ZK migrations. Cannot continue with ZK migrations enabled.",
+            assertThrows(RuntimeException.class, () -> getActivationRecords(MetadataVersion.IBP_3_4_IV0, Optional.empty(), true)).getMessage()
+        );
 
         featureControl = getActivationRecords(MetadataVersion.IBP_3_4_IV0, Optional.empty(), false);
         assertEquals(MetadataVersion.IBP_3_4_IV0, featureControl.metadataVersion());
@@ -1540,8 +1541,8 @@ public class QuorumControllerTest {
     @Test
     public void testActivationRecordsNonEmptyLog() {
         FeatureControlManager featureControl = getActivationRecords(
-            MetadataVersion.IBP_3_4_IV0, Optional.empty(), true);
-        assertEquals(MetadataVersion.IBP_3_4_IV0, featureControl.metadataVersion());
+            MetadataVersion.IBP_3_6_IV1, Optional.empty(), true);
+        assertEquals(MetadataVersion.IBP_3_6_IV1, featureControl.metadataVersion());
         assertEquals(ZkMigrationState.PRE_MIGRATION, featureControl.zkMigrationState());
     }
 
@@ -1732,7 +1733,7 @@ public class QuorumControllerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = MetadataVersion.class, names = {"IBP_3_4_IV0", "IBP_3_5_IV0", "IBP_3_6_IV0", "IBP_3_6_IV1"})
+    @EnumSource(value = MetadataVersion.class, names = {"IBP_3_6_IV1", "IBP_3_6_IV2", "IBP_3_7_IV0"})
     public void testBrokerHeartbeatDuringMigration(MetadataVersion metadataVersion) throws Exception {
         try (
             LocalLogManagerTestEnv logEnv = new LocalLogManagerTestEnv.Builder(1).build()


### PR DESCRIPTION
Since 3.9 is our last 3.x release, it is a likely version for users to be on when doing ZK to KRaft migrations. Since we have made many fixes since the initial preview of migrations in 3.4, we should ensure that users cannot start a migration without certain improvements. Specifically, we do not want any users attempting migrations without the support of KIP-868 Metadata Transactions. 

This patch prevents the controller from activating if the log is empty, migrations are enabled, and the bootstrap metadata version does not support transactions.

If the log is not empty on startup, as in the case of a software upgrade, we allow the migration to continue where it left off.