### PR TITLE
MINOR: add a space for kafka.metrics.polling.interval.secs description

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/metrics/MetricConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/MetricConfigs.java
@@ -61,7 +61,7 @@ public class MetricConfigs {
             " the standard MBean convention.";
     public static final String KAFKA_METRICS_POLLING_INTERVAL_SECONDS_CONFIG = "kafka.metrics.polling.interval.secs";
     public static final int KAFKA_METRICS_POLLING_INTERVAL_SECONDS_DEFAULT = 10;
-    public static final String KAFKA_METRICS_POLLING_INTERVAL_SECONDS_DOC = "The metrics polling interval (in seconds) which can be used in" +
+    public static final String KAFKA_METRICS_POLLING_INTERVAL_SECONDS_DOC = "The metrics polling interval (in seconds) which can be used in " +
             KAFKA_METRICS_REPORTER_CLASSES_CONFIG + " implementations.";
 
     /** ********* Kafka Client Telemetry Metrics Configuration ***********/


### PR DESCRIPTION
As title, there should be a space between `in` and `kafka.metrics.reporters` words.
![CleanShot 2024-09-24 at 02 16 41](https://github.com/user-attachments/assets/4fed41f2-7fe4-42a1-85e4-d3b466829a66)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
