### PR TITLE
HOTFIX Fix ci.yml for push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     with:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
-      is-public-fork: ${{ github.event.pull_request.head.repo.fork }}
+      is-public-fork: ${{ github.event.pull_request.head.repo.fork || false }}
     secrets:
       inherit


### PR DESCRIPTION
On trunk, our CI runs in response to "push" events. The change in #17227 causes the workflow template to be invalid, which prevents the build from starting. 