### PR TITLE
MINOR: Fix a race and add JMH bench for HdrHistogram

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3195,6 +3195,7 @@ project(':jmh-benchmarks') {
     implementation project(':server')
     implementation project(':raft')
     implementation project(':clients')
+    implementation project(':coordinator-common')
     implementation project(':group-coordinator')
     implementation project(':group-coordinator:group-coordinator-api')
     implementation project(':metadata')

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -29,6 +29,7 @@
     <allow pkg="java.security"/>
     <allow pkg="javax.net.ssl"/>
     <allow pkg="javax.security"/>
+    <allow pkg="com.yammer.metrics.core"/>
     <allow pkg="org.apache.kafka.common"/>
     <allow pkg="org.apache.kafka.clients.producer"/>
     <allow pkg="kafka.cluster"/>
@@ -51,6 +52,7 @@
     <allow pkg="org.apache.kafka.server"/>
     <allow pkg="org.apache.kafka.storage"/>
     <allow pkg="org.apache.kafka.clients"/>
+    <allow class="org.apache.kafka.coordinator.common.runtime.HdrHistogram"/>
     <allow pkg="org.apache.kafka.coordinator.group"/>
     <allow pkg="org.apache.kafka.image"/>
     <allow pkg="org.apache.kafka.metadata"/>

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/HdrHistogram.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/HdrHistogram.java
@@ -20,8 +20,6 @@ import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
 import org.HdrHistogram.ValueRecorder;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 /**
  * <p>A wrapper on top of the HdrHistogram API. It handles writing to the histogram by delegating
  * to an internal {@link ValueRecorder} implementation, and reading from the histogram by
@@ -35,6 +33,7 @@ public final class HdrHistogram {
 
     private static final long DEFAULT_MAX_SNAPSHOT_AGE_MS = 1000L;
 
+    private final Object lock = new Object();
     /**
      * The duration (in millis) after which the latest histogram snapshot is considered outdated and
      * subsequent calls to {@link #latestHistogram(long)} will result in the snapshot being recreated.
@@ -54,7 +53,7 @@ public final class HdrHistogram {
      * The latest snapshot of the internal HdrHistogram. Automatically updated by
      * {@link #latestHistogram(long)} if older than {@link #maxSnapshotAgeMs}.
      */
-    private final AtomicReference<Timestamped<Histogram>> timestampedHistogramSnapshot;
+    private volatile Timestamped<Histogram> timestampedHistogramSnapshot;
 
     public HdrHistogram(
         long highestTrackableValue,
@@ -70,19 +69,20 @@ public final class HdrHistogram {
     ) {
         this.maxSnapshotAgeMs = maxSnapshotAgeMs;
         recorder = new Recorder(highestTrackableValue, numberOfSignificantValueDigits);
-        this.timestampedHistogramSnapshot = new AtomicReference<>(new Timestamped<>(0, null));
+        this.timestampedHistogramSnapshot = new Timestamped<>(0, null);
     }
 
     private Histogram latestHistogram(long now) {
-        Timestamped<Histogram> latest = timestampedHistogramSnapshot.get();
-        while (now - latest.timestamp > maxSnapshotAgeMs) {
-            Histogram currentSnapshot = recorder.getIntervalHistogram();
-            boolean updatedLatest = timestampedHistogramSnapshot.compareAndSet(
-                latest, new Timestamped<>(now, currentSnapshot));
-
-            latest = timestampedHistogramSnapshot.get();
-            if (updatedLatest) {
-                break;
+        Timestamped<Histogram> latest = timestampedHistogramSnapshot;
+        if (now - latest.timestamp > maxSnapshotAgeMs) {
+            // Double-checked locking ensures that the thread that extracts the histogram data is
+            // the one that updates the internal snapshot.
+            synchronized (lock) {
+                latest = timestampedHistogramSnapshot;
+                if (now - latest.timestamp > maxSnapshotAgeMs) {
+                    latest = new Timestamped<>(now, recorder.getIntervalHistogram());
+                    timestampedHistogramSnapshot = latest;
+                }
             }
         }
         return latest.value;

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/HdrHistogramTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/HdrHistogramTest.java
@@ -16,22 +16,23 @@
  */
 package org.apache.kafka.coordinator.common.runtime;
 
+import org.apache.kafka.common.utils.ThreadUtils;
+
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import org.apache.kafka.common.utils.ThreadUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
@@ -51,8 +51,8 @@ public class HistogramBenchmark {
 
     /*
      * This benchmark compares the performance of the most commonly used in the Kafka codebase
-     * Yammer histograms and HdrHistogram. It does it by focusing on the write path in a multiple
-     * writers, multiple readers scenario.
+     * Yammer histogram and the new HdrHistogram. It does it by focusing on the write path in a
+     * multiple writers, multiple readers scenario.
      *
      * The benchmark relies on JMH Groups which allows us to distribute the number of worker threads
      * to the different benchmark methods.
@@ -60,8 +60,8 @@ public class HistogramBenchmark {
 
     private static final long MAX_VALUE = TimeUnit.MINUTES.toMillis(1L);
 
-    private volatile Histogram yammerHistogram;
-    private volatile HdrHistogram hdrHistogram;
+    private Histogram yammerHistogram;
+    private HdrHistogram hdrHistogram;
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -78,14 +78,14 @@ public class HistogramBenchmark {
     @Benchmark
     @Group("runner")
     @GroupThreads(3)
-    public void write_YammerHistogram() {
+    public void writeYammerHistogram() {
         yammerHistogram.update(ThreadLocalRandom.current().nextLong(MAX_VALUE));
     }
 
     @Benchmark
     @Group("runner")
     @GroupThreads(3)
-    public void write_HdrHistogram() {
+    public void writeHdrHistogram() {
         hdrHistogram.record(ThreadLocalRandom.current().nextLong(MAX_VALUE));
     }
 
@@ -101,7 +101,7 @@ public class HistogramBenchmark {
     @Benchmark
     @Group("runner")
     @GroupThreads(2)
-    public double read_YammerHistogram() {
+    public double readYammerHistogram() {
         long now = System.currentTimeMillis();
         if (now % 199 == 0) {
             return yammerHistogram.getSnapshot().get999thPercentile();
@@ -112,7 +112,7 @@ public class HistogramBenchmark {
     @Benchmark
     @Group("runner")
     @GroupThreads(2)
-    public double read_HdrHistogram() {
+    public double readHdrHistogram() {
         long now = System.currentTimeMillis();
         if (now % 199 == 0) {
             return hdrHistogram.measurePercentile(now, 99.9);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.jmh.metrics;
 
-import java.util.concurrent.ThreadLocalRandom;
 import org.apache.kafka.coordinator.common.runtime.HdrHistogram;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 
@@ -38,6 +37,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.metrics;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.kafka.coordinator.group.metrics.HdrHistogram;
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
+
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.MetricName;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Threads(10)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class HistogramBenchmark {
+
+    /*
+     * This benchmark compares the performance of the most commonly used in the Kafka codebase
+     * Yammer histograms and HdrHistogram. It does it by focusing on the write path in a multiple
+     * writers, multiple readers scenario.
+     *
+     * The benchmark relies on JMH Groups which allows us to distribute the number of worker threads
+     * to the different benchmark methods.
+     */
+
+    private static final long MAX_VALUE = TimeUnit.MINUTES.toMillis(1L);
+
+    private volatile Histogram yammerHistogram;
+    private volatile HdrHistogram hdrHistogram;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        yammerHistogram = KafkaYammerMetrics.defaultRegistry().newHistogram(new MetricName("a", "", ""), true);
+        hdrHistogram = new HdrHistogram(MAX_VALUE, 3);
+    }
+
+    /*
+     * The write benchmark methods below are the core of the benchmark. They use ThreadLocalRandom
+     * to generate values to record. This is much faster than the actual histogram recording, so
+     * the benchmark results are representative of the histogram implementation.
+     */
+
+    @Benchmark
+    @Group("runner")
+    @GroupThreads(3)
+    public void write_YammerHistogram() {
+        yammerHistogram.update(ThreadLocalRandom.current().nextLong(MAX_VALUE));
+    }
+
+    @Benchmark
+    @Group("runner")
+    @GroupThreads(3)
+    public void write_HdrHistogram() {
+        hdrHistogram.record(ThreadLocalRandom.current().nextLong(MAX_VALUE));
+    }
+
+    /*
+     * The read benchmark methods below are not real benchmark methods!
+     * They are there only to simulate the concurrent exercise of the read and the write paths in
+     * the histogram implementations (with the read path exercised significantly less often). The
+     * measurements for these benchmark methods should be ignored as although not optimized away
+     * (that's why the methods have a return value), they practically measure the cost of a
+     * System.currentTimeMillis() call.
+     */
+
+    @Benchmark
+    @Group("runner")
+    @GroupThreads(2)
+    public double read_YammerHistogram() {
+        long now = System.currentTimeMillis();
+        if (now % 199 == 0) {
+            return yammerHistogram.getSnapshot().get999thPercentile();
+        }
+        return now;
+    }
+
+    @Benchmark
+    @Group("runner")
+    @GroupThreads(2)
+    public double read_HdrHistogram() {
+        long now = System.currentTimeMillis();
+        if (now % 199 == 0) {
+            return hdrHistogram.measurePercentile(now, 99.9);
+        }
+        return now;
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metrics/HistogramBenchmark.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.jmh.metrics;
 
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.kafka.coordinator.group.metrics.HdrHistogram;
+import org.apache.kafka.coordinator.common.runtime.HdrHistogram;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 
 import com.yammer.metrics.core.Histogram;


### PR DESCRIPTION
### About
An encore of #17184, this addresses the race described https://github.com/apache/kafka/pull/16949#discussion_r1750273695 and adds a JMH benchmark comparing `HdrHistogram` with Yammer's histogram. It also addresses some nits from that previous PR and rebases on top of the #17011 changes.

A sample result from a local run on my development machine:
```
Benchmark                                       Mode  Cnt     Score    Error  Units
HistogramBenchmark.runner                       avgt    5   422.372 ± 13.081  ns/op
HistogramBenchmark.runner:readHdrHistogram      avgt    5    50.952 ±  1.330  ns/op
HistogramBenchmark.runner:readYammerHistogram   avgt    5    51.249 ±  1.319  ns/op
HistogramBenchmark.runner:writeHdrHistogram     avgt    5   319.489 ± 52.221  ns/op
HistogramBenchmark.runner:writeYammerHistogram  avgt    5  1020.283 ± 18.695  ns/op
```

### Testing
In addition to the JMH benchmark, and unlike the original PR, #17184, this also includes a fairly reliable test for the race that's being fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
