### PR TITLE
MINOR Don't run tests for Draft PRs

### DIFF
--- a/.github/actions/gh-api-update-check/action.yml
+++ b/.github/actions/gh-api-update-check/action.yml
@@ -16,8 +16,8 @@
 # under the License.
 #
 ---
-name: "Update Commit Status Check"
-description: "Update the status of a commit check using the GH CLI"
+name: "Update Check Run"
+description: "Update the status of a commit check using the GH CLI. See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run"
 inputs:
   # Composite actions do not support typed parameters. Everything is treated as a string
   # See: https://github.com/actions/runner/issues/2238
@@ -39,10 +39,10 @@ inputs:
     description: "The text to display next to the check"
     default: ""
     required: false
-  context:
-    description: "The name of the status check"
+  title:
+    description: "The title of the status check"
     required: true
-  state:
+  status:
     description: "The status of the check. Can be one of: queued, in_progress, completed, waiting, requested, pending"
     required: true
   conclusion:
@@ -52,7 +52,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Update Check
+    - if: inputs.conclusion == ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
@@ -60,7 +60,22 @@ runs:
         gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
         /repos/${{ inputs.repository }}/check-runs \
         -f "head_sha=${{ inputs.commit_sha }}" \
-        -f "status=${{ inputs.state }}" \
+        -f "status=${{ inputs.status }}" \
         -f "details_url=${{ inputs.url }}" \
-        -f "output[title]=${{ inputs.description }}" \
-        -f "name=${{ inputs.context }}"
+        -f "output[title]=${{ inputs.title }}" \
+        -f "output[summary]=${{ inputs.description }}" \
+        -f "name=${{ inputs.title }}"
+    - if: inputs.conclusion != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+      run: |
+        gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+        /repos/${{ inputs.repository }}/check-runs \
+        -f "head_sha=${{ inputs.commit_sha }}" \
+        -f "status=${{ inputs.status }}" \
+        -f "conclusion=${{ inputs.conclusion }}" \
+        -f "details_url=${{ inputs.url }}" \
+        -f "output[title]=${{ inputs.title }}" \
+        -f "output[summary]=${{ inputs.description }}" \
+        -f "name=${{ inputs.title }}"

--- a/.github/actions/gh-api-update-status/action.yml
+++ b/.github/actions/gh-api-update-status/action.yml
@@ -43,8 +43,11 @@ inputs:
     description: "The name of the status check"
     required: true
   state:
-    description: "The state of the check. Can be one of: error, failure, pending, success"
+    description: "The status of the check. Can be one of: queued, in_progress, completed, waiting, requested, pending"
     required: true
+  conclusion:
+    description: "Required if status is 'completed'. Can be one of: action_required, cancelled, failure, neutral, success, skipped, stale, timed_out"
+    required: false
 
 runs:
   using: "composite"
@@ -55,7 +58,9 @@ runs:
         GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/${{ inputs.repository }}/statuses/${{ inputs.commit_sha }} \
-        -f "state=${{ inputs.state }}" -f "target_url=${{ inputs.url }}" \
-        -f "description=${{ inputs.description }}" \
-        -f "context=${{ inputs.context }}"
+        /repos/${{ inputs.repository }}/check-runs \
+        -f "head_sha=${{ inputs.commit_sha }}" \
+        -f "status=${{ inputs.state }}" \
+        -f "details_url=${{ inputs.url }}" \
+        -f "output[title]=${{ inputs.description }}" \
+        -f "name=${{ inputs.context }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ on:
         description: "Is this CI run from a public fork?"
         default: true
         type: boolean
-      is-draft:
-        description: "Is this CI run from a draft PR?"
-        default: false
-        type: boolean
 
 jobs:
   validate:
@@ -43,11 +39,21 @@ jobs:
       matrix:
         java: [ 21, 17, 11, 8 ]
     name: Compile and Check Java ${{ matrix.java }}
+    outputs:
+      is-draft: ${{ steps.check-draft-pr.outputs.is-draft }}
     steps:
       - name: Env
         run: printenv
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Check for Draft PR
+        id: check-draft-pr
+        if: |
+          github.event_name == 'pull_request' && (
+            github.event.pull_request.draft ||
+            contains(github.event.pull_request.title, 'WIP')
+          )
+        run: echo "is-draft=true" >> "$GITHUB_OUTPUT"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -90,7 +96,7 @@ jobs:
 
   test:
     needs: validate
-    if: ${{ ! inputs.is-draft }}
+    if: ${{ ! needs.validate.outputs.is-draft }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ on:
         description: "Is this CI run from a public fork?"
         default: true
         type: boolean
+      is-draft:
+        description: "Is this CI run from a draft PR?"
+        default: false
+        type: boolean
 
 jobs:
   validate:
@@ -86,6 +90,7 @@ jobs:
 
   test:
     needs: validate
+    if: ! inputs.is-draft
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,8 @@ jobs:
       - name: Check for Draft PR
         id: check-draft-pr
         if: |
-          github.event_name == 'pull_request' && (
-            github.event.pull_request.draft ||
-            contains(github.event.pull_request.title, 'WIP')
-          )
+          github.event_name == 'pull_request' && 
+          github.event.pull_request.draft
         run: echo "is-draft=true" >> "$GITHUB_OUTPUT"
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
   test:
     needs: validate
-    if: ! inputs.is-draft
+    if: ${{ ! inputs.is-draft }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -70,15 +70,15 @@ jobs:
           path: ~/.gradle/build-scan-data  # This is where Gradle buffers unpublished build scan data when --no-scan is given
       - name: Handle missing scan
         if: ${{ steps.download-build-scan.outcome == 'failure' }}
-        uses: ./.github/actions/gh-api-update-status
+        uses: ./.github/actions/gh-api-update-check
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
-          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'completed'
+          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          status: 'completed'
           conclusion: 'skipped'
       - name: Publish Scan
         id: publish-build-scan
@@ -99,25 +99,25 @@ jobs:
           fi
       - name: Handle failed publish
         if: ${{ failure() && steps.publish-build-scan.outcome == 'failure' }}
-        uses: ./.github/actions/gh-api-update-status
+        uses: ./.github/actions/gh-api-update-check
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'The build scan failed to be published'
-          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'completed'
+          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          status: 'completed'
           conclusion: 'failure'
       - name: Update Status Check
         if: ${{ steps.publish-build-scan.outcome == 'success' }}
-        uses: ./.github/actions/gh-api-update-status
+        uses: ./.github/actions/gh-api-update-check
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'
-          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'completed'
+          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          status: 'completed'
           conclusion: 'success'

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -78,7 +78,8 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'error'
+          state: 'completed'
+          conclusion: 'skipped'
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}
@@ -106,7 +107,8 @@ jobs:
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'The build scan failed to be published'
           context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'error'
+          state: 'completed'
+          conclusion: 'failure'
       - name: Update Status Check
         if: ${{ steps.publish-build-scan.outcome == 'success' }}
         uses: ./.github/actions/gh-api-update-status
@@ -117,4 +119,5 @@ jobs:
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'
           context: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          state: 'success'
+          state: 'completed'
+          conclusion: 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,6 @@ jobs:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
       is-public-fork: ${{ github.event.pull_request.head.repo.fork || false }}
+      is-draft: ${{ github.event.pull_request.draft || false }}
     secrets:
       inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,5 @@ jobs:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
       is-public-fork: ${{ github.event.pull_request.head.repo.fork || false }}
-      is-draft: |
-        github.event_name == 'pull_request' && (
-          github.event.pull_request.draft ||
-          contains(github.event.pull_request.title, 'WIP')
-        )
     secrets:
       inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - 'trunk'
 
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [ opened, synchronize, ready_for_review, reopened ]
     branches:
       - 'trunk'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
       gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
       gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
       is-public-fork: ${{ github.event.pull_request.head.repo.fork || false }}
-      is-draft: ${{ github.event.pull_request.draft || false }}
+      is-draft: |
+        github.event_name == 'pull_request' && (
+          github.event.pull_request.draft ||
+          contains(github.event.pull_request.title, 'WIP')
+        )
     secrets:
       inherit


### PR DESCRIPTION
This patch updates our CI workflow to skip the JUnit tests if the PR is marked as a Draft. Also, change to using the more modern "checks" API instead of "statuses" for the feedback from CI Complete.