### PR TITLE
KAFKA-17508: Adding some guard for fallback deletion logic

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -805,6 +805,9 @@ public class LogSegment implements Closeable {
                 if (logIfMissing) {
                     LOGGER.info("Failed to delete {} {} because it does not exist.", fileType, file.getAbsolutePath());
                 }
+                if (file.getParent() == null) {
+                    return null;
+                }
 
                 // During alter log dir, the log segment may be moved to a new directory, so async delete may fail.
                 // Fallback to delete the file in the new directory to avoid orphan file.


### PR DESCRIPTION
In [KAFKA-16424](https://issues.apache.org/jira/browse/KAFKA-16424), we added a fallback logic to delete the logs, but the file has no parent. It'd be better we have some guard from it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
