### PR TITLE
MINOR: Fix DefaultRecordBatch and DefaultRecord protocol documentation.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -41,10 +41,15 @@ import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
  *   Attributes => Int8
  *   TimestampDelta => Varlong
  *   OffsetDelta => Varint
+ *   KeyLength => Varint
  *   Key => Bytes
+ *   ValueLength => Varint
  *   Value => Bytes
+ *   HeadersCount => Varint
  *   Headers => [HeaderKey HeaderValue]
+ *     HeaderKeyLength => Varint
  *     HeaderKey => String
+ *     HeaderValueLength => Varint
  *     HeaderValue => Bytes
  *
  * Note that in this schema, the Bytes and String types use a variable length integer to represent
@@ -423,7 +428,7 @@ public class DefaultRecord implements Record {
      * No-op for case where bytesToSkip <= 0. This could occur for cases where field is expected to be null.
      * @throws InvalidRecordException if end of stream is encountered before we could skip required bytes.
      * @throws IOException is an I/O error occurs while trying to skip from InputStream.
-     * 
+     *
      * @see java.io.InputStream#skip(long)
      */
     private static void skipBytes(InputStream in, int bytesToSkip) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -428,7 +428,7 @@ public class DefaultRecord implements Record {
      * No-op for case where bytesToSkip <= 0. This could occur for cases where field is expected to be null.
      * @throws InvalidRecordException if end of stream is encountered before we could skip required bytes.
      * @throws IOException is an I/O error occurs while trying to skip from InputStream.
-     *
+     * 
      * @see java.io.InputStream#skip(long)
      */
     private static void skipBytes(InputStream in, int bytesToSkip) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -159,7 +159,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     /**
      * Gets the base timestamp of the batch which is used to calculate the record timestamps from the deltas.
-     *
+     * 
      * @return The base timestamp
      */
     public long baseTimestamp() {

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -57,6 +57,7 @@ import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
  *  ProducerId => Int64
  *  ProducerEpoch => Int16
  *  BaseSequence => Int32
+ *  RecordsCount => Int32
  *  Records => [Record]
  *
  * Note that when compression is enabled (see attributes below), the compressed record data is serialized
@@ -158,7 +159,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     /**
      * Gets the base timestamp of the batch which is used to calculate the record timestamps from the deltas.
-     * 
+     *
      * @return The base timestamp
      */
     public long baseTimestamp() {

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -55,6 +55,7 @@ maxTimestamp: int64
 producerId: int64
 producerEpoch: int16
 baseSequence: int32
+recordsCount: int32
 records: [Record]</code></pre>
     <p> Note that when compression is enabled, the compressed record data is serialized directly following the count of the number of records. </p>
 

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -89,8 +89,9 @@ timestampDelta: varlong
 offsetDelta: varint
 keyLength: varint
 key: byte[]
-valueLen: varint
+valueLength: varint
 value: byte[]
+headersCount: varint
 Headers => [Header]</code></pre>
 	<h5 class="anchor-heading"><a id="recordheader" class="anchor-link"></a><a href="#recordheader">5.3.2.1 Record Header</a></h5>
 	<pre><code class="language-text">headerKeyLength: varint


### PR DESCRIPTION
The documentation for the DefaultRecordBatch protocol does not list recordsCount, which can be ambiguous for someone looking at the RecordBatch protocol through the official documentation or code comments.