### PR TITLE
KAFKA-17515: Fix flaky RestoreIntegrationTest.shouldInvokeUserDefinedGlobalStateRestoreListener

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -580,13 +580,14 @@ public class RestoreIntegrationTest {
         validateReceivedMessages(sampleData, outputTopic);
 
         // Close kafkaStreams1 (with cleanup) and start it again to force the restoration of the state.
-        kafkaStreams.close(Duration.ofMillis(IntegrationTestUtils.DEFAULT_TIMEOUT));
+        kafkaStreams.close();
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfigurations);
 
         final TestStateRestoreListener kafkaStreams1StateRestoreListener = new TestStateRestoreListener("ks1", RESTORATION_DELAY);
         kafkaStreams = startKafkaStreams(builder, kafkaStreams1StateRestoreListener, kafkaStreams1Configuration);
 
-        // Must make ensure all the restoring tasks are in active state before starting the new instance.
+        // Ensure all the restoring tasks are in active state before starting the new instance.
+        // Otherwise, the tasks which assigned to first kafka streams won't encounter "restoring suspend" after being reassigned to the second instance.
         waitForActiveRestoringTask(kafkaStreams, 5, IntegrationTestUtils.DEFAULT_TIMEOUT);
 
         assertTrue(kafkaStreams1StateRestoreListener.awaitUntilRestorationStarts());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -635,6 +635,19 @@ public class IntegrationTestUtils {
     }
 
     /**
+     * Wait until enough restoring tasks have been started
+     */
+    public static void waitForActiveRestoringTask(final KafkaStreams streams,
+                                                  final int expectedTasks,
+                                                  final long timeoutMilliseconds) throws Exception {
+        TestUtils.waitForCondition(() -> {
+            return streams.metrics().entrySet().stream()
+                    .filter(metric -> metric.getKey().name().equals("active-restoring-tasks"))
+                    .anyMatch(metric -> ((Number) metric.getValue().metricValue()).intValue() == expectedTasks);
+        }, timeoutMilliseconds, "Timed out waiting for active restoring task");
+    }
+
+    /**
      * Wait until enough data (consumer records) has been consumed.
      *
      * @param consumerConfig      Kafka Consumer configuration

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -640,11 +640,10 @@ public class IntegrationTestUtils {
     public static void waitForActiveRestoringTask(final KafkaStreams streams,
                                                   final int expectedTasks,
                                                   final long timeoutMilliseconds) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            return streams.metrics().entrySet().stream()
-                    .filter(metric -> metric.getKey().name().equals("active-restoring-tasks"))
-                    .anyMatch(metric -> ((Number) metric.getValue().metricValue()).intValue() == expectedTasks);
-        }, timeoutMilliseconds, "Timed out waiting for active restoring task");
+        TestUtils.waitForCondition(() -> streams.metrics().entrySet().stream()
+                        .filter(metric -> metric.getKey().name().equals("active-restoring-tasks"))
+                        .anyMatch(metric -> ((Number) metric.getValue().metricValue()).intValue() == expectedTasks),
+                timeoutMilliseconds, "Timed out waiting for active restoring task");
     }
 
     /**


### PR DESCRIPTION
It's regarding [KAFKA-17515](https://issues.apache.org/jira/browse/KAFKA-17515). 
Found two issues in the flaky tests: (Put the log analysis under Jira comments.)

1. The error "java.nio.file.DirectoryNotEmptyException" occurs if the flush() of kafkaStreams.close() and purgeLocalStreamsState() are triggered in the same time. (The current timeout is 5 sec, which is too short since the CI is unstable and slow). 
2. Racing issue: Task to-be restored in `ks-1` are rebalanced to `ks-2` before entering active restoring state. So no onRestoreSuspend() was triggered. 

To solve the issues:
1. Remove the timeout  in kafkaStreams.close() 
2. Ensure all tasks in `ks-1` are active restoring before start second KafkaStreams(`ks-2`)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
