### PR TITLE
KAFKA-17479 Fix ignoreFailures logic in CI workflow [3/n]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
         # --continue:     Keep running even if a test fails
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         timeout-minutes: 180  # 3 hours
+        continue-on-error: true
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \
-          -PignoreFailures=true -PmaxParallelForks=2 \
+          -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
           test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           ./gradlew --build-cache --scan --continue \
           -PtestLoggingEvents=started,passed,skipped,failed \
-          -PmaxParallelForks=2 \
+          -PignoreFailures=true -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
           test

--- a/build.gradle
+++ b/build.gradle
@@ -471,10 +471,12 @@ subprojects {
 
   test {
     ext {
+      isGithubActions = System.getenv('GITHUB_ACTIONS') != null
       hadFailure = false  // Used to track if any tests failed, see afterSuite below
     }
+
     maxParallelForks = maxTestForks
-    ignoreFailures = true
+    ignoreFailures = userIgnoreFailures || ext.isGithubActions
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs
@@ -513,19 +515,19 @@ subprojects {
     // This closure will copy JUnit XML files out of the sub-project's build directory and into
     // a top-level build/junit-xml directory. This is necessary to avoid reporting on tests which
     // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.
-    //
-    // This closure will not run if a test fails and ignoreFailures is not true.
     doLast {
-      def dest = rootProject.layout.buildDirectory.dir("junit-xml/${project.name}").get().asFile
-      println "Copy JUnit XML for ${project.name} to $dest"
-      ant.copy(todir: "$dest") {
-        ant.fileset(dir: "${test.reports.junitXml.entryPoint}")
-      }
+      if (ext.isGithubActions) {
+        def dest = rootProject.layout.buildDirectory.dir("junit-xml/${project.name}").get().asFile
+        println "Copy JUnit XML for ${project.name} to $dest"
+        ant.copy(todir: "$dest") {
+          ant.fileset(dir: "${test.reports.junitXml.entryPoint}")
+        }
 
-      // If there were any test failures, we want to fail the task to prevent the failures
-      // from being cached.
-      if (ext.hadFailure && !userIgnoreFailures) {
-        throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
+        // If there were any test failures, we want to fail the task to prevent the failures
+        // from being cached.
+        if (ext.hadFailure) {
+          throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -470,8 +470,11 @@ subprojects {
   def testsToExclude = ['**/*Suite.class']
 
   test {
+    ext {
+      hadFailure = false  // Used to track if any tests failed, see afterSuite below
+    }
     maxParallelForks = maxTestForks
-    ignoreFailures = userIgnoreFailures
+    ignoreFailures = true
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs
@@ -497,6 +500,32 @@ subprojects {
       testRetry {
         maxRetries = userMaxTestRetries
         maxFailures = userMaxTestRetryFailures
+      }
+    }
+    
+    // As we process results, check if there were any test failures.
+    afterSuite { desc, result ->
+      if (result.resultType == TestResult.ResultType.FAILURE) {
+        ext.hadFailure = true
+      }
+    }
+
+    // This closure will copy JUnit XML files out of the sub-project's build directory and into
+    // a top-level build/junit-xml directory. This is necessary to avoid reporting on tests which
+    // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.
+    //
+    // This closure will not run if a test fails and ignoreFailures is not true.
+    doLast {
+      def dest = rootProject.layout.buildDirectory.dir("junit-xml/${project.name}").get().asFile
+      println "Copy JUnit XML for ${project.name} to $dest"
+      ant.copy(todir: "$dest") {
+        ant.fileset(dir: "${test.reports.junitXml.entryPoint}")
+      }
+
+      // If there were any test failures, we want to fail the task to prevent the failures
+      // from being cached.
+      if (ext.hadFailure) {
+        throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
       }
     }
   }
@@ -568,14 +597,6 @@ subprojects {
     cleanTest {
       delete t.reports.junitXml.outputLocation
       delete t.reports.html.outputLocation
-    }
-
-    doLast {
-      def dest = rootProject.layout.buildDirectory.dir("junit-xml/${project.name}").get().asFile
-      println "Copy JUnit XML for ${project.name} to $dest"
-      ant.copy(todir: "$dest") {
-        ant.fileset(dir: "${test.reports.junitXml.entryPoint}")
-      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext {
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
       Math.min(Runtime.runtime.availableProcessors(), 8)
-  userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false
+  userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures.toBoolean() : false
 
   userMaxTestRetries = project.hasProperty('maxTestRetries') ? maxTestRetries.toInteger() : 0
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
@@ -524,7 +524,7 @@ subprojects {
 
       // If there were any test failures, we want to fail the task to prevent the failures
       // from being cached.
-      if (ext.hadFailure) {
+      if (ext.hadFailure && !userIgnoreFailures) {
         throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
       }
     }


### PR DESCRIPTION
This property was removed in #17066 to prevent test failures from being cached. However, this breaks the JUnit report and makes the github workflow less user friendly. 

The problem is that we are copying the junit test report files into a new directory (added in #17098) in a Gradle `doLast` closure. If we don't run with `ignoreFailures=true`, then this closure will not run and the test failures won't be processed by junit.py. 

This patch adds logic to ensure the doLast closure of `:test` is always run. The user provided `-PignoreFailures` is still honored for the test tasks.