### PR TITLE
KAFKA-17515: Fix flaky RestoreIntegrationTest.shouldInvokeUserDefinedGlobalStateRestoreListener by increasing stream client start timeout

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -588,7 +588,7 @@ public class RestoreIntegrationTest {
 
         // Ensure all the restoring tasks are in active state before starting the new instance.
         // Otherwise, the tasks which assigned to first kafka streams won't encounter "restoring suspend" after being reassigned to the second instance.
-        waitForActiveRestoringTask(kafkaStreams, 5, IntegrationTestUtils.DEFAULT_TIMEOUT);
+        waitForActiveRestoringTask(kafkaStreams, 5, 180_000);
 
         assertTrue(kafkaStreams1StateRestoreListener.awaitUntilRestorationStarts());
         assertTrue(kafkaStreams1StateRestoreListener.awaitUntilBatchRestoredIsCalled());
@@ -603,7 +603,7 @@ public class RestoreIntegrationTest {
                                                                   kafkaStreams2Configuration)) {
 
             waitForCondition(() -> State.RUNNING == kafkaStreams2.state(),
-                             90_000,
+                             180_000,
                              () -> "kafkaStreams2 never transitioned to a RUNNING state.");
 
             assertTrue(kafkaStreams1StateRestoreListener.awaitUntilRestorationSuspends());


### PR DESCRIPTION
It's regarding [KAFKA-17515 Fix flaky RestoreIntegrationTest.shouldInvokeUserDefinedGlobalStateRestoreListener](https://issues.apache.org/jira/browse/KAFKA-17515).

Found one more issue in the flaky test after PR #17187 

- KafkaStream(ks-1) took more than 60 seconds to initialize  stream tasks after kafkaStreams.start(), (5 of 115 flaky run over past 5 days) (The flaky test was observed up to 70 secs to initialize KafkaStream)(Put the flaky link under Jira comments.)

To solve this issue, increase timeout from 60 sec to 180 sec.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
