### PR TITLE
MINOR Fix trunk build scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
           GRADLE_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
       - name: Archive Build Scan
-        if: ${{ inputs.is-public-fork == 'true' }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: build-scan-test-${{ matrix.java }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     with:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
-      is-public-fork: ${{ github.event.pull_request.head.repo.full_name != 'apache/kafka' }}
+      is-public-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'apache/kafka' }}
     secrets:
       inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     with:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
-      is-public-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'apache/kafka' }}
+      is-public-fork: ${{ github.event.pull_request.head.repo.fork == 'true' }}
     secrets:
       inherit


### PR DESCRIPTION
Trunk builds are run off of "push" events rather than "pull_request". We were missing some logic in the `is-public-fork` condition that mistakenly caused some trunk builds to skip the build scan.