### PR TITLE
MINOR: Increase logging verbosity in Connect integration tests

### DIFF
--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -31,3 +31,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 log4j.logger.kafka=WARN
 log4j.logger.state.change.logger=OFF
 log4j.logger.org.apache.kafka.connect=DEBUG
+
+# Troubleshooting KAFKA-17493.
+log4j.logger.org.apache.kafka.consumer=DEBUG
+log4j.logger.org.apache.kafka.coordinator.group=DEBUG


### PR DESCRIPTION
This patch increases the verbosity of the logging in Connect's integration tests. This is to better understand the causes of the flaky tests described in KAFKA-17493.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
