### PR TITLE
KAFKA-17581: AsyncKafkaConsumer can't unsubscribe invalid topics

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
@@ -18,6 +18,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.InvalidTopicException
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
@@ -227,11 +228,29 @@ class PlaintextConsumerSubscriptionTest extends AbstractConsumerTest {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
-  def testSubscribeInvalidTopic(quorum: String, groupProtocol: String): Unit = {
-    // Invalid topic name due to space
-    val invalidTopicName = "topic abc"
+  def testSubscribeInvalidTopicCanUnsubscribe(quorum: String, groupProtocol: String): Unit = {
     val consumer = createConsumer()
 
+    setupSubscribeInvalidTopic(consumer)
+    assertDoesNotThrow(new Executable {
+      override def execute(): Unit = consumer.unsubscribe()
+    })
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testSubscribeInvalidTopicCanClose(quorum: String, groupProtocol: String): Unit = {
+    val consumer = createConsumer()
+
+    setupSubscribeInvalidTopic(consumer)
+    assertDoesNotThrow(new Executable {
+      override def execute(): Unit = consumer.close()
+    })
+  }
+
+  def setupSubscribeInvalidTopic(consumer: Consumer[Array[Byte], Array[Byte]]): Unit = {
+    // Invalid topic name due to space
+    val invalidTopicName = "topic abc"
     consumer.subscribe(List(invalidTopicName).asJava)
 
     var exception : InvalidTopicException = null


### PR DESCRIPTION
If AsyncKafkaConsumer subscribes an invalid topic, the background thread will keep sending MetadataRequest with invalid topic, so background event queue will keep receiving ErrorEvent. When AsyncKafkaConsumer unsubscribes, it drains all background events and process them. ErrorEvent will be thrown in application thread and users can't unsubscribe topics without exception.

We can ignore error events before unsubscribe call to avoid this error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
