### PR TITLE
KAFKA-17585: `offsetResetStrategyTimestamp` should return `long` instead of `Long`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
@@ -234,8 +234,7 @@ class OffsetFetcherUtils {
         Set<TopicPartition> partitions = subscriptionState.partitionsNeedingReset(time.milliseconds());
         final Map<TopicPartition, Long> offsetResetTimestamps = new HashMap<>();
         for (final TopicPartition partition : partitions) {
-            long timestamp = offsetResetStrategyTimestamp(partition);
-            offsetResetTimestamps.put(partition, timestamp);
+            offsetResetTimestamps.put(partition, offsetResetStrategyTimestamp(partition));
         }
 
         return offsetResetTimestamps;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
@@ -234,9 +234,8 @@ class OffsetFetcherUtils {
         Set<TopicPartition> partitions = subscriptionState.partitionsNeedingReset(time.milliseconds());
         final Map<TopicPartition, Long> offsetResetTimestamps = new HashMap<>();
         for (final TopicPartition partition : partitions) {
-            Long timestamp = offsetResetStrategyTimestamp(partition);
-            if (timestamp != null)
-                offsetResetTimestamps.put(partition, timestamp);
+            long timestamp = offsetResetStrategyTimestamp(partition);
+            offsetResetTimestamps.put(partition, timestamp);
         }
 
         return offsetResetTimestamps;
@@ -286,7 +285,7 @@ class OffsetFetcherUtils {
         return offsetsResults;
     }
 
-    private Long offsetResetStrategyTimestamp(final TopicPartition partition) {
+    private long offsetResetStrategyTimestamp(final TopicPartition partition) {
         OffsetResetStrategy strategy = subscriptionState.resetStrategy(partition);
         if (strategy == OffsetResetStrategy.EARLIEST)
             return ListOffsetsRequest.EARLIEST_TIMESTAMP;


### PR DESCRIPTION
As title

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
