### PR TITLE
KAFKA-17392: Remove whitelist option in ConsoleConsumerOptions

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -42,6 +42,10 @@
             <li>
                 The <code>kafka.tools.NoOpMessageFormatter</code> class has been removed. Please use the <code>org.apache.kafka.tools.consumer.NoOpMessageFormatter</code> class instead.
             </li>
+            <li>
+                The <code>--whitelist</code> option was removed from the <code>kafka-console-consumer</code> command line tool.
+                Please use <code>--include</code> instead.
+            </li>
         </ul>
     </ul>
 

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -264,6 +264,7 @@ public class ReplicaVerificationTool {
         private final OptionSpec<String> brokerListOpt;
         private final OptionSpec<Integer> fetchSizeOpt;
         private final OptionSpec<Integer> maxWaitMsOpt;
+        private final OptionSpec<String> topicWhiteListOpt;
         private final OptionSpec<String> topicsIncludeOpt;
         private final OptionSpec<Long> initialOffsetTimeOpt;
         private final OptionSpec<Long> reportIntervalOpt;
@@ -284,6 +285,12 @@ public class ReplicaVerificationTool {
                 .describedAs("ms")
                 .ofType(Integer.class)
                 .defaultsTo(1_000);
+            topicWhiteListOpt = parser.accepts("topic-white-list", "DEPRECATED use --topics-include instead; " +
+                    "ignored if --topics-include specified. List of topics to verify replica consistency.")
+                .withRequiredArg()
+                .describedAs("Java regex (String)")
+                .ofType(String.class)
+                .defaultsTo(".*");
             topicsIncludeOpt = parser.accepts("topics-include", "List of topics to verify replica consistency.")
                 .withRequiredArg()
                 .describedAs("Java regex (String)")
@@ -307,6 +314,7 @@ public class ReplicaVerificationTool {
                 CommandLineUtils.printVersionAndExit();
             }
             CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt);
+            CommandLineUtils.checkInvalidArgs(parser, options, topicsIncludeOpt, topicWhiteListOpt);
 
         }
 
@@ -323,7 +331,7 @@ public class ReplicaVerificationTool {
         }
 
         TopicFilter.IncludeList topicsIncludeFilter() {
-            String regex = options.valueOf(topicsIncludeOpt);
+            String regex = options.valueOf(options.has(topicsIncludeOpt) ? topicsIncludeOpt : topicWhiteListOpt);
             try {
                 Pattern.compile(regex);
             } catch (PatternSyntaxException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -264,7 +264,6 @@ public class ReplicaVerificationTool {
         private final OptionSpec<String> brokerListOpt;
         private final OptionSpec<Integer> fetchSizeOpt;
         private final OptionSpec<Integer> maxWaitMsOpt;
-        private final OptionSpec<String> topicWhiteListOpt;
         private final OptionSpec<String> topicsIncludeOpt;
         private final OptionSpec<Long> initialOffsetTimeOpt;
         private final OptionSpec<Long> reportIntervalOpt;
@@ -285,12 +284,6 @@ public class ReplicaVerificationTool {
                 .describedAs("ms")
                 .ofType(Integer.class)
                 .defaultsTo(1_000);
-            topicWhiteListOpt = parser.accepts("topic-white-list", "DEPRECATED use --topics-include instead; " +
-                    "ignored if --topics-include specified. List of topics to verify replica consistency.")
-                .withRequiredArg()
-                .describedAs("Java regex (String)")
-                .ofType(String.class)
-                .defaultsTo(".*");
             topicsIncludeOpt = parser.accepts("topics-include", "List of topics to verify replica consistency.")
                 .withRequiredArg()
                 .describedAs("Java regex (String)")
@@ -314,7 +307,6 @@ public class ReplicaVerificationTool {
                 CommandLineUtils.printVersionAndExit();
             }
             CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt);
-            CommandLineUtils.checkInvalidArgs(parser, options, topicsIncludeOpt, topicWhiteListOpt);
 
         }
 
@@ -331,7 +323,7 @@ public class ReplicaVerificationTool {
         }
 
         TopicFilter.IncludeList topicsIncludeFilter() {
-            String regex = options.valueOf(options.has(topicsIncludeOpt) ? topicsIncludeOpt : topicWhiteListOpt);
+            String regex = options.valueOf(topicsIncludeOpt);
             try {
                 Pattern.compile(regex);
             } catch (PatternSyntaxException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -47,7 +47,6 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
     private static final Random RANDOM = new Random();
 
     private final OptionSpec<String> topicOpt;
-    private final OptionSpec<String> whitelistOpt;
     private final OptionSpec<String> includeOpt;
     private final OptionSpec<Integer> partitionIdOpt;
     private final OptionSpec<String> offsetOpt;
@@ -75,11 +74,6 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
         topicOpt = parser.accepts("topic", "The topic to consume on.")
                 .withRequiredArg()
                 .describedAs("topic")
-                .ofType(String.class);
-        whitelistOpt = parser.accepts("whitelist",
-                        "DEPRECATED, use --include instead; ignored if --include specified. Regular expression specifying list of topics to include for consumption.")
-                .withRequiredArg()
-                .describedAs("Java regex (String)")
                 .ofType(String.class);
         includeOpt = parser.accepts("include",
                         "Regular expression specifying list of topics to include for consumption.")
@@ -194,10 +188,9 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
     private void checkRequiredArgs() {
         List<Optional<String>> topicOrFilterArgs = new ArrayList<>(Arrays.asList(topicArg(), includedTopicsArg()));
         topicOrFilterArgs.removeIf(arg -> !arg.isPresent());
-        // user need to specify value for either --topic or one of the include filters options (--include or --whitelist)
+        // user need to specify value for either --topic or --include options)
         if (topicOrFilterArgs.size() != 1) {
-            CommandLineUtils.printUsageAndExit(parser, "Exactly one of --include/--topic is required. " +
-                    (options.has(whitelistOpt) ? "--whitelist is DEPRECATED use --include instead; ignored if --include specified." : ""));
+            CommandLineUtils.printUsageAndExit(parser, "Exactly one of --include/--topic is required. ");
         }
 
         if (partitionArg().isPresent()) {
@@ -416,7 +409,7 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
     Optional<String> includedTopicsArg() {
         return options.has(includeOpt)
                 ? Optional.of(options.valueOf(includeOpt))
-                : Optional.ofNullable(options.valueOf(whitelistOpt));
+                : Optional.empty();
     }
 
     Properties formatterArgs() throws IOException {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -74,35 +74,6 @@ public class ConsoleConsumerOptionsTest {
     }
 
     @Test
-    public void shouldParseWhitelistArgument() throws IOException {
-        String[] args = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--whitelist", "whitelistTest*",
-            "--from-beginning"
-        };
-
-        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
-
-        assertEquals("localhost:9092", config.bootstrapServer());
-        assertEquals("whitelistTest*", config.includedTopicsArg().orElse(""));
-        assertTrue(config.fromBeginning());
-    }
-
-    @Test
-    public void shouldIgnoreWhitelistArgumentIfIncludeSpecified() throws IOException {
-        String[] args = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--include", "includeTest*",
-            "--whitelist", "whitelistTest*",
-            "--from-beginning"
-        };
-        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
-        assertEquals("localhost:9092", config.bootstrapServer());
-        assertEquals("includeTest*", config.includedTopicsArg().orElse(""));
-        assertTrue(config.fromBeginning());
-    }
-
-    @Test
     public void shouldParseValidSimpleConsumerValidConfigWithNumericOffset() throws IOException {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
@@ -528,25 +499,6 @@ public class ConsoleConsumerOptionsTest {
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
             "--include", "includeTest*"
-        };
-
-        try {
-            assertThrows(IllegalArgumentException.class, () -> new ConsoleConsumerOptions(args));
-        } finally {
-            Exit.resetExitProcedure();
-        }
-    }
-
-    @Test
-    public void shouldExitIfTopicAndWhitelistSpecified() {
-        Exit.setExitProcedure((code, message) -> {
-            throw new IllegalArgumentException(message);
-        });
-
-        String[] args = new String[]{
-            "--bootstrap-server", "localhost:9092",
-            "--topic", "test",
-            "--whitelist", "whitelistTest*"
         };
 
         try {


### PR DESCRIPTION
As title. Additionally, I found some code related to `whitelist` in `ReplicaVerificationTool`. However, since the tool will be removed in 5.0 [1], I won't make any changes to the tool.

[1] [[KAFKA-17074] Remove ReplicaVerificationTool](https://issues.apache.org/jira/browse/KAFKA-17074)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
