### PR TITLE
KAFKA-17603: KRaftMigrationDriverTest testNoDualWriteBeforeMigration became flaky

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -758,19 +758,18 @@ public class KRaftMigrationDriverTest {
             TestUtils.waitForCondition(() -> driver.migrationState().get(1, TimeUnit.MINUTES).equals(MigrationDriverState.WAIT_FOR_CONTROLLER_QUORUM),
                 "Waiting for KRaftMigrationDriver to enter WAIT_FOR_CONTROLLER_QUORUM state");
 
-            driver.onMetadataUpdate(delta, image, logDeltaManifestBuilder(provenance, newLeader).build());
-
             driver.transitionTo(MigrationDriverState.WAIT_FOR_BROKERS);
             driver.transitionTo(MigrationDriverState.BECOME_CONTROLLER);
             driver.transitionTo(MigrationDriverState.ZK_MIGRATION);
             driver.transitionTo(MigrationDriverState.SYNC_KRAFT_TO_ZK);
+
+            driver.onMetadataUpdate(delta, image, logDeltaManifestBuilder(provenance, newLeader).build());
 
             provenance = new MetadataProvenance(200, 1, 1);
             delta = new MetadataDelta(image);
             RecordTestUtils.replayAll(delta, DELTA1_RECORDS);
             image = delta.apply(provenance);
             driver.onMetadataUpdate(delta, image, new SnapshotManifest(provenance, 100));
-
 
             // Wait for migration
             TestUtils.waitForCondition(() -> driver.migrationState().get(1, TimeUnit.MINUTES).equals(MigrationDriverState.DUAL_WRITE),


### PR DESCRIPTION
There may have race condition between test thread and  `KafkaEventQueue`.

The original `KRaftMigrationDriverTest#testNoDualWriteBeforeMigration` can be reproduced steadily by adding `Thread.sleep(1000);` after `driver.onMetadataUpdate(delta, image, logDeltaManifestBuilder(provenance, newLeader).build());`.

If `MetadataChangeEvent` is finished, it changes `KRaftMigrationDriver#firstPublish` to `true` and `KRaftMigrationDriver#image` to new image which contains `ZkMigrationState#PRE_MIGRATION`.  And then following events will eventually change `KRaftMigrationDriver#migrationState` to `MigrationDriverState#DUAL_WRITE`.

* `WaitForControllerQuorumEvent`  -> `MigrationDriverState#WAIT_FOR_BROKERS`
* `WaitForZkBrokersEvent` -> `MigrationDriverState#BECOME_CONTROLLER`
* `BecomeZkControllerEvent` -> `MigrationDriverState#ZK_MIGRATION`
* `MigrateMetadataEvent` -> `MigrationDriverState#SYNC_KRAFT_TO_ZK`
* `SyncKRaftMetadataEvent` -> `MigrationDriverState#KRAFT_CONTROLLER_TO_BROKER_COMM`
* `SendRPCsToBrokersEvent` -> `MigrationDriverState#DUAL_WRITE`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
