### PR TITLE
MINOR Add a thread dump on build timeout

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -263,9 +263,9 @@ if __name__ == "__main__":
         logger.debug(f"Gradle command timed out. These are partial results!")
         logger.debug(summary)
         if thread_dump_url:
-            print("The JUnit tests were cancelled due to a timeout.")
-            print(f"Thread dumps were generated before the job was cancelled. Download [thread dumps]({thread_dump_url})")
-            logger.debug(f"Failing this step because the tests timed out. Thread dumps were archived: {thread_dump_url}")
+            print("\nThe JUnit tests were cancelled due to a timeout. Thread dumps were generated before the job was cancelled. "
+                  "Download [thread dumps]({thread_dump_url}).\n")
+            logger.debug(f"Failing this step because the tests timed out. Thread dumps were taken and archived here: {thread_dump_url}")
         else:
             logger.debug(f"Failing this step because the tests timed out. Thread dumps were not archived, check logs in JUnit step.")
         exit(1)

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -263,8 +263,8 @@ if __name__ == "__main__":
         logger.debug(f"Gradle command timed out. These are partial results!")
         logger.debug(summary)
         if thread_dump_url:
-            print("\nThe JUnit tests were cancelled due to a timeout. Thread dumps were generated before the job was cancelled. "
-                  "Download [thread dumps]({thread_dump_url}).\n")
+            print(f"\nThe JUnit tests were cancelled due to a timeout. Thread dumps were generated before the job was cancelled. "
+                  f"Download [thread dumps]({thread_dump_url}).\n")
             logger.debug(f"Failing this step because the tests timed out. Thread dumps were taken and archived here: {thread_dump_url}")
         else:
             logger.debug(f"Failing this step because the tests timed out. Thread dumps were not archived, check logs in JUnit step.")

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -262,7 +262,10 @@ if __name__ == "__main__":
         thread_dump_url = get_env("THREAD_DUMP_URL")
         logger.debug(f"Gradle command timed out. These are partial results!")
         logger.debug(summary)
-        logger.debug(f"Failing this step because the tests timed out. Download [thread dumps]({thread_dump_url}).")
+        if thread_dump_url:
+            logger.debug(f"Failing this step because the tests timed out. Download [thread dumps]({thread_dump_url}).")
+        else:
+            logger.debug(f"Failing this step because the tests timed out.")
         exit(1)
     elif exit_code in (0, 1):
         logger.debug(summary)

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
     logger.info(f"Finished processing {len(reports)} reports")
 
     # Print summary
-    report_url = get_env("REPORT_URL")
+    report_url = get_env("JUNIT_REPORT_URL")
     report_md = f"Download [HTML report]({report_url})."
     summary = (f"{total_run} tests cases run in {duration}. "
                f"{total_success} {PASSED}, {total_failures} {FAILED}, "
@@ -259,9 +259,10 @@ if __name__ == "__main__":
     # Print special message if there was a timeout
     exit_code = get_env("GRADLE_EXIT_CODE", int)
     if exit_code == 124:
+        thread_dump_url = get_env("THREAD_DUMP_URL")
         logger.debug(f"Gradle command timed out. These are partial results!")
         logger.debug(summary)
-        logger.debug("Failing this step because the tests timed out.")
+        logger.debug(f"Failing this step because the tests timed out. Download [thread dumps]({thread_dump_url}).")
         exit(1)
     elif exit_code in (0, 1):
         logger.debug(summary)

--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -263,9 +263,11 @@ if __name__ == "__main__":
         logger.debug(f"Gradle command timed out. These are partial results!")
         logger.debug(summary)
         if thread_dump_url:
-            logger.debug(f"Failing this step because the tests timed out. Download [thread dumps]({thread_dump_url}).")
+            print("The JUnit tests were cancelled due to a timeout.")
+            print(f"Thread dumps were generated before the job was cancelled. Download [thread dumps]({thread_dump_url})")
+            logger.debug(f"Failing this step because the tests timed out. Thread dumps were archived: {thread_dump_url}")
         else:
-            logger.debug(f"Failing this step because the tests timed out.")
+            logger.debug(f"Failing this step because the tests timed out. Thread dumps were not archived, check logs in JUnit step.")
         exit(1)
     elif exit_code in (0, 1):
         logger.debug(summary)

--- a/.github/scripts/thread-dump.sh
+++ b/.github/scripts/thread-dump.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SLEEP_MINUTES=$(($TIMEOUT_MINUTES-5))
+echo "Dumping threads in $SLEEP_MINUTES minutes"
+sleep $(($SLEEP_MINUTES*60));
+
+echo "Dumping threads now..."
+sleep 5;
+
+for GRADLE_WORKER_PID in `jps | grep GradleWorkerMain | awk -F" " '{print $1}'`;
+do
+  echo "Thread Dump for GradleWorkerMain pid $GRADLE_WORKER_PID";
+  kill -3 $GRADLE_WORKER_PID;
+  sleep 10;
+done;

--- a/.github/scripts/thread-dump.sh
+++ b/.github/scripts/thread-dump.sh
@@ -24,7 +24,7 @@ sleep 5;
 
 for GRADLE_WORKER_PID in `jps | grep GradleWorkerMain | awk -F" " '{print $1}'`;
 do
-  echo "Thread Dump for GradleWorkerMain pid $GRADLE_WORKER_PID";
+  echo "Dumping threads for GradleWorkerMain pid $GRADLE_WORKER_PID";
   jstack $GRADLE_WORKER_PID > thread-dumps/GradleWorkerMain-$GRADLE_WORKER_PID.txt
   sleep 5;
 done;

--- a/.github/scripts/thread-dump.sh
+++ b/.github/scripts/thread-dump.sh
@@ -18,12 +18,13 @@ SLEEP_MINUTES=$(($TIMEOUT_MINUTES-5))
 echo "Dumping threads in $SLEEP_MINUTES minutes"
 sleep $(($SLEEP_MINUTES*60));
 
-echo "Dumping threads now..."
+echo "Timed out after $SLEEP_MINUTES minutes. Dumping threads now..."
+mkdir thread-dumps
 sleep 5;
 
 for GRADLE_WORKER_PID in `jps | grep GradleWorkerMain | awk -F" " '{print $1}'`;
 do
   echo "Thread Dump for GradleWorkerMain pid $GRADLE_WORKER_PID";
-  kill -3 $GRADLE_WORKER_PID;
-  sleep 10;
+  jstack $GRADLE_WORKER_PID > thread-dumps/GradleWorkerMain-$GRADLE_WORKER_PID.txt
+  sleep 5;
 done;

--- a/.github/scripts/thread-dump.sh
+++ b/.github/scripts/thread-dump.sh
@@ -24,7 +24,12 @@ sleep 5;
 
 for GRADLE_WORKER_PID in `jps | grep GradleWorkerMain | awk -F" " '{print $1}'`;
 do
-  echo "Dumping threads for GradleWorkerMain pid $GRADLE_WORKER_PID";
-  jstack $GRADLE_WORKER_PID > thread-dumps/GradleWorkerMain-$GRADLE_WORKER_PID.txt
+  echo "Dumping threads for GradleWorkerMain pid $GRADLE_WORKER_PID into $FILENAME";
+  FILENAME="thread-dumps/GradleWorkerMain-$GRADLE_WORKER_PID.txt"
+  jstack $GRADLE_WORKER_PID > $FILENAME
+  if ! grep -q "kafka" $FILENAME; then
+    echo "No match for 'kafka' in thread dump file $FILENAME, discarding it."
+    rm $FILENAME;
+  fi;
   sleep 5;
 done;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 180
+          TIMEOUT_MINUTES: 10
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 180  # 3 hours
+          TIMEOUT_MINUTES: 6  # 3 hours
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 6  # 3 hours
+          TIMEOUT_MINUTES: 10  # 3 hours
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,16 +144,11 @@ jobs:
         with:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
-      - name: Print Steps
-        run: printenv
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          STEPS_CONTEXT: ${{ toJson(steps) }}
       - name: Archive Thread Dumps
         if: always() && steps.junit-test.outputs.exitcode == '124'
         uses: actions/upload-artifact@v4
         with:
-          name: thread-dumps-${{ matrix.java }}
+          name: junit-thread-dumps-${{ matrix.java }}
           path: |
             thread-dumps/*
           if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 6
+          TIMEOUT_MINUTES: 180  # 3 hours
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,9 +110,12 @@ jobs:
         # --continue:     Keep running even if a test fails
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
+        env:
+          TIMEOUT_MINUTES: 180
         run: |
           set +e
-          timeout 180m ./gradlew --build-cache --continue \
+          ./.github/scripts/thread-dump.sh &
+          timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue \
           ${{ inputs.is-public-fork == 'true' && '--no-scan' || '--scan' }} \
           -PtestLoggingEvents=started,passed,skipped,failed \
           -PmaxParallelForks=2 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
           name: check-reports-${{ matrix.java }}
           path: |
             **/build/**/*.html
+          compression-level: 9
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
         # Avoid duplicate annotations, only run on java 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           STEPS_CONTEXT: ${{ toJson(steps) }}
       - name: Archive Thread Dumps
+        if: always() && steps.junit-test.outputs.exitcode == '124'
         uses: actions/upload-artifact@v4
         with:
           name: thread-dumps-${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,12 +131,24 @@ jobs:
           name: junit-reports-${{ matrix.java }}
           path: |
             **/build/reports/tests/test/*
+          compression-level: 9
+          if-no-files-found: ignore
+      - name: Archive Thread Dumps
+        id: thread-dump-upload-artifact
+        if: always() && steps.junit-test.outputs.exitcode == '124'
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-thread-dumps-${{ matrix.java }}
+          path: |
+            thread-dumps/*
+          compression-level: 9
           if-no-files-found: ignore
       - name: Parse JUnit tests
         run: python .github/scripts/junit.py >> $GITHUB_STEP_SUMMARY
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
+          JUNIT_REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
+          THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
           GRADLE_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
       - name: Archive Build Scan
         if: always()
@@ -144,11 +156,5 @@ jobs:
         with:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
-      - name: Archive Thread Dumps
-        if: always() && steps.junit-test.outputs.exitcode == '124'
-        uses: actions/upload-artifact@v4
-        with:
-          name: junit-thread-dumps-${{ matrix.java }}
-          path: |
-            thread-dumps/*
+          compression-level: 9
           if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,8 +144,12 @@ jobs:
         with:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
+      - name: Print Steps
+        run: printenv
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          STEPS_CONTEXT: ${{ toJson(steps) }}
       - name: Archive Thread Dumps
-        if: ${{ steps.junit-test.outputs.exitcode == '124' }}
         uses: actions/upload-artifact@v4
         with:
           name: thread-dumps-${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 10
+          TIMEOUT_MINUTES: 180
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 10
+          TIMEOUT_MINUTES: 6
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
@@ -145,7 +145,7 @@ jobs:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
       - name: Archive Thread Dumps
-        if: steps.junit-test.outputs.exitcode == 124
+        if: steps.junit-test.outputs.exitcode == '124'
         uses: actions/upload-artifact@v4
         with:
           name: thread-dumps-${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 180
+          TIMEOUT_MINUTES: 10
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
@@ -144,3 +144,11 @@ jobs:
         with:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
+      - name: Archive Thread Dumps
+        if: steps.junit-test.outputs.exitcode == 124
+        uses: actions/upload-artifact@v4
+        with:
+          name: thread-dumps-${{ matrix.java }}
+          path: |
+            thread-dumps/*
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           name: build-scan-test-${{ matrix.java }}
           path: ~/.gradle/build-scan-data
       - name: Archive Thread Dumps
-        if: steps.junit-test.outputs.exitcode == '124'
+        if: ${{ steps.junit-test.outputs.exitcode == '124' }}
         uses: actions/upload-artifact@v4
         with:
           name: thread-dumps-${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
         env:
-          TIMEOUT_MINUTES: 10  # 3 hours
+          TIMEOUT_MINUTES: 180  # 3 hours
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &


### PR DESCRIPTION
To help with debugging build timeouts, this patch adds a thread dump script to run in parallel with the JUnit tests. 5 minutes prior to the build timeout of 3 hours, this script will iteratively run `jstack` to the Gradle worker processes in order to obtain thread dumps. 