### PR TITLE
KAFKA-17524: StreamThreadTest shouldReturnErrorIfProducerInstanceIdNotInitialized hanging

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -254,6 +254,9 @@ public class DefaultTaskExecutor implements TaskExecutor {
     public void requestShutdown() {
         if (taskExecutorThread != null) {
             taskExecutorThread.shutdownRequested.set(true);
+            // TaskManager#awaitProcessableTasks may hang for long time and can't wait for a processable task,
+            // so we interrupt the thread to make it stop waiting.
+            taskExecutorThread.interrupt();
         }
     }
 


### PR DESCRIPTION
The `TaskManager#shutdownSchedulingTaskManager` uses `Long.MAX_VALUE` to wait for task executor shutdown. The `DefaultTaskExecutor#runOnce` ignores interrupt if there is no processable task. However, during this time, `TaskExecutorThread#shutdownrequested` may not be updated. If `DefaultTaskExecutor` gets into `TaskManager#awaitProcessableTasks` again, it may hang for long time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
