### PR TITLE
KAFKA-17492: skip KIP-584 features with minVersion of 0 in older RPCs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -289,19 +289,17 @@ public class ApiVersionsResponse extends AbstractResponse {
         SupportedFeatureKeyCollection converted = new SupportedFeatureKeyCollection();
         for (Map.Entry<String, SupportedVersionRange> feature : latestSupportedFeatures.features().entrySet()) {
             final SupportedVersionRange versionRange = feature.getValue();
-            final SupportedFeatureKey key = new SupportedFeatureKey();
-            key.setName(feature.getKey());
             if (alterV0 && versionRange.min() == 0) {
                 // Some older clients will have deserialization problems if a feature's
                 // minimum supported level is 0. Therefore, when preparing ApiVersionResponse
-                // at versions less than 4, we must set the minimum version for these features
-                // to 1 rather than 0. See KAFKA-17011 for details.
-                key.setMinVersion((short) 1);
+                // at versions less than 4, we must omit these features. See KAFKA-17492.
             } else {
+                final SupportedFeatureKey key = new SupportedFeatureKey();
+                key.setName(feature.getKey());
                 key.setMinVersion(versionRange.min());
+                key.setMaxVersion(versionRange.max());
+                converted.add(key);
             }
-            key.setMaxVersion(versionRange.max());
-            converted.add(key);
         }
 
         return converted;

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -47,14 +47,14 @@ public class BrokerRegistrationRequest extends AbstractRequest {
         @Override
         public BrokerRegistrationRequest build(short version) {
             if (version < 4) {
-                // Workaround for KAFKA-17011: for BrokerRegistrationRequest versions older than 4,
-                // translate minSupportedVersion = 0 to minSupportedVersion = 1.
+                // Workaround for KAFKA-17492: for BrokerRegistrationRequest versions older than 4,
+                // remove features with minSupportedVersion = 0.
                 BrokerRegistrationRequestData newData = data.duplicate();
                 for (Iterator<BrokerRegistrationRequestData.Feature> iter = newData.features().iterator();
                      iter.hasNext(); ) {
                     BrokerRegistrationRequestData.Feature feature = iter.next();
                     if (feature.minSupportedVersion() == 0) {
-                        feature.setMinSupportedVersion((short) 1);
+                        iter.remove();
                     }
                 }
                 return new BrokerRegistrationRequest(newData, version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -288,11 +288,7 @@ public class ApiVersionsResponseTest {
             setAlterFeatureLevel0(alterV0Features).
             build();
         if (alterV0Features) {
-            assertEquals(new SupportedFeatureKey().
-                setName("my.feature").
-                setMinVersion((short) 1).
-                setMaxVersion((short) 1),
-                response.data().supportedFeatures().find("my.feature"));
+            assertNull(response.data().supportedFeatures().find("my.feature"));
         } else {
             assertEquals(new SupportedFeatureKey().
                 setName("my.feature").

--- a/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
@@ -113,11 +113,7 @@ class BrokerRegistrationRequestTest {
                     new BrokerRegistrationRequestData.Feature().
                         setName("metadata.version").
                         setMinSupportedVersion((short) 1).
-                        setMaxSupportedVersion((short) 17),
-                    new BrokerRegistrationRequestData.Feature().
-                        setName("kraft.version").
-                        setMinSupportedVersion((short) 1).
-                        setMaxSupportedVersion((short) 1)).iterator()), data.features());
+                        setMaxSupportedVersion((short) 17)).iterator()), data.features());
         } else {
             assertEquals(new BrokerRegistrationRequestData.FeatureCollection(
                 Arrays.asList(

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsResponseIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsResponseIntegrationTest.scala
@@ -18,7 +18,7 @@ import org.apache.kafka.common.requests.ApiVersionsRequest
 import org.apache.kafka.common.requests.ApiVersionsResponse
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.config.ServerConfigs
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertNull}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -44,7 +44,7 @@ class ApiVersionsResponseIntegrationTest extends BaseRequestTest {
     val response = sendApiVersionsRequest(3)
     if (quorum.equals("kraft")) {
       assertFeatureHasMinVersion("metadata.version", response.data().supportedFeatures(), 1)
-      assertFeatureHasMinVersion("kraft.version", response.data().supportedFeatures(), 1)
+      assertFeatureMissing("kraft.version", response.data().supportedFeatures())
     } else {
       assertEquals(0, response.data().supportedFeatures().size())
     }
@@ -71,5 +71,13 @@ class ApiVersionsResponseIntegrationTest extends BaseRequestTest {
     assertNotNull(key)
     assertEquals(name, key.name())
     assertEquals(expectedMinVersion, key.minVersion())
+  }
+
+  def assertFeatureMissing(
+    name: String,
+    coll: SupportedFeatureKeyCollection,
+  ): Unit = {
+    val key = coll.find(name)
+    assertNull(key)
   }
 }


### PR DESCRIPTION
Some older clients will have deserialization problems if a KIP-584 feature's minimum supported level is 0.  Therefore, when preparing an ApiVersionResponse for a version less than 4, we must omit features with a minimum supported level of 0. This is reasonable to do because older software could not handle setting these features to a level other than 0 in any case.

A similar problem applies to BrokerRegistrationRequest. Here we must omit features with minVersion = 0 when the RPC version is less than 4.

Note that this fix supersedes an earlier compatibility preservation effort in KAFKA-17011.