### PR TITLE
KAFKA-17559: Fix the flaky RemoteLogOffsetReader#testTaskQueueFullAndCancelTask

### DIFF
--- a/core/src/test/java/kafka/log/remote/RemoteLogOffsetReaderTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogOffsetReaderTest.java
@@ -111,8 +111,11 @@ class RemoteLogOffsetReaderTest {
         holderList.get(2).jobFuture().cancel(false);
 
         rlm.resume();
-        AsyncOffsetReadFutureHolder<Either<Exception, Option<TimestampAndOffset>>> last = holderList.get(holderList.size() - 1);
-        last.taskFuture().get(100, TimeUnit.MILLISECONDS);
+        for (AsyncOffsetReadFutureHolder<Either<Exception, Option<TimestampAndOffset>>> holder : holderList) {
+            if (!holder.jobFuture().isCancelled()) {
+                holder.taskFuture().get(1, TimeUnit.SECONDS);
+            }
+        }
 
         assertEquals(12, holderList.size());
         assertEquals(11, holderList.stream().filter(h -> h.taskFuture().isDone()).count());

--- a/core/src/test/java/kafka/log/remote/RemoteLogOffsetReaderTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogOffsetReaderTest.java
@@ -70,7 +70,7 @@ class RemoteLogOffsetReaderTest {
         logDir = Files.createTempDirectory("kafka-test");
         LeaderEpochCheckpointFile checkpoint = new LeaderEpochCheckpointFile(TestUtils.tempFile(), new LogDirFailureChannel(1));
         cache = new LeaderEpochFileCache(topicPartition, checkpoint, time.scheduler);
-        rlm = new MockRemoteLogManager(2, 10, logDir.toString());
+        rlm = new MockRemoteLogManager(2, 3, logDir.toString());
     }
 
     @AfterEach
@@ -98,8 +98,8 @@ class RemoteLogOffsetReaderTest {
         rlm.pause();
 
         List<AsyncOffsetReadFutureHolder<Either<Exception, Option<TimestampAndOffset>>>> holderList = new ArrayList<>();
-        // Task queue size is 10 and number of threads is 2, so it can accept at-most 12 items
-        for (int i = 0; i < 12; i++) {
+        // Task queue size is 3 and number of threads is 2, so it can accept at-most 5 items
+        for (int i = 0; i < 5; i++) {
             holderList.add(rlm.asyncOffsetRead(topicPartition, time.milliseconds(), 0L, cache, Option::empty));
         }
         assertThrows(TimeoutException.class, () -> holderList.get(0).taskFuture().get(10, TimeUnit.MILLISECONDS));
@@ -116,16 +116,15 @@ class RemoteLogOffsetReaderTest {
                 holder.taskFuture().get(1, TimeUnit.SECONDS);
             }
         }
-
-        assertEquals(12, holderList.size());
-        assertEquals(11, holderList.stream().filter(h -> h.taskFuture().isDone()).count());
+        assertEquals(5, holderList.size());
+        assertEquals(4, holderList.stream().filter(h -> h.taskFuture().isDone()).count());
         assertEquals(1, holderList.stream().filter(h -> !h.taskFuture().isDone()).count());
     }
 
     @Test
     public void testThrowErrorOnFindOffsetByTimestamp() throws Exception {
         RemoteStorageException exception = new RemoteStorageException("Error");
-        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 10, logDir.toString()) {
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 3, logDir.toString()) {
             @Override
             public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
                                                                       long timestamp,


### PR DESCRIPTION


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
