### PR TITLE
KAFKA-17599 :: Updating consumer subscription object with the latest subscription before "invokePartitionRevoked".

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -109,12 +109,12 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
         // rebalance
         this.records.clear();
-
+        // Updating subscription here so that both onPartitionsRevoked and onPartitionsAssigned has access to the latest subscription
+        this.subscriptions.assignFromSubscribed(newAssignment);
         // rebalance callbacks
         if (!removed.isEmpty()) {
             this.subscriptions.rebalanceListener().ifPresent(crl -> crl.onPartitionsRevoked(removed));
         }
-        this.subscriptions.assignFromSubscribed(newAssignment);
         this.subscriptions.rebalanceListener().ifPresent(crl -> crl.onPartitionsAssigned(added));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -374,6 +374,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             return;
         }
 
+        // Updating subscription here so that both invokePartitionRevoked and invokePartitionAssigned has access to the latest subscription
+        subscriptions.assignFromSubscribed(assignedPartitions);
+        
         final AtomicReference<Exception> firstException = new AtomicReference<>(null);
         SortedSet<TopicPartition> addedPartitions = new TreeSet<>(COMPARATOR);
         addedPartitions.addAll(assignedPartitions);
@@ -418,8 +421,6 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         // Reschedule the auto commit starting from now
         if (autoCommitEnabled)
             this.nextAutoCommitTimer.updateAndReset(autoCommitIntervalMs);
-
-        subscriptions.assignFromSubscribed(assignedPartitions);
 
         // Add partitions that were not previously owned but are now assigned
         firstException.compareAndSet(null, rebalanceListenerInvoker.invokePartitionsAssigned(addedPartitions));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkTask.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkTask.java
@@ -1,0 +1,46 @@
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SampleSinkTask extends SinkTask {
+
+    private Set<TopicPartition> currentAssignment;
+    @Override
+    public String version() {
+        return null;
+    }
+
+    public void open(Collection<TopicPartition> topicPartitions) {
+        this.currentAssignment = context.assignment();
+    }
+
+    public void close(Collection<TopicPartition> topicPartitions) {
+        this.currentAssignment = context.assignment();
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        this.currentAssignment = new HashSet<>();
+    }
+
+    @Override
+    public void put(Collection<SinkRecord> records) {
+
+    }
+
+    public Set<TopicPartition> getCurrentAssignment() {
+        return this.currentAssignment;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkTask.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkTask.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.TopicPartition;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -1783,10 +1783,12 @@ public class WorkerSinkTaskTest {
                 keyConverter, valueConverter, errorHandlingMetrics, headerConverter,
                 transformationChain, mockConsumer, pluginLoader, time,
                 RetryWithToleranceOperatorTest.noopOperator(), null, statusBackingStore, Collections::emptyList);
-        mockConsumer.updateBeginningOffsets(new HashMap<TopicPartition, Long>() {{
-            put(TOPIC_PARTITION, 0 * 1L);
-            put(TOPIC_PARTITION2, 0 * 1L);
-        }});
+        mockConsumer.updateBeginningOffsets(
+                new HashMap<TopicPartition, Long>() {{
+                    put(TOPIC_PARTITION, 0L);
+                    put(TOPIC_PARTITION2, 0L);
+                }}
+        );
         // Initialized sink task with task config.
         workerTask.initialize(TASK_CONFIG);
         // Initialized and started worker sink task.


### PR DESCRIPTION
Summary:
Ensure that the Kafka consumer subscription object is updated with the current partition assignment before partition revocation, so that close() method of the sink connector's has the access to current updated partition.
Description:
In scenarios where Kafka Connect Sink Tasks handle partition revocation events, it is critical to update the consumer subscription object with the current partition assignment before the revocation process begins. This will allow for better management of partition state and ensure that partition ownership is clear and accurately reflected in the consumer group.
Current Behaviour:
When partitions are revoked due to rebalancing, the current assignment is not explicitly updated in the consumer subscription object before revocation, leading close() being rendered to the old assignment state and it might be possible that no open is called for this.
Race Conditions:
Also this leads to some very rare race conditions. Race conditions in some scenario in sink connectors: There could be race conditions leading to sometime updated values and sometime old values of the current assigned partitions in some scenarios.
Consider this:
Since the put call goes in a loop and we have some work in put which is using "context.assignment" to access the current assignment. Let's say the task is assigned [0, 1] and [2] is being added to it and [0] is being removed from this. If the call happens in this case:
1. Close call partition [0].
2. Put call comes with a batch of records
3. Open call comes [2]
In this scenario accessing context.assignment inside put gives -> [0,1].
But if the call happens in this way:
1. Close call partition [0].
2. Open call comes for partition [2]
3. Put call comes with a batch of records.
In this scenario accessing context.assignment inside put gives -> [1,2].
This leads to stale and inconsistent situation which leads to inconsistent behaviour for the connectors.
Proposed Behavior:
Before partition revocation occurs, update the consumer subscription object with the current partition assignment to ensure consistent state tracking and smoother transitions during rebalancing.
