### PR TITLE
KAFKA-17574: Allow overriding TestKitNodes baseDirectory

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -43,6 +43,7 @@
     <suppress checks="ClassFanOutComplexity" files="RemoteLogManagerTest.java"/>
     <suppress checks="MethodLength"
               files="(KafkaClusterTestKit).java"/>
+    <suppress checks="NPathComplexity" files="TestKitNodes.java"/>
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity" files="SharePartitionManagerTest"/>

--- a/test-common/src/test/java/org/apache/kafka/common/test/KafkaClusterTestKitTest.java
+++ b/test-common/src/test/java/org/apache/kafka/common/test/KafkaClusterTestKitTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaClusterTestKitTest {
     @ParameterizedTest
@@ -88,7 +89,7 @@ public class KafkaClusterTestKitTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testCreateClusterAndCloseWithMultipleLogDirs(boolean combined) {
+    public void testCreateClusterAndCloseWithMultipleLogDirs(boolean combined) throws Exception {
         try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
                 new TestKitNodes.Builder().
                         setNumBrokerNodes(5).
@@ -118,8 +119,23 @@ public class KafkaClusterTestKitTest {
                 String expected = combined ? String.format("combined_%d_0", controllerId) : String.format("controller_%d", controllerId);
                 assertEquals(expected, Paths.get(node.metadataDirectory()).getFileName().toString());
             });
-        } catch (Exception e) {
-            fail("failed to init cluster", e);
+        }
+    }
+
+    @Test
+    public void testCreateClusterWithSpecificBaseDir() throws Exception {
+        Path baseDirectory = TestUtils.tempDirectory().toPath();
+        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
+                new TestKitNodes.Builder().
+                        setBaseDirectory(baseDirectory).
+                        setNumBrokerNodes(1).
+                        setCombined(true).
+                        setNumControllerNodes(1).build()).build()) {
+            assertEquals(cluster.nodes().baseDirectory(), baseDirectory.toFile().getAbsolutePath());
+            cluster.nodes().controllerNodes().values().forEach(controller ->
+                assertTrue(Paths.get(controller.metadataDirectory()).startsWith(baseDirectory)));
+            cluster.nodes().brokerNodes().values().forEach(broker ->
+                assertTrue(Paths.get(broker.metadataDirectory()).startsWith(baseDirectory)));
         }
     }
 }


### PR DESCRIPTION
This allows shutting down a KafkaClusterTestKit from a JVM shutdown hook without risking error logs because the base directory has already been deleted by the shutdown hook TestUtils.tempDirectory sets up.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

Added a test that uses the new method and asserts that the controller and broker metadata directories are inside the specified directory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
