### PR TITLE
KAFKA-17375: Fix reassignment after segment.bytes changes

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -871,12 +871,6 @@ class UnifiedLog(@volatile var logStartOffset: Long,
             }
           }
 
-          // check messages set size may be exceed config.segmentSize
-          if (validRecords.sizeInBytes > config.segmentSize) {
-            throw new RecordBatchTooLargeException(s"Message batch size is ${validRecords.sizeInBytes} bytes in append " +
-              s"to partition $topicPartition, which exceeds the maximum configured segment size of ${config.segmentSize}.")
-          }
-
           // maybe roll the log if this segment is full
           val segment = maybeRoll(validRecords.sizeInBytes, appendInfo)
 

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -1807,21 +1807,6 @@ class UnifiedLogTest {
     }
   }
 
-  /**
-   *  MessageSet size shouldn't exceed the config.segmentSize, check that it is properly enforced by
-   * appending a message set larger than the config.segmentSize setting and checking that an exception is thrown.
-   */
-  @Test
-  def testMessageSetSizeCheck(): Unit = {
-    val messageSet = MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("You".getBytes), new SimpleRecord("bethe".getBytes))
-    // append messages to log
-    val configSegmentSize = messageSet.sizeInBytes - 1
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = configSegmentSize)
-    val log = createLog(logDir, logConfig)
-
-    assertThrows(classOf[RecordBatchTooLargeException], () => log.appendAsLeader(messageSet, leaderEpoch = 0))
-  }
-
   @Test
   def testCompactedTopicConstraints(): Unit = {
     val keyedMessage = new SimpleRecord("and here it is".getBytes, "this message has a key".getBytes)


### PR DESCRIPTION
Remove too late check that prevents partition reassignment if `segment.bytes` has been changed to smaller value than size of existing message.  Checks for `segment.bytes` limit should be only handled when a client produces new messages, but not during partition reassignments.



*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
