### PR TITLE
KAFKA-17231: Add missing node latency metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -629,8 +629,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 if (!closeFuture.isDone()) {
                     closeFuture.complete(null);
                 }
-
-                metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
             } else {
                 if (!acknowledgeRequestState.sessionHandler.handleResponse(response, resp.requestHeader().apiVersion())) {
                     // Received a response-level error code.
@@ -646,7 +644,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                     metadata.topicNames().get(shareAcknowledgeTopicResponse.topicId()));
 
                             acknowledgeRequestState.handleAcknowledgeErrorCode(tip, response.error());
-                            metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
                         }));
                         acknowledgeRequestState.processingComplete();
                     }
@@ -678,9 +675,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                         acknowledgeRequestState.onSuccessfulAttempt(responseCompletionTimeMs);
                     }
                     acknowledgeRequestState.processingComplete();
-                    metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
                 }
             }
+
+            metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
         } finally {
             log.debug("Removing pending request for node {} - success", fetchTarget.id());
             nodesWithPendingRequests.remove(fetchTarget.id());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -566,7 +566,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 }
             }
 
-            metricsManager.recordLatency(resp.requestLatencyMs());
+            metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
         } finally {
             log.debug("Removing pending request for node {} - success", fetchTarget.id());
             nodesWithPendingRequests.remove(fetchTarget.id());
@@ -630,7 +630,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     closeFuture.complete(null);
                 }
 
-                metricsManager.recordLatency(resp.requestLatencyMs());
+                metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
             } else {
                 if (!acknowledgeRequestState.sessionHandler.handleResponse(response, resp.requestHeader().apiVersion())) {
                     // Received a response-level error code.
@@ -646,7 +646,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                     metadata.topicNames().get(shareAcknowledgeTopicResponse.topicId()));
 
                             acknowledgeRequestState.handleAcknowledgeErrorCode(tip, response.error());
-                            metricsManager.recordLatency(resp.requestLatencyMs());
+                            metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
                         }));
                         acknowledgeRequestState.processingComplete();
                     }
@@ -678,7 +678,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                         acknowledgeRequestState.onSuccessfulAttempt(responseCompletionTimeMs);
                     }
                     acknowledgeRequestState.processingComplete();
-                    metricsManager.recordLatency(resp.requestLatencyMs());
+                    metricsManager.recordLatency(resp.destination(), resp.requestLatencyMs());
                 }
             }
         } finally {


### PR DESCRIPTION
This is the equivalent of https://github.com/apache/kafka/pull/16755 for the share group consumer.

The node request-latency-max and request-latency-avg were not being recorded and thus reported as NaN for the share group consumer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
