### PR TITLE
KAFKA-17479 Relocate junit XML files [2/n]

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Parse JUnit XML results.")
     parser.add_argument("--path",
                         required=False,
-                        default="**/test-results/**/*.xml",
+                        default="build/junit-xml/**/*.xml",
                         help="Path to XML files. Glob patterns are supported.")
 
     if not os.getenv("GITHUB_WORKSPACE"):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         # --scan:         Attempt to publish build scans in PRs. This will only work on PRs from apache/kafka, not public forks.
         # --continue:     Keep running even if a test fails
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
-        timeout-minutes: 10  # 3 hours
+        timeout-minutes: 180  # 3 hours
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,12 @@ jobs:
         timeout-minutes: 180  # 3 hours
         continue-on-error: true
         run: |
-          ./gradlew --info --build-cache --scan --continue \
+          ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \
           -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
-          :metadata:test
+          test
       - name: Archive JUnit reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,7 @@ jobs:
         # --scan:         Attempt to publish build scans in PRs. This will only work on PRs from apache/kafka, not public forks.
         # --continue:     Keep running even if a test fails
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
-        timeout-minutes: 180  # 3 hours
-        continue-on-error: true
+        timeout-minutes: 10  # 3 hours
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,12 @@ jobs:
         timeout-minutes: 180  # 3 hours
         continue-on-error: true
         run: |
-          ./gradlew --build-cache --scan --continue \
+          ./gradlew --info --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \
           -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
-          test
+          :metadata:test
       - name: Archive JUnit reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/build.gradle
+++ b/build.gradle
@@ -569,6 +569,14 @@ subprojects {
       delete t.reports.junitXml.outputLocation
       delete t.reports.html.outputLocation
     }
+
+    doLast {
+      def dest = rootProject.layout.buildDirectory.dir("junit-xml/${project.name}").get().asFile
+      println "Copy JUnit XML for ${project.name} to $dest"
+      ant.copy(todir: "$dest") {
+        ant.fileset(dir: "${test.reports.junitXml.entryPoint}")
+      }
+    }
   }
 
   jar {


### PR DESCRIPTION
In #17066, we fixed caching for ":jar" and ":test" tasks. However, now in PRs, the test results will be restored as part of the Gradle cache resolution. This means tasks which show as FROM-CACHE and are not run will still have test results in their build directory. To avoid incorrectly reporting these results in the job summary, this patch uses a `doLast` task handler to relocate JUnit XML files into a new directory.

Another option would be to move the test summary logic from junit.py into a Gradle task that can properly hook into the Gradle lifecycle. However, this approach seems to work and is less complex.