### PR TITLE
Revert "KAFKA-16803: Change fork, update ShadowJavaPlugin to 8.1.7 (#16295)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,9 @@ plugins {
   // be dropped from gradle/resources/dependencycheck-suppressions.xml
   id "com.github.spotbugs" version '5.1.3' apply false
   id 'org.scoverage' version '8.0.3' apply false
-  id 'io.github.goooler.shadow' version '8.1.3' apply false
+  // Updating the shadow plugin version to 8.1.1 causes issue with signing and publishing the shadowed
+  // artifacts - see https://github.com/johnrengelman/shadow/issues/901
+  id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
   //  Spotless 6.13.0 has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), and Spotless 6.14.0+ requires JRE 11
   //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
   //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
@@ -336,7 +338,7 @@ subprojects {
           if (!shouldPublishWithShadow) {
             from components.java
           } else {
-            apply plugin: 'io.github.goooler.shadow'
+            apply plugin: 'com.github.johnrengelman.shadow'
             project.shadow.component(mavenJava)
 
             // Fix for avoiding inclusion of runtime dependencies marked as 'shadow' in MANIFEST Class-Path.
@@ -2958,7 +2960,7 @@ project(':streams:upgrade-system-tests-38') {
 
 project(':jmh-benchmarks') {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.github.johnrengelman.shadow'
 
   shadowJar {
     archiveBaseName = 'kafka-jmh-benchmarks'


### PR DESCRIPTION
Revert "KAFKA-16803: Change fork, update ShadowJavaPlugin to 8.1.7 (#16295)"

This reverts commit 391778b8d737f4af074422ffe61bc494b21e6555.

Unfortunately that commit re-introduced bug #15127 which prevented the publishing of kafka-clients
artifacts to remote maven. As that bug says:

    The issue triggers only with publishMavenJavaPublicationToMavenRepository due to signing.
    Generating signed asc files error out for shadowed release artifacts as the module name
    (clients) differs from the artifact name (kafka-clients).

    The fix is basically to explicitly define artifact of shadowJar to signing and publish plugin.
    project.shadow.component(mavenJava) previously outputs the name as client-<version>-all.jar
    though the classifier and archivesBaseName are already defined correctly in :clients and
    shadowJar construction.