### PR TITLE
KAFKA-17497: Add e2e for zk migration with old controller

### DIFF
--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -93,8 +93,8 @@ class TestMigration(ProduceConsumeValidateTest):
 
         server_prop_overrides = [["zookeeper.metadata.migration.enable", "false"]]
 
-        if str(from_kafka_version) != str(DEV_BRANCH):
-            server_prop_overrides.append([config_property.INTER_BROKER_PROTOCOL_VERSION, "3.7"])
+        if from_kafka_version != str(DEV_BRANCH):
+            server_prop_overrides.append([config_property.INTER_BROKER_PROTOCOL_VERSION, str(from_kafka_version)])
 
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -17,7 +17,7 @@ from functools import partial
 import time
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 from ducktape.mark.resource import cluster
 from ducktape.errors import TimeoutError
 
@@ -29,7 +29,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import DEV_BRANCH, LATEST_3_4
+from kafkatest.version import DEV_BRANCH, LATEST_3_4, LATEST_3_7, KafkaVersion
 
 
 class TestMigration(ProduceConsumeValidateTest):
@@ -51,10 +51,10 @@ class TestMigration(ProduceConsumeValidateTest):
             wait_until(lambda: len(self.kafka.isr_idx_list(self.topic, partition)) == self.replication_factor, timeout_sec=60,
                        backoff_sec=1, err_msg="Replicas did not rejoin the ISR in a reasonable amount of time")
 
-    def do_migration(self, roll_controller = False, downgrade_to_zk = False):
+    def do_migration(self, roll_controller=False, downgrade_to_zk=False, from_kafka_version=str(DEV_BRANCH)):
         # Start up KRaft controller in migration mode
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
-        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=DEV_BRANCH,
+        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=KafkaVersion(from_kafka_version),
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
@@ -86,9 +86,8 @@ class TestMigration(ProduceConsumeValidateTest):
                 controller.start_node(node)
 
     @cluster(num_nodes=7)
-    @parametrize(roll_controller = True)
-    @parametrize(roll_controller = False)
-    def test_online_migration(self, roll_controller):
+    @matrix(roll_controller=[True, False], from_kafka_version=[str(DEV_BRANCH), str(LATEST_3_7)])
+    def test_online_migration(self, roll_controller, from_kafka_version):
         zk_quorum = partial(ServiceQuorumInfo, zk)
         self.zk = ZookeeperService(self.test_context, num_nodes=1, version=DEV_BRANCH)
         self.kafka = KafkaService(self.test_context,
@@ -128,7 +127,7 @@ class TestMigration(ProduceConsumeValidateTest):
                                         self.topic, consumer_timeout_ms=30000,
                                         message_validator=is_int, version=DEV_BRANCH)
 
-        self.run_produce_consume_validate(core_test_action=partial(self.do_migration, roll_controller = roll_controller))
+        self.run_produce_consume_validate(core_test_action=partial(self.do_migration, roll_controller=roll_controller, from_kafka_version=from_kafka_version))
         self.kafka.stop()
 
     @cluster(num_nodes=7)

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -94,7 +94,7 @@ class TestMigration(ProduceConsumeValidateTest):
         server_prop_overrides = [["zookeeper.metadata.migration.enable", "false"]]
 
         if from_kafka_version != str(DEV_BRANCH):
-            server_prop_overrides.append([config_property.INTER_BROKER_PROTOCOL_VERSION, str(from_kafka_version)])
+            server_prop_overrides.append([config_property.INTER_BROKER_PROTOCOL_VERSION, from_kafka_version])
 
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -93,7 +93,7 @@ class TestMigration(ProduceConsumeValidateTest):
 
         server_prop_overrides = [["zookeeper.metadata.migration.enable", "false"]]
 
-        if from_kafka_version != str(DEV_BRANCH):
+        if str(from_kafka_version) != str(DEV_BRANCH):
             server_prop_overrides.append([config_property.INTER_BROKER_PROTOCOL_VERSION, "3.7"])
 
         self.kafka = KafkaService(self.test_context,


### PR DESCRIPTION
JIRA: [KAFKA-17497
](https://issues.apache.org/jira/browse/KAFKA-17497)
> This is follow-up of [KAFKA-17011](https://issues.apache.org/jira/browse/KAFKA-17011) that zk migration will encounter min=0 issue when the cluster consists of "new" broker and "old" controller.
The e2e `zookeeper_migration_test` [0] is a good test for online migration, but it does not test hybrid version. Hence, we can leverage it to increase test coverage.
[0] https://github.com/apache/kafka/blob/trunk/tests/kafkatest/tests/core/zookeeper_migration_test.py#L91

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
