### PR TITLE
KAFKA-17410: Disable testPollThrowsInterruptExceptionIfInterrupted for AsyncConsumer

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1273,7 +1273,7 @@ public class KafkaConsumerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(GroupProtocol.class)
+    @EnumSource(value = GroupProtocol.class, names = "CLASSIC")
     public void testPollThrowsInterruptExceptionIfInterrupted(GroupProtocol groupProtocol) {
         final ConsumerMetadata metadata = createMetadata(subscription);
         final MockClient client = new MockClient(time, metadata);


### PR DESCRIPTION
See discussion under [KAFKA-17410](https://issues.apache.org/jira/browse/KAFKA-17410)

We have already confirmed consistent coverage for the new consumer in `AsyncKafkaConsumerTest.testPollThrowsInterruptExceptionIfInterrupted`, so this PR disables the test for AsyncConsumer and leaves it running only for the classic consumer.

We will revisit the test once the related fix(#16885), currently in progress, is merged and reevaluate if necessary. For now, we disable this test temporally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
