### PR TITLE
KAFKA-16495 Fix flaky TransactionsWithTieredStoreTest#testCommitTransactionTimeout

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -495,7 +495,7 @@ class TransactionsTest extends IntegrationTestHarness {
 
   private def testTimeout(needInitAndSendMsg: Boolean,
                   timeoutProcess: KafkaProducer[Array[Byte], Array[Byte]] => Unit): Unit = {
-    val producer = createTransactionalProducer("transactionProducer", maxBlockMs = 3000)
+    val producer = createTransactionalProducer("transactionProducer", maxBlockMs = 10000)
     if (needInitAndSendMsg) {
       producer.initTransactions()
       producer.beginTransaction()


### PR DESCRIPTION
In this test, I think is the [max.block.ms](https://kafka.apache.org/documentation/#producerconfigs_max.block.ms) is so short for `initTransactions()`, however this test should test that commit fail, so we should accept the timeout more logner, just test for 10s

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
