### PR TITLE
KAFKA-17498: Reduce the number of remote calls when serving LIST_OFFSETS request

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -650,7 +650,7 @@ public class RemoteLogManager implements Closeable {
 
     /**
      * Search the message offset in the remote storage for the given timestamp and starting-offset.
-     * Once the target segment is found:
+     * Once the target segment where the search to be performed is found:
      * 1. If the target segment lies in the local storage (common segments that lies in both remote and local storage),
      *    then the search will be performed in the local storage.
      * 2. If the target segment is found only in the remote storage, then the search will be performed in the remote storage.

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -597,7 +597,7 @@ public class RemoteLogManager implements Closeable {
         return remoteLogMetadataManager.remoteLogSegmentMetadata(new TopicIdPartition(topicId, topicPartition), epochForOffset, offset);
     }
 
-    private Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset)
+    Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset)
             throws RemoteStorageException, IOException {
         int startPos = indexCache.lookupTimestamp(rlsMetadata, timestamp, startingOffset);
 
@@ -674,12 +674,10 @@ public class RemoteLogManager implements Closeable {
         if (topicId == null) {
             throw new KafkaException("Topic id does not exist for topic partition: " + tp);
         }
-
         Optional<UnifiedLog> unifiedLogOptional = fetchLog.apply(tp);
         if (!unifiedLogOptional.isPresent()) {
             throw new KafkaException("UnifiedLog does not exist for topic partition: " + tp);
         }
-
         UnifiedLog unifiedLog = unifiedLogOptional.get();
 
         // Get the respective epoch in which the starting-offset exists.
@@ -688,7 +686,6 @@ public class RemoteLogManager implements Closeable {
         NavigableMap<Integer, Long> epochWithOffsets = buildFilteredLeaderEpochMap(leaderEpochCache.epochWithOffsets());
         while (maybeEpoch.isPresent()) {
             int epoch = maybeEpoch.getAsInt();
-
             // KAFKA-15802: Add a new API for RLMM to choose how to implement the predicate.
             // currently, all segments are returned and then iterated, and filtered
             Iterator<RemoteLogSegmentMetadata> iterator = remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition, epoch);
@@ -698,14 +695,24 @@ public class RemoteLogManager implements Closeable {
                     && rlsMetadata.endOffset() >= startingOffset
                     && isRemoteSegmentWithinLeaderEpochs(rlsMetadata, unifiedLog.logEndOffset(), epochWithOffsets)
                     && rlsMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
-                    return lookupTimestamp(rlsMetadata, timestamp, startingOffset);
+                    // cache to avoid race conditions
+                    List<LogSegment> segmentsCopy = new ArrayList<>(unifiedLog.logSegments());
+                    if (segmentsCopy.isEmpty() || rlsMetadata.startOffset() < segmentsCopy.get(0).baseOffset()) {
+                        // search in remote-log
+                        return lookupTimestamp(rlsMetadata, timestamp, startingOffset);
+                    } else {
+                        // search in local-log
+                        for (LogSegment segment : segmentsCopy) {
+                            if (segment.largestTimestamp() >= timestamp) {
+                                return segment.findOffsetByTimestamp(timestamp, startingOffset);
+                            }
+                        }
+                    }
                 }
             }
-
             // Move to the next epoch if not found with the current epoch.
             maybeEpoch = leaderEpochCache.nextEpoch(epoch);
         }
-
         return Optional.empty();
     }
 

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -649,8 +649,13 @@ public class RemoteLogManager implements Closeable {
     }
 
     /**
-     * Search the message offset in the remote storage based on timestamp and offset.
-     * <p>
+     * Search the message offset in the remote storage for the given timestamp and starting-offset.
+     * Once the target segment is found:
+     * 1. If the target segment lies in the local storage (common segments that lies in both remote and local storage),
+     *    then the search will be performed in the local storage.
+     * 2. If the target segment is found only in the remote storage, then the search will be performed in the remote storage.
+     *
+     *  <p>
      * This method returns an option of TimestampOffset. The returned value is determined using the following ordered list of rules:
      * <p>
      * - If there are no messages in the remote storage, return Empty


### PR DESCRIPTION
If the index to be fetched exists locally, then avoid fetching the remote indexes to serve the LIST_OFFSETS request.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
