### PR TITLE
KAFKA-17543: Improve and clarify the error message about generated broker IDs in migration

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -847,7 +847,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       }
       if (brokerIdGenerationEnable) {
         if (migrationEnabled) {
-          require(brokerId >= -1, "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
+          require(brokerId >= 0, "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
         }
         require(brokerId >= -1 && brokerId <= maxReservedBrokerId, "broker.id must be greater than or equal to -1 and not greater than reserved.broker.max.id")
       } else {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -847,7 +847,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       }
       if (brokerIdGenerationEnable) {
         if (migrationEnabled) {
-          require(brokerId != -1, "broker id generation is incompatible with migration to ZK. Please disable it before enabling migration")
+          require(brokerId != -1, "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
         }
         require(brokerId >= -1 && brokerId <= maxReservedBrokerId, "broker.id must be greater than or equal to -1 and not greater than reserved.broker.max.id")
       } else {
@@ -967,7 +967,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       // ZK-based
       if (migrationEnabled) {
         require(brokerId >= 0,
-          "broker broker.id.generation.enable is incompatible with migration to ZK. Please disable it before enabling migration")
+          "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
         validateQuorumVotersAndQuorumBootstrapServerForMigration()
         require(controllerListenerNames.nonEmpty,
           s"${KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG} must not be empty when running in ZooKeeper migration mode: ${controllerListenerNames.asJava}")

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -847,7 +847,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       }
       if (brokerIdGenerationEnable) {
         if (migrationEnabled) {
-          require(brokerId != -1, "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
+          require(brokerId >= -1, "broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).")
         }
         require(brokerId >= -1 && brokerId <= maxReservedBrokerId, "broker.id must be greater than or equal to -1 and not greater than reserved.broker.max.id")
       } else {

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1890,7 +1890,7 @@ class KafkaConfigTest {
     props.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "3000@localhost:9093")
     props.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER")
     assertEquals(
-      "requirement failed: broker id generation is incompatible with migration to ZK. Please disable it before enabling migration",
+      "requirement failed: broker.id generation is incompatible with ZooKeeper migration. Please stop using it before enabling migration (set broker.id to a value greater or equal to 0).",
       assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props)).getMessage)
   }
 


### PR DESCRIPTION
This PR tries to improve the error message when `broker.id` is set to `-1` when migration is enabled. It is not needed to disable the `broker.id.generation.enable` option. It is sufficient to just not use it (by not setting the `broker.id` to `-1`). This was discussed in 

### Committer Checklist (excluded from commit message)

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
