### PR TITLE
KAFKA-17109: implement exponential backoff for state directory lock

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -713,7 +713,7 @@ public class StateDirectory implements AutoCloseable {
         private static final double JITTER = 0.5;
 
         private long attempts;
-        private ExponentialBackoff exponentialBackoff;
+        private final ExponentialBackoff exponentialBackoff;
 
         public BackoffRecord() {
             this.attempts = 0;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -100,9 +100,6 @@ public class StateDirectory implements AutoCloseable {
 
     private final HashMap<TaskId, BackoffRecord> lockedTasksToBackoffRecord = new HashMap<>();
 
-    private static final long INTERVALS_MS = 10;
-    private static final long MAX_ATTEMPTS = 50;
-
 
     private FileChannel stateDirLockChannel;
     private FileLock stateDirLock;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -100,9 +100,6 @@ public class StateDirectory implements AutoCloseable {
 
     private final HashMap<TaskId, BackoffRecord> lockedTasksToBackoffRecord = new HashMap<>();
 
-    private static final ExponentialBackoff exponentialBackoff = new ExponentialBackoff(1, 2, 1000, 0.5);
-
-
     private FileChannel stateDirLockChannel;
     private FileLock stateDirLock;
 
@@ -707,13 +704,15 @@ public class StateDirectory implements AutoCloseable {
     public static class BackoffRecord {
         private long attempts;
         private long lastAttemptMs;
+        private static final ExponentialBackoff EXPONENTIAL_BACKOFF = new ExponentialBackoff(1, 2, 1000, 0.5);
+
 
         public BackoffRecord() {
             this.attempts = 0;
         }
 
         public boolean canAttempt(final long nowMs) {
-            return  attempts == 0 || nowMs - lastAttemptMs >= exponentialBackoff.backoff(attempts);
+            return  attempts == 0 || nowMs - lastAttemptMs >= EXPONENTIAL_BACKOFF.backoff(attempts);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -93,7 +93,9 @@ final class StateManagerUtil {
         }
 
         final TaskId id = stateMgr.taskId();
-        if (!stateDirectory.lock(id)) {
+        if (!stateDirectory.canTryLock(id, System.currentTimeMillis())) {
+            log.debug("Task {} is still not allowed to retry acquiring the state directory lock", id);
+        } else if (!stateDirectory.lock(id)) {
             throw new LockException(String.format("%sFailed to lock the state directory for task %s", logPrefix, id));
         }
         log.debug("Acquired state directory lock");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -94,22 +94,23 @@ final class StateManagerUtil {
 
         final TaskId id = stateMgr.taskId();
         if (!stateDirectory.canTryLock(id, System.currentTimeMillis())) {
-            log.debug("Task {} is still not allowed to retry acquiring the state directory lock", id);
+            log.trace("Task {} is still not allowed to retry acquiring the state directory lock", id);
         } else if (!stateDirectory.lock(id)) {
             throw new LockException(String.format("%sFailed to lock the state directory for task %s", logPrefix, id));
+        } else {
+            log.debug("Acquired state directory lock");
+
+            final boolean storeDirsEmpty = stateDirectory.directoryForTaskIsEmpty(id);
+
+            stateMgr.registerStateStores(topology.stateStores(), processorContext);
+            log.debug("Registered state stores");
+
+            // We should only load checkpoint AFTER the corresponding state directory lock has been acquired and
+            // the state stores have been registered; we should not try to load at the state manager construction time.
+            // See https://issues.apache.org/jira/browse/KAFKA-8574
+            stateMgr.initializeStoreOffsetsFromCheckpoint(storeDirsEmpty);
+            log.debug("Initialized state stores");
         }
-        log.debug("Acquired state directory lock");
-
-        final boolean storeDirsEmpty = stateDirectory.directoryForTaskIsEmpty(id);
-
-        stateMgr.registerStateStores(topology.stateStores(), processorContext);
-        log.debug("Registered state stores");
-
-        // We should only load checkpoint AFTER the corresponding state directory lock has been acquired and
-        // the state stores have been registered; we should not try to load at the state manager construction time.
-        // See https://issues.apache.org/jira/browse/KAFKA-8574
-        stateMgr.initializeStoreOffsetsFromCheckpoint(storeDirsEmpty);
-        log.debug("Initialized state stores");
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -81,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -180,6 +181,7 @@ public class StandbyTaskTest {
     @Test
     public void shouldThrowLockExceptionIfFailedToLockStateDirectory() throws IOException {
         stateDirectory = mock(StateDirectory.class);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(true);
         when(stateDirectory.lock(taskId)).thenReturn(false);
         when(stateManager.taskType()).thenReturn(TaskType.STANDBY);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -450,11 +450,14 @@ public class StateDirectoryTest {
         final Thread thread = new Thread(() -> directory.lock(taskId));
         thread.start();
         thread.join(30000);
+
+        assertTrue(directory.canTryLock(taskId, System.currentTimeMillis()));
+
         assertFalse(directory.lock(taskId));
         assertFalse(directory.lock(taskId));
         assertFalse(directory.lock(taskId));
         // after 3 unsuccessful retries, backoff time is > 0
-        assertTrue(directory.canTryLock(taskId, System.currentTimeMillis()));
+        assertFalse(directory.canTryLock(taskId, System.currentTimeMillis()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -77,6 +77,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -442,6 +443,18 @@ public class StateDirectoryTest {
         thread.start();
         thread.join(30000);
         assertFalse(directory.lock(taskId));
+    }
+
+    @Test
+    public void shouldSleepIfStateDirLockedByAnotherThread() throws Exception {
+        final TaskId taskId = new TaskId(0, 0);
+        assertEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
+        final Thread thread = new Thread(() -> directory.lock(taskId));
+        thread.start();
+        thread.join(30000);
+        assertEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
+        assertFalse(directory.lock(taskId));
+        assertNotEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -446,18 +446,6 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldSleepIfStateDirLockedByAnotherThread() throws Exception {
-        final TaskId taskId = new TaskId(0, 0);
-        assertEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
-        final Thread thread = new Thread(() -> directory.lock(taskId));
-        thread.start();
-        thread.join(30000);
-        assertEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
-        assertFalse(directory.lock(taskId));
-        assertNotEquals(directory.updateOrCreateBackoffRecord(taskId), 0);
-    }
-
-    @Test
     public void shouldNotUnLockStateDirLockedByAnotherThread() throws Exception {
         final TaskId taskId = new TaskId(0, 0);
         final CountDownLatch lockLatch = new CountDownLatch(1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -103,7 +103,6 @@ public class StateManagerUtilTest {
         when(topology.stateStores()).thenReturn(singletonList(new MockKeyValueStore("store", false)));
         when(stateManager.taskId()).thenReturn(taskId);
         when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(false);
-        when(stateDirectory.lock(taskId)).thenReturn(false);
 
         assertDoesNotThrow(() -> StateManagerUtil.registerStateStores(logger, "logPrefix:",
                         topology, stateManager, stateDirectory, processorContext));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -43,8 +43,11 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mockStatic;
@@ -85,6 +88,7 @@ public class StateManagerUtilTest {
     public void testRegisterStateStoreFailToLockStateDirectory() {
         when(topology.stateStores()).thenReturn(singletonList(new MockKeyValueStore("store", false)));
         when(stateManager.taskId()).thenReturn(taskId);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(true);
         when(stateDirectory.lock(taskId)).thenReturn(false);
 
         final LockException thrown = assertThrows(LockException.class,
@@ -95,6 +99,18 @@ public class StateManagerUtilTest {
     }
 
     @Test
+    public void testRegisterStateStoreWhenTryLockIsNotAllowed() {
+        when(topology.stateStores()).thenReturn(singletonList(new MockKeyValueStore("store", false)));
+        when(stateManager.taskId()).thenReturn(taskId);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(false);
+        when(stateDirectory.lock(taskId)).thenReturn(false);
+
+        assertDoesNotThrow(() -> StateManagerUtil.registerStateStores(logger, "logPrefix:",
+                        topology, stateManager, stateDirectory, processorContext));
+
+    }
+
+    @Test
     public void testRegisterStateStores() {
         final MockKeyValueStore store1 = new MockKeyValueStore("store1", false);
         final MockKeyValueStore store2 = new MockKeyValueStore("store2", false);
@@ -102,6 +118,7 @@ public class StateManagerUtilTest {
         final InOrder inOrder = inOrder(stateManager);
         when(topology.stateStores()).thenReturn(stateStores);
         when(stateManager.taskId()).thenReturn(taskId);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(true);
         when(stateDirectory.lock(taskId)).thenReturn(true);
         when(stateDirectory.directoryForTaskIsEmpty(taskId)).thenReturn(true);
         when(topology.stateStores()).thenReturn(stateStores);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -316,7 +316,7 @@ public class StreamTaskTest {
         // Clean up state directory created as part of setup
         stateDirectory.close();
         stateDirectory = mock(StateDirectory.class);
-        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(false);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(true);
         when(stateDirectory.lock(taskId)).thenReturn(false);
 
         task = createStatefulTask(createConfig("100"), false);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -134,6 +134,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -315,6 +316,7 @@ public class StreamTaskTest {
         // Clean up state directory created as part of setup
         stateDirectory.close();
         stateDirectory = mock(StateDirectory.class);
+        when(stateDirectory.canTryLock(any(), anyLong())).thenReturn(false);
         when(stateDirectory.lock(taskId)).thenReturn(false);
 
         task = createStatefulTask(createConfig("100"), false);


### PR DESCRIPTION
This PR implements exponential backoff for state directory lock to increase the time between two consecutive attempts of acquiring the lock.

P.S.: This [PR](https://github.com/apache/kafka/pull/17209) solve the issue in a proper way.
