### PR TITLE
KAFKA-17546: Admin.listGroups and kafka-groups.sh

### DIFF
--- a/bin/kafka-groups.sh
+++ b/bin/kafka-groups.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.GroupsCommand "$@"

--- a/bin/windows/kafka-groups.bat
+++ b/bin/windows/kafka-groups.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.GroupsCommand %*

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractListGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractListGroupsResult.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * This class implements the common APIs that are shared by results classes
+ * for various AdminClient commands for listing groups.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public abstract class AbstractListGroupsResult<T extends GroupListing> {
+    private final KafkaFutureImpl<Collection<T>> all;
+    private final KafkaFutureImpl<Collection<T>> valid;
+    private final KafkaFutureImpl<Collection<Throwable>> errors;
+
+    @SuppressWarnings("unchecked")
+    AbstractListGroupsResult(KafkaFuture<Collection<Object>> future) {
+        this.all = new KafkaFutureImpl<>();
+        this.valid = new KafkaFutureImpl<>();
+        this.errors = new KafkaFutureImpl<>();
+        future.thenApply((KafkaFuture.BaseFunction<Collection<Object>, Void>) results -> {
+            ArrayList<Throwable> curErrors = new ArrayList<>();
+            ArrayList<T> curValid = new ArrayList<>();
+            for (Object resultObject : results) {
+                if (resultObject instanceof Throwable) {
+                    curErrors.add((Throwable) resultObject);
+                } else {
+                    curValid.add((T) resultObject);
+                }
+            }
+            if (!curErrors.isEmpty()) {
+                all.completeExceptionally(curErrors.get(0));
+            } else {
+                all.complete(curValid);
+            }
+            valid.complete(curValid);
+            errors.complete(curErrors);
+            return null;
+        });
+    }
+
+    /**
+     * Returns a future that yields either an exception, or the full set of group listings.
+     * <p>
+     * In the event of a failure, the future yields nothing but the first exception which
+     * occurred.
+     */
+    public KafkaFuture<Collection<T>> all() {
+        return all;
+    }
+
+    /**
+     * Returns a future which yields just the valid listings.
+     * <p>
+     * This future never fails with an error, no matter what happens.  Errors are completely
+     * ignored.  If nothing can be fetched, an empty collection is yielded.
+     * If there is an error, but some results can be returned, this future will yield
+     * those partial results.  When using this future, it is a good idea to also check
+     * the errors future so that errors can be displayed and handled.
+     */
+    public KafkaFuture<Collection<T>> valid() {
+        return valid;
+    }
+
+    /**
+     * Returns a future which yields just the errors which occurred.
+     * <p>
+     * If this future yields a non-empty collection, it is very likely that elements are
+     * missing from the valid() set.
+     * <p>
+     * This future itself never fails with an error.  In the event of an error, this future
+     * will successfully yield a collection containing at least one exception.
+     */
+    public KafkaFuture<Collection<Throwable>> errors() {
+        return errors;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1022,6 +1022,26 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
+     * List the groups available in the cluster with the default options.
+     *
+     * <p>This is a convenience method for {@link #listGroups(ListGroupsOptions)} with default options.
+     * See the overload for more details.
+     *
+     * @return The ListGroupsResult.
+     */
+    default ListGroupsResult listGroups() {
+        return listGroups(new ListGroupsOptions());
+    }
+
+    /**
+     * List the groups available in the cluster.
+     *
+     * @param options The options to use when listing the groups.
+     * @return The ListGroupsResult.
+     */
+    ListGroupsResult listGroups(ListGroupsOptions options);
+
+    /**
      * Elect a replica as leader for topic partitions.
      * <p>
      * This is a convenience method for {@link #electLeaders(ElectionType, Set, ElectLeadersOptions)}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.GroupType;
 
@@ -26,11 +27,9 @@ import java.util.Optional;
 /**
  * A listing of a consumer group in the cluster.
  */
-public class ConsumerGroupListing {
-    private final String groupId;
+public class ConsumerGroupListing extends GroupListing {
     private final boolean isSimpleConsumerGroup;
     private final Optional<ConsumerGroupState> state;
-    private final Optional<GroupType> type;
 
     /**
      * Create an instance with the specified parameters.
@@ -67,17 +66,9 @@ public class ConsumerGroupListing {
         Optional<ConsumerGroupState> state,
         Optional<GroupType> type
     ) {
-        this.groupId = groupId;
+        super(groupId, type, isSimpleConsumerGroup ? "" : ConsumerProtocol.PROTOCOL_TYPE);
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;
         this.state = Objects.requireNonNull(state);
-        this.type = Objects.requireNonNull(type);
-    }
-
-    /**
-     * Consumer Group Id
-     */
-    public String groupId() {
-        return groupId;
     }
 
     /**
@@ -94,28 +85,17 @@ public class ConsumerGroupListing {
         return state;
     }
 
-    /**
-     * The type of the consumer group.
-     *
-     * @return An Optional containing the type, if available.
-     */
-    public Optional<GroupType> type() {
-        return type;
-    }
-
     @Override
     public String toString() {
-        return "(" +
-            "groupId='" + groupId + '\'' +
+        return "(" + toStringBase() +
             ", isSimpleConsumerGroup=" + isSimpleConsumerGroup +
             ", state=" + state +
-            ", type=" + type +
             ')';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, isSimpleConsumerGroup(), state, type);
+        return super.hashCode() + Objects.hash(isSimpleConsumerGroup(), state);
     }
 
     @Override
@@ -123,9 +103,8 @@ public class ConsumerGroupListing {
         if (this == o) return true;
         if (!(o instanceof ConsumerGroupListing)) return false;
         ConsumerGroupListing that = (ConsumerGroupListing) o;
-        return isSimpleConsumerGroup() == that.isSimpleConsumerGroup() &&
-            Objects.equals(groupId, that.groupId) &&
-            Objects.equals(state, that.state) &&
-            Objects.equals(type, that.type);
+        return super.equals(o) &&
+            isSimpleConsumerGroup() == that.isSimpleConsumerGroup() &&
+            Objects.equals(state, that.state);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -309,6 +309,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public ListGroupsResult listGroups(ListGroupsOptions options) {
+        return delegate.listGroups(options);
+    }
+
+    @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return delegate.metrics();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.kafka.common.GroupType;
+
+/**
+ * A listing of a group in the cluster.
+ */
+public class GroupListing {
+    private final String groupId;
+    private final Optional<GroupType> type;
+    private final String protocol;
+
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param groupId Group Id
+     * @param protocol Protocol
+     */
+    public GroupListing(String groupId, String protocol) {
+        this.groupId = groupId;
+        this.type = Optional.empty();
+        this.protocol = protocol;
+    }
+
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param groupId Group Id
+     * @param type Group type
+     * @param protocol Protocol
+     */
+    public GroupListing(String groupId, GroupType type, String protocol) {
+        this.groupId = groupId;
+        this.type = Optional.of(Objects.requireNonNull(type));
+        this.protocol = protocol;
+    }
+
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param groupId Group Id
+     * @param type Group type
+     * @param protocol Protocol
+     */
+    public GroupListing(String groupId, Optional<GroupType> type, String protocol) {
+        this.groupId = groupId;
+        this.type = Objects.requireNonNull(type);
+        this.protocol = protocol;
+    }
+
+    /**
+     * The group Id.
+     *
+     * @return Group Id
+     */
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * The type of the group.
+     *
+     * @return An Optional containing the type, if available
+     */
+    public Optional<GroupType> type() {
+        return type;
+    }
+
+    /**
+     * The protocol of the group.
+     *
+     * @return The protocol
+     */
+    public String protocol() {
+        return protocol;
+    }
+
+    @Override
+    public String toString() {
+        return "(" +
+                "groupId='" + groupId + '\'' +
+                ", type=" + type +
+                ", protocol=" + protocol +
+                ')';
+    }
+
+    protected String toStringBase() {
+        return "groupId='" + groupId + '\'' +
+                ", type=" + type +
+                ", protocol=" + protocol;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GroupListing)) return false;
+        GroupListing that = (GroupListing) o;
+        return Objects.equals(groupId, that.groupId) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(protocol, that.protocol);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3489,6 +3489,138 @@ public class KafkaAdminClient extends AdminClient {
         return new DescribeDelegationTokenResult(tokensFuture);
     }
 
+    private static final class ListGroupsResults {
+        private final List<Throwable> errors;
+        private final HashMap<String, GroupListing> listings;
+        private final HashSet<Node> remaining;
+        private final KafkaFutureImpl<Collection<Object>> future;
+
+        ListGroupsResults(Collection<Node> leaders,
+                                  KafkaFutureImpl<Collection<Object>> future) {
+            this.errors = new ArrayList<>();
+            this.listings = new HashMap<>();
+            this.remaining = new HashSet<>(leaders);
+            this.future = future;
+            tryComplete();
+        }
+
+        synchronized void addError(Throwable throwable, Node node) {
+            ApiError error = ApiError.fromThrowable(throwable);
+            if (error.message() == null || error.message().isEmpty()) {
+                errors.add(error.error().exception("Error listing groups on " + node));
+            } else {
+                errors.add(error.error().exception("Error listing groups on " + node + ": " + error.message()));
+            }
+        }
+
+        synchronized void addListing(GroupListing listing) {
+            listings.put(listing.groupId(), listing);
+        }
+
+        synchronized void tryComplete(Node leader) {
+            remaining.remove(leader);
+            tryComplete();
+        }
+
+        private synchronized void tryComplete() {
+            if (remaining.isEmpty()) {
+                ArrayList<Object> results = new ArrayList<>(listings.values());
+                results.addAll(errors);
+                future.complete(results);
+            }
+        }
+    }
+
+    @Override
+    public ListGroupsResult listGroups(ListGroupsOptions options) {
+        final KafkaFutureImpl<Collection<Object>> all = new KafkaFutureImpl<>();
+        final long nowMetadata = time.milliseconds();
+        final long deadline = calcDeadlineMs(nowMetadata, options.timeoutMs());
+        runnable.call(new Call("findAllBrokers", deadline, new LeastLoadedNodeProvider()) {
+            @Override
+            MetadataRequest.Builder createRequest(int timeoutMs) {
+                return new MetadataRequest.Builder(new MetadataRequestData()
+                    .setTopics(Collections.emptyList())
+                    .setAllowAutoTopicCreation(true));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                MetadataResponse metadataResponse = (MetadataResponse) abstractResponse;
+                Collection<Node> nodes = metadataResponse.brokers();
+                if (nodes.isEmpty())
+                    throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
+
+                HashSet<Node> allNodes = new HashSet<>(nodes);
+                final ListGroupsResults results = new ListGroupsResults(allNodes, all);
+
+                for (final Node node : allNodes) {
+                    final long nowList = time.milliseconds();
+                    runnable.call(new Call("listConsumerGroups", deadline, new ConstantNodeIdProvider(node.id())) {
+                        @Override
+                        ListGroupsRequest.Builder createRequest(int timeoutMs) {
+                            List<String> groupTypes = options.types()
+                                .stream()
+                                .map(GroupType::toString)
+                                .collect(Collectors.toList());
+                            return new ListGroupsRequest.Builder(new ListGroupsRequestData()
+                                .setTypesFilter(groupTypes)
+                            );
+                        }
+
+                        private void maybeAddGroup(ListGroupsResponseData.ListedGroup group) {
+                            final String groupId = group.groupId();
+                            final GroupType type = group.groupType().isEmpty()
+                                ? GroupType.UNKNOWN
+                                : GroupType.parse(group.groupType());
+                            final String protocolType = group.protocolType();
+                            final GroupListing groupListing = new GroupListing(
+                                groupId,
+                                type,
+                                protocolType
+                            );
+                            results.addListing(groupListing);
+                        }
+
+                        @Override
+                        void handleResponse(AbstractResponse abstractResponse) {
+                            final ListGroupsResponse response = (ListGroupsResponse) abstractResponse;
+                            synchronized (results) {
+                                Errors error = Errors.forCode(response.data().errorCode());
+                                if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.COORDINATOR_NOT_AVAILABLE) {
+                                    throw error.exception();
+                                } else if (error != Errors.NONE) {
+                                    results.addError(error.exception(), node);
+                                } else {
+                                    for (ListGroupsResponseData.ListedGroup group : response.data().groups()) {
+                                        maybeAddGroup(group);
+                                    }
+                                }
+                                results.tryComplete(node);
+                            }
+                        }
+
+                        @Override
+                        void handleFailure(Throwable throwable) {
+                            synchronized (results) {
+                                results.addError(throwable, node);
+                                results.tryComplete(node);
+                            }
+                        }
+                    }, nowList);
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                KafkaException exception = new KafkaException("Failed to find brokers to send ListGroups", throwable);
+                all.complete(Collections.singletonList(exception));
+            }
+        }, nowMetadata);
+
+        return new ListGroupsResult(all);
+    }
+
     @Override
     public DescribeConsumerGroupsResult describeConsumerGroups(final Collection<String> groupIds,
                                                                final DescribeConsumerGroupsOptions options) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -19,9 +19,7 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -30,70 +28,9 @@ import java.util.Collection;
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving
-public class ListConsumerGroupsResult {
-    private final KafkaFutureImpl<Collection<ConsumerGroupListing>> all;
-    private final KafkaFutureImpl<Collection<ConsumerGroupListing>> valid;
-    private final KafkaFutureImpl<Collection<Throwable>> errors;
+public class ListConsumerGroupsResult extends AbstractListGroupsResult<ConsumerGroupListing> {
 
     ListConsumerGroupsResult(KafkaFuture<Collection<Object>> future) {
-        this.all = new KafkaFutureImpl<>();
-        this.valid = new KafkaFutureImpl<>();
-        this.errors = new KafkaFutureImpl<>();
-        future.thenApply((KafkaFuture.BaseFunction<Collection<Object>, Void>) results -> {
-            ArrayList<Throwable> curErrors = new ArrayList<>();
-            ArrayList<ConsumerGroupListing> curValid = new ArrayList<>();
-            for (Object resultObject : results) {
-                if (resultObject instanceof Throwable) {
-                    curErrors.add((Throwable) resultObject);
-                } else {
-                    curValid.add((ConsumerGroupListing) resultObject);
-                }
-            }
-            if (!curErrors.isEmpty()) {
-                all.completeExceptionally(curErrors.get(0));
-            } else {
-                all.complete(curValid);
-            }
-            valid.complete(curValid);
-            errors.complete(curErrors);
-            return null;
-        });
-    }
-
-    /**
-     * Returns a future that yields either an exception, or the full set of consumer group
-     * listings.
-     *
-     * In the event of a failure, the future yields nothing but the first exception which
-     * occurred.
-     */
-    public KafkaFuture<Collection<ConsumerGroupListing>> all() {
-        return all;
-    }
-
-    /**
-     * Returns a future which yields just the valid listings.
-     *
-     * This future never fails with an error, no matter what happens.  Errors are completely
-     * ignored.  If nothing can be fetched, an empty collection is yielded.
-     * If there is an error, but some results can be returned, this future will yield
-     * those partial results.  When using this future, it is a good idea to also check
-     * the errors future so that errors can be displayed and handled.
-     */
-    public KafkaFuture<Collection<ConsumerGroupListing>> valid() {
-        return valid;
-    }
-
-    /**
-     * Returns a future which yields just the errors which occurred.
-     *
-     * If this future yields a non-empty collection, it is very likely that elements are
-     * missing from the valid() set.
-     *
-     * This future itself never fails with an error.  In the event of an error, this future
-     * will successfully yield a collection containing at least one exception.
-     */
-    public KafkaFuture<Collection<Throwable>> errors() {
-        return errors;
+        super(future);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListGroupsOptions.java
@@ -17,20 +17,36 @@
 
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.common.KafkaFuture;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
-import java.util.Collection;
-
 /**
- * The result of the {@link Admin#listShareGroups(ListShareGroupsOptions)} call.
+ * Options for {@link Admin#listGroups()}.
  * <p>
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving
-public class ListShareGroupsResult extends AbstractListGroupsResult<ShareGroupListing> {
+public class ListGroupsOptions extends AbstractOptions<ListGroupsOptions> {
 
-    ListShareGroupsResult(KafkaFuture<Collection<Object>> future) {
-        super(future);
+    private Set<GroupType> types = Collections.emptySet();
+
+    /**
+     * If types is set, only groups of these types will be returned by listGroups().
+     * Otherwise, all groups are returned.
+     */
+    public ListGroupsOptions withTypes(Set<GroupType> types) {
+        this.types = (types == null || types.isEmpty()) ? Collections.emptySet() : new HashSet<>(types);
+        return this;
+    }
+
+    /**
+     * Returns the list of group types that are requested or empty if no types have been specified.
+     */
+    public Set<GroupType> types() {
+        return types;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListGroupsResult.java
@@ -23,14 +23,14 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import java.util.Collection;
 
 /**
- * The result of the {@link Admin#listShareGroups(ListShareGroupsOptions)} call.
+ * The result of the {@link Admin#listGroups()} call.
  * <p>
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving
-public class ListShareGroupsResult extends AbstractListGroupsResult<ShareGroupListing> {
+public class ListGroupsResult extends AbstractListGroupsResult<GroupListing> {
 
-    ListShareGroupsResult(KafkaFuture<Collection<Object>> future) {
+    ListGroupsResult(KafkaFuture<Collection<Object>> future) {
         super(future);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupListing.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.ShareGroupState;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
@@ -29,8 +30,7 @@ import java.util.Optional;
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving
-public class ShareGroupListing {
-    private final String groupId;
+public class ShareGroupListing extends GroupListing {
     private final Optional<ShareGroupState> state;
 
     /**
@@ -49,15 +49,8 @@ public class ShareGroupListing {
      * @param state The state of the share group
      */
     public ShareGroupListing(String groupId, Optional<ShareGroupState> state) {
-        this.groupId = groupId;
+        super(groupId, GroupType.SHARE, "share");
         this.state = Objects.requireNonNull(state);
-    }
-
-    /**
-     * The id of the share group.
-     */
-    public String groupId() {
-        return groupId;
     }
 
     /**
@@ -69,15 +62,14 @@ public class ShareGroupListing {
 
     @Override
     public String toString() {
-        return "(" +
-            "groupId='" + groupId + '\'' +
+        return "(" + toStringBase() +
             ", state=" + state +
             ')';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, state);
+        return super.hashCode() + Objects.hash(state);
     }
 
     @Override
@@ -85,7 +77,7 @@ public class ShareGroupListing {
         if (this == o) return true;
         if (!(o instanceof ShareGroupListing)) return false;
         ShareGroupListing that = (ShareGroupListing) o;
-        return Objects.equals(groupId, that.groupId) &&
+        return super.equals(o) &&
             Objects.equals(state, that.state);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -140,6 +140,16 @@ public class AdminClientTestUtils {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> KafkaFuture.completedFuture(e.getValue()))));
     }
 
+    public static ListGroupsResult listGroupsResult(GroupListing... groups) {
+        return new ListGroupsResult(
+            KafkaFuture.completedFuture(Arrays.stream(groups)
+                .collect(Collectors.toList())));
+    }
+
+    public static ListGroupsResult listGroupsResult(KafkaException exception) {
+        return new ListGroupsResult(KafkaFuture.completedFuture(Collections.singleton(exception)));
+    }
+
     public static ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult(Map<String, Map<TopicPartition, OffsetAndMetadata>> offsets) {
         Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> resultMap = offsets.entrySet().stream()
             .collect(Collectors.toMap(e -> CoordinatorKey.byGroupId(e.getKey()),

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -19,7 +19,9 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -717,6 +719,13 @@ public class MockAdminClient extends AdminClient {
         }
 
         return new DescribeDelegationTokenResult(future);
+    }
+
+    @Override
+    public synchronized ListGroupsResult listGroups(ListGroupsOptions options) {
+        KafkaFutureImpl<Collection<Object>> future = new KafkaFutureImpl<>();
+        future.complete(groupConfigs.keySet().stream().map(g -> new GroupListing(g, GroupType.CONSUMER, ConsumerProtocol.PROTOCOL_TYPE)).collect(Collectors.toList()));
+        return new ListGroupsResult(future);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.util.CommandDefaultOptions;
+import org.apache.kafka.server.util.CommandLineUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GroupsCommand {
+    private static final Logger LOG = LoggerFactory.getLogger(GroupsCommand.class);
+
+    public static void main(String... args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    static int mainNoExit(String... args) {
+        try {
+            execute(args);
+            return 0;
+        } catch (Throwable e) {
+            System.err.println(e.getMessage());
+            System.err.println(Utils.stackTrace(e));
+            return 1;
+        }
+    }
+
+    static void execute(String... args) throws Exception {
+        GroupsCommandOptions opts = new GroupsCommandOptions(args);
+
+        Properties config = opts.commandConfig();
+        config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.bootstrapServer());
+
+        int exitCode = 0;
+        try (GroupsService service = new GroupsService(config)) {
+            if (opts.hasDescribeOption()) {
+                service.describeGroups(opts);
+            } else if (opts.hasListOption()) {
+                service.listGroups(opts);
+            }
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                printException(cause);
+            } else {
+                printException(e);
+            }
+            exitCode = 1;
+        } catch (Throwable t) {
+            printException(t);
+            exitCode = 1;
+        } finally {
+            Exit.exit(exitCode);
+        }
+    }
+
+    public static class GroupsService implements AutoCloseable {
+        private final Admin adminClient;
+
+        public GroupsService(Properties config) {
+            this.adminClient = Admin.create(config);
+        }
+
+        // Visible for testing
+        GroupsService(Admin adminClient) {
+            this.adminClient = adminClient;
+        }
+
+        public void describeGroups(GroupsCommandOptions opts) throws Exception {
+            Collection<GroupListing> resources = adminClient.listGroups()
+                    .all().get(30, TimeUnit.SECONDS);
+            printGroupDetails(resources, opts.groupType(), opts.protocol(), opts.hasConsumerOption());
+        }
+
+        public void listGroups(GroupsCommandOptions opts) throws Exception {
+            Collection<GroupListing> resources = adminClient.listGroups()
+                    .all().get(30, TimeUnit.SECONDS);
+            String results = resources.stream()
+                    .filter(g -> combinedFilter(g, opts.groupType(), opts.protocol(), opts.hasConsumerOption()))
+                    .map(GroupListing::groupId)
+                    .collect(Collectors.joining("\n"));
+            System.out.println(results);
+        }
+
+        private void printGroupDetails(Collection<GroupListing> groups,
+                                       Optional<GroupType> groupTypeFilter,
+                                       Optional<String> protocolFilter,
+                                       boolean consumerGroupFilter) {
+            List<List<String>> lineItems = new ArrayList<>();
+            int maxLen = 20;
+            for (GroupListing group : groups) {
+                if (combinedFilter(group, groupTypeFilter, protocolFilter, consumerGroupFilter)) {
+                    List<String> lineItem = new ArrayList<>();
+                    lineItem.add(group.groupId());
+                    lineItem.add(group.type().map(GroupType::toString).orElse(""));
+                    lineItem.add(group.protocol());
+                    for (String item : lineItem) {
+                        if (item != null) {
+                            maxLen = Math.max(maxLen, item.length());
+                        }
+                    }
+                    lineItems.add(lineItem);
+                }
+            }
+
+            String fmt = "%" + (-maxLen) + "s";
+            String header = fmt + " " + fmt + " " + fmt;
+            System.out.printf(header, "GROUP", "TYPE", "PROTOCOL");
+            System.out.println();
+            for (List<String> item : lineItems) {
+                for (String atom : item) {
+                    System.out.printf(fmt + " ", atom);
+                }
+                System.out.println();
+            }
+        }
+
+        private boolean combinedFilter(GroupListing group,
+                                       Optional<GroupType> groupTypeFilter,
+                                       Optional<String> protocolFilter,
+                                       boolean consumerGroupFilter) {
+            boolean pass = true;
+            Optional<GroupType> groupType = group.type();
+            String protocol = group.protocol();
+
+            if (groupTypeFilter.isPresent()) {
+                pass = protocolFilter.map(s -> protocol.equals(s) && groupType.filter(gt -> gt == groupTypeFilter.get()).isPresent())
+                        .orElseGet(() -> groupType.filter(gt -> gt == groupTypeFilter.get()).isPresent());
+            } else if (protocolFilter.isPresent()) {
+                pass = protocol.equals(protocolFilter.get());
+            } else if (consumerGroupFilter) {
+                pass = protocol.equals("consumer") || protocol.isEmpty() || groupType.filter(gt -> gt == GroupType.CONSUMER).isPresent();
+            }
+            return pass;
+        }
+
+        @Override
+        public void close() throws Exception {
+            adminClient.close();
+        }
+    }
+
+    private static void printException(Throwable e) {
+        System.out.println("Error while executing groups command : " + e.getMessage());
+        LOG.error(Utils.stackTrace(e));
+    }
+
+    public static final class GroupsCommandOptions extends CommandDefaultOptions {
+        private final ArgumentAcceptingOptionSpec<String> bootstrapServerOpt;
+
+        private final ArgumentAcceptingOptionSpec<String> commandConfigOpt;
+
+        private final OptionSpecBuilder describeOpt;
+
+        private final OptionSpecBuilder listOpt;
+
+        private final ArgumentAcceptingOptionSpec<String> groupTypeOpt;
+
+        private final ArgumentAcceptingOptionSpec<String> protocolOpt;
+
+        private final OptionSpecBuilder consumerOpt;
+
+        public GroupsCommandOptions(String[] args) {
+            super(args);
+            bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The Kafka server to connect to.")
+                    .withRequiredArg()
+                    .describedAs("server to connect to")
+                    .ofType(String.class);
+            commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client.")
+                    .withRequiredArg()
+                    .describedAs("command config property file")
+                    .ofType(String.class);
+
+            describeOpt = parser.accepts("describe", "Describe the details of the groups.");
+            listOpt = parser.accepts("list", "List all groups.");
+
+            groupTypeOpt = parser.accepts("group-type", "Filters the groups based on group type. "
+                            + "Valid types are: 'classic', 'consumer' and 'share'.")
+                    .withRequiredArg()
+                    .describedAs("type")
+                    .ofType(String.class);
+
+            protocolOpt = parser.accepts("protocol", "Filters the groups based on protocol type.")
+                    .withRequiredArg()
+                    .describedAs("protocol")
+                    .ofType(String.class);
+
+            consumerOpt = parser.accepts("consumer", "Filters the groups to show all kinds of consumer groups, including classic and simple consumer groups. This matches group type 'consumer', and group type 'classic' where the protocol type is 'consumer' or empty.");
+
+            options = parser.parse(args);
+
+            checkArgs();
+        }
+
+        public Boolean has(OptionSpec<?> builder) {
+            return options.has(builder);
+        }
+
+        public <A> Optional<A> valueAsOption(OptionSpec<A> option) {
+            return valueAsOption(option, Optional.empty());
+        }
+
+        public <A> Optional<A> valueAsOption(OptionSpec<A> option, Optional<A> defaultValue) {
+            if (has(option)) {
+                return Optional.of(options.valueOf(option));
+            } else {
+                return defaultValue;
+            }
+        }
+
+        public String bootstrapServer() {
+            return options.valueOf(bootstrapServerOpt);
+        }
+
+        public Properties commandConfig() throws IOException {
+            if (has(commandConfigOpt)) {
+                return Utils.loadProps(options.valueOf(commandConfigOpt));
+            } else {
+                return new Properties();
+            }
+        }
+
+        public Optional<GroupType> groupType() {
+            return valueAsOption(groupTypeOpt).map(GroupType::parse).filter(gt -> gt != GroupType.UNKNOWN);
+        }
+
+        public Optional<String> protocol() {
+            return valueAsOption(protocolOpt);
+        }
+
+        public boolean hasConsumerOption() {
+            return has(consumerOpt);
+        }
+
+        public boolean hasDescribeOption() {
+            return has(describeOpt);
+        }
+
+        public boolean hasListOption() {
+            return has(listOpt);
+        }
+
+        public void checkArgs() {
+            if (args.length == 0)
+                CommandLineUtils.printUsageAndExit(parser, "This tool helps to list and describe groups of all types.");
+
+            CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to list and describe groups of all types.");
+
+            // should have exactly one action
+            long actions = Stream.of(describeOpt, listOpt).filter(options::has).count();
+            if (actions != 1)
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --describe or --list.");
+
+            // check required args
+            if (!has(bootstrapServerOpt))
+                throw new IllegalArgumentException("--bootstrap-server must be specified.");
+
+            if (has(groupTypeOpt)) {
+                if (!groupType().isPresent()) {
+                    throw new IllegalArgumentException("--group-type must be a valid group type.");
+                }
+            }
+
+            // check invalid args
+            CommandLineUtils.checkInvalidArgs(parser, options, describeOpt);
+            CommandLineUtils.checkInvalidArgs(parser, options, listOpt);
+            CommandLineUtils.checkInvalidArgs(parser, options, consumerOpt, groupTypeOpt, protocolOpt);
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientTestUtils;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsResult;
+import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.Exit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GroupsCommandTest {
+
+    private final String bootstrapServer = "localhost:9092";
+    private final ToolsTestUtils.MockExitProcedure exitProcedure = new ToolsTestUtils.MockExitProcedure();
+
+    @BeforeEach
+    public void setupExitProcedure() {
+        Exit.setExitProcedure(exitProcedure);
+    }
+
+    @AfterEach
+    public void resetExitProcedure() {
+        Exit.resetExitProcedure();
+    }
+
+    @Test
+    public void testOptionsNoActionFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer});
+    }
+
+    @Test
+    public void testOptionsListSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--list"});
+        assertTrue(opts.hasListOption());
+    }
+
+    @Test
+    public void testOptionsListConsumerFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--consumer"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.hasConsumerOption());
+    }
+
+    @Test
+    public void testOptionsListProtocolFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--protocol", "anyproto"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.protocol().isPresent());
+        assertEquals("anyproto", opts.protocol().get());
+    }
+
+    @Test
+    public void testOptionsListTypeFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--group-type", "share"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.groupType().isPresent());
+        assertEquals(GroupType.SHARE, opts.groupType().get());
+    }
+
+    @Test
+    public void testOptionsListInvalidTypeFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--group-type", "invalid"});
+    }
+
+    @Test
+    public void testOptionsListProtocolAndTypeFiltersSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--protocol", "anyproto", "--group-type", "share"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.protocol().isPresent());
+        assertEquals("anyproto", opts.protocol().get());
+        assertTrue(opts.groupType().isPresent());
+        assertEquals(GroupType.SHARE, opts.groupType().get());
+    }
+
+    @Test
+    public void testOptionsListConsumerAndProtocolFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--consumer", "--protocol", "anyproto"});
+    }
+
+    @Test
+    public void testOptionsListConsumerAndTypeFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--list", "--consumer", "--group-type", "share"});
+    }
+
+    @Test
+    public void testOptionsDescribeSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe"});
+        assertTrue(opts.hasDescribeOption());
+    }
+
+    @Test
+    public void testOptionsDescribeConsumerFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--consumer"});
+        assertTrue(opts.hasDescribeOption());
+        assertTrue(opts.hasConsumerOption());
+    }
+
+    @Test
+    public void testOptionsDescribeProtocolFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--protocol", "anyproto"});
+        assertTrue(opts.hasDescribeOption());
+        assertTrue(opts.protocol().isPresent());
+        assertEquals("anyproto", opts.protocol().get());
+    }
+
+    @Test
+    public void testOptionsDescribeTypeFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--group-type", "share"});
+        assertTrue(opts.hasDescribeOption());
+        assertTrue(opts.groupType().isPresent());
+        assertEquals(GroupType.SHARE, opts.groupType().get());
+    }
+
+    @Test
+    public void testOptionsDescribeInvalidTypeFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--group-type", "invalid"});
+    }
+
+    @Test
+    public void testOptionsDescribeProtocolAndTypeFiltersSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--protocol", "anyproto", "--group-type", "share"});
+        assertTrue(opts.hasDescribeOption());
+        assertTrue(opts.protocol().isPresent());
+        assertEquals("anyproto", opts.protocol().get());
+        assertTrue(opts.groupType().isPresent());
+        assertEquals(GroupType.SHARE, opts.groupType().get());
+    }
+
+    @Test
+    public void testOptionsDescribeConsumerAndProtocolFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--consumer", "--protocol", "anyproto"});
+    }
+
+    @Test
+    public void testOptionsDescribeConsumerAndTypeFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+                new String[] {"--bootstrap-server", bootstrapServer, "--describe", "--consumer", "--group-type", "share"});
+    }
+
+    @Test
+    public void testListGroupsEmpty() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult();
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("", capturedOutput);
+    }
+
+    @Test
+    public void testListGroups() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("CGclassic,CGconsumer,SG", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsConsumerFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--consumer"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("CGclassic,CGconsumer", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsConsumerFilterSimpleCG() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("CGsimple", GroupType.CLASSIC, ""),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--consumer"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("CGclassic,CGconsumer,CGsimple", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsProtocolFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--protocol", "consumer"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("CGclassic,CGconsumer", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsTypeFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--group-type", "share"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("SG", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsProtocolAndTypeFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--protocol", "consumer", "--group-type", "classic"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("CGclassic", String.join(",", capturedOutput.split("\n")));
+    }
+
+    @Test
+    public void testListGroupsProtocolAndTypeFilterNoMatch() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--list", "--protocol", "consumer", "--group-type", "classic"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertEquals("", capturedOutput);
+    }
+
+    @Test
+    public void testDescribeGroupsEmpty() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult();
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput);
+    }
+
+    @Test
+    public void testDescribeGroups() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput,
+                new String[]{"CGclassic", "Classic", "consumer"},
+                new String[]{"CGconsumer", "Consumer", "consumer"},
+                new String[]{"SG", "Share", "share"});
+    }
+
+    @Test
+    public void testDescribeGroupsConsumerFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--consumer"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput,
+                new String[]{"CGclassic", "Classic", "consumer"},
+                new String[]{"CGconsumer", "Consumer", "consumer"});
+    }
+
+    @Test
+    public void testDescribeGroupsProtocolFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--protocol", "consumer"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput,
+                new String[]{"CGclassic", "Classic", "consumer"},
+                new String[]{"CGconsumer", "Consumer", "consumer"});
+    }
+
+    @Test
+    public void testDescribeGroupsTypeFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--group-type", "share"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput,
+                new String[]{"SG", "Share", "share"});
+    }
+
+    @Test
+    public void testDescribeGroupsProtocolAndTypeFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGclassic", GroupType.CLASSIC, "consumer"),
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--protocol", "consumer", "--group-type", "classic"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput,
+                new String[]{"CGclassic", "Classic", "consumer"});
+    }
+
+    @Test
+    public void testDescribeGroupsProtocolAndTypeFilterNoMatch() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+                new GroupListing("CGconsumer", GroupType.CONSUMER, "consumer"),
+                new GroupListing("SG", GroupType.SHARE, "share")
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+                        new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--protocol", "consumer", "--group-type", "classic"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedDescribeOutput(capturedOutput);
+    }
+
+    @Test
+    public void testDescribeGroupsFailsWithException() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(Errors.COORDINATOR_NOT_AVAILABLE.exception());
+        when(adminClient.listGroups()).thenReturn(result);
+
+        assertThrows(ExecutionException.class, () -> service.describeGroups(new GroupsCommand.GroupsCommandOptions(
+            new String[]{"--bootstrap-server", bootstrapServer, "--describe"}
+        )));
+    }
+
+    private void assertInitializeInvalidOptionsExitCode(int expected, String[] options) {
+        Exit.setExitProcedure((exitCode, message) -> {
+            assertEquals(expected, exitCode);
+            throw new RuntimeException();
+        });
+        try {
+            assertThrows(RuntimeException.class, () -> new ClientMetricsCommand.ClientMetricsCommandOptions(options));
+        } finally {
+            Exit.resetExitProcedure();
+        }
+    }
+
+    private void assertCapturedDescribeOutput(String capturedOutput, String[]... expectedLines) {
+        String[] capturedLines = capturedOutput.split("\n");
+        assertEquals(expectedLines.length + 1, capturedLines.length);
+        assertEquals("GROUP,TYPE,PROTOCOL", String.join(",", capturedLines[0].split(" +")));
+        int i = 1;
+        for (String[] line : expectedLines) {
+            assertEquals(String.join(",", line), String.join(",", capturedLines[i++].split(" +")));
+        }
+    }
+}


### PR DESCRIPTION
KIP-1043 defines Admin.listGroups and kafka-groups.sh. This is the implementation of the admin client and tools parts of the KIP.

An integration test will be part of a follow-on PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
