### PR TITLE
KAFKA-17555: uncomment all checks of testCommonNameLoggingTrustManagerMixValidAndInvalidCertificates

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapperTest.java
@@ -469,17 +469,17 @@ public class CommonNameLoggingTrustManagerFactoryWrapperTest {
             CommonNameLoggingTrustManager testTrustManager = new CommonNameLoggingTrustManager(origTrustManager, 2);
 
             // Call with valid certificate
-            //assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
+            assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
             // Call with invalid certificate
             assertThrows(CertificateException.class,
                     () -> testTrustManager.checkClientTrusted(invalidChainWithoutCa, "RSA"));
             // Call with valid certificate again
-            //assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
+            assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
             // Call with invalid certificate
             assertThrows(CertificateException.class,
                     () -> testTrustManager.checkClientTrusted(invalidChainWithoutCa, "RSA"));
             // Call with valid certificate again
-            //assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
+            assertDoesNotThrow(() -> testTrustManager.checkClientTrusted(validChainWithoutCa, "RSA"));
         }
     }
 


### PR DESCRIPTION
As title. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
