### PR TITLE
MINOR: Update LICENSE-binary with missing licenses 

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -213,7 +213,7 @@ commons-collections-3.2.2
 commons-digester-2.1
 commons-io-2.11.0
 commons-lang3-3.12.0
-commons-logging-1.2
+commons-logging-1.3.2
 commons-validator-1.9.0
 error_prone_annotations-2.10.0
 jackson-annotations-2.16.2
@@ -328,6 +328,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 BSD 2-Clause
 
 zstd-jni-1.5.6-6 see: licenses/zstd-jni-BSD-2-clause
+HdrHistogram-2.2.2 see: licenses/hdrHistogram-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/licenses/hdrHistogram-BSD-2-clause
+++ b/licenses/hdrHistogram-BSD-2-clause
@@ -1,0 +1,41 @@
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Fix dependency version for existing license (commons-logging), and add a missing license for a recently added dependency (HdrHistogram)

Before this PR, checking missing licenses would output:

HdrHistogram-2.2.2 is missing in license file
commons-logging-1.3.2 is missing in license file

With this PR the output is empty (all licenses found)
