### PR TITLE
KAFKA-17253: Deprecate Leaking Getter Methods in Joined Helper Class

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Joined.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Joined.java
@@ -271,18 +271,35 @@ public class Joined<K, VLeft, VRight> implements NamedOperation<Joined<K, VLeft,
         return new Joined<>(keySerde, leftValueSerde, rightValueSerde, name, gracePeriod);
     }
 
+
+    /**
+     * @deprecated since 4.0 and should not be used any longer.
+     */
+    @Deprecated
     public Duration gracePeriod() {
         return gracePeriod;
     }
 
+    /**
+     * @deprecated since 4.0 and should not be used any longer.
+     */
+    @Deprecated
     public Serde<K> keySerde() {
         return keySerde;
     }
 
+    /**
+     * @deprecated since 4.0 and should not be used any longer.
+     */
+    @Deprecated
     public Serde<VLeft> valueSerde() {
         return leftValueSerde;
     }
 
+    /**
+     * @deprecated since 4.0 and should not be used any longer.
+     */
+    @Deprecated
     public Serde<VRight> otherValueSerde() {
         return rightValueSerde;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/JoinedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/JoinedInternal.java
@@ -27,10 +27,12 @@ public class JoinedInternal<K, VLeft, VRight> extends Joined<K, VLeft, VRight>  
         super(joined);
     }
 
+    @SuppressWarnings("deprecation")
     public Duration gracePeriod() {
         return gracePeriod;
     }
 
+    @SuppressWarnings("deprecation")
     public Serde<K> keySerde() {
         return keySerde;
     }


### PR DESCRIPTION
JIRA: [KAFKA-17253](https://issues.apache.org/jira/browse/KAFKA-17253)
> The helper class `Joined` has four getter methods `gracePeriod()`, `keySerde()`, `valueSerde()` and `otherValueSerde()` which don't belong to this class.
We should deprecate them for future removal – all four are already available via JoinedInternal where they belong to.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
