### PR TITLE
KAFKA-17317: Validate and maybe trigger downgrade after static member replacement

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1096,16 +1096,18 @@ public class GroupMetadataManager {
     /**
      * Maybe downgrade the consumer group to a classic group if it's valid for online downgrade.
      *
-     * @param groupId   The group id.
+     * @param groupId           The group id.
+     * @param needsRebalance    The boolean indicating whether a rebalance should be triggered after the conversion.
      * @return The CoordinatorResult to be applied.
      */
     private <T> CoordinatorResult<T, CoordinatorRecord> consumerGroupDowngradeOperation(
-        String groupId
+        String groupId,
+        boolean needsRebalance
     ) {
         try {
             ConsumerGroup consumerGroup = consumerGroup(groupId);
             if (validateOnlineDowngrade(consumerGroup)) {
-                return convertToClassicGroup(consumerGroup);
+                return convertToClassicGroup(consumerGroup, needsRebalance);
             }
         } catch (GroupIdNotFoundException e) {
             log.debug("Cannot downgrade group {} because the group doesn't exist or it's not a consumer group.");
@@ -1117,10 +1119,12 @@ public class GroupMetadataManager {
      * Creates a ClassicGroup corresponding to the given ConsumerGroup.
      *
      * @param consumerGroup     The converted ConsumerGroup.
+     * @param needsRebalance    The boolean indicating whether a rebalance should be triggered after the conversion.
      * @return A CoordinatorResult.
      */
     private <T> CoordinatorResult<T, CoordinatorRecord> convertToClassicGroup(
-        ConsumerGroup consumerGroup
+        ConsumerGroup consumerGroup,
+        boolean needsRebalance
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
         consumerGroup.createGroupTombstoneRecords(records);
@@ -1152,7 +1156,12 @@ public class GroupMetadataManager {
 
         classicGroup.allMembers().forEach(member -> rescheduleClassicGroupMemberHeartbeat(classicGroup, member));
 
-        prepareRebalance(classicGroup, String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId()));
+        if (needsRebalance) {
+            prepareRebalance(
+                classicGroup,
+                String.format("Downgrade group %s from consumer to classic.", classicGroup.groupId())
+            );
+        }
 
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.exceptionally(__ -> {
@@ -2092,8 +2101,9 @@ public class GroupMetadataManager {
                 responseFuture.complete(response);
 
                 // Maybe downgrade the consumer group if the last member using the
-                // consumer protocol is replaced by the joining member.
-                scheduleConsumerGroupDowngradeTimeout(group);
+                // consumer protocol is replaced by the joining member. No rebalance
+                // is needed after the replacement.
+                scheduleConsumerGroupDowngradeTimeout(group, false);
             }
         });
 
@@ -2788,7 +2798,8 @@ public class GroupMetadataManager {
             records.add(newConsumerGroupSubscriptionMetadataRecord(group.groupId(), subscriptionMetadata));
         }
 
-        // We bump the group epoch if the group doesn't need a downgrade.
+        // We bump the group epoch if the group doesn't need a downgrade,
+        // or the rebalance will be triggered after the downgrade conversion.
         if (!validateOnlineDowngradeWithFencedMember(group, member.memberId())) {
             int groupEpoch = group.groupEpoch() + 1;
             records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch));
@@ -2799,7 +2810,7 @@ public class GroupMetadataManager {
         CompletableFuture<Void> appendFuture = new CompletableFuture<>();
         appendFuture.whenComplete((__, t) -> {
             if (t == null) {
-                scheduleConsumerGroupDowngradeTimeout(group);
+                scheduleConsumerGroupDowngradeTimeout(group, true);
             }
         });
 
@@ -3181,10 +3192,12 @@ public class GroupMetadataManager {
     /**
      * Maybe schedules the downgrade timeout for the consumer group.
      *
-     * @param consumerGroup The group to downgrade.
+     * @param consumerGroup     The group to downgrade.
+     * @param needsRebalance    The boolean indicating whether a rebalance should be triggered after the conversion.
      */
     private void scheduleConsumerGroupDowngradeTimeout(
-        ConsumerGroup consumerGroup
+        ConsumerGroup consumerGroup,
+        boolean needsRebalance
     ) {
         if (validateOnlineDowngrade(consumerGroup)) {
             timer.scheduleIfAbsent(
@@ -3192,7 +3205,7 @@ public class GroupMetadataManager {
                 0,
                 TimeUnit.MILLISECONDS,
                 true,
-                () -> consumerGroupDowngradeOperation(consumerGroup.groupId())
+                () -> consumerGroupDowngradeOperation(consumerGroup.groupId(), needsRebalance)
             );
         }
     }
@@ -3820,7 +3833,7 @@ public class GroupMetadataManager {
                             );
                         }
                     });
-                    scheduleConsumerGroupDowngradeTimeout(consumerGroup);
+                    scheduleConsumerGroupDowngradeTimeout(consumerGroup, true);
                     break;
 
                 case CLASSIC:

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -913,8 +913,19 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @return A boolean indicating whether all the members use the classic protocol.
      */
-    public boolean allMembersUseClassic() {
+    public boolean allMembersUseClassicProtocol() {
         return numClassicProtocolMembers() == members().size();
+    }
+
+    /**
+     * Checks whether all the members use the classic protocol except the given member.
+     *
+     * @param memberId The member to remove.
+     * @return A boolean indicating whether all the members use the classic protocol.
+     */
+    public boolean allMembersUseClassicProtocolExcept(String memberId) {
+        return numClassicProtocolMembers() == members().size() - 1 &&
+            !getOrMaybeCreateMember(memberId, false).useClassicProtocol();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -909,14 +909,12 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     }
 
     /**
-     * Checks whether all the members use the classic protocol except the given member.
+     * Checks whether all the members use the classic protocol.
      *
-     * @param memberId The member to remove.
      * @return A boolean indicating whether all the members use the classic protocol.
      */
-    public boolean allMembersUseClassicProtocolExcept(String memberId) {
-        return numClassicProtocolMembers() == members().size() - 1 &&
-            !getOrMaybeCreateMember(memberId, false).useClassicProtocol();
+    public boolean allMembersUseClassic() {
+        return numClassicProtocolMembers() == members().size();
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -10895,7 +10895,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            11,
+            10,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -10929,7 +10929,7 @@ public class GroupMetadataManagerTest {
         );
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.
@@ -11047,7 +11047,6 @@ public class GroupMetadataManagerTest {
         }));
 
         context.commit();
-        ConsumerGroup consumerGroup = context.groupMetadataManager.consumerGroup(groupId);
 
         // A new member using classic protocol with the same instance id joins, scheduling the downgrade.
         JoinGroupRequestData joinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
@@ -11165,10 +11164,11 @@ public class GroupMetadataManagerTest {
         ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
             classicGroupJoinKey(groupId)
         );
+        assertNotNull(groupJoinTimeout);
 
-        // No rebalance is triggered. The group is stable.
+        // A new rebalance is triggered.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(STABLE));
+        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
     }
 
     @Test
@@ -11300,7 +11300,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            11,
+            10,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11334,7 +11334,7 @@ public class GroupMetadataManagerTest {
 
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.STABLE, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.
@@ -11510,7 +11510,7 @@ public class GroupMetadataManagerTest {
             STABLE,
             context.time,
             context.metrics,
-            12,
+            11,
             Optional.of(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.of("range"),
             Optional.of(memberId1),
@@ -11544,7 +11544,7 @@ public class GroupMetadataManagerTest {
         );
         assertRecordsEquals(expectedRecords, downgradeTimeout.result.records());
 
-        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.ASSIGNING, null);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.RECONCILING, null);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, STABLE);
 
         // The new classic member 1 has a heartbeat timeout.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -3142,20 +3142,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3232,20 +3223,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId);
         context.assertNoRebalanceTimeout(groupId, memberId);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3537,20 +3519,11 @@ public class GroupMetadataManagerTest {
             timeout.result.records()
         );
 
-        // Verify that there is a downgrade timer scheduled if the append future is completed without exception.
+        // Verify that there are no timers.
         timeout.result.appendFuture().complete(null);
         context.assertNoSessionTimeout(groupId, memberId1);
         context.assertNoRebalanceTimeout(groupId, memberId1);
-        context.assertDowngradeTimeout(groupId);
-
-        // The downgrade is not triggered.
-        assertEquals(
-            new ExpiredTimeout<Void, CoordinatorRecord>(
-                consumerGroupDowngradeKey(groupId),
-                new CoordinatorResult<>(Collections.emptyList())
-            ),
-            context.sleep(0).get(0)
-        );
+        context.assertNoDowngradeTimeout(groupId);
     }
 
     @Test
@@ -3605,8 +3578,8 @@ public class GroupMetadataManagerTest {
         // foo-1 should also have a revocation timeout in place.
         assertNotNull(context.timer.timeout(consumerGroupRebalanceTimeoutKey("foo", "foo-1")));
 
-        // The group has a downgrade timeout scheduled.
-        assertNotNull(context.timer.timeout(consumerGroupDowngradeKey("foo")));
+        // No downgrade timeout is scheduled.
+        assertNull(context.timer.timeout(consumerGroupDowngradeKey("foo")));
     }
 
     @Test
@@ -11192,11 +11165,10 @@ public class GroupMetadataManagerTest {
         ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
             classicGroupJoinKey(groupId)
         );
-        assertNotNull(groupJoinTimeout);
 
-        // A new rebalance is triggered.
+        // No rebalance is triggered. The group is stable.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
+        assertTrue(classicGroup.isInState(STABLE));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -11160,15 +11160,10 @@ public class GroupMetadataManagerTest {
             classicGroupHeartbeatKey(groupId, memberId1)
         );
         assertNotNull(heartbeatTimeout);
-        // The new rebalance has a groupJoin timeout.
-        ScheduledTimeout<Void, CoordinatorRecord> groupJoinTimeout = context.timer.timeout(
-            classicGroupJoinKey(groupId)
-        );
-        assertNotNull(groupJoinTimeout);
 
-        // A new rebalance is triggered.
+        // No rebalance is triggered.
         ClassicGroup classicGroup = context.groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, false);
-        assertTrue(classicGroup.isInState(PREPARING_REBALANCE));
+        assertTrue(classicGroup.isInState(STABLE));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -11041,8 +11041,8 @@ public class GroupMetadataManagerTest {
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
             {
-                put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
-                put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 2, mkMapOfPartitionRacks(2)));
+                put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6));
+                put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 2));
             }
         }));
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -111,6 +111,7 @@ import static org.apache.kafka.coordinator.group.Assertions.assertSyncGroupRespo
 import static org.apache.kafka.coordinator.group.GroupConfigManagerTest.createConfigManager;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.EMPTY_RESULT;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupHeartbeatKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupDowngradeKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupJoinKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupRebalanceTimeoutKey;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupSyncKey;
@@ -749,6 +750,16 @@ public class GroupMetadataManagerTestContext {
         MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
             timer.timeout(consumerGroupSyncKey(groupId, memberId));
         assertNull(timeout);
+    }
+
+    public MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> assertDowngradeTimeout(
+        String groupId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
+            timer.timeout(consumerGroupDowngradeKey(groupId));
+        assertNotNull(timeout);
+        assertEquals(time.milliseconds(), timeout.deadlineMs);
+        return timeout;
     }
 
     ClassicGroup createClassicGroup(String groupId) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -762,6 +762,15 @@ public class GroupMetadataManagerTestContext {
         return timeout;
     }
 
+    public MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> assertNoDowngradeTimeout(
+        String groupId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, CoordinatorRecord> timeout =
+            timer.timeout(consumerGroupDowngradeKey(groupId));
+        assertNull(timeout);
+        return timeout;
+    }
+
     ClassicGroup createClassicGroup(String groupId) {
         return groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, true);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1409,14 +1409,16 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member1);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertTrue(consumerGroup.allMembersUseClassic());
+        assertTrue(consumerGroup.allMembersUseClassicProtocol());
+        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept(member1.memberId()));
 
         // The group has member 1 (using the classic protocol) and member 2 (using the consumer protocol).
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member-2")
             .build();
         consumerGroup.updateMember(member2);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassic());
+        assertFalse(consumerGroup.allMembersUseClassicProtocol());
+        assertTrue(consumerGroup.allMembersUseClassicProtocolExcept(member2.memberId()));
 
         // The group has member 2 (using the consumer protocol) and member 3 (using the consumer protocol).
         consumerGroup.removeMember(member1.memberId());
@@ -1424,12 +1426,13 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member3);
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassic());
+        assertFalse(consumerGroup.allMembersUseClassicProtocol());
+        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept(member2.memberId()));
 
         // The group is empty.
         consumerGroup.removeMember(member2.memberId());
         consumerGroup.removeMember(member3.memberId());
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertTrue(consumerGroup.allMembersUseClassic());
+        assertTrue(consumerGroup.allMembersUseClassicProtocol());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1409,14 +1409,14 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member1);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
+        assertTrue(consumerGroup.allMembersUseClassic());
 
         // The group has member 1 (using the classic protocol) and member 2 (using the consumer protocol).
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member-2")
             .build();
         consumerGroup.updateMember(member2);
         assertEquals(1, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept("member-1"));
-        assertTrue(consumerGroup.allMembersUseClassicProtocolExcept("member-2"));
+        assertFalse(consumerGroup.allMembersUseClassic());
 
         // The group has member 2 (using the consumer protocol) and member 3 (using the consumer protocol).
         consumerGroup.removeMember(member1.memberId());
@@ -1424,15 +1424,12 @@ public class ConsumerGroupTest {
             .build();
         consumerGroup.updateMember(member3);
         assertEquals(0, consumerGroup.numClassicProtocolMembers());
-        assertFalse(consumerGroup.allMembersUseClassicProtocolExcept("member-2"));
+        assertFalse(consumerGroup.allMembersUseClassic());
 
-        // The group has member 2 (using the classic protocol).
+        // The group is empty.
         consumerGroup.removeMember(member2.memberId());
-        member2 = new ConsumerGroupMember.Builder("member-2")
-            .setClassicMemberMetadata(new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                .setSupportedProtocols(protocols))
-            .build();
-        consumerGroup.updateMember(member2);
-        assertEquals(1, consumerGroup.numClassicProtocolMembers());
+        consumerGroup.removeMember(member3.memberId());
+        assertEquals(0, consumerGroup.numClassicProtocolMembers());
+        assertTrue(consumerGroup.allMembersUseClassic());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-17317

This patch makes the online downgrade trigger asynchronous by scheduling a timer to downgrade the group in the appendFuture of the coordinator result. To avoid duplication, the rebalance is only triggered after the downgrade conversion but not after the last consumer protocol member leaves the group. If the downgrade is triggered by static member replacement, no rebalance will be triggered.

This also fixes the bug discovered in the system test, where the group can't be downgraded when the last static member using the consumer protocol is replaced by a classic member with the same instance id.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
