### PR TITLE
KAFKA-6197: Update Streams API and Javadoc references in documentation

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -57,10 +57,10 @@
 
 	<h3 class="anchor-heading"><a id="streamsapi" class="anchor-link"></a><a href="#streamsapi">2.3 Streams API</a></h3>
 
-	The <a href="#streamsapi">Streams</a> API allows transforming streams of data from input topics to output topics.
+	The <a href="/{{version}}/documentation/streams">Streams</a> API allows transforming streams of data from input topics to output topics.
 	<p>
 	Examples showing how to use this library are given in the
-	<a href="/{{version}}/javadoc/index.html?org/apache/kafka/streams/KafkaStreams.html" title="Kafka {{dotVersion}} Javadoc">javadocs</a>
+	<a href="/{{version}}/javadoc/index.html?org/apache/kafka/streams/KafkaStreams.html" title="Kafka {{dotVersion}} Javadoc">javadocs</a>.
 	<p>
 	Additional documentation on using the Streams API is available <a href="/{{version}}/documentation/streams">here</a>.
 	<p>
@@ -75,7 +75,7 @@
 	<p>
 	When using Scala you may optionally include the <code>kafka-streams-scala</code> library.  Additional documentation on using the Kafka Streams DSL for Scala is available <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html#scala-dsl">in the developer guide</a>.
 	<p>
-	To use Kafka Streams DSL for Scala for Scala {{scalaVersion}} you can use the following maven dependency:
+	To use Kafka Streams DSL for Scala {{scalaVersion}} you can use the following maven dependency:
 
 	<pre class="line-numbers"><code class="language-xml">&lt;dependency&gt;
 	&lt;groupId&gt;org.apache.kafka&lt;/groupId&gt;

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -103,7 +103,7 @@
     <h2 class="anchor-heading"><a id="connect" class="anchor-link"></a><a href="#connect">8. Kafka Connect</a></h2>
     <!--#include virtual="connect.html" -->
 
-    <h2><a id="streams" href="/documentation/streams">9. Kafka Streams</a></h2>
+    <h2><a id="streams" href="#streams">9. Kafka Streams</a></h2>
     <p>
         Kafka Streams is a client library for processing and analyzing data stored in Kafka. It builds upon important stream processing concepts such as properly distinguishing between event time and processing time, windowing support, exactly-once processing semantics and simple yet efficient management of application state.
     </p>
@@ -111,7 +111,7 @@
         Kafka Streams has a <b>low barrier to entry</b>: You can quickly write and run a small-scale proof-of-concept on a single machine; and you only need to run additional instances of your application on multiple machines to scale up to high-volume production workloads. Kafka Streams transparently handles the load balancing of multiple instances of the same application by leveraging Kafka's parallelism model.
     </p>
 
-    <p>Learn More about Kafka Streams read <a href="/documentation/streams">this</a> Section.</p>
+    <p>Learn More about Kafka Streams by reading <a href="/documentation/streams">this</a> section.</p>
 
 <!--#include virtual="../includes/_footer.htm" -->
 <!--#include virtual="../includes/_docs_footer.htm" -->

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -103,7 +103,7 @@
     <h2 class="anchor-heading"><a id="connect" class="anchor-link"></a><a href="#connect">8. Kafka Connect</a></h2>
     <!--#include virtual="connect.html" -->
 
-    <h2><a id="streams" href="/documentation/streams">9. Kafka Streams</a></h2>
+    <h2><a id="streams" href="#streams">9. Kafka Streams</a></h2>
     <p>
         Kafka Streams is a client library for processing and analyzing data stored in Kafka. It builds upon important stream processing concepts such as properly distinguishing between event time and processing time, windowing support, exactly-once processing semantics and simple yet efficient management of application state.
     </p>
@@ -111,7 +111,7 @@
         Kafka Streams has a <b>low barrier to entry</b>: You can quickly write and run a small-scale proof-of-concept on a single machine; and you only need to run additional instances of your application on multiple machines to scale up to high-volume production workloads. Kafka Streams transparently handles the load balancing of multiple instances of the same application by leveraging Kafka's parallelism model.
     </p>
 
-    <p>Learn More about Kafka Streams read <a href="/documentation/streams">this</a> Section.</p>
+    <p>To learn more about Kafka Streams, visit <a href="/documentation/streams">this</a> page.</p>
 
 <!--#include virtual="../includes/_footer.htm" -->
 <!--#include virtual="../includes/_docs_footer.htm" -->

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -111,7 +111,7 @@
         Kafka Streams has a <b>low barrier to entry</b>: You can quickly write and run a small-scale proof-of-concept on a single machine; and you only need to run additional instances of your application on multiple machines to scale up to high-volume production workloads. Kafka Streams transparently handles the load balancing of multiple instances of the same application by leveraging Kafka's parallelism model.
     </p>
 
-    <p>To learn more about Kafka Streams, visit <a href="/documentation/streams">this</a> page.</p>
+    <p>To learn more about Kafka Streams, visit the <a href="/documentation/streams">Kafka Streams page</a>.</p>
 
 <!--#include virtual="../includes/_footer.htm" -->
 <!--#include virtual="../includes/_docs_footer.htm" -->

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -45,6 +45,7 @@
                 <a href="/{{version}}/documentation/streams/core-concepts">Concepts</a>
                 <a href="/{{version}}/documentation/streams/architecture">Architecture</a>
                 <a href="/{{version}}/documentation/streams/developer-guide/">Developer Guide</a>
+                <a href="/{{version}}/javadoc/index.html?org/apache/kafka/streams/KafkaStreams.html">Javadoc</a>
                 <a href="/{{version}}/documentation/streams/upgrade-guide">Upgrade</a>
             </div>
         </div>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -34,7 +34,7 @@
             <ul>
                 <li><a href="#producerapi">2.1 Producer API</a>
                 <li><a href="#consumerapi">2.2 Consumer API</a>
-                <li><a href="/{{version}}/documentation/streams">2.3 Streams API</a>
+                <li><a href="#streamsapi">2.3 Streams API</a>
                 <li><a href="#connectapi">2.4 Connect API</a>
                 <li><a href="#adminapi">2.5 Admin API</a>
             </ul>
@@ -239,7 +239,7 @@
                 <li><a href="#connect_administration">8.4 Administration</a>
             </ul>
         
-        <li><a href="/{{version}}/documentation/streams">9. Kafka Streams</a>
+        <li><a href="#streams">9. Kafka Streams</a>
             <ul>
                 <li><a href="/{{version}}/documentation/streams/quickstart">9.1 Play with a Streams Application</a>
                 <li><a href="/{{version}}/documentation/streams/tutorial">9.2 Write your own Streams Applications</a>


### PR DESCRIPTION
Updated the Streams heading links in documentation TOC to redirect to headings in the documentation, as redirecting to the newer streams landing page was confusing. Also added a section of Javadocs to the Streams landing page.

Reference for documentation changes - https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Website+Documentation+Changes

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)