### PR TITLE
KAFKA-17470: CommitRequestManager should record failed request only once even if multiple errors in response

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -79,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -900,6 +901,37 @@ public class CommitRequestManagerTest {
         assertFutureThrows(commitResult, RetriableCommitFailedException.class);
     }
 
+    @ParameterizedTest
+    @MethodSource("offsetCommitExceptionSupplier")
+    public void testOffsetCommitOnFailAttemptsWhenPartitionError(final Errors error) {
+        CommitRequestManager commitRequestManager = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("t1", 1), new OffsetAndMetadata(1));
+        offsets.put(new TopicPartition("t1", 2), new OffsetAndMetadata(2));
+        offsets.put(new TopicPartition("t1", 3), new OffsetAndMetadata(3));
+
+        commitRequestManager.commitSync(offsets, time.milliseconds() + defaultApiTimeoutMs);
+        NetworkClientDelegate.PollResult res = commitRequestManager.poll(time.milliseconds());
+        assertEquals(1, res.unsentRequests.size());
+        List<OffsetCommitResponseData.OffsetCommitResponsePartition> partitions = new ArrayList<>();
+        partitions.add(new OffsetCommitResponseData.OffsetCommitResponsePartition().setErrorCode(error.code()).setPartitionIndex(1));
+        partitions.add(new OffsetCommitResponseData.OffsetCommitResponsePartition().setErrorCode(error.code()).setPartitionIndex(2));
+        partitions.add(new OffsetCommitResponseData.OffsetCommitResponsePartition().setErrorCode(error.code()).setPartitionIndex(3));
+
+        res.unsentRequests.get(0).handler().onComplete(mockOffsetCommitResponse("topic", partitions, (short) 1));
+        CommitRequestManager.OffsetCommitRequestState commitRequest = commitRequestManager.pendingRequests.unsentOffsetCommits.peek();
+        if (error.exception() instanceof RetriableException) {
+            assertNotNull(commitRequest);
+            assertEquals(1, commitRequest.numAttempts, "Request should only retry once no matter how many partition error");
+            time.sleep(retryBackoffMs);
+            res = commitRequestManager.poll(time.milliseconds());
+            res.unsentRequests.get(0).handler().onComplete(mockOffsetCommitResponse("topic", partitions, (short) 1));
+            assertEquals(2, commitRequest.numAttempts, "Request should only retry once no matter how many partition error");
+        } else assertNull(commitRequest);
+    }
+
     @Test
     public void testEnsureBackoffRetryOnOffsetCommitRequestTimeout() {
         CommitRequestManager commitRequestManager = create(true, 100);
@@ -1205,6 +1237,8 @@ public class CommitRequestManagerTest {
                                final Errors error
     ) {
         futures.forEach(f -> assertFalse(f.isDone()));
+        assertEquals(1, commitRequestManager.pendingRequests.unsentOffsetFetches.get(0).numAttempts,
+                "Request should only retry once no matter how many partition error");
 
         // The manager should backoff before retry
         time.sleep(retryBackoffMs);
@@ -1212,6 +1246,8 @@ public class CommitRequestManagerTest {
         assertEquals(1, poll.unsentRequests.size());
         futures.forEach(f -> assertFalse(f.isDone()));
         mimicResponse(error, poll);
+        assertEquals(2, commitRequestManager.pendingRequests.unsentOffsetFetches.get(0).numAttempts,
+                "Request should only retry once no matter how many partition error");
 
         // Sleep util timeout
         time.sleep(defaultApiTimeoutMs);
@@ -1294,8 +1330,10 @@ public class CommitRequestManagerTest {
         Set<TopicPartition> partitions = new HashSet<>();
         TopicPartition tp1 = new TopicPartition("t1", 2);
         TopicPartition tp2 = new TopicPartition("t2", 3);
+        TopicPartition tp3 = new TopicPartition("t3", 4);
         partitions.add(tp1);
         partitions.add(tp2);
+        partitions.add(tp3);
         long deadlineMs = time.milliseconds() + defaultApiTimeoutMs;
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future =
                 commitRequestManager.fetchOffsets(partitions, deadlineMs);
@@ -1307,6 +1345,7 @@ public class CommitRequestManagerTest {
         HashMap<TopicPartition, OffsetFetchResponse.PartitionData> topicPartitionData = new HashMap<>();
         topicPartitionData.put(tp1, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", error));
         topicPartitionData.put(tp2, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", Errors.NONE));
+        topicPartitionData.put(tp3, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", error));
 
         res.unsentRequests.get(0).handler().onComplete(buildOffsetFetchClientResponse(
                 res.unsentRequests.get(0),
@@ -1488,6 +1527,37 @@ public class CommitRequestManagerTest {
         when(response.data()).thenReturn(responseData);
         return new ClientResponse(
             new RequestHeader(ApiKeys.OFFSET_COMMIT, apiKeyVersion, "", 1),
+                null,
+                "-1",
+                createdTimeMs,
+                receivedTimeMs,
+                false,
+                null,
+                null,
+                new OffsetCommitResponse(responseData)
+        );
+    }
+
+    public ClientResponse mockOffsetCommitResponse(String topic,
+                                                   List<OffsetCommitResponseData.OffsetCommitResponsePartition> partitions,
+                                                   short apiKeyVersion) {
+        return mockOffsetCommitResponse(topic, partitions, apiKeyVersion, time.milliseconds(), time.milliseconds());
+    }
+
+    public ClientResponse mockOffsetCommitResponse(String topic,
+                                                   List<OffsetCommitResponseData.OffsetCommitResponsePartition> partitions,
+                                                   short apiKeyVersion,
+                                                   long createdTimeMs,
+                                                   long receivedTimeMs) {
+        OffsetCommitResponseData responseData = new OffsetCommitResponseData()
+                .setTopics(Collections.singletonList(
+                        new OffsetCommitResponseData.OffsetCommitResponseTopic()
+                                .setName(topic)
+                                .setPartitions(partitions)));
+        OffsetCommitResponse response = mock(OffsetCommitResponse.class);
+        when(response.data()).thenReturn(responseData);
+        return new ClientResponse(
+                new RequestHeader(ApiKeys.OFFSET_COMMIT, apiKeyVersion, "", 1),
                 null,
                 "-1",
                 createdTimeMs,


### PR DESCRIPTION
JIRA: [KAFKA-17470](https://issues.apache.org/jira/browse/KAFKA-17470)
> The commitRequestManager calls onFailedAttempt to register a failed request, and this call directly affects the count of attempts, considered to determine the backoff to apply. Therefore, this onFailedAttempts should only be called once per request, but currently the CommitRequestManager may call it multiple times for a single request (if the response contains multiple partition errors):
on commit: https://github.com/apache/kafka/blob/2f9b23625917fed841a176a73bbbc02bfa330a2d/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java#L726
on fetch: https://github.com/apache/kafka/blob/2f9b23625917fed841a176a73bbbc02bfa330a2d/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java#L1049 
We should ensure that onFailedAttempt is only called once per request, and add a test that covers both cases above, of responses with multiple partition errors in it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
