### PR TITLE
MINOR Fix build scan status on PRs

### DIFF
--- a/.github/actions/gh-api-update-status/action.yml
+++ b/.github/actions/gh-api-update-status/action.yml
@@ -22,9 +22,6 @@ inputs:
   gh-token:
     description: "The GitHub token for use with the CLI"
     required: true
-  repository:
-    description: "The repository where the commit is located"
-    default: "apache/kafka"
   commit_sha:
     description: "The SHA of the commit we are updating"
     required: true
@@ -52,7 +49,7 @@ runs:
         GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/${{ inputs.repository }}/statuses/${{ inputs.commit_sha }} \
+        /repos/apache/kafka/statuses/${{ inputs.commit_sha }} \
         -f "state=${{ inputs.state }}" -f "target_url=${{ inputs.url }}" \
         -f "description=${{ inputs.description }}" \
         -f "context=${{ inputs.context }}"

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -35,9 +35,6 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 # If we need to do things like comment on, label, or otherwise modify PRs from public forks. This
 # workflow is the place to do it. PR number is ${{ github.event.workflow_run.pull_requests[0].number }}
 
-permissions:
-  statuses: write
-
 jobs:
   upload-build-scan:
     # Skip this workflow if CI was run for anything other than "pull_request" (like "push").
@@ -81,7 +78,6 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'Could not find build scan'
@@ -102,7 +98,6 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'The build scan failed to be published'
@@ -113,7 +108,6 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'


### PR DESCRIPTION
Set statuses on apache/kafka repo, not the head repo of the PR