### PR TITLE
KAFKA-13588: We should consolidate `changelogFor` methods to simplify the generation of internal topic names

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
@@ -48,17 +48,6 @@ public final class ProcessorContextUtils {
         return (StreamsMetricsImpl) context.metrics();
     }
 
-    public static String changelogFor(final ProcessorContext context, final String storeName, final Boolean newChangelogTopic) {
-        final String prefix = topicNamePrefix(context.appConfigs(), context.applicationId());
-        if (context instanceof InternalProcessorContext && !newChangelogTopic) {
-            final String changelogTopic = ((InternalProcessorContext) context).changelogFor(storeName);
-            if (changelogTopic != null)
-                return changelogTopic;
-
-        }
-        return ProcessorStateManager.storeChangelogTopic(prefix, storeName, context.taskId().topologyName());
-    }
-
     public static String changelogFor(final StateStoreContext context, final String storeName, final Boolean newChangelogTopic) {
         final String prefix = topicNamePrefix(context.appConfigs(), context.applicationId());
         if (context instanceof InternalProcessorContext && !newChangelogTopic) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
-import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
@@ -161,15 +160,6 @@ public class MeteredKeyValueStore<K, V>
 
     protected Serde<V> prepareValueSerdeForStore(final Serde<V> valueSerde, final SerdeGetter getter) {
         return WrappingNullableUtils.prepareValueSerde(valueSerde, getter);
-    }
-
-
-    @Deprecated
-    protected void initStoreSerde(final ProcessorContext context) {
-        final String storeName = name();
-        final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(
-            context, storeName, changelogTopic, keySerde, valueSerde, this::prepareValueSerdeForStore);
     }
 
     protected void initStoreSerde(final StateStoreContext context) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
-import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
@@ -292,18 +291,6 @@ public class MeteredVersionedKeyValueStore<K, V>
             } else {
                 return super.prepareValueSerdeForStore(valueSerde, getter);
             }
-        }
-
-        @Deprecated
-        @Override
-        protected void initStoreSerde(final ProcessorContext context) {
-            super.initStoreSerde(context);
-
-            // additionally init raw value serde
-            final String storeName = super.name();
-            final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(
-                context, storeName, changelogTopic, keySerde, plainValueSerde, WrappingNullableUtils::prepareValueSerde);
         }
 
         @Override


### PR DESCRIPTION
As title, see detail:  https://github.com/apache/kafka/pull/11611#discussion_r772625486

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
