### PR TITLE
KAFKA-16331: remove KafkaClientSupplier from StreamsProducer

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -192,7 +192,7 @@
               files="KTableImpl.java"/>
 
     <suppress checks="ParameterNumber"
-              files="StreamThread.java"/>
+              files="(StreamThread|ActiveTaskCreator).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(InternalTopologyBuilder|KafkaStreams|KStreamImpl|KTableImpl|StreamsPartitionAssignor).java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1781,24 +1781,13 @@ public class StreamsConfig extends AbstractConfig {
      * @return Map of the producer configuration.
      */
     @SuppressWarnings("WeakerAccess")
-    public Map<String, Object> getProducerConfigs(final String clientId,
-                                                  final UUID processId,
-                                                  final int threadIdx) {
+    public Map<String, Object> getProducerConfigs(final String clientId) {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());
 
         checkIfUnexpectedUserSpecifiedConsumerConfig(clientProvidedProps, NON_CONFIGURABLE_PRODUCER_EOS_CONFIGS);
 
         // generate producer configs from original properties and overridden maps
-        final Map<String, Object> props;
-        if (eosEnabled) {
-            props = new HashMap<>(PRODUCER_EOS_OVERRIDES);
-            props.put(
-                ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-                getString(StreamsConfig.APPLICATION_ID_CONFIG) + "-" + processId + "-" + threadIdx
-            );
-        } else {
-            props = new HashMap<>(PRODUCER_DEFAULT_OVERRIDES);
-        }
+        final Map<String, Object> props = new HashMap<>(eosEnabled ? PRODUCER_EOS_OVERRIDES : PRODUCER_DEFAULT_OVERRIDES);
         props.putAll(getClientCustomProps());
         props.putAll(clientProvidedProps);
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1780,13 +1781,24 @@ public class StreamsConfig extends AbstractConfig {
      * @return Map of the producer configuration.
      */
     @SuppressWarnings("WeakerAccess")
-    public Map<String, Object> getProducerConfigs(final String clientId) {
+    public Map<String, Object> getProducerConfigs(final String clientId,
+                                                  final UUID processId,
+                                                  final int threadIdx) {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());
 
         checkIfUnexpectedUserSpecifiedConsumerConfig(clientProvidedProps, NON_CONFIGURABLE_PRODUCER_EOS_CONFIGS);
 
         // generate producer configs from original properties and overridden maps
-        final Map<String, Object> props = new HashMap<>(eosEnabled ? PRODUCER_EOS_OVERRIDES : PRODUCER_DEFAULT_OVERRIDES);
+        final Map<String, Object> props;
+        if (eosEnabled) {
+            props = new HashMap<>(PRODUCER_EOS_OVERRIDES);
+            props.put(
+                ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+                getString(StreamsConfig.APPLICATION_ID_CONFIG) + "-" + processId + "-" + threadIdx
+            );
+        } else {
+            props = new HashMap<>(PRODUCER_DEFAULT_OVERRIDES);
+        }
         props.putAll(getClientCustomProps());
         props.putAll(clientProvidedProps);
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -65,7 +65,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -64,7 +64,6 @@ public class ClientUtils {
         }
     }
 
-
     public static String adminClientId(final String clientId) {
         return clientId + "-admin";
     }
@@ -77,7 +76,7 @@ public class ClientUtils {
         return threadClientId + "-restore-consumer";
     }
 
-    public static String threadProducerClientId(final String threadClientId) {
+    public static String producerClientId(final String threadClientId) {
         return threadClientId + "-producer";
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -76,7 +76,6 @@ public class RecordCollectorImpl implements RecordCollector {
     private final TaskId taskId;
     private final StreamsProducer streamsProducer;
     private final ProductionExceptionHandler productionExceptionHandler;
-    private final boolean eosEnabled;
     private final Map<TopicPartition, Long> offsets;
 
     private final StreamsMetricsImpl streamsMetrics;
@@ -99,7 +98,6 @@ public class RecordCollectorImpl implements RecordCollector {
         this.streamsProducer = streamsProducer;
         this.sendException = streamsProducer.sendException();
         this.productionExceptionHandler = productionExceptionHandler;
-        this.eosEnabled = streamsProducer.eosEnabled();
         this.streamsMetrics = streamsMetrics;
 
         final String threadId = Thread.currentThread().getName();
@@ -122,7 +120,7 @@ public class RecordCollectorImpl implements RecordCollector {
 
     @Override
     public void initialize() {
-        if (eosEnabled) {
+        if (streamsProducer.eosEnabled()) {
             streamsProducer.initTransaction();
         }
     }
@@ -531,7 +529,7 @@ public class RecordCollectorImpl implements RecordCollector {
     public void closeDirty() {
         log.info("Closing record collector dirty");
 
-        if (eosEnabled) {
+        if (streamsProducer.eosEnabled()) {
             // We may be closing dirty because the commit failed, so we must abort the transaction to be safe
             streamsProducer.abortTransaction();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -408,6 +408,7 @@ public class StreamThread extends Thread implements ProcessingThread {
             time,
             clientSupplier,
             threadId,
+            threadIdx,
             processId,
             log,
             stateUpdaterEnabled,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -37,8 +37,6 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
@@ -49,13 +47,11 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
-import static org.apache.kafka.streams.processor.internals.ClientUtils.threadProducerClientId;
 
 /**
  * {@code StreamsProducer} manages the producers within a Kafka Streams application.
@@ -69,8 +65,6 @@ public class StreamsProducer {
     private final Logger log;
     private final String logPrefix;
 
-    private final Map<String, Object> eosV2ProducerConfigs;
-    private final KafkaClientSupplier clientSupplier;
     private final ProcessingMode processingMode;
     private final Time time;
 
@@ -80,48 +74,15 @@ public class StreamsProducer {
     private double oldProducerTotalBlockedTime = 0;
     private final AtomicReference<KafkaException> sendException = new AtomicReference<>(null);
 
-    public StreamsProducer(final StreamsConfig config,
-                           final String threadId,
-                           final KafkaClientSupplier clientSupplier,
-                           final UUID processId,
+    public StreamsProducer(final ProcessingMode processingMode,
+                           final Producer<byte[], byte[]> producer,
                            final LogContext logContext,
                            final Time time) {
-        Objects.requireNonNull(config, "config cannot be null");
-        Objects.requireNonNull(threadId, "threadId cannot be null");
-        this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier cannot be null");
+        this.processingMode = Objects.requireNonNull(processingMode, "processingMode cannot be null");
+        this.producer = Objects.requireNonNull(producer, "producer cannot be null");
         log = Objects.requireNonNull(logContext, "logContext cannot be null").logger(getClass());
         logPrefix = logContext.logPrefix().trim();
-        this.time = Objects.requireNonNull(time, "time");
-
-        processingMode = StreamsConfigUtils.processingMode(config);
-
-        final Map<String, Object> producerConfigs;
-        switch (processingMode) {
-            case AT_LEAST_ONCE: {
-                producerConfigs = config.getProducerConfigs(threadProducerClientId(threadId));
-                eosV2ProducerConfigs = null;
-
-                break;
-            }
-            case EXACTLY_ONCE_V2: {
-                producerConfigs = config.getProducerConfigs(threadProducerClientId(threadId));
-
-                final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-                producerConfigs.put(
-                    ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-                    applicationId + "-" +
-                        Objects.requireNonNull(processId, "processId cannot be null for exactly-once v2") +
-                        "-" + threadId.split("-StreamThread-")[1]);
-
-                eosV2ProducerConfigs = producerConfigs;
-
-                break;
-            }
-            default:
-                throw new IllegalArgumentException("Unknown processing mode: " + processingMode);
-        }
-
-        producer = clientSupplier.getProducer(producerConfigs);
+        this.time = Objects.requireNonNull(time, "time cannot be null");
     }
 
     private String formatException(final String message) {
@@ -171,18 +132,18 @@ public class StreamsProducer {
         }
     }
 
-    public void resetProducer() {
+    public void resetProducer(final Producer<byte[], byte[]> producer) {
         if (processingMode != EXACTLY_ONCE_V2) {
             throw new IllegalStateException("Expected eos-v2 to be enabled, but the processing mode was " + processingMode);
         }
 
-        oldProducerTotalBlockedTime += totalBlockedTime(producer);
+        oldProducerTotalBlockedTime += totalBlockedTime(this.producer);
         final long start = time.nanoseconds();
         close();
         final long closeTime = time.nanoseconds() - start;
         oldProducerTotalBlockedTime += closeTime;
 
-        producer = clientSupplier.getProducer(eosV2ProducerConfigs);
+        this.producer = producer;
     }
 
     private double getMetricValue(final Map<MetricName, ? extends Metric> metrics,

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -58,7 +58,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 import static java.util.Collections.nCopies;
 import static org.apache.kafka.common.IsolationLevel.READ_COMMITTED;
@@ -152,7 +151,7 @@ public class StreamsConfigTest {
 
     @Test
     public void testGetProducerConfigs() {
-        final Map<String, Object> returnedProps = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> returnedProps = streamsConfig.getProducerConfigs(clientId);
         assertThat(returnedProps.get(ProducerConfig.CLIENT_ID_CONFIG), equalTo(clientId));
         assertThat(returnedProps.get(ProducerConfig.LINGER_MS_CONFIG), equalTo("100"));
     }
@@ -308,7 +307,7 @@ public class StreamsConfigTest {
     public void shouldSupportPrefixedPropertiesThatAreNotPartOfProducerConfig() {
         props.put(producerPrefix("interceptor.statsd.host"), "host");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         assertEquals("host", producerConfigs.get("interceptor.statsd.host"));
     }
 
@@ -317,7 +316,7 @@ public class StreamsConfigTest {
         props.put(producerPrefix(ProducerConfig.BUFFER_MEMORY_CONFIG), 10);
         props.put(producerPrefix(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG), 1);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId);
         assertEquals(10, configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG));
         assertEquals(1, configs.get(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG));
     }
@@ -345,7 +344,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 10);
         props.put(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG, 1);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId);
         assertEquals(10, configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG));
         assertEquals(1, configs.get(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG));
     }
@@ -356,7 +355,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> restoreConsumerConfigs = streamsConfig.getRestoreConsumerConfigs(clientId);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         final Map<String, Object> adminConfigs = streamsConfig.getAdminConfigs(clientId);
         assertEquals("host", consumerConfigs.get("custom.property.host"));
         assertEquals("host", restoreConsumerConfigs.get("custom.property.host"));
@@ -373,7 +372,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> restoreConsumerConfigs = streamsConfig.getRestoreConsumerConfigs(clientId);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         final Map<String, Object> adminConfigs = streamsConfig.getAdminConfigs(clientId);
         assertEquals("host1", consumerConfigs.get("custom.property.host"));
         assertEquals("host1", restoreConsumerConfigs.get("custom.property.host"));
@@ -418,7 +417,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.producerPrefix(ProducerConfig.LINGER_MS_CONFIG), "10000");
         props.put(StreamsConfig.producerPrefix(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), "30000");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         assertEquals("10000", producerConfigs.get(ProducerConfig.LINGER_MS_CONFIG));
         assertEquals("30000", producerConfigs.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG));
     }
@@ -561,7 +560,7 @@ public class StreamsConfigTest {
     public void shouldNotSetInternalAutoDowngradeTxnCommitToTrueInProducerForEosV2() {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         assertThat(producerConfigs.get("internal.auto.downgrade.txn.commit"), is(nullValue()));
     }
 
@@ -630,7 +629,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "anyValue");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         assertTrue((Boolean) producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
     }
 
@@ -638,7 +637,7 @@ public class StreamsConfigTest {
     public void shouldAllowSettingProducerEnableIdempotenceIfEosDisabled() {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
         assertThat(producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG), equalTo(false));
     }
 
@@ -648,7 +647,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
         assertThat(
             consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
@@ -666,10 +665,9 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "user-TxId");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
-        final UUID processId = UUID.randomUUID();
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, processId, 0);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
-        assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(groupId + "-" + processId + "-0"));
+        assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
     }
 
     @Test
@@ -679,7 +677,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.RETRIES_CONFIG, numberOfRetries);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
         assertThat(producerConfigs.get(ProducerConfig.RETRIES_CONFIG), equalTo(numberOfRetries));
     }
@@ -769,7 +767,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 7);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         try {
-            streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
+            streamsConfig.getProducerConfigs(clientId);
             fail("Should throw ConfigException when ESO is enabled and maxInFlight requests exceeds 5");
         } catch (final ConfigException e) {
             assertEquals(
@@ -785,7 +783,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "3");
 
-        new StreamsConfig(props).getProducerConfigs(clientId, UUID.randomUUID(), 0);
+        new StreamsConfig(props).getProducerConfigs(clientId);
     }
 
     @Test
@@ -794,7 +792,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "not-a-number");
 
         try {
-            new StreamsConfig(props).getProducerConfigs(clientId, UUID.randomUUID(), 0);
+            new StreamsConfig(props).getProducerConfigs(clientId);
             fail("Should throw ConfigException when EOS is enabled and maxInFlight cannot be paresed into an integer");
         } catch (final ConfigException e) {
             assertEquals(
@@ -1242,7 +1240,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertNull(
-            streamsConfig.getProducerConfigs("clientId", null, -1)
+            streamsConfig.getProducerConfigs("clientId")
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertNull(
@@ -1269,7 +1267,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertTrue(
-            (Boolean) streamsConfig.getProducerConfigs("clientId", null, -1)
+            (Boolean) streamsConfig.getProducerConfigs("clientId")
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertTrue(
@@ -1296,7 +1294,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertFalse(
-            (Boolean) streamsConfig.getProducerConfigs("clientId", null, -1)
+            (Boolean) streamsConfig.getProducerConfigs("clientId")
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertFalse(

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -58,6 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 import static java.util.Collections.nCopies;
 import static org.apache.kafka.common.IsolationLevel.READ_COMMITTED;
@@ -103,7 +104,7 @@ public class StreamsConfigTest {
 
     @BeforeEach
     public void setUp() {
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, groupId);
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
@@ -151,7 +152,7 @@ public class StreamsConfigTest {
 
     @Test
     public void testGetProducerConfigs() {
-        final Map<String, Object> returnedProps = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> returnedProps = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertThat(returnedProps.get(ProducerConfig.CLIENT_ID_CONFIG), equalTo(clientId));
         assertThat(returnedProps.get(ProducerConfig.LINGER_MS_CONFIG), equalTo("100"));
     }
@@ -307,7 +308,7 @@ public class StreamsConfigTest {
     public void shouldSupportPrefixedPropertiesThatAreNotPartOfProducerConfig() {
         props.put(producerPrefix("interceptor.statsd.host"), "host");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertEquals("host", producerConfigs.get("interceptor.statsd.host"));
     }
 
@@ -316,7 +317,7 @@ public class StreamsConfigTest {
         props.put(producerPrefix(ProducerConfig.BUFFER_MEMORY_CONFIG), 10);
         props.put(producerPrefix(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG), 1);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertEquals(10, configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG));
         assertEquals(1, configs.get(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG));
     }
@@ -344,7 +345,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 10);
         props.put(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG, 1);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> configs = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertEquals(10, configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG));
         assertEquals(1, configs.get(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG));
     }
@@ -355,7 +356,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> restoreConsumerConfigs = streamsConfig.getRestoreConsumerConfigs(clientId);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
         final Map<String, Object> adminConfigs = streamsConfig.getAdminConfigs(clientId);
         assertEquals("host", consumerConfigs.get("custom.property.host"));
         assertEquals("host", restoreConsumerConfigs.get("custom.property.host"));
@@ -372,7 +373,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> restoreConsumerConfigs = streamsConfig.getRestoreConsumerConfigs(clientId);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
         final Map<String, Object> adminConfigs = streamsConfig.getAdminConfigs(clientId);
         assertEquals("host1", consumerConfigs.get("custom.property.host"));
         assertEquals("host1", restoreConsumerConfigs.get("custom.property.host"));
@@ -417,7 +418,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.producerPrefix(ProducerConfig.LINGER_MS_CONFIG), "10000");
         props.put(StreamsConfig.producerPrefix(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), "30000");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertEquals("10000", producerConfigs.get(ProducerConfig.LINGER_MS_CONFIG));
         assertEquals("30000", producerConfigs.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG));
     }
@@ -560,7 +561,7 @@ public class StreamsConfigTest {
     public void shouldNotSetInternalAutoDowngradeTxnCommitToTrueInProducerForEosV2() {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
         assertThat(producerConfigs.get("internal.auto.downgrade.txn.commit"), is(nullValue()));
     }
 
@@ -629,7 +630,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "anyValue");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
         assertTrue((Boolean) producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
     }
 
@@ -637,7 +638,7 @@ public class StreamsConfigTest {
     public void shouldAllowSettingProducerEnableIdempotenceIfEosDisabled() {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
         assertThat(producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG), equalTo(false));
     }
 
@@ -647,7 +648,7 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, null, -1);
 
         assertThat(
             consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
@@ -665,9 +666,10 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "user-TxId");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final UUID processId = UUID.randomUUID();
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, processId, 0);
 
-        assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
+        assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(groupId + "-" + processId + "-0"));
     }
 
     @Test
@@ -677,7 +679,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.RETRIES_CONFIG, numberOfRetries);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
-        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
+        final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
 
         assertThat(producerConfigs.get(ProducerConfig.RETRIES_CONFIG), equalTo(numberOfRetries));
     }
@@ -767,7 +769,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 7);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         try {
-            streamsConfig.getProducerConfigs(clientId);
+            streamsConfig.getProducerConfigs(clientId, UUID.randomUUID(), 0);
             fail("Should throw ConfigException when ESO is enabled and maxInFlight requests exceeds 5");
         } catch (final ConfigException e) {
             assertEquals(
@@ -783,7 +785,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "3");
 
-        new StreamsConfig(props).getProducerConfigs(clientId);
+        new StreamsConfig(props).getProducerConfigs(clientId, UUID.randomUUID(), 0);
     }
 
     @Test
@@ -792,7 +794,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "not-a-number");
 
         try {
-            new StreamsConfig(props).getProducerConfigs(clientId);
+            new StreamsConfig(props).getProducerConfigs(clientId, UUID.randomUUID(), 0);
             fail("Should throw ConfigException when EOS is enabled and maxInFlight cannot be paresed into an integer");
         } catch (final ConfigException e) {
             assertEquals(
@@ -1240,7 +1242,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertNull(
-            streamsConfig.getProducerConfigs("clientId")
+            streamsConfig.getProducerConfigs("clientId", null, -1)
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertNull(
@@ -1267,7 +1269,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertTrue(
-            (Boolean) streamsConfig.getProducerConfigs("clientId")
+            (Boolean) streamsConfig.getProducerConfigs("clientId", null, -1)
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertTrue(
@@ -1294,7 +1296,7 @@ public class StreamsConfigTest {
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertFalse(
-            (Boolean) streamsConfig.getProducerConfigs("clientId")
+            (Boolean) streamsConfig.getProducerConfigs("clientId", null, -1)
                 .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
         );
         assertFalse(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -310,6 +310,7 @@ public class ActiveTaskCreatorTest {
             new MockTime(),
             mockClientSupplier,
             "clientId-StreamThread-0",
+            0,
             uuid,
             new LogContext().logger(ActiveTaskCreator.class),
             false,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -729,7 +729,6 @@ public class RecordCollectorTest {
     @Test
     public void shouldForwardFlushToStreamsProducer() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        when(streamsProducer.eosEnabled()).thenReturn(false);
         doNothing().when(streamsProducer).flush();
         when(streamsProducer.sendException()).thenReturn(new AtomicReference<>(null));
         final ProcessorTopology topology = mock(ProcessorTopology.class);
@@ -750,7 +749,6 @@ public class RecordCollectorTest {
     @Test
     public void shouldForwardFlushToStreamsProducerEosEnabled() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        when(streamsProducer.eosEnabled()).thenReturn(true);
         when(streamsProducer.sendException()).thenReturn(new AtomicReference<>(null));
         doNothing().when(streamsProducer).flush();
         final ProcessorTopology topology = mock(ProcessorTopology.class);
@@ -779,7 +777,6 @@ public class RecordCollectorTest {
 
     private void shouldClearOffsetsOnClose(final boolean clean) {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        when(streamsProducer.eosEnabled()).thenReturn(true);
         when(streamsProducer.sendException()).thenReturn(new AtomicReference<>(null));
         final long offset = 1234L;
         final RecordMetadata metadata = new RecordMetadata(
@@ -831,7 +828,6 @@ public class RecordCollectorTest {
     @Test
     public void shouldNotAbortTxOnCloseCleanIfEosEnabled() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        when(streamsProducer.eosEnabled()).thenReturn(true);
         when(streamsProducer.sendException()).thenReturn(new AtomicReference<>(null));
         final ProcessorTopology topology = mock(ProcessorTopology.class);
         

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.MockProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Cluster;
@@ -55,6 +54,7 @@ import org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExce
 import org.apache.kafka.streams.errors.ProductionExceptionHandler.SerializationExceptionOrigin;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -77,7 +77,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -140,7 +139,6 @@ public class RecordCollectorTest {
 
     private final StringSerializer stringSerializer = new StringSerializer();
     private final ByteArraySerializer byteArraySerializer = new ByteArraySerializer();
-    private final UUID processId = UUID.randomUUID();
 
     private final StreamPartitioner<String, Object> streamPartitioner =
         (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Integer.parseInt(key) % numPartitions));
@@ -156,15 +154,13 @@ public class RecordCollectorTest {
     public void setup() {
         final MockClientSupplier clientSupplier = new MockClientSupplier();
         clientSupplier.setCluster(cluster);
+        mockProducer = (MockProducer<byte[], byte[]>) clientSupplier.getProducer(config.originals());
         streamsProducer = new StreamsProducer(
-            config,
-            processId + "-StreamThread-1",
-            clientSupplier,
-            processId,
+            StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+            mockProducer,
             logContext,
             Time.SYSTEM
         );
-        mockProducer = clientSupplier.producers.get(0);
         final SinkNode<?, ?> sinkNode = new SinkNode<>(
             sinkNodeName,
             new StaticTopicNameExtractor<>(topic),
@@ -1387,20 +1383,13 @@ public class RecordCollectorTest {
             logContext,
             taskId,
             new StreamsProducer(
-                eosConfig,
-                "-StreamThread-1",
-                new MockClientSupplier() {
+                StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+                new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
                     @Override
-                    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                        return new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
-                            @Override
-                            public void abortTransaction() {
-                                functionCalled.set(true);
-                            }
-                        };
+                    public void abortTransaction() {
+                        functionCalled.set(true);
                     }
                 },
-                processId,
                 logContext,
                 Time.SYSTEM
             ),
@@ -1419,20 +1408,13 @@ public class RecordCollectorTest {
             logContext,
             taskId,
             new StreamsProducer(
-                config,
-                processId + "-StreamThread-1",
-                new MockClientSupplier() {
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
                     @Override
-                    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                        return new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
-                            @Override
-                            public List<PartitionInfo> partitionsFor(final String topic) {
-                                return Collections.emptyList();
-                            }
-                        };
+                    public List<PartitionInfo> partitionsFor(final String topic) {
+                        return Collections.emptyList();
                     }
                 },
-                null,
                 logContext,
                 Time.SYSTEM
             ),
@@ -1459,15 +1441,8 @@ public class RecordCollectorTest {
             logContext,
             taskId,
             new StreamsProducer(
-                eosConfig,
-                processId + "-StreamThread-1",
-                new MockClientSupplier() {
-                    @Override
-                    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                        return mockProducer;
-                    }
-                },
-                processId,
+                StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+                mockProducer,
                 logContext,
                 Time.SYSTEM
             ),
@@ -1862,21 +1837,14 @@ public class RecordCollectorTest {
 
     private StreamsProducer getExceptionalStreamsProducerOnSend(final Exception exception) {
         return new StreamsProducer(
-            config,
-            processId + "-StreamThread-1",
-            new MockClientSupplier() {
+            StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+            new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
                 @Override
-                public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                    return new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
-                        @Override
-                        public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
-                            callback.onCompletion(null, exception);
-                            return null;
-                        }
-                    };
+                public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+                    callback.onCompletion(null, exception);
+                    return null;
                 }
             },
-            null,
             logContext,
             Time.SYSTEM
         );
@@ -1884,20 +1852,13 @@ public class RecordCollectorTest {
 
     private StreamsProducer getExceptionalStreamProducerOnPartitionsFor(final RuntimeException exception) {
         return new StreamsProducer(
-            config,
-            processId + "-StreamThread-1",
-            new MockClientSupplier() {
+            StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+            new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
                 @Override
-                public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                    return new MockProducer<byte[], byte[]>(cluster, true, byteArraySerializer, byteArraySerializer) {
-                        @Override
-                        public synchronized List<PartitionInfo> partitionsFor(final String topic) {
-                            throw exception;
-                        }
-                    };
+                public synchronized List<PartitionInfo> partitionsFor(final String topic) {
+                    throw exception;
                 }
             },
-            null,
             logContext,
             Time.SYSTEM
         );
@@ -1986,6 +1947,7 @@ public class RecordCollectorTest {
             return response.orElse(null);
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public ProductionExceptionHandlerResponse handleSerializationException(final ErrorHandlerContext context,
                                                                                final ProducerRecord record,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
@@ -151,10 +152,9 @@ public class StreamsProducerTest {
         eosMockClientSupplier.setCluster(cluster);
         eosMockClientSupplier.setApplicationIdForProducer("appId");
         final String clientId = "threadId-StreamThread-0";
-        final UUID processId = UUID.randomUUID();
-        eosMockProducer = (MockProducer<byte[], byte[]>) eosMockClientSupplier.getProducer(
-            eosConfig.getProducerConfigs(clientId, processId, 0)
-        );
+        final Map<String, Object> producerConfig = eosConfig.getProducerConfigs(clientId);
+        producerConfig.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "appId-" + UUID.randomUUID() + "-0");
+        eosMockProducer = (MockProducer<byte[], byte[]>) eosMockClientSupplier.getProducer(producerConfig);
         eosStreamsProducer =
             new StreamsProducer(
                 StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
@@ -37,10 +36,10 @@ import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.test.MockClientSupplier;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -63,8 +62,6 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -111,25 +108,15 @@ public class StreamsProducerTest {
 
     @SuppressWarnings("unchecked")
     final Producer<byte[], byte[]> mockedProducer = mock(Producer.class);
-    final KafkaClientSupplier clientSupplier = new MockClientSupplier() {
-        @Override
-        public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-            return mockedProducer;
-        }
-    };
     final StreamsProducer streamsProducerWithMock = new StreamsProducer(
-        nonEosConfig,
-        "threadId",
-        clientSupplier,
-        null,
+        StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+        mockedProducer,
         logContext,
         mockTime
     );
     final StreamsProducer eosStreamsProducerWithMock = new StreamsProducer(
-        eosConfig,
-        "threadId-StreamThread-0",
-        clientSupplier,
-        UUID.randomUUID(),
+        StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+        mockedProducer,
         logContext,
         mockTime
     );
@@ -152,30 +139,30 @@ public class StreamsProducerTest {
     @BeforeEach
     public void before() {
         mockClientSupplier.setCluster(cluster);
+        nonEosMockProducer = (MockProducer<byte[], byte[]>) mockClientSupplier.getProducer(nonEosConfig.originals());
         nonEosStreamsProducer =
             new StreamsProducer(
-                nonEosConfig,
-                "threadId-StreamThread-0",
-                mockClientSupplier,
-                null,
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                nonEosMockProducer,
                 logContext,
                 mockTime
             );
-        nonEosMockProducer = mockClientSupplier.producers.get(0);
 
         eosMockClientSupplier.setCluster(cluster);
         eosMockClientSupplier.setApplicationIdForProducer("appId");
+        final String clientId = "threadId-StreamThread-0";
+        final UUID processId = UUID.randomUUID();
+        eosMockProducer = (MockProducer<byte[], byte[]>) eosMockClientSupplier.getProducer(
+            eosConfig.getProducerConfigs(clientId, processId, 0)
+        );
         eosStreamsProducer =
             new StreamsProducer(
-                eosConfig,
-                "threadId-StreamThread-0",
-                eosMockClientSupplier,
-                UUID.randomUUID(),
+                StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+                eosMockProducer,
                 logContext,
                 mockTime
             );
         eosStreamsProducer.initTransaction();
-        eosMockProducer = eosMockClientSupplier.producers.get(0);
         when(mockTime.nanoseconds()).thenReturn(Time.SYSTEM.nanoseconds());
     }
 
@@ -202,12 +189,11 @@ public class StreamsProducerTest {
     @Test
     public void shouldResetTransactionInFlightOnReset() {
         // given:
-        eosStreamsProducer.send(
-            new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
+        eosStreamsProducer.send(new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
         assertThat(eosStreamsProducer.transactionInFlight(), is(true));
 
         // when:
-        eosStreamsProducer.resetProducer();
+        eosStreamsProducer.resetProducer(null);
 
         // then:
         assertThat(eosStreamsProducer.transactionInFlight(), is(false));
@@ -252,51 +238,31 @@ public class StreamsProducerTest {
     // error handling tests
 
     @Test
-    public void shouldFailIfStreamsConfigIsNull() {
+    public void shouldFailIfProcessingModeIsNull() {
         final NullPointerException thrown = assertThrows(
             NullPointerException.class,
             () -> new StreamsProducer(
                 null,
-                "threadId-StreamThread-0",
-                mockClientSupplier,
-                UUID.randomUUID(),
+                mockedProducer,
                 logContext,
                 mockTime)
         );
 
-        assertThat(thrown.getMessage(), is("config cannot be null"));
+        assertThat(thrown.getMessage(), is("processingMode cannot be null"));
     }
 
     @Test
-    public void shouldFailIfThreadIdIsNull() {
+    public void shouldFailIfProducerIsNull() {
         final NullPointerException thrown = assertThrows(
             NullPointerException.class,
             () -> new StreamsProducer(
-                nonEosConfig,
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
                 null,
-                mockClientSupplier,
-                UUID.randomUUID(),
                 logContext,
                 mockTime)
         );
 
-        assertThat(thrown.getMessage(), is("threadId cannot be null"));
-    }
-
-    @Test
-    public void shouldFailIfClientSupplierIsNull() {
-        final NullPointerException thrown = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsProducer(
-                nonEosConfig,
-                "threadId-StreamThread-0",
-                null,
-                UUID.randomUUID(),
-                logContext,
-                mockTime)
-        );
-
-        assertThat(thrown.getMessage(), is("clientSupplier cannot be null"));
+        assertThat(thrown.getMessage(), is("producer cannot be null"));
     }
 
     @Test
@@ -304,10 +270,8 @@ public class StreamsProducerTest {
         final NullPointerException thrown = assertThrows(
             NullPointerException.class,
             () -> new StreamsProducer(
-                nonEosConfig,
-                "threadId-StreamThread-0",
-                mockClientSupplier,
-                UUID.randomUUID(),
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                mockedProducer,
                 null,
                 mockTime)
         );
@@ -316,10 +280,24 @@ public class StreamsProducerTest {
     }
 
     @Test
+    public void shouldFailIfTimeIsNull() {
+        final NullPointerException thrown = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsProducer(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                mockedProducer,
+                logContext,
+                null)
+        );
+
+        assertThat(thrown.getMessage(), is("time cannot be null"));
+    }
+
+    @Test
     public void shouldFailOnResetProducerForAtLeastOnce() {
         final IllegalStateException thrown = assertThrows(
             IllegalStateException.class,
-            () -> nonEosStreamsProducer.resetProducer()
+            () -> nonEosStreamsProducer.resetProducer(null)
         );
 
         assertThat(thrown.getMessage(), is("Expected eos-v2 to be enabled, but the processing mode was AT_LEAST_ONCE"));
@@ -329,25 +307,6 @@ public class StreamsProducerTest {
     // non-EOS tests
 
     // functional tests
-
-    @Test
-    public void shouldNotSetTransactionIdIfEosDisabled() {
-        final Map<String, Object> producerConfig = new HashMap<>();
-        final StreamsConfig mockConfig = mock(StreamsConfig.class);
-        when(mockConfig.getProducerConfigs("threadId-producer")).thenReturn(producerConfig);
-        when(mockConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).thenReturn(StreamsConfig.AT_LEAST_ONCE);
-
-        new StreamsProducer(
-            mockConfig,
-            "threadId",
-            mockClientSupplier,
-            null,
-            logContext,
-            mockTime
-        );
-
-        assertFalse(producerConfig.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
-    }
 
     @Test
     public void shouldNotHaveEosEnabledIfEosDisabled() {
@@ -440,27 +399,6 @@ public class StreamsProducerTest {
     }
 
     @Test
-    public void shouldSetTransactionIdUsingProcessIdIfEosV2Enabled() {
-        final UUID processId = UUID.randomUUID();
-        final Map<String, Object> producerConfig = new HashMap<>();
-        final StreamsConfig mockConfig = mock(StreamsConfig.class);
-        when(mockConfig.getProducerConfigs("threadId-StreamThread-0-producer")).thenReturn(producerConfig);
-        when(mockConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("appId");
-        when(mockConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).thenReturn(StreamsConfig.EXACTLY_ONCE_V2);
-
-        new StreamsProducer(
-            mockConfig,
-            "threadId-StreamThread-0",
-            eosMockClientSupplier,
-            processId,
-            logContext,
-            mockTime
-        );
-
-        assertEquals("appId-" + processId + "-0", producerConfig.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
-    }
-
-    @Test
     public void shouldHaveEosEnabledIfEosEnabled() {
         assertThat(eosStreamsProducer.eosEnabled(), is(true));
     }
@@ -531,10 +469,8 @@ public class StreamsProducerTest {
         when(mockedProducer.send(record, null)).thenReturn(null);
 
         final StreamsProducer streamsProducer = new StreamsProducer(
-            eosConfig,
-            "threadId-StreamThread-0",
-            clientSupplier,
-            UUID.randomUUID(),
+            StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+            mockedProducer,
             logContext,
             mockTime
         );
@@ -577,37 +513,13 @@ public class StreamsProducerTest {
     // error handling tests
 
     @Test
-    public void shouldFailIfProcessIdNullForEos() {
-        final NullPointerException thrown = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsProducer(
-                eosConfig,
-                "threadId",
-                mockClientSupplier,
-                null,
-                logContext,
-                mockTime)
-        );
-
-        assertThat(thrown.getMessage(), is("processId cannot be null for exactly-once v2"));
-    }
-
-    @Test
     public void shouldThrowTimeoutExceptionOnEosInitTxTimeout() {
         // use `nonEosMockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new TimeoutException("KABOOM!");
-        final KafkaClientSupplier clientSupplier = new MockClientSupplier() {
-            @Override
-            public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                return nonEosMockProducer;
-            }
-        };
 
         final StreamsProducer streamsProducer = new StreamsProducer(
-            eosConfig,
-            "threadId-StreamThread-0",
-            clientSupplier,
-            UUID.randomUUID(),
+            StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+            nonEosMockProducer,
             logContext,
             mockTime
         );
@@ -622,12 +534,11 @@ public class StreamsProducerTest {
 
     @Test
     public void shouldFailOnMaybeBeginTransactionIfTransactionsNotInitializedForEos() {
+        // use `nonEosMockProducer` instead of `eosMockProducer` to avoid auto-init Tx
         final StreamsProducer streamsProducer =
             new StreamsProducer(
-                eosConfig,
-                "threadId-StreamThread-0",
-                eosMockClientSupplier,
-                UUID.randomUUID(),
+                StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+                nonEosMockProducer,
                 logContext,
                 mockTime
             );
@@ -644,18 +555,10 @@ public class StreamsProducerTest {
     public void shouldThrowStreamsExceptionOnEosInitError() {
         // use `nonEosMockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new KafkaException("KABOOM!");
-        final KafkaClientSupplier clientSupplier = new MockClientSupplier() {
-            @Override
-            public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                return nonEosMockProducer;
-            }
-        };
 
         final StreamsProducer streamsProducer = new StreamsProducer(
-            eosConfig,
-            "threadId-StreamThread-0",
-            clientSupplier,
-            UUID.randomUUID(),
+            StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+            nonEosMockProducer,
             logContext,
             mockTime
         );
@@ -673,18 +576,10 @@ public class StreamsProducerTest {
     public void shouldFailOnEosInitFatal() {
         // use `nonEosMockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new RuntimeException("KABOOM!");
-        final KafkaClientSupplier clientSupplier = new MockClientSupplier() {
-            @Override
-            public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                return nonEosMockProducer;
-            }
-        };
 
         final StreamsProducer streamsProducer = new StreamsProducer(
-            eosConfig,
-            "threadId-StreamThread-0",
-            clientSupplier,
-            UUID.randomUUID(),
+            StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+            nonEosMockProducer,
             logContext,
             mockTime
         );
@@ -986,26 +881,25 @@ public class StreamsProducerTest {
 
     @Test
     public void shouldCloseExistingProducerOnResetProducer() {
-        eosStreamsProducer.resetProducer();
+        eosStreamsProducer.resetProducer(null);
 
         assertTrue(eosMockProducer.closed());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void shouldSetNewProducerOnResetProducer() {
-        eosStreamsProducer.resetProducer();
+        final Producer<byte[], byte[]> newProducer = mock(Producer.class);
+        eosStreamsProducer.resetProducer(newProducer);
 
-        assertThat(eosMockClientSupplier.producers.size(), is(2));
-        assertThat(eosStreamsProducer.kafkaProducer(), is(eosMockClientSupplier.producers.get(1)));
+        assertThat(eosStreamsProducer.kafkaProducer(), is(newProducer));
     }
 
     @Test
     public void shouldResetTransactionInitializedOnResetProducer() {
         final StreamsProducer streamsProducer = new StreamsProducer(
-            eosConfig,
-            "threadId-StreamThread-0",
-            clientSupplier,
-            UUID.randomUUID(),
+            StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2,
+            mockedProducer,
             logContext,
             mockTime
         );
@@ -1013,7 +907,7 @@ public class StreamsProducerTest {
 
         when(mockedProducer.metrics()).thenReturn(Collections.emptyMap());
 
-        streamsProducer.resetProducer();
+        streamsProducer.resetProducer(mockedProducer);
         streamsProducer.initTransaction();
 
         verify(mockedProducer).close();
@@ -1064,9 +958,9 @@ public class StreamsProducerTest {
         final long closeStart = 1L;
         final long clodeDelay = 1L;
         when(mockTime.nanoseconds()).thenReturn(closeStart).thenReturn(closeStart + clodeDelay);
-        eosStreamsProducer.resetProducer();
+        eosStreamsProducer.resetProducer(eosMockProducer);
         setProducerMetrics(
-            eosMockClientSupplier.producers.get(1),
+            eosMockProducer,
             BUFFER_POOL_WAIT_TIME,
             FLUSH_TME,
             TXN_INIT_TIME,

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -26,6 +27,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -41,7 +43,6 @@ import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.state.internals.MeteredKeyValueStore;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.test.InternalMockProcessorContext;
-import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockRocksDbConfigSetter;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
@@ -212,10 +213,8 @@ public class KeyValueStoreTestDriver<K, V> {
             logContext,
             new TaskId(0, 0),
             new StreamsProducer(
-                new StreamsConfig(props),
-                "threadId",
-                new MockClientSupplier(),
-                null,
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                new MockProducer<>(null, true, null, null),
                 logContext,
                 Time.SYSTEM),
             new DefaultProductionExceptionHandler(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -81,7 +81,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -434,10 +433,8 @@ public class StreamThreadStateStoreProviderTest {
             logContext,
             taskId,
             new StreamsProducer(
-                streamsConfig,
-                "threadId",
-                clientSupplier,
-                UUID.randomUUID(),
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                clientSupplier.getProducer(streamsConfig.originals()),
                 logContext,
                 Time.SYSTEM
             ),

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -109,7 +109,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -347,28 +347,8 @@ public class TopologyTestDriver implements Closeable {
             }
         };
         testDriverProducer = new TestDriverProducer(
-            streamsConfig,
-            new KafkaClientSupplier() {
-                @Override
-                public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
-                    return producer;
-                }
-
-                @Override
-                public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
-                    throw new IllegalStateException();
-                }
-
-                @Override
-                public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
-                    throw new IllegalStateException();
-                }
-
-                @Override
-                public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
-                    throw new IllegalStateException();
-                }
-            },
+            StreamsConfigUtils.processingMode(streamsConfig),
+            producer,
             logContext,
             mockWallClockTime
         );
@@ -1374,11 +1354,11 @@ public class TopologyTestDriver implements Closeable {
 
     private static class TestDriverProducer extends StreamsProducer {
 
-        public TestDriverProducer(final StreamsConfig config,
-                                  final KafkaClientSupplier clientSupplier,
+        public TestDriverProducer(final StreamsConfigUtils.ProcessingMode processingMode,
+                                  final Producer<byte[], byte[]> producer,
                                   final LogContext logContext,
                                   final Time time) {
-            super(config, "TopologyTestDriver-StreamThread-1", clientSupplier, UUID.randomUUID(), logContext, time);
+            super(processingMode, producer, logContext, time);
         }
 
         @Override


### PR DESCRIPTION
With EOSv1 removed, we don't need to create a producer per task, and thus can simplify the code by removing `KafkaClientSupplier` from the deeply nested `StreamsProducer`, to simplify the code.