### PR TITLE
KAFKA-15073 Close stale PRs [2/n]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -46,7 +46,7 @@ jobs:
           days-before-stale: 90
           days-before-close: 120
           stale-pr-label: 'stale'
-          stale-pr-message: >
+          stale-pr-message: |
             This PR is being marked as stale since it has not had any activity in 90 days. If you
             would like to keep this PR alive, please ask a committer for review. If the PR has 
             merge conflicts, please update it with the latest from trunk (or appropriate release branch).
@@ -56,3 +56,7 @@ jobs:
             <p>
             If this PR is no longer valid or desired, please feel free to close it. If no activity
             occurs in the next 30 days, it will be automatically closed.
+          close-pr-label: 'closed-stale'
+          close-pr-message: |
+            This PR has been closed since it has not had any activity in 120 days. If you fell like this
+            was a mistake, please feel free to re-open the PR and ask a committer for a review.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -48,8 +48,8 @@ jobs:
           stale-pr-label: 'stale'
           stale-pr-message: |
             This PR is being marked as stale since it has not had any activity in 90 days. If you
-            would like to keep this PR alive, please ask a committer for review. If the PR has 
-            merge conflicts, please update it with the latest from trunk (or appropriate release branch).
+            would like to keep this PR alive, please leave a comment asking for a review. If the PR has 
+            merge conflicts, update it with the latest from the base branch.
             <p>
             If you are having difficulty finding a reviewer, please reach out on the 
             [mailing list](https://kafka.apache.org/contact).
@@ -59,4 +59,5 @@ jobs:
           close-pr-label: 'closed-stale'
           close-pr-message: |
             This PR has been closed since it has not had any activity in 120 days. If you feel like this
-            was a mistake, please feel free to re-open the PR and ask a committer for a review.
+            was a mistake, or you would like to continue working on it, please feel free to re-open the 
+            PR and ask for a review.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,14 +42,17 @@ jobs:
         with:
           debug-only: ${{ inputs.dryRun || false }}
           operations-per-run: ${{ inputs.operationsPerRun || 100 }}
+          ascending: true
           days-before-stale: 90
-          days-before-close: -1
+          days-before-close: 120
           stale-pr-label: 'stale'
           stale-pr-message: >
             This PR is being marked as stale since it has not had any activity in 90 days. If you
             would like to keep this PR alive, please ask a committer for review. If the PR has 
-            merge conflicts, please update it with the latest from trunk (or appropriate release branch)
+            merge conflicts, please update it with the latest from trunk (or appropriate release branch).
+            <p>
+            If you are having difficulty finding a reviewer, please reach out on the 
+            [mailing list](https://kafka.apache.org/contact).
             <p>
             If this PR is no longer valid or desired, please feel free to close it. If no activity
             occurs in the next 30 days, it will be automatically closed.
-          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -58,5 +58,5 @@ jobs:
             occurs in the next 30 days, it will be automatically closed.
           close-pr-label: 'closed-stale'
           close-pr-message: |
-            This PR has been closed since it has not had any activity in 120 days. If you fell like this
+            This PR has been closed since it has not had any activity in 120 days. If you feel like this
             was a mistake, please feel free to re-open the PR and ask a committer for a review.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,7 +44,7 @@ jobs:
           operations-per-run: ${{ inputs.operationsPerRun || 100 }}
           ascending: true
           days-before-stale: 90
-          days-before-close: 120
+          days-before-close: 30  # Since adding 'stale' will update the PR, days-before-close is relative to that.
           stale-pr-label: 'stale'
           stale-pr-message: |
             This PR is being marked as stale since it has not had any activity in 90 days. If you


### PR DESCRIPTION
As a follow-up of #13827, this patch will allow the stale Github Action to actually close old PRs.