### PR TITLE
MINOR Always publish build scan in CI Complete workflow

### DIFF
--- a/.github/actions/gh-api-update-status/action.yml
+++ b/.github/actions/gh-api-update-status/action.yml
@@ -22,6 +22,10 @@ inputs:
   gh-token:
     description: "The GitHub token for use with the CLI"
     required: true
+  repository:
+    description: "The GitHub repository"
+    required: true
+    default: "apache/kafka"
   commit_sha:
     description: "The SHA of the commit we are updating"
     required: true
@@ -49,7 +53,7 @@ runs:
         GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/apache/kafka/statuses/${{ inputs.commit_sha }} \
+        /repos/${{ inputs.repository }}/statuses/${{ inputs.commit_sha }} \
         -f "state=${{ inputs.state }}" -f "target_url=${{ inputs.url }}" \
         -f "description=${{ inputs.description }}" \
         -f "context=${{ inputs.context }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Test
         # Gradle flags
         # --build-cache:  Let Gradle restore the build cache
-        # --scan:         Attempt to publish build scans in PRs. This will only work on PRs from apache/kafka, not public forks.
+        # --no-scan:      Don't attempt to publish the scan yet. We want to archive it first.
         # --continue:     Keep running even if a test fails
         # -PcommitId      Prevent the Git SHA being written into the jar files (which breaks caching)
         id: junit-test
@@ -116,8 +116,7 @@ jobs:
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
-          timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue \
-          ${{ inputs.is-public-fork == 'true' && '--no-scan' || '--scan' }} \
+          timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
           -PtestLoggingEvents=started,passed,skipped,failed \
           -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
-          test
+          :metadata:test
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           -PmaxParallelForks=2 \
           -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
           -PcommitId=xxxxxxxxxxxxxxxx \
-          :metadata:test
+          test
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit reports

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -97,7 +97,7 @@ jobs:
             echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
           fi
       - name: Handle failed publish
-        if: ${{ failed() && steps.publish-build-scan.outcome == 'failure' }}
+        if: ${{ failure() && steps.publish-build-scan.outcome == 'failure' }}
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -75,7 +75,7 @@ jobs:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
-          url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
+          url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: 'Gradle Build Scan / Java ${{ matrix.java }}'
           state: 'error'

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -78,6 +78,7 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'Could not find build scan'
@@ -98,6 +99,7 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'The build scan failed to be published'
@@ -108,6 +110,7 @@ jobs:
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Download build scan archive
         id: download-build-scan
         uses: actions/download-artifact@v4
-        continue-on-error: true
+        continue-on-error: true  # Don't want this step to fail the overall workflow
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -97,7 +97,7 @@ jobs:
             echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
           fi
       - name: Handle failed publish
-        if: ${{ steps.publish-build-scan.outcome == 'failure' }}
+        if: ${{ failed() && steps.publish-build-scan.outcome == 'failure' }}
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -37,13 +37,8 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 
 jobs:
   upload-build-scan:
-    # Skip this workflow if CI was run for anything other than "pull_request" (like "push").
-    # Skip this workflow if the PR was from apache/kafka. Those will have already published the build scan in CI.
-    # Skip this workflow if the run was skipped or cancelled
-    if: |
-      github.event.workflow_run.event == 'pull_request' && 
-      github.event.workflow_run.head_repository.full_name != 'apache/kafka' &&
-       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    # Skip this workflow if the CI run was skipped or cancelled
+    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,14 +81,21 @@ jobs:
           state: 'error'
       - name: Publish Scan
         id: publish-build-scan
-        continue-on-error: true
         if: ${{ steps.download-build-scan.outcome == 'success' }}
         run: |
+          set +e
           ./gradlew --info buildScanPublishPrevious > gradle.out
-          SCAN_URL=$(grep '^https://.*$' gradle.out)
-          cat gradle.out
-          echo "Published build scan to $SCAN_URL" >> $GITHUB_STEP_SUMMARY
-          echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
+          exitcode="$?"
+          if [ $exitcode -ne 0 ]; then
+            cat gradle.out
+            echo "Failed to publish build scan" >> $GITHUB_STEP_SUMMARY
+            exit $exitcode
+          else
+            SCAN_URL=$(grep '^https://.*$' gradle.out)
+            cat gradle.out
+            echo "Published build scan to $SCAN_URL" >> $GITHUB_STEP_SUMMARY
+            echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
+          fi
       - name: Handle failed publish
         if: ${{ steps.publish-build-scan.outcome == 'failure' }}
         uses: ./.github/actions/gh-api-update-status

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -37,13 +37,8 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 
 jobs:
   upload-build-scan:
-    # Skip this workflow if CI was run for anything other than "pull_request" (like "push").
-    # Skip this workflow if the PR was from apache/kafka. Those will have already published the build scan in CI.
-    # Skip this workflow if the run was skipped or cancelled
-    if: |
-      github.event.workflow_run.event == 'pull_request' && 
-      github.event.workflow_run.head_repository.full_name != 'apache/kafka' &&
-       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    # Skip this workflow if the CI run was skipped or cancelled
+    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -85,14 +80,21 @@ jobs:
           state: 'error'
       - name: Publish Scan
         id: publish-build-scan
-        continue-on-error: true
         if: ${{ steps.download-build-scan.outcome == 'success' }}
         run: |
+          set +e
           ./gradlew --info buildScanPublishPrevious > gradle.out
-          SCAN_URL=$(grep '^https://.*$' gradle.out)
-          cat gradle.out
-          echo "Published build scan to $SCAN_URL" >> $GITHUB_STEP_SUMMARY
-          echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
+          exitcode="$?"
+          if [ $exitcode -ne 0 ]; then
+            cat gradle.out
+            echo "Failed to publish build scan" >> $GITHUB_STEP_SUMMARY
+            exit $exitcode
+          else
+            SCAN_URL=$(grep '^https://.*$' gradle.out)
+            cat gradle.out
+            echo "Published build scan to $SCAN_URL" >> $GITHUB_STEP_SUMMARY
+            echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
+          fi
       - name: Handle failed publish
         if: ${{ steps.publish-build-scan.outcome == 'failure' }}
         uses: ./.github/actions/gh-api-update-status

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ def isCI = isGithubActions || isJenkins
 def currentJvm = JavaVersion.current()
 
 develocity {
-    server = "https://example.org"
+    server = "https://ge.apache.org"
     projectId = "kafka"
     buildScan {
         uploadInBackground = !isCI

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ def isCI = isGithubActions || isJenkins
 def currentJvm = JavaVersion.current()
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://example.org"
     projectId = "kafka"
     buildScan {
         uploadInBackground = !isCI


### PR DESCRIPTION
Change the CI workflow to unconditionally run with `--no-scan` to ensure we can capture and archive the build scan. 

Change the CI Complete workflow to run on trunk as well as PRs.