### PR TITLE
MINOR: Simplify the test for `ListOffsetsRequestTest#testListOffsetsRequestOldestVersion`

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -184,4 +184,32 @@ public class ListOffsetsRequestTest {
                 () -> versionInfo.latestUsableVersion(apiKey, (short) version, apiKey.latestVersion()));
         assertEquals("The node does not support " + apiKey, exception.getMessage());
     }
+
+    @Test
+    public void testListOffsetsRequestOldestVersion() {
+        ListOffsetsRequest.Builder consumerRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED);
+
+        ListOffsetsRequest.Builder requireTimestampRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(true, IsolationLevel.READ_UNCOMMITTED);
+
+        ListOffsetsRequest.Builder requestCommittedRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(false, IsolationLevel.READ_COMMITTED);
+
+        ListOffsetsRequest.Builder maxTimestampRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, false);
+
+        ListOffsetsRequest.Builder requireEarliestLocalTimestampRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, false);
+
+        ListOffsetsRequest.Builder requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
+            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true);
+
+        assertEquals((short) 0, consumerRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 1, requireTimestampRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 2, requestCommittedRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 7, maxTimestampRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 8, requireEarliestLocalTimestampRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 9, requireTieredStorageTimestampRequestBuilder.oldestAllowedVersion());
+    }
 }

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -24,7 +24,6 @@ import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.server.config.ServerConfigs
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -91,34 +90,6 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     assertResponseError(Errors.NOT_LEADER_OR_FOLLOWER, nonReplica, consumerRequest)
     assertResponseError(Errors.NOT_LEADER_OR_FOLLOWER, nonReplica, replicaRequest)
     assertResponseError(Errors.NOT_LEADER_OR_FOLLOWER, nonReplica, debugReplicaRequest)
-  }
-
-  @Test
-  def testListOffsetsRequestOldestVersion(): Unit = {
-    val consumerRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
-
-    val requireTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
-
-    val requestCommittedRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_COMMITTED)
-
-    val maxTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, true, false, false)
-
-    val requireEarliestLocalTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, true, false)
-
-    val requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
-      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true)
-
-    assertEquals(0.toShort, consumerRequestBuilder.oldestAllowedVersion())
-    assertEquals(1.toShort, requireTimestampRequestBuilder.oldestAllowedVersion())
-    assertEquals(2.toShort, requestCommittedRequestBuilder.oldestAllowedVersion())
-    assertEquals(7.toShort, maxTimestampRequestBuilder.oldestAllowedVersion())
-    assertEquals(8.toShort, requireEarliestLocalTimestampRequestBuilder.oldestAllowedVersion())
-    assertEquals(9.toShort, requireTieredStorageTimestampRequestBuilder.oldestAllowedVersion())
   }
 
   def assertResponseErrorForEpoch(error: Errors, brokerId: Int, currentLeaderEpoch: Optional[Integer]): Unit = {

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.server.config.ServerConfigs
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -92,8 +93,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     assertResponseError(Errors.NOT_LEADER_OR_FOLLOWER, nonReplica, debugReplicaRequest)
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @Test
   def testListOffsetsRequestOldestVersion(): Unit = {
     val consumerRequestBuilder = ListOffsetsRequest.Builder
       .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)


### PR DESCRIPTION
The junit test `ListOffsetsRequestTest#testListOffsetsRequestOldestVersion` is defined by: 
```
@ParameterizedTest
@ValueSource(strings = Array("zk", "kraft"))
```
But the method just need the simple test, it do not need test the `zk` or `kraft` mode

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
