### PR TITLE
KAFKA-17483: Complete pending share fetch requests on broker close

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -504,6 +504,12 @@ public class SharePartitionManager implements AutoCloseable {
     public void close() throws Exception {
         this.timer.close();
         this.persister.stop();
+        if (!fetchQueue.isEmpty()) {
+            log.warn("Closing SharePartitionManager with pending fetch requests count: {}", fetchQueue.size());
+            fetchQueue.forEach(shareFetchPartitionData -> shareFetchPartitionData.future.completeExceptionally(
+                Errors.BROKER_NOT_AVAILABLE.exception()));
+            fetchQueue.clear();
+        }
     }
 
     private ShareSessionKey shareSessionKey(String groupId, Uuid memberId) {
@@ -519,7 +525,7 @@ public class SharePartitionManager implements AutoCloseable {
      */
     // Visible for testing.
     void maybeProcessFetchQueue() {
-        if (!processFetchQueueLock.compareAndSet(false, true)) {
+        if (!acquireProcessFetchQueueLock()) {
             // The queue is already being processed hence avoid re-triggering.
             return;
         }
@@ -688,6 +694,11 @@ public class SharePartitionManager implements AutoCloseable {
     void releaseFetchQueueAndPartitionsLock(String groupId, Set<TopicIdPartition> topicIdPartitions) {
         topicIdPartitions.forEach(tp -> partitionCacheMap.get(sharePartitionKey(groupId, tp)).releaseFetchLock());
         releaseProcessFetchQueueLock();
+    }
+
+    // Visible for testing.
+    boolean acquireProcessFetchQueueLock() {
+        return processFetchQueueLock.compareAndSet(false, true);
     }
 
     private void releaseProcessFetchQueueLock() {


### PR DESCRIPTION
The PR adds capability to complete pending fetch requests on broker shutdown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
