### PR TITLE
KAFKA-15859: Add timeout field to the ListOffsets request

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4185,7 +4185,7 @@ public class KafkaAdminClient extends AdminClient {
             ListOffsetsHandler.newFuture(topicPartitionOffsets.keySet());
         Map<TopicPartition, Long> offsetQueriesByPartition = topicPartitionOffsets.entrySet().stream()
             .collect(Collectors.toMap(Map.Entry::getKey, e -> getOffsetFromSpec(e.getValue())));
-        ListOffsetsHandler handler = new ListOffsetsHandler(offsetQueriesByPartition, options, logContext);
+        ListOffsetsHandler handler = new ListOffsetsHandler(offsetQueriesByPartition, options, logContext, defaultApiTimeoutMs);
         invokeDriver(handler, future, options.timeoutMs);
         return new ListOffsetsResult(future.all());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -66,7 +66,7 @@ public class OffsetFetcher {
     private final SubscriptionState subscriptions;
     private final ConsumerNetworkClient client;
     private final Time time;
-    private final long requestTimeoutMs;
+    private final int requestTimeoutMs;
     private final IsolationLevel isolationLevel;
     private final OffsetsForLeaderEpochClient offsetsForLeaderEpochClient;
     private final ApiVersions apiVersions;
@@ -78,7 +78,7 @@ public class OffsetFetcher {
                          SubscriptionState subscriptions,
                          Time time,
                          long retryBackoffMs,
-                         long requestTimeoutMs,
+                         int requestTimeoutMs,
                          IsolationLevel isolationLevel,
                          ApiVersions apiVersions) {
         this.log = logContext.logger(getClass());
@@ -392,7 +392,8 @@ public class OffsetFetcher {
                                                                   boolean requireTimestamp) {
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
                 .forConsumer(requireTimestamp, isolationLevel)
-                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch));
+                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch))
+                .setTimeoutMs(requestTimeoutMs);
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
         return client.send(node, builder)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -87,7 +87,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
 
     private final Set<ListOffsetsRequestState> requestsToRetry;
     private final List<NetworkClientDelegate.UnsentRequest> requestsToSend;
-    private final long requestTimeoutMs;
+    private final int requestTimeoutMs;
     private final Time time;
     private final ApiVersions apiVersions;
     private final NetworkClientDelegate networkClientDelegate;
@@ -115,7 +115,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                                  final IsolationLevel isolationLevel,
                                  final Time time,
                                  final long retryBackoffMs,
-                                 final long requestTimeoutMs,
+                                 final int requestTimeoutMs,
                                  final long defaultApiTimeoutMs,
                                  final ApiVersions apiVersions,
                                  final NetworkClientDelegate networkClientDelegate,
@@ -609,7 +609,8 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
             List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
                 .forConsumer(requireTimestamps, isolationLevel)
-                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(targetTimes));
+                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(targetTimes))
+                .setTimeoutMs(requestTimeoutMs);
 
         log.debug("Creating ListOffset request {} for broker {} to reset positions", builder,
                 node);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -101,6 +101,11 @@ public class ListOffsetsRequest extends AbstractRequest {
             return this;
         }
 
+        public Builder setTimeoutMs(int timeoutMs) {
+            data.setTimeoutMs(timeoutMs);
+            return this;
+        }
+
         @Override
         public ListOffsetsRequest build(short version) {
             return new ListOffsetsRequest(data, version);
@@ -179,6 +184,10 @@ public class ListOffsetsRequest extends AbstractRequest {
 
     public Set<TopicPartition> duplicatePartitions() {
         return duplicatePartitions;
+    }
+
+    public int timeoutMs() {
+        return data.timeoutMs();
     }
 
     public static ListOffsetsRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -36,7 +36,9 @@
   // Version 8 enables listing offsets by local log start offset (KIP-405).
   //
   // Version 9 enables listing offsets by last tiered offset (KIP-1005).
-  "validVersions": "0-9",
+  //
+  // Version 10 enables async remote list offsets support (KIP-1075)
+  "validVersions": "0-10",
   "deprecatedVersions": "0",
   "flexibleVersions": "6+",
   "latestVersionUnstable": false,
@@ -60,6 +62,8 @@
         { "name": "MaxNumOffsets", "type": "int32", "versions": "0", "default": "1",
           "about": "The maximum number of offsets to report." }
       ]}
-    ]}
+    ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "10+",
+      "about": "The timeout to await a response in milliseconds for remote requests." }
   ]
 }

--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -64,6 +64,6 @@
       ]}
     ]},
     { "name": "TimeoutMs", "type": "int32", "versions": "10+",
-      "about": "The timeout to await a response in milliseconds for remote requests." }
+      "about": "The timeout to await a response in milliseconds for requests that require reading from remote storage for topics enabled with tiered storage." }
   ]
 }

--- a/clients/src/main/resources/common/message/ListOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/ListOffsetsResponse.json
@@ -36,7 +36,9 @@
   // This is the earliest log start offset in the local log. (KIP-405).
   //
   // Version 9 enables listing offsets by last tiered offset (KIP-1005).
-  "validVersions": "0-9",
+  //
+  // Version 10 enables async remote list offsets support (KIP-1075)
+  "validVersions": "0-10",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "2+", "ignorable": true,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -182,7 +182,7 @@ public class FetchRequestManagerTest {
     private final int maxWaitMs = 0;
     private final int fetchSize = 1000;
     private final long retryBackoffMs = 100;
-    private final long requestTimeoutMs = 30000;
+    private final int requestTimeoutMs = 30000;
     private final ApiVersions apiVersions = new ApiVersions();
     private MockTime time = new MockTime(1);
     private SubscriptionState subscriptions;
@@ -3597,7 +3597,7 @@ public class FetchRequestManagerTest {
                 metadata,
                 time,
                 retryBackoffMs,
-                (int) requestTimeoutMs,
+                requestTimeoutMs,
                 Integer.MAX_VALUE);
         offsetFetcher = new OffsetFetcher(logContext,
                 consumerNetworkClient,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -181,7 +181,7 @@ public class FetcherTest {
     private final int maxBytes = Integer.MAX_VALUE;
     private final int maxWaitMs = 0;
     private final long retryBackoffMs = 100;
-    private final long requestTimeoutMs = 30000;
+    private final int requestTimeoutMs = 30000;
     private final ApiVersions apiVersions = new ApiVersions();
     private int fetchSize = 1000;
     private MockTime time = new MockTime(1);

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -64,6 +64,7 @@ public class ListOffsetsRequestTest {
                 .setReplicaId(-1);
         ListOffsetsRequest request = ListOffsetsRequest.parse(MessageUtil.toByteBuffer(data, (short) 0), (short) 0);
         assertEquals(Collections.singleton(new TopicPartition("topic", 0)), request.duplicatePartitions());
+        assertEquals(0, data.timeoutMs()); // default value
     }
 
     @Test

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1189,7 +1189,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     } else {
       replicaManager.fetchOffset(authorizedRequestInfo, offsetRequest.duplicatePartitions().asScala,
         offsetRequest.isolationLevel(), offsetRequest.replicaId(), clientId, correlationId, version,
-        buildErrorResponse, sendV1ResponseCallback)
+        buildErrorResponse, sendV1ResponseCallback, offsetRequest.timeoutMs())
     }
   }
 

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -45,7 +45,7 @@ public @interface ClusterTest {
     AutoStart autoStart() default AutoStart.DEFAULT;
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_0_IV2;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_0_IV3;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4123,7 +4123,8 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.anyInt(), // correlationId
       ArgumentMatchers.anyShort(), // version
       ArgumentMatchers.any[(Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse](),
-      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit]()
+      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit](),
+      ArgumentMatchers.anyInt() // timeoutMs
     )).thenAnswer(ans => {
       val callback = ans.getArgument[List[ListOffsetsTopicResponse] => Unit](8)
       val partitionResponse = new ListOffsetsPartitionResponse()
@@ -10137,7 +10138,8 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.anyInt(), // correlationId
       ArgumentMatchers.anyShort(), // version
       ArgumentMatchers.any[(Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse](),
-      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit]()
+      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit](),
+      ArgumentMatchers.anyInt() // timeoutMs
     )).thenAnswer(ans => {
       val version = ans.getArgument[Short](6)
       val callback = ans.getArgument[List[ListOffsetsTopicResponse] => Unit](8)
@@ -10188,7 +10190,8 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.anyInt(), // correlationId
       ArgumentMatchers.anyShort(), // version
       ArgumentMatchers.any[(Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse](),
-      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit]()
+      ArgumentMatchers.any[List[ListOffsetsTopicResponse] => Unit](),
+      ArgumentMatchers.anyInt() // timeoutMs
     )).thenAnswer(ans => {
       val callback = ans.getArgument[List[ListOffsetsTopicResponse] => Unit](8)
       val partitionResponse = new ListOffsetsPartitionResponse()

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -221,6 +221,7 @@ public enum MetadataVersion {
     IBP_4_0_IV1(23, "4.0", "IV1", true),
 
     // Bootstrap metadata version for transaction versions 1 and 2 (KIP-890)
+    // Enables async remote LIST_OFFSETS support (KIP-1075)
     IBP_4_0_IV2(24, "4.0", "IV2", false);
 
     // NOTES when adding a new version:
@@ -475,7 +476,9 @@ public enum MetadataVersion {
     }
 
     public short listOffsetRequestVersion() {
-        if (this.isAtLeast(IBP_3_9_IV0)) {
+        if (this.isAtLeast(IBP_4_0_IV2)) {
+            return 10;
+        } else if (this.isAtLeast(IBP_3_9_IV0)) {
             return 9;
         } else if (this.isAtLeast(IBP_3_5_IV0)) {
             return 8;

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -221,8 +221,10 @@ public enum MetadataVersion {
     IBP_4_0_IV1(23, "4.0", "IV1", true),
 
     // Bootstrap metadata version for transaction versions 1 and 2 (KIP-890)
+    IBP_4_0_IV2(24, "4.0", "IV2", false),
+
     // Enables async remote LIST_OFFSETS support (KIP-1075)
-    IBP_4_0_IV2(24, "4.0", "IV2", false);
+    IBP_4_0_IV3(25, "4.0", "IV3", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -476,7 +478,7 @@ public enum MetadataVersion {
     }
 
     public short listOffsetRequestVersion() {
-        if (this.isAtLeast(IBP_4_0_IV2)) {
+        if (this.isAtLeast(IBP_4_0_IV3)) {
             return 10;
         } else if (this.isAtLeast(IBP_3_9_IV0)) {
             return 9;

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -493,4 +493,15 @@ class MetadataVersionTest {
     public void assertLatestIsNotProduction() {
         assertFalse(MetadataVersion.latestTesting().isProduction());
     }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testListOffsetsValueVersion(MetadataVersion metadataVersion) {
+        final short expectedVersion = 10;
+        if (metadataVersion.isAtLeast(IBP_4_0_IV2)) {
+            assertEquals(expectedVersion, metadataVersion.listOffsetRequestVersion());
+        } else {
+            assertTrue(metadataVersion.listOffsetRequestVersion() < expectedVersion);
+        }
+    }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -196,6 +196,7 @@ class MetadataVersionTest {
         assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0"));
         assertEquals(IBP_4_0_IV1, MetadataVersion.fromVersionString("4.0-IV1"));
         assertEquals(IBP_4_0_IV2, MetadataVersion.fromVersionString("4.0-IV2"));
+        assertEquals(IBP_4_0_IV3, MetadataVersion.fromVersionString("4.0-IV3"));
     }
 
     @Test
@@ -260,6 +261,7 @@ class MetadataVersionTest {
         assertEquals("4.0", IBP_4_0_IV0.shortVersion());
         assertEquals("4.0", IBP_4_0_IV1.shortVersion());
         assertEquals("4.0", IBP_4_0_IV2.shortVersion());
+        assertEquals("4.0", IBP_4_0_IV3.shortVersion());
     }
 
     @Test
@@ -313,6 +315,7 @@ class MetadataVersionTest {
         assertEquals("4.0-IV0", IBP_4_0_IV0.version());
         assertEquals("4.0-IV1", IBP_4_0_IV1.version());
         assertEquals("4.0-IV2", IBP_4_0_IV2.version());
+        assertEquals("4.0-IV3", IBP_4_0_IV3.version());
     }
 
     @Test
@@ -498,7 +501,7 @@ class MetadataVersionTest {
     @EnumSource(value = MetadataVersion.class)
     public void testListOffsetsValueVersion(MetadataVersion metadataVersion) {
         final short expectedVersion = 10;
-        if (metadataVersion.isAtLeast(IBP_4_0_IV2)) {
+        if (metadataVersion.isAtLeast(IBP_4_0_IV3)) {
             assertEquals(expectedVersion, metadataVersion.listOffsetRequestVersion());
         } else {
             assertTrue(metadataVersion.listOffsetRequestVersion() < expectedVersion);


### PR DESCRIPTION
This is the part-3 of the [KIP-1075](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1075%3A+Introduce+delayed+remote+list+offsets+purgatory+to+make+LIST_OFFSETS+async)

Added a `timeoutMs` field to the ListOffsets request. This timeout is applicable only for the topic/partitions that are enabled with remote storage. 

When the timeout is defined in the request, then we use it to define the delay timeout for DelayedRemoteListOffsets request. When the timeout is not defined (requests from older client), then we take the dynamic `remote.list.offsets.request.timeout.ms` server config as the timeout.

Consumer and Admin client behavior are different. Consumer retries the LIST_OFFSETS request in-case of an error but not the AdminClient. And, consumer timeouts the request, if the response exceeds `request.timeout.ms`, whereas, AdminClient timeouts the request when it exceeds the `default.api.timeout.ms`. 

To retain the same behavior, we are passing the requestTimeoutMs as timeout from the consumer and defaultApiTimeout / overwritten ListOffsetsOption timeout from the admin.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
