### PR TITLE
MINOR: Bump zstd-jni from 1.5.6-5 to 1.5.6-6

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -327,7 +327,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.6-5 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.6-6 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/docker/native/native-image-configs/resource-config.json
+++ b/docker/native/native-image-configs/resource-config.json
@@ -25,9 +25,9 @@
   }, {
     "pattern":"\\Qkafka/kafka-version.properties\\E"
   }, {
-    "pattern":"\\Qlinux/amd64/libzstd-jni-1.5.6-5.so\\E"
+    "pattern":"\\Qlinux/amd64/libzstd-jni-1.5.6-6.so\\E"
   }, {
-    "pattern":"\\Qlinux/aarch64/libzstd-jni-1.5.6-5.so\\E"
+    "pattern":"\\Qlinux/aarch64/libzstd-jni-1.5.6-6.so\\E"
   }, {
     "pattern":"\\Qnet/jpountz/util/linux/amd64/liblz4-java.so\\E"
   }, {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -160,7 +160,7 @@ versions += [
   zookeeper: "3.8.4",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
-  zstd: "1.5.6-5",
+  zstd: "1.5.6-6",
   junitPlatform: "1.10.2",
   hdrHistogram: "2.2.2"
 ]


### PR DESCRIPTION
This is the closest we have to release notes:
https://github.com/luben/zstd-jni/compare/v1.5.6-5...v1.5.6-6