### PR TITLE
KAFKA-17503: Fix incorrect calculation of poll-idle-ratio-avg for con…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -132,6 +132,7 @@ import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.THROW_ON
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createLogContext;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetricConfigWithoutTags;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
 import static org.apache.kafka.clients.consumer.internals.events.CompletableEvent.calculateDeadlineMs;
@@ -467,7 +468,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         this.isolationLevel = IsolationLevel.READ_UNCOMMITTED;
         this.interceptors = new ConsumerInterceptors<>(Collections.emptyList());
         this.time = time;
-        this.metrics = new Metrics(time);
+        this.metrics = new Metrics(createMetricConfigWithoutTags(config), time);
         this.metadata = metadata;
         this.metadataVersionSnapshot = metadata.updateVersion();
         this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
@@ -92,6 +92,7 @@ import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configur
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createConsumerNetworkClient;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createLogContext;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetricConfigWithoutTags;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
@@ -286,7 +287,7 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         this.time = time;
         this.subscriptions = subscriptions;
         this.metadata = metadata;
-        this.metrics = new Metrics(time);
+        this.metrics = new Metrics(createMetricConfigWithoutTags(config), time);
         this.clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
         this.groupId = Optional.ofNullable(config.getString(ConsumerConfig.GROUP_ID_CONFIG));
         this.deserializers = new Deserializers<>(keyDeserializer, valueDeserializer);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -143,14 +143,18 @@ public final class ConsumerUtils {
     public static Metrics createMetrics(ConsumerConfig config, Time time, List<MetricsReporter> reporters) {
         String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
         Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
-        MetricConfig metricConfig = new MetricConfig()
-                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
-                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
-                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+        MetricConfig metricConfig = createMetricConfigWithoutTags(config)
                 .tags(metricsTags);
         MetricsContext metricsContext = new KafkaMetricsContext(CONSUMER_JMX_PREFIX,
                 config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
         return new Metrics(metricConfig, reporters, time, metricsContext);
+    }
+
+    public static MetricConfig createMetricConfigWithoutTags(ConsumerConfig config) {
+        return new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)));
     }
 
     public static FetchMetricsManager createFetchMetricsManager(Metrics metrics) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/TimeRatio2.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/TimeRatio2.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.metrics;
+
+import org.apache.kafka.common.metrics.Sensor;
+
+/**
+ * Maintains a ratio of the duration of a periodic event
+ * over a rolling fixed-size window, emitting the measured ratio to the specified sensor for each window.
+ * For example, this can be used to compute the ratio of
+ * time that a thread is busy or idle.
+ */
+public class TimeRatio2 {
+
+    private final long windowSizeMs;
+    private final Sensor sensor;
+    private long lastWindowEndMs;
+    private long msSpentInEventInCurrentWindow;
+    private long msSpentOutsideEventInCurrentWindow;
+    private long lastEventStartMs;
+    private long lastEventEndMs;
+
+    public TimeRatio2(long windowSizeMs, Sensor sensor) {
+        if (windowSizeMs < 0.0) {
+            throw new IllegalArgumentException("Invalid window size: value " + windowSizeMs + " is less than 0.");
+        }
+        this.windowSizeMs = windowSizeMs;
+        this.sensor = sensor;
+    }
+
+    private void updateWindow(long nowMs, long msSpentInEvent, long msSpentOutsideEvent) {
+        long msSinceLastSamplingIntervalEnd = nowMs - this.lastWindowEndMs;
+        if (msSinceLastSamplingIntervalEnd < this.windowSizeMs) {
+            // We can't fill a window yet, so just add the last event's millis to the counters
+            this.msSpentInEventInCurrentWindow += msSpentInEvent;
+            this.msSpentOutsideEventInCurrentWindow += msSpentOutsideEvent;
+        } else {
+            // We can fill at least one window.
+            // Add millis from the last event to fill this window and flush the ratio to the sensor,
+            // then start a new window with any remaining millis we couldn't fit in the flushed window.
+            // As each event period starts with "inside event" time and ends with "outside event" time,
+            // we prefer to insert "inside event" time into the window first.
+            long missingMsToCompleteWindow = this.windowSizeMs - (this.msSpentInEventInCurrentWindow + this.msSpentOutsideEventInCurrentWindow);
+            long inEventMsFittingInWindow = Math.min(missingMsToCompleteWindow, msSpentInEvent);
+            long outsideEventMsFittingInWindow = missingMsToCompleteWindow - inEventMsFittingInWindow;
+
+            double eventRatio = (this.msSpentInEventInCurrentWindow + inEventMsFittingInWindow) * 1.0 / this.windowSizeMs;
+            long currentWindowEndMs = this.lastWindowEndMs + this.windowSizeMs;
+            this.sensor.record(eventRatio, currentWindowEndMs);
+
+            this.msSpentInEventInCurrentWindow = 0;
+            this.msSpentOutsideEventInCurrentWindow = 0;
+            this.lastWindowEndMs = currentWindowEndMs;
+            updateWindow(nowMs, msSpentInEvent - inEventMsFittingInWindow, msSpentOutsideEvent - outsideEventMsFittingInWindow);
+        }
+    }
+
+    public void recordEventStart(long nowMs) {
+        if (this.lastWindowEndMs == 0) {
+            this.lastWindowEndMs = nowMs;
+        } else {
+            long msSpentInEvent = this.lastEventEndMs - this.lastEventStartMs;
+            long msSpentOutsideEvent = nowMs - this.lastEventEndMs;
+            updateWindow(nowMs, msSpentInEvent, msSpentOutsideEvent);
+        }
+        this.lastEventStartMs = nowMs;
+    }
+
+    public void recordEventEnd(long nowMs) {
+        this.lastEventEndMs = nowMs;
+    }
+
+}


### PR DESCRIPTION
…sumers

The calculation of the metric was slightly off because the divisor ends up covering more than one full poll cycle. It instead covers a full poll cycle, plus the duration of the latest call to poll.

As an example, say a thread consistently spends 10 ms in poll and 10 ms outside poll. We would expect a fraction of 0.5.

The metric as it was implemented would return 0.33.

At time 0, we enter poll.
At time 10, we exit poll, registering a meaningless metric value. 
At time 20, we enter poll, and update timeSinceLastPollMs to 20. 
At time 30, we exit poll, and compute the metric value to 10 / (10 + 20) = 0.33

This commit changes the implementation to track the timestamp when we enter and exit poll, and updates the metric when we enter a new poll cycle.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
