### PR TITLE
KAFKA-17473 Speed Up ClientTelemetryTest

### DIFF
--- a/core/src/test/java/kafka/admin/ClientTelemetryTest.java
+++ b/core/src/test/java/kafka/admin/ClientTelemetryTest.java
@@ -60,8 +60,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.admin.AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -70,11 +68,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(value = ClusterTestExtensions.class)
 public class ClientTelemetryTest {
 
-    @ClusterTest(types = Type.KRAFT,
+    @ClusterTest(
+            types = Type.KRAFT, 
+            brokers = 3,
             serverProperties = {
                     @ClusterConfigProperty(key = METRIC_REPORTER_CLASSES_CONFIG, value = "kafka.admin.ClientTelemetryTest$GetIdClientTelemetry"),
-                    @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-                    @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1")
             })
     public void testClientInstanceId(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException {
         Map<String, Object> configs = new HashMap<>();

--- a/core/src/test/java/kafka/admin/ClientTelemetryTest.java
+++ b/core/src/test/java/kafka/admin/ClientTelemetryTest.java
@@ -59,6 +59,9 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.clients.admin.AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -68,8 +71,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ClientTelemetryTest {
 
     @ClusterTest(types = Type.KRAFT,
-            serverProperties = @ClusterConfigProperty(key = AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG,
-                    value = "kafka.admin.ClientTelemetryTest$GetIdClientTelemetry"))
+            serverProperties = {
+                    @ClusterConfigProperty(key = METRIC_REPORTER_CLASSES_CONFIG, value = "kafka.admin.ClientTelemetryTest$GetIdClientTelemetry"),
+                    @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+                    @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1")
+            })
     public void testClientInstanceId(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException {
         Map<String, Object> configs = new HashMap<>();
         configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
@@ -113,7 +119,6 @@ public class ClientTelemetryTest {
                 consumerClientId = consumer.clientInstanceId(Duration.ofSeconds(3));
                 assertNotNull(consumerClientId);
                 assertEquals(consumerClientId, consumer.clientInstanceId(Duration.ofSeconds(3)));
-                consumer.close(Duration.ofSeconds(3));
             }
             Uuid uuid = admin.clientInstanceId(Duration.ofSeconds(3));
             assertNotNull(uuid);

--- a/core/src/test/java/kafka/admin/ClientTelemetryTest.java
+++ b/core/src/test/java/kafka/admin/ClientTelemetryTest.java
@@ -113,6 +113,7 @@ public class ClientTelemetryTest {
                 consumerClientId = consumer.clientInstanceId(Duration.ofSeconds(3));
                 assertNotNull(consumerClientId);
                 assertEquals(consumerClientId, consumer.clientInstanceId(Duration.ofSeconds(3)));
+                consumer.close(Duration.ofSeconds(3));
             }
             Uuid uuid = admin.clientInstanceId(Duration.ofSeconds(3));
             assertNotNull(uuid);


### PR DESCRIPTION
~As title, I found the main reason is consumer close will wait for the default timeout 30s, thus I reduce the close timeout~
| test name | type | time(Before) | time(After) |
| --- | --- | --- | --- |
| ClientTelemetryTest | | 36s 969ms | 9s 736ms |
| testClientInstanceId | Type=Raft-Isolated, MetadataVersion=4.0-IV2,Security=PLAINTEXT | 36s 954ms | 9s 720ms |

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
