### PR TITLE
MINOR: Need to split the controller bootstrap servers on ',' in list comprehenson

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -875,7 +875,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             else:
                 self.controller_quorum_voters = ','.join(["%s@%s" % (self.controller_quorum.idx(node) + first_node_id - 1,
                                                                      bootstrap_server)
-                                                          for bootstrap_server in controller_quorum_bootstrap_servers])
+                                                          for bootstrap_server in controller_quorum_bootstrap_servers.split(',')])
             # define controller.listener.names
             self.controller_listener_names = ','.join(self.controller_listener_name_list(node))
             # define sasl.mechanism.controller.protocol to match the isolated quorum if one exists


### PR DESCRIPTION
Kafka Streams system tests were failing with this error:
```
 Failed to parse host name from entry 3001@d for the configuration controller.quorum.voters.  Each entry should be in the form `{id}@{host}:{port}`.
```
The cause is that in `kafka.py` line 876, we create a delimited string from a list comprehension, but the input is a string itself, so each character gets appended vs. the bootstrap server string of `host:port`.  To fix this, this PR adds `split(',')` to `controller_quorum_bootstrap_servers`.  Note that this only applies when `dynamicRaftQuorum=False` 

I'll kick off a system test build and post the results here

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
