### PR TITLE
MINOR Fix is-public-fork input type

### DIFF
--- a/.github/actions/gh-api-update-status/action.yml
+++ b/.github/actions/gh-api-update-status/action.yml
@@ -19,6 +19,8 @@
 name: "Update Commit Status Check"
 description: "Update the status of a commit check using the GH CLI"
 inputs:
+  # Composite actions do not support typed parameters. Everything is treated as a string
+  # See: https://github.com/actions/runner/issues/2238
   gh-token:
     description: "The GitHub token for use with the CLI"
     required: true

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -19,6 +19,8 @@
 name: "Gradle Setup"
 description: "Setup Java and Gradle"
 inputs:
+  # Composite actions do not support typed parameters. Everything is treated as a string
+  # See: https://github.com/actions/runner/issues/2238
   java-version:
     description: "Java version to use"
     default: "17"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,10 +6,12 @@ The entry point for our build is the "CI" workflow which is defined in ci.yml.
 This is used for both PR and trunk builds. The jobs and steps of the workflow
 are defined in build.yml.
 
-## Opting-in to GitHub Actions
-
-To opt-in to the new GitHub actions workflows, simply name your branch with a
-prefix of "gh-". For example, `gh-KAFKA-17433-deflake`
+For Pull Requests, the "CI" workflow runs in an unprivileged context. This means
+it does not have access to repository secrets. After the "CI" workflow is complete, 
+the "CI Complete" workflow is automatically run. This workflow consumes artifacts
+from the "CI" workflow and does run in a privileged context. This is how we are
+able to upload Gradle Build Scans to Develocity without exposing our access
+token to the Pull Requests.
 
 ## Disabling Email Notifications
 
@@ -17,24 +19,12 @@ By default, GitHub sends an email for each failed action run. To change this,
 visit https://github.com/settings/notifications and find System -> Actions.
 Here you can change your notification preferences.
 
-## Publishing Build Scans
+## GitHub Actions Quirks
 
-> This only works for committers (who have ASF accounts on ge.apache.org).
+### Composite Actions
 
-There are two ways committers can have build scans published. The simplest
-way is to push their branches to apache/kafka. This will allow GitHub Actions to
-have access to the repository secret needed to publish the scan.
+Composite actions are a convenient way to reuse build logic, but they have
+some limitations. 
 
-Alternatively, committers create pull requests against their own forks and
-configure their own access key as a repository secret.
-
-Log in to https://ge.apache.org/, click on My Settings and then Access Keys
-
-Generate an Access Key and give it a name like "github-actions". Copy the key
-down somewhere safe.
-
-On your fork of apache/kafka, navigate to Settings -> Security -> Secrets and
-Variables -> Actions. In the Secrets tab, click Create a New Repository Secret.
-The name of the secret should be `GE_ACCESS_TOKEN` and the value should
-be `ge.apache.org=abc123` where "abc123" is substituted for the Access Key you
-previously generated.
+- Cannot run more than one step in a composite action (see `workflow_call` instead)
+- Inputs can only be strings, no support for typed parameters. See: https://github.com/actions/runner/issues/2238

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ on:
         type: string
       is-public-fork:
         description: "Is this CI run from a public fork?"
-        default: "true"
-        type: string
+        default: true
+        type: boolean
 
 jobs:
   validate:
@@ -66,7 +66,7 @@ jobs:
         # --no-scan:      For public fork PRs, we won't attempt to publish the scan
         run: |
           ./gradlew --build-cache --info  \
-          ${{ inputs.is-public-fork == 'true' && '--no-scan' || '--scan' }} \
+          ${{ inputs.is-public-fork && '--no-scan' || '--scan' }} \
           check -x test
       - name: Archive check reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ on:
     inputs:
       gradle-cache-read-only:
         description: "Should the Gradle cache be read-only?"
-        default: "true"
-        type: string
+        default: true
+        type: boolean
       gradle-cache-write-only:
         description: "Should the Gradle cache be write-only?"
-        default: "false"
-        type: string
+        default: false
+        type: boolean
       is-public-fork:
         description: "Is this CI run from a public fork?"
         default: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     with:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
-      is-public-fork: ${{ github.event.pull_request.head.repo.fork == 'true' }}
+      is-public-fork: ${{ github.event.pull_request.head.repo.fork }}
     secrets:
       inherit


### PR DESCRIPTION
PRs are getting the wrong value for this workflow input. The context value we are checking is a boolean and we were treating it as a string. This patch fixes that by defining the workflow input as a boolean and treating it as such.