### PR TITLE
KAFKA-17552: Handle LIST_OFFSETS request for max_timestamp when remote storage is enabled

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.record.internal.Record;
 import org.apache.kafka.common.record.internal.RecordBatch;
 import org.apache.kafka.common.record.internal.RemoteLogInputStream;
 import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
@@ -697,8 +698,16 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
      *    then the search will be performed in the local storage.
      * 2. If the target segment is found only in the remote storage, then the search will be performed in the remote storage.
      *
-     *  <p>
-     * This method returns an option of TimestampOffset. The returned value is determined using the following ordered list of rules:
+     * <p>When {@code timestamp} is not {@link ListOffsetsRequest#MAX_TIMESTAMP}, this performs a
+     * regular timestamp search: it walks epochs in order and returns the offset of the first message
+     * whose timestamp is {@code >= timestamp} and whose offset is {@code >= startingOffset}.
+     *
+     * <p>When {@code timestamp} is {@link ListOffsetsRequest#MAX_TIMESTAMP}, this performs a
+     * {@code MAX_TIMESTAMP} search: it scans all remote segments (no epoch filter) to find the one
+     * with the highest {@code maxTimestampMs}, then returns the offset of the record carrying that
+     * maximum timestamp. In this mode {@code startingOffset} and {@code leaderEpochCache} are ignored.
+     *
+     * <p>This method returns an option of TimestampOffset. The returned value is determined using the following ordered list of rules:
      * <p>
      * - If there are no messages in the remote storage, return Empty
      * - If all the messages in the remote storage have smaller offsets, return Empty
@@ -707,9 +716,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
      * is greater than or equals to the target timestamp and whose offset is greater than or equals to the startingOffset.
      *
      * @param tp               topic partition in which the offset to be found.
-     * @param timestamp        The timestamp to search for.
-     * @param startingOffset   The starting offset to search.
-     * @param leaderEpochCache LeaderEpochFileCache of the topic partition.
+     * @param timestamp        The timestamp to search for. Pass {@link ListOffsetsRequest#MAX_TIMESTAMP} to
+     *                         trigger a MAX_TIMESTAMP search across all remote segments.
+     * @param startingOffset   The starting offset to search. Ignored when {@code timestamp} is
+     *                         {@link ListOffsetsRequest#MAX_TIMESTAMP}.
+     * @param leaderEpochCache LeaderEpochFileCache of the topic partition. Ignored when {@code timestamp} is
+     *                         {@link ListOffsetsRequest#MAX_TIMESTAMP}.
      * @return the timestamp and offset of the first message that meets the requirements. Empty will be returned if there
      * is no such message.
      */
@@ -726,39 +738,76 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             throw new KafkaException("UnifiedLog does not exist for topic partition: " + tp);
         }
         UnifiedLog unifiedLog = unifiedLogOptional.get();
-
-        // Get the respective epoch in which the starting-offset exists.
-        OptionalInt maybeEpoch = leaderEpochCache.epochForOffset(startingOffset);
         TopicIdPartition topicIdPartition = new TopicIdPartition(topicId, tp);
-        NavigableMap<Integer, Long> epochWithOffsets = buildFilteredLeaderEpochMap(leaderEpochCache.epochWithOffsets());
-        while (maybeEpoch.isPresent()) {
-            int epoch = maybeEpoch.getAsInt();
-            // KAFKA-15802: Add a new API for RLMM to choose how to implement the predicate.
-            // currently, all segments are returned and then iterated, and filtered
-            Iterator<RemoteLogSegmentMetadata> iterator = remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(topicIdPartition, epoch);
+
+        if (timestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
+            // MAX_TIMESTAMP path: scan all remote segments to find the one with the highest maxTimestampMs.
+            RemoteLogSegmentMetadata maxTsSegment = null;
+            Iterator<RemoteLogSegmentMetadata> iterator =
+                    remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(topicIdPartition);
             while (iterator.hasNext()) {
-                RemoteLogSegmentMetadata rlsMetadata = iterator.next();
-                if (rlsMetadata.maxTimestampMs() >= timestamp
-                    && rlsMetadata.endOffset() >= startingOffset
-                    && isRemoteSegmentWithinLeaderEpochs(rlsMetadata, unifiedLog.logEndOffset(), epochWithOffsets)
-                    && rlsMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
-                    // cache to avoid race conditions
-                    List<LogSegment> segmentsCopy = unifiedLog.logSegments();
-                    if (segmentsCopy.isEmpty() || rlsMetadata.startOffset() < segmentsCopy.get(0).baseOffset()) {
-                        // search in remote-log
-                        return lookupTimestamp(rlsMetadata, timestamp, startingOffset);
-                    } else {
-                        // search in local-log
-                        for (LogSegment segment : segmentsCopy) {
-                            if (segment.largestTimestamp() >= timestamp) {
-                                return segment.findOffsetByTimestamp(timestamp, startingOffset);
+                RemoteLogSegmentMetadata candidate = iterator.next();
+                if (!candidate.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
+                    continue;
+                }
+                if (maxTsSegment == null
+                        || candidate.maxTimestampMs() > maxTsSegment.maxTimestampMs()
+                        || (candidate.maxTimestampMs() == maxTsSegment.maxTimestampMs()
+                                && candidate.endOffset() > maxTsSegment.endOffset())) {
+                    maxTsSegment = candidate;
+                }
+            }
+
+            if (maxTsSegment == null) {
+                return Optional.empty();
+            }
+
+            // If the max timestamp segment is in the overlap region, prefer the local copy.
+            List<LogSegment> localSegments = unifiedLogOptional.get().logSegments();
+            if (!localSegments.isEmpty()
+                && maxTsSegment.startOffset() >= localSegments.get(0).baseOffset()) {
+                for (LogSegment segment : localSegments) {
+                    if (segment.largestTimestamp() >= maxTsSegment.maxTimestampMs()) {
+                        return segment.findOffsetByTimestamp(maxTsSegment.maxTimestampMs(), maxTsSegment.startOffset());
+                    }
+                }
+            }
+
+            // The max timestamp segment is purely in remote storage (or local lookup failed).
+            return lookupTimestamp(maxTsSegment, maxTsSegment.maxTimestampMs(), maxTsSegment.startOffset());
+        } else {
+            // Get the respective epoch in which the starting-offset exists.
+            OptionalInt maybeEpoch = leaderEpochCache.epochForOffset(startingOffset);
+            NavigableMap<Integer, Long> epochWithOffsets = buildFilteredLeaderEpochMap(leaderEpochCache.epochWithOffsets());
+            while (maybeEpoch.isPresent()) {
+                int epoch = maybeEpoch.getAsInt();
+                // KAFKA-15802: Add a new API for RLMM to choose how to implement the predicate.
+                // currently, all segments are returned and then iterated, and filtered
+                Iterator<RemoteLogSegmentMetadata> iterator = remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(topicIdPartition, epoch);
+                while (iterator.hasNext()) {
+                    RemoteLogSegmentMetadata rlsMetadata = iterator.next();
+                    if (rlsMetadata.maxTimestampMs() >= timestamp
+                        && rlsMetadata.endOffset() >= startingOffset
+                        && isRemoteSegmentWithinLeaderEpochs(rlsMetadata, unifiedLog.logEndOffset(), epochWithOffsets)
+                        && rlsMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
+                        // cache to avoid race conditions
+                        List<LogSegment> segmentsCopy = unifiedLog.logSegments();
+                        if (segmentsCopy.isEmpty() || rlsMetadata.startOffset() < segmentsCopy.get(0).baseOffset()) {
+                            // search in remote-log
+                            return lookupTimestamp(rlsMetadata, timestamp, startingOffset);
+                        } else {
+                            // search in local-log
+                            for (LogSegment segment : segmentsCopy) {
+                                if (segment.largestTimestamp() >= timestamp) {
+                                    return segment.findOffsetByTimestamp(timestamp, startingOffset);
+                                }
                             }
                         }
                     }
                 }
+                // Move to the next epoch if not found with the current epoch.
+                maybeEpoch = leaderEpochCache.nextEpoch(epoch);
             }
-            // Move to the next epoch if not found with the current epoch.
-            maybeEpoch = leaderEpochCache.nextEpoch(epoch);
         }
         return Optional.empty();
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogOffsetReader.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogOffsetReader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.server.log.remote.storage;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.internal.FileRecords;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache;
 import org.apache.kafka.storage.internals.log.AsyncOffsetReader;
 import org.apache.kafka.storage.internals.log.OffsetResultHolder;
@@ -62,7 +63,13 @@ public class RemoteLogOffsetReader implements Callable<Void> {
             // If it is not found in remote storage, then search in the local storage starting with local log start offset.
             Optional<FileRecords.TimestampAndOffset> timestampAndOffsetOpt =
                     rlm.findOffsetByTimestamp(tp, timestamp, startingOffset, leaderEpochCache);
-            if (timestampAndOffsetOpt.isEmpty()) {
+            if (timestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
+                // For MAX_TIMESTAMP both remote and local results must be compared; the one with
+                // the higher timestamp wins (ties broken by higher offset).
+                Optional<FileRecords.TimestampAndOffset> localResult = searchInLocalLog.get();
+                timestampAndOffsetOpt = merge(timestampAndOffsetOpt, localResult);
+            } else if (timestampAndOffsetOpt.isEmpty()) {
+                // For regular timestamp searches, fall back to local only when remote found nothing.
                 timestampAndOffsetOpt = searchInLocalLog.get();
             }
             result = new OffsetResultHolder.FileRecordsOrError(Optional.empty(), timestampAndOffsetOpt);
@@ -73,5 +80,22 @@ public class RemoteLogOffsetReader implements Callable<Void> {
         }
         callback.accept(result);
         return null;
+    }
+
+    /**
+     * Merge two MAX_TIMESTAMP candidates. Return one with the higher timestamp.
+     * If timestamps are equal, return the one with the higher offset.
+     */
+    private static Optional<FileRecords.TimestampAndOffset> merge(
+            Optional<FileRecords.TimestampAndOffset> a,
+            Optional<FileRecords.TimestampAndOffset> b) {
+        if (a.isEmpty()) return b;
+        if (b.isEmpty()) return a;
+        FileRecords.TimestampAndOffset ta = a.get();
+        FileRecords.TimestampAndOffset tb = b.get();
+        if (ta.timestamp > tb.timestamp || (ta.timestamp == tb.timestamp && ta.offset > tb.offset)) {
+            return a;
+        }
+        return b;
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1724,7 +1724,7 @@ public class UnifiedLog implements AutoCloseable {
                     } else if (targetTimestamp == ListOffsetsRequest.EARLIEST_PENDING_UPLOAD_TIMESTAMP) {
                         return fetchEarliestPendingUploadOffset(remoteOffsetReader);
                     } else if (targetTimestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
-                        // Cache to avoid race conditions.
+                        // Cache local segments to avoid race conditions with rolling/truncation.
                         List<LogSegment> segments = logSegments();
                         LogSegment latestTimestampSegment = null;
                         for (LogSegment segment : segments) {
@@ -1734,19 +1734,37 @@ public class UnifiedLog implements AutoCloseable {
                                 latestTimestampSegment = segment;
                             }
                         }
-                        // cache the timestamp and offset
-                        TimestampOffset maxTimestampSoFar = latestTimestampSegment.readMaxTimestampAndOffsetSoFar();
-                        // lookup the position of batch to avoid extra I/O
-                        OffsetPosition position = latestTimestampSegment.offsetIndex().lookup(maxTimestampSoFar.offset());
-                        Optional<FileRecords.TimestampAndOffset> timestampAndOffsetOpt = findFirst(
-                                latestTimestampSegment.log().batchesFrom(position.position()),
+
+                        LogSegment logMaxSegment = latestTimestampSegment;
+                        AsyncOffsetReader.TimestampAndOffsetSupplier localMaxSupplier = () -> {
+                            if (logMaxSegment == null) {
+                                return Optional.empty();
+                            }
+                            // cache the timestamp and offset
+                            TimestampOffset maxTimestampSoFar = logMaxSegment.readMaxTimestampAndOffsetSoFar();
+                            // lookup the position of batch to avoid extra I/O
+                            OffsetPosition position = logMaxSegment.offsetIndex().lookup(maxTimestampSoFar.offset());
+                            return findFirst(
+                                logMaxSegment.log().batchesFrom(position.position()),
                                 item -> item.maxTimestamp() == maxTimestampSoFar.timestamp())
-                                    .flatMap(batch -> batch.offsetOfMaxTimestamp()
-                                        .map(offset -> new FileRecords.TimestampAndOffset(
-                                            batch.maxTimestamp(),
-                                            offset,
-                                            Optional.of(batch.partitionLeaderEpoch()).filter(epoch -> epoch >= 0))));
-                        return new OffsetResultHolder(timestampAndOffsetOpt);
+                                .flatMap(batch -> batch.offsetOfMaxTimestamp()
+                                    .map(offset -> new FileRecords.TimestampAndOffset(
+                                        batch.maxTimestamp(),
+                                        offset,
+                                        Optional.of(batch.partitionLeaderEpoch()).filter(epoch -> epoch >= 0))));
+                        };
+
+                        if (remoteLogEnabled() && !isEmpty()) {
+                            if (remoteOffsetReader.isEmpty()) {
+                                throw new KafkaException("RemoteLogManager is empty even though the remote log storage is enabled.");
+                            }
+                            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> asyncOffsetReadFutureHolder =
+                                    remoteOffsetReader.get().asyncOffsetRead(topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP,
+                                    logStartOffset, leaderEpochCache, localMaxSupplier);
+                            return new OffsetResultHolder(Optional.empty(), Optional.of(asyncOffsetReadFutureHolder));
+                        } else {
+                            return new OffsetResultHolder(localMaxSupplier.get());
+                        }
                     } else {
                         // We need to search the first segment whose largest timestamp is >= the target timestamp if there is one.
                         if (remoteLogEnabled() && !isEmpty()) {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.record.internal.RecordBatch;
 import org.apache.kafka.common.record.internal.RemoteLogInputStream;
 import org.apache.kafka.common.record.internal.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -1825,6 +1826,230 @@ public class RemoteLogManagerTest {
         // the indexes needs to be fetched from the remote storage
         localLogOffsetState.set(oneSegmentBaseOffset101);
         assertEquals(Optional.of(expectedRemoteResult), remoteLogManager.findOffsetByTimestamp(tp, timestamp + 1, 0L, cache));
+    }
+
+    /**
+     * Sets up a RemoteLogManager with a mocked RLMM and a mocked lookupTimestamp so that each
+     * test can inject whatever segments they need via {@code listRemoteLogSegments(topicIdPartition)}.
+     *
+     * The provided {@code topicIdPartition} must already be registered in the RLM (via
+     * onLeadershipChange) so that topicIdByPartitionMap is populated.
+     */
+    private RemoteLogManager buildRlmForMaxTimestamp(TopicIdPartition tpId,
+                                                     List<RemoteLogSegmentMetadata> remoteSegments,
+                                                     FileRecords.TimestampAndOffset lookupResult) throws Exception {
+        RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                partition -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata,
+                                                                     long timestamp,
+                                                                     long startingOffset) {
+                return Optional.ofNullable(lookupResult);
+            }
+        };
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(tpId)))
+                .thenReturn(remoteSegments.iterator());
+        rlm.onLeadershipChange(Set.of(), Set.of(mockPartition(tpId)),
+                Map.of(tpId.topicPartition().topic(), tpId.topicId()));
+        return rlm;
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampNoRemoteSegments() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+        when(mockLog.logSegments()).thenReturn(List.of());
+        when(mockLog.logEndOffset()).thenReturn(0L);
+
+        try (RemoteLogManager rlm = buildRlmForMaxTimestamp(tpId, List.of(), null)) {
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, 0L, null);
+            assertEquals(Optional.empty(), result);
+        }
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampSingleRemoteSegment() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+        long maxTs = 1000L;
+        long startOffset = 0L;
+        long endOffset = 99L;
+
+        RemoteLogSegmentMetadata seg = mock(RemoteLogSegmentMetadata.class);
+        when(seg.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(seg.maxTimestampMs()).thenReturn(maxTs);
+        when(seg.startOffset()).thenReturn(startOffset);
+        when(seg.endOffset()).thenReturn(endOffset);
+
+        // No local segments — segment is purely remote.
+        when(mockLog.logSegments()).thenReturn(List.of());
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        FileRecords.TimestampAndOffset expected = new FileRecords.TimestampAndOffset(maxTs, 50L, Optional.of(1));
+        try (RemoteLogManager rlm = buildRlmForMaxTimestamp(tpId, List.of(seg), expected)) {
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, startOffset, null);
+            assertEquals(Optional.of(expected), result);
+        }
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampPicksSegmentWithHighestMaxTimestamp() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+
+        RemoteLogSegmentMetadata low = mock(RemoteLogSegmentMetadata.class);
+        when(low.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(low.maxTimestampMs()).thenReturn(500L);
+        when(low.startOffset()).thenReturn(0L);
+        when(low.endOffset()).thenReturn(49L);
+
+        RemoteLogSegmentMetadata high = mock(RemoteLogSegmentMetadata.class);
+        when(high.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(high.maxTimestampMs()).thenReturn(1000L);
+        when(high.startOffset()).thenReturn(50L);
+        when(high.endOffset()).thenReturn(99L);
+
+        when(mockLog.logSegments()).thenReturn(List.of());
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        FileRecords.TimestampAndOffset expected = new FileRecords.TimestampAndOffset(1000L, 75L, Optional.of(1));
+        try (RemoteLogManager rlm = buildRlmForMaxTimestamp(tpId, List.of(low, high), expected)) {
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, 0L, null);
+            assertEquals(Optional.of(expected), result);
+        }
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampWithSameMaxTimestampMs() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+        long sameTs = 1000L;
+
+        RemoteLogSegmentMetadata earlier = mock(RemoteLogSegmentMetadata.class);
+        when(earlier.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(earlier.maxTimestampMs()).thenReturn(sameTs);
+        when(earlier.startOffset()).thenReturn(0L);
+        when(earlier.endOffset()).thenReturn(49L);
+
+        RemoteLogSegmentMetadata later = mock(RemoteLogSegmentMetadata.class);
+        when(later.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(later.maxTimestampMs()).thenReturn(sameTs);
+        when(later.startOffset()).thenReturn(50L);
+        when(later.endOffset()).thenReturn(99L);
+
+        when(mockLog.logSegments()).thenReturn(List.of());
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        FileRecords.TimestampAndOffset expectedFromLater = new FileRecords.TimestampAndOffset(sameTs, 75L, Optional.of(1));
+        RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                partition -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata,
+                                                                     long timestamp, long startingOffset) {
+                // Assert that the segment with the higher endOffset was chosen.
+                assertEquals(50L, rlsMetadata.startOffset());
+                return Optional.of(expectedFromLater);
+            }
+        };
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(tpId)))
+                .thenReturn(List.of(earlier, later).iterator());
+        rlm.onLeadershipChange(Set.of(), Set.of(mockPartition(tpId)),
+                Map.of(tpId.topicPartition().topic(), tpId.topicId()));
+
+        try (RemoteLogManager ignored = rlm) {
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, 0L, null);
+            assertEquals(Optional.of(expectedFromLater), result);
+        }
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampSkipsNotReadySegments() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+
+        // Only segment is not yet fully copied — should be skipped.
+        RemoteLogSegmentMetadata notReady = mock(RemoteLogSegmentMetadata.class);
+        when(notReady.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_STARTED);
+        when(notReady.maxTimestampMs()).thenReturn(9999L);
+        when(notReady.startOffset()).thenReturn(0L);
+        when(notReady.endOffset()).thenReturn(99L);
+
+        when(mockLog.logSegments()).thenReturn(List.of());
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        try (RemoteLogManager rlm = buildRlmForMaxTimestamp(tpId, List.of(notReady), null)) {
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, 0L, null);
+            assertEquals(Optional.empty(), result);
+        }
+    }
+
+    @Test
+    void testFindOffsetByMaxTimestampUsesLocalCopyWhenMaxTsSegIsInOverlap() throws Exception {
+        TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("sample", 0));
+        long maxTs = 1000L;
+        long remoteStartOffset = 50L;
+
+        RemoteLogSegmentMetadata seg = mock(RemoteLogSegmentMetadata.class);
+        when(seg.state()).thenReturn(RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(seg.maxTimestampMs()).thenReturn(maxTs);
+        when(seg.startOffset()).thenReturn(remoteStartOffset);
+        when(seg.endOffset()).thenReturn(99L);
+
+        // Local log starts at offset 50 — so segment is in the overlap region.
+        FileRecords.TimestampAndOffset localResult = new FileRecords.TimestampAndOffset(maxTs, 60L, Optional.of(2));
+        LogSegment localSeg = mockLogSegment(remoteStartOffset, maxTs, localResult);
+
+        when(mockLog.logSegments()).thenReturn(List.of(localSeg));
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        // lookupTimestamp must NOT be called since we prefer local.
+        try (RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                partition -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata,
+                                                                     long timestamp, long startingOffset) {
+                throw new AssertionError("Should have used local copy instead of fetching from remote");
+            }
+        }) {
+            when(remoteLogMetadataManager.listRemoteLogSegments(eq(tpId)))
+                    .thenReturn(List.of(seg).iterator());
+            rlm.onLeadershipChange(Set.of(), Set.of(mockPartition(tpId)),
+                    Map.of(tpId.topicPartition().topic(), tpId.topicId()));
+
+            Optional<FileRecords.TimestampAndOffset> result = rlm.findOffsetByTimestamp(
+                    tpId.topicPartition(), ListOffsetsRequest.MAX_TIMESTAMP, remoteStartOffset, null);
+            assertEquals(Optional.of(localResult), result);
+        }
     }
 
     private LogSegment mockLogSegment(long baseOffset,

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogOffsetReaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogOffsetReaderTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.log.remote.storage;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.MockTime;
 import org.apache.kafka.storage.internals.checkpoint.LeaderEpochCheckpointFile;
@@ -135,6 +136,169 @@ class RemoteLogOffsetReaderTest {
             assertTrue(futureHolder.taskFuture().isDone());
             assertTrue(futureHolder.taskFuture().get().hasException());
             assertEquals(exception, futureHolder.taskFuture().get().exception().get());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampInRemote() throws Exception {
+        TimestampAndOffset remoteResult = new TimestampAndOffset(200L, 5L, Optional.of(1));
+        TimestampAndOffset localResult  = new TimestampAndOffset(100L, 9L, Optional.of(1));
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.of(remoteResult);
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            () -> Optional.of(localResult));
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.of(remoteResult), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampInLocal() throws Exception {
+        TimestampAndOffset remoteResult = new TimestampAndOffset(200L, 5L, Optional.of(1));
+        TimestampAndOffset localResult  = new TimestampAndOffset(300L, 10L, Optional.of(2));
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.of(remoteResult);
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            () -> Optional.of(localResult));
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.of(localResult), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampWithHigherOffset() throws Exception {
+        long sameTs = 500L;
+        TimestampAndOffset lowerOffset  = new TimestampAndOffset(sameTs, 3L, Optional.of(1));
+        TimestampAndOffset higherOffset = new TimestampAndOffset(sameTs, 7L, Optional.of(1));
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.of(lowerOffset);
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            () -> Optional.of(higherOffset));
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.of(higherOffset), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampWithoutRemoteData() throws Exception {
+        TimestampAndOffset localResult = new TimestampAndOffset(400L, 8L, Optional.of(2));
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.empty();
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            () -> Optional.of(localResult));
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.of(localResult), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampWithoutLocalData() throws Exception {
+        TimestampAndOffset remoteResult = new TimestampAndOffset(250L, 4L, Optional.of(1));
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.of(remoteResult);
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            Optional::empty);
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.of(remoteResult), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampWithoutData() throws Exception {
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) {
+                return Optional.empty();
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            Optional::empty);
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertFalse(holder.taskFuture().get().hasException());
+            assertEquals(Optional.empty(), holder.taskFuture().get().timestampAndOffset());
+        }
+    }
+
+    @Test
+    public void testMaxTimestampRemoteExceptionIsReportedInResult() throws Exception {
+        RemoteStorageException exception = new RemoteStorageException("remote error");
+
+        try (RemoteLogManager rlm = new MockRemoteLogManager(2, 1, logDir.toString()) {
+            @Override
+            public Optional<TimestampAndOffset> findOffsetByTimestamp(TopicPartition tp,
+                                                                      long timestamp,
+                                                                      long startingOffset,
+                                                                      LeaderEpochFileCache leaderEpochCache) throws RemoteStorageException {
+                throw exception;
+            }
+        }) {
+            AsyncOffsetReadFutureHolder<OffsetResultHolder.FileRecordsOrError> holder =
+                    rlm.asyncOffsetRead(topicPartition, ListOffsetsRequest.MAX_TIMESTAMP, 0L, cache,
+                            Optional::empty);
+            holder.taskFuture().get(1, TimeUnit.SECONDS);
+
+            assertTrue(holder.taskFuture().get().hasException());
+            assertEquals(exception, holder.taskFuture().get().exception().get());
         }
     }
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -3315,6 +3315,106 @@ public class UnifiedLogTest {
     }
 
     @Test
+    public void testFetchOffsetByMaxTimestampWithRemoteStorageAsyncPathProducesResult() throws Exception {
+        // When remote storage is enabled and the log is non-empty, MAX_TIMESTAMP must go
+        // through the async path and return a valid result via the future.
+        DelayedOperationPurgatory<DelayedRemoteListOffsets> purgatory =
+                new DelayedOperationPurgatory<>("RemoteListOffsets", 0);
+        RemoteLogManager remoteLogManager = spy(new RemoteLogManager(createRemoteLogManagerConfig(),
+                0,
+                logDir.getAbsolutePath(),
+                "clusterId",
+                mockTime,
+                tp -> Optional.empty(),
+                (tp, offset) -> { },
+                brokerTopicStats,
+                new Metrics(),
+                Optional.empty()));
+        remoteLogManager.setDelayedOperationPurgatory(purgatory);
+
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
+                .segmentBytes(200)
+                .indexIntervalBytes(1)
+                .remoteLogStorageEnable(true)
+                .build();
+        log = createLog(logDir, logConfig, true);
+
+        long firstTs = mockTime.milliseconds();
+        int firstEpoch = 0;
+        log.appendAsLeader(singletonRecords(TestUtils.randomBytes(10), firstTs), firstEpoch);
+        long secondTs = firstTs + 1;
+        int secondEpoch = 1;
+        log.appendAsLeader(singletonRecords(TestUtils.randomBytes(10), secondTs), secondEpoch);
+
+        // Remote returns nothing for MAX_TIMESTAMP (simulates all data still local).
+        doAnswer(ans -> Optional.empty()).when(remoteLogManager).findOffsetByTimestamp(
+                eq(log.topicPartition()), anyLong(), anyLong(), eq(log.leaderEpochCache()));
+
+        // The local supplier should pick the record with secondTs.
+        OffsetResultHolder holder = log.fetchOffsetByTimestamp(
+                ListOffsetsRequest.MAX_TIMESTAMP, Optional.of(remoteLogManager));
+        assertTrue(holder.futureHolderOpt().isPresent(), "Async path should produce a future");
+
+        holder.futureHolderOpt().get().taskFuture().get(1, TimeUnit.SECONDS);
+        assertTrue(holder.futureHolderOpt().get().taskFuture().isDone());
+        assertFalse(holder.futureHolderOpt().get().taskFuture().get().hasException());
+        Optional<FileRecords.TimestampAndOffset> result =
+                holder.futureHolderOpt().get().taskFuture().get().timestampAndOffset();
+        assertTrue(result.isPresent());
+        assertEquals(secondTs, result.get().timestamp);
+    }
+
+    @Test
+    public void testFetchOffsetByMaxTimestampWithRemoteStorage() throws Exception {
+        DelayedOperationPurgatory<DelayedRemoteListOffsets> purgatory =
+                new DelayedOperationPurgatory<>("RemoteListOffsets", 0);
+        RemoteLogManager remoteLogManager = spy(new RemoteLogManager(createRemoteLogManagerConfig(),
+                0,
+                logDir.getAbsolutePath(),
+                "clusterId",
+                mockTime,
+                tp -> Optional.empty(),
+                (tp, offset) -> { },
+                brokerTopicStats,
+                new Metrics(),
+                Optional.empty()));
+        remoteLogManager.setDelayedOperationPurgatory(purgatory);
+
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
+                .segmentBytes(200)
+                .indexIntervalBytes(1)
+                .remoteLogStorageEnable(true)
+                .build();
+        log = createLog(logDir, logConfig, true);
+
+        long localTs = mockTime.milliseconds();
+        long remoteTs = localTs + 9999;
+        int localEpoch = 0;
+        log.appendAsLeader(singletonRecords(TestUtils.randomBytes(10), remoteTs), localEpoch);
+        log.appendAsLeader(singletonRecords(TestUtils.randomBytes(10), localTs), localEpoch);
+        // Simulate the local record being deleted (moved to remote-only).
+        log.updateLocalLogStartOffset(1);
+
+        int remoteEpoch = 0;
+        FileRecords.TimestampAndOffset remoteResult =
+                new FileRecords.TimestampAndOffset(remoteTs, 0L, Optional.of(remoteEpoch));
+        doAnswer(ans -> Optional.of(remoteResult)).when(remoteLogManager).findOffsetByTimestamp(
+                eq(log.topicPartition()), anyLong(), anyLong(), eq(log.leaderEpochCache()));
+
+        OffsetResultHolder holder = log.fetchOffsetByTimestamp(
+                ListOffsetsRequest.MAX_TIMESTAMP, Optional.of(remoteLogManager));
+        assertTrue(holder.futureHolderOpt().isPresent());
+
+        holder.futureHolderOpt().get().taskFuture().get(1, TimeUnit.SECONDS);
+        assertFalse(holder.futureHolderOpt().get().taskFuture().get().hasException());
+        Optional<FileRecords.TimestampAndOffset> result =
+                holder.futureHolderOpt().get().taskFuture().get().timestampAndOffset();
+        assertTrue(result.isPresent());
+        assertEquals(remoteTs, result.get().timestamp);
+        assertEquals(0L, result.get().offset);
+    }
+
+    @Test
     public void testFetchOffsetByTimestampFromRemoteStorage() throws Exception {
         DelayedOperationPurgatory<DelayedRemoteListOffsets> purgatory = new DelayedOperationPurgatory<DelayedRemoteListOffsets>("RemoteListOffsets", 0);
         RemoteLogManager remoteLogManager = spy(new RemoteLogManager(createRemoteLogManagerConfig(),


### PR DESCRIPTION
## Why
- `ListOffsets` with `MAX_TIMESTAMP` is expected to return the offset of
the record carrying the largest timestamp in the partition.
- With tiered storage enabled, the lookup previously scanned only
**local** log segments and ignored segments already uploaded to remote
storage.
- As a result, when the record with the maximum timestamp resides in a
remote segment, the request returned a wrong offset.

## How
- `UnifiedLog#findOffsetByTimestamp` (MAX_TIMESTAMP branch): extract the
local max-timestamp lookup into a lazy supplier. When remote storage is
enabled and the log is non-empty, route through the async
`asyncOffsetRead` path (handing it the local supplier) and return an
async future holder; otherwise return the local result directly.
- `RemoteLogManager#findOffsetByTimestamp`: add a dedicated
MAX_TIMESTAMP path that scans all remote segments for the partition (no
epoch/offset filtering) and selects the one with the highest
`maxTimestampMs` (ties broken by higher `endOffset`). If that segment
overlaps the local log, the local copy is preferred; otherwise the
remote segment is looked up. Regular timestamp lookups keep the existing
epoch-based logic.
- `RemoteLogOffsetReader#call`: for MAX_TIMESTAMP, compute both the
remote and local candidates and merge them, keeping the higher timestamp
(ties broken by higher offset). Regular lookups still fall back to local
only when remote returns nothing.
