### PR TITLE
KIP-1071: Broker-side automatic creation of internal topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import java.util.Collection;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
@@ -45,8 +46,6 @@ public class StreamsAssignmentInterface {
 
     private Map<String, Subtopology> subtopologyMap;
 
-    private Map<String, Object> assignmentConfiguration;
-
     private Map<TaskId, Long> taskLags;
 
     private AtomicBoolean shutdownRequested;
@@ -72,10 +71,6 @@ public class StreamsAssignmentInterface {
 
     public Map<String, Subtopology> subtopologyMap() {
         return subtopologyMap;
-    }
-
-    public Map<String, Object> assignmentConfiguration() {
-        return assignmentConfiguration;
     }
 
     // TODO: This needs to be used somewhere
@@ -190,11 +185,14 @@ public class StreamsAssignmentInterface {
     public static class TopicInfo {
 
         public final Optional<Integer> numPartitions;
+        public final Optional<Short> replicationFactor;
         public final Map<String, String> topicConfigs;
 
         public TopicInfo(final Optional<Integer> numPartitions,
+                         final Optional<Short> replicationFactor,
                          final Map<String, String> topicConfigs) {
             this.numPartitions = numPartitions;
+            this.replicationFactor = replicationFactor;
             this.topicConfigs = topicConfigs;
         }
 
@@ -202,10 +200,10 @@ public class StreamsAssignmentInterface {
         public String toString() {
             return "TopicInfo{" +
                 "numPartitions=" + numPartitions +
+                ", replicationFactor=" + replicationFactor +
                 ", topicConfigs=" + topicConfigs +
                 '}';
         }
-
     }
 
     public static class TaskId {
@@ -241,15 +239,19 @@ public class StreamsAssignmentInterface {
         public final Set<String> sinkTopics;
         public final Map<String, TopicInfo> stateChangelogTopics;
         public final Map<String, TopicInfo> repartitionSourceTopics;
+        public final Collection<Set<String>> copartitionGroups;
 
         public Subtopology(final Set<String> sourceTopics,
                            final Set<String> sinkTopics,
                            final Map<String, TopicInfo> repartitionSourceTopics,
-                           final Map<String, TopicInfo> stateChangelogTopics) {
+                           final Map<String, TopicInfo> stateChangelogTopics,
+                           final Collection<Set<String>> copartitionGroups
+        ) {
             this.sourceTopics = sourceTopics;
             this.sinkTopics = sinkTopics;
             this.stateChangelogTopics = stateChangelogTopics;
             this.repartitionSourceTopics = repartitionSourceTopics;
+            this.copartitionGroups = copartitionGroups;
         }
 
         @Override
@@ -259,6 +261,7 @@ public class StreamsAssignmentInterface {
                 ", sinkTopics=" + sinkTopics +
                 ", stateChangelogTopics=" + stateChangelogTopics +
                 ", repartitionSourceTopics=" + repartitionSourceTopics +
+                ", copartitionGroups=" + copartitionGroups +
                 '}';
         }
     }
@@ -267,14 +270,12 @@ public class StreamsAssignmentInterface {
                                       Optional<HostInfo> endpoint,
                                       String assignor,
                                       Map<String, Subtopology> subtopologyMap,
-                                      Map<String, Object> assignmentConfiguration,
                                       Map<String, String> clientTags
     ) {
         this.processId = processId;
         this.endpoint = endpoint;
         this.assignor = assignor;
         this.subtopologyMap = subtopologyMap;
-        this.assignmentConfiguration = assignmentConfiguration;
         this.taskLags = new HashMap<>();
         this.shutdownRequested = new AtomicBoolean(false);
         this.clientTags = clientTags;
@@ -287,7 +288,6 @@ public class StreamsAssignmentInterface {
             ", endpoint='" + endpoint + '\'' +
             ", assignor='" + assignor + '\'' +
             ", subtopologyMap=" + subtopologyMap +
-            ", assignmentConfiguration=" + assignmentConfiguration +
             ", taskLags=" + taskLags +
             ", clientTags=" + clientTags +
             '}';

--- a/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
@@ -48,18 +48,18 @@
         { "name":  "Topology", "type": "[]Subtopology", "versions": "0+", "nullableVersions": "0+", "default": "null",
           "about": "The sub-topologies of the streams application. Null if uninitialized.",
           "fields": [
-            { "name": "Subtopology", "type": "string", "versions": "0+",
-              "about": "String to uniquely identify the sub-topology." },
+            { "name": "SubtopologyId", "type": "string", "versions": "0+",
+              "about": "String to uniquely identify the sub-topology. Deterministically generated from the topology." },
             { "name": "SourceTopics", "type": "[]string", "versions": "0+",
               "about": "The topics the topology reads from." },
-            { "name": "SourceTopicRegex", "type": "string", "versions": "0+",
-              "about": "The regular expressions identifying topics the topology reads from." },
-            { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
-              "about": "The repartition topics the topology writes to." },
+            { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+              "about": "Regular expressions identifying topics the sub-topology reads from." },
             { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
-              "about": "The set of state changelog topics associated with this sub-topology. Created automatically." },
+              "about": "The set of state changelog topics associated with this sub-topology." },
+            { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
+              "about": "The repartition topics the sub-topology writes to." },
             { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-              "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+              "about": "The set of source topics that are internally created repartition topics." }
           ]
         },
         { "name": "Members", "type": "[]Member", "versions": "0+",
@@ -143,7 +143,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]KeyValue", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]KeyValue", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
@@ -32,14 +32,25 @@
           "about": "String to uniquely identify the sub-topology. Deterministically generated from the topology" },
         { "name": "SourceTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology reads from." },
-        { "name": "SourceTopicRegex", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-          "about": "The regular expressions identifying topics the sub-topology reads from." },
+        { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+          "about": "Regular expressions identifying topics the sub-topology reads from." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
           "about": "The set of state changelog topics associated with this sub-topology. Created automatically." },
         { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
           "about": "The repartition topics the sub-topology writes to." },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+          "about": "The set of source topics that are internally created repartition topics. Created automatically." },
+        { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
+          "about": "A subset of source topics that must be copartitioned.",
+          "fields": [
+            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The topics the topology reads from. Index into the array on the subtopology level." },
+            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+              "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
+            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
+          ]
+        }
       ]
     }
   ],
@@ -56,7 +67,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -110,8 +110,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
 
     private final Map<String, Subtopology> subtopologyMap = new HashMap<>();
 
-    private final Map<String, Object> assignmentConfiguration = new HashMap<>();
-
     private final Map<String, String> clientTags = new HashMap<>();
 
     private final Node coordinatorNode = new Node(1, "localhost", 9092);
@@ -121,7 +119,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
         config = config();
 
         subtopologyMap.clear();
-        assignmentConfiguration.clear();
         clientTags.clear();
         streamsAssignmentInterface =
             new StreamsAssignmentInterface(
@@ -129,7 +126,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
                 Optional.of(endPoint),
                 assignor,
                 subtopologyMap,
-                assignmentConfiguration,
                 clientTags
             );
         LogContext logContext = new LogContext("test");
@@ -204,7 +200,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
     @Test
     void testFullStaticInformationWhenJoining() {
         mockJoiningState();
-        assignmentConfiguration.put("config1", "value1");
         clientTags.put("clientTag1", "value2");
 
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
@@ -244,7 +239,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
         final Uuid uuid0 = Uuid.randomUuid();
         final Uuid uuid1 = Uuid.randomUuid();
 
-        final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Collections.emptyMap());
+        final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Optional.empty(), Collections.emptyMap());
 
         when(metadata.topicIds()).thenReturn(
             mkMap(
@@ -257,21 +252,24 @@ class StreamsGroupHeartbeatRequestManagerTest {
                 Collections.singleton("source0"),
                 Collections.singleton("sink0"),
                 Collections.singletonMap("repartition0", emptyTopicInfo),
-                Collections.singletonMap("changelog0", emptyTopicInfo)
+                Collections.singletonMap("changelog0", emptyTopicInfo),
+                Collections.emptySet() // TODO
             ));
         streamsAssignmentInterface.subtopologyMap().put("1",
             new Subtopology(
                 Collections.singleton("source1"),
                 Collections.singleton("sink1"),
                 Collections.singletonMap("repartition1", emptyTopicInfo),
-                Collections.singletonMap("changelog1", emptyTopicInfo)
+                Collections.singletonMap("changelog1", emptyTopicInfo),
+                Collections.emptySet() // TODO
             ));
         streamsAssignmentInterface.subtopologyMap().put("2",
             new Subtopology(
                 Collections.singleton("source2"),
                 Collections.singleton("sink2"),
                 Collections.singletonMap("repartition2", emptyTopicInfo),
-                Collections.singletonMap("changelog2", emptyTopicInfo)
+                Collections.singletonMap("changelog2", emptyTopicInfo),
+                Collections.emptySet() // TODO
             ));
 
         StreamsGroupHeartbeatResponseData data = new StreamsGroupHeartbeatResponseData()

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManagerTest.java
@@ -72,19 +72,20 @@ class StreamsGroupInitializeRequestManagerTest {
         final Set<String> sourceTopics = mkSet("sourceTopic1", "sourceTopic2");
         final Set<String> sinkTopics = mkSet("sinkTopic1", "sinkTopic2", "sinkTopic3");
         final Map<String, StreamsAssignmentInterface.TopicInfo> repartitionTopics = mkMap(
-            mkEntry("repartitionTopic1", new StreamsAssignmentInterface.TopicInfo(Optional.of(2), Collections.emptyMap())),
-            mkEntry("repartitionTopic2", new StreamsAssignmentInterface.TopicInfo(Optional.of(3), Collections.emptyMap()))
+            mkEntry("repartitionTopic1", new StreamsAssignmentInterface.TopicInfo(Optional.of(2), Optional.of((short) 1), Collections.emptyMap())),
+            mkEntry("repartitionTopic2", new StreamsAssignmentInterface.TopicInfo(Optional.of(3), Optional.of((short) 3), Collections.emptyMap()))
         );
         final Map<String, StreamsAssignmentInterface.TopicInfo> changelogTopics = mkMap(
-            mkEntry("changelogTopic1", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Collections.emptyMap())),
-            mkEntry("changelogTopic2", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Collections.emptyMap())),
-            mkEntry("changelogTopic3", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Collections.emptyMap()))
+            mkEntry("changelogTopic1", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Optional.of((short) 1), Collections.emptyMap())),
+            mkEntry("changelogTopic2", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Optional.of((short) 2), Collections.emptyMap())),
+            mkEntry("changelogTopic3", new StreamsAssignmentInterface.TopicInfo(Optional.empty(), Optional.of((short) 3), Collections.emptyMap()))
         );
         final StreamsAssignmentInterface.Subtopology subtopology1 = new StreamsAssignmentInterface.Subtopology(
             sourceTopics,
             sinkTopics,
             repartitionTopics,
-            changelogTopics
+            changelogTopics,
+            Collections.emptySet() // TODO
         );
         final String subtopologyName1 = "subtopology1";
         when(streamsAssignmentInterface.subtopologyMap()).thenReturn(
@@ -121,11 +122,14 @@ class StreamsGroupInitializeRequestManagerTest {
         subtopology.repartitionSourceTopics().forEach(topicInfo -> {
             final StreamsAssignmentInterface.TopicInfo repartitionTopic = repartitionTopics.get(topicInfo.name());
             assertEquals(repartitionTopic.numPartitions.get(), topicInfo.partitions());
+            assertEquals(repartitionTopic.replicationFactor.get(), topicInfo.replicationFactor());
         });
         assertEquals(changelogTopics.size(), subtopology.stateChangelogTopics().size());
         subtopology.stateChangelogTopics().forEach(topicInfo -> {
             assertTrue(changelogTopics.containsKey(topicInfo.name()));
             assertEquals(0, topicInfo.partitions());
+            final StreamsAssignmentInterface.TopicInfo changelogTopic = changelogTopics.get(topicInfo.name());
+            assertEquals(changelogTopic.replicationFactor.get(), topicInfo.replicationFactor());
         });
     }
 }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -20,13 +20,14 @@ import kafka.common.OffsetAndMetadata
 import kafka.server.{KafkaConfig, ReplicaManager}
 import kafka.utils.Implicits.MapExtensionMethods
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, StreamsGroupDescribeResponseData, StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData, StreamsGroupInitializeRequestData, StreamsGroupInitializeResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, StreamsGroupDescribeResponseData, StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData, StreamsGroupInitializeRequestData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{OffsetCommitRequest, RequestContext, TransactionResult}
 import org.apache.kafka.common.utils.{BufferSupplier, Time}
 import org.apache.kafka.coordinator.group
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.util.FutureUtils
@@ -81,7 +82,7 @@ private[group] class GroupCoordinatorAdapter(
   override def streamsGroupInitialize(
                                    context: RequestContext,
                                    request: StreamsGroupInitializeRequestData
-                                 ): CompletableFuture[StreamsGroupInitializeResponseData] = {
+                                 ): CompletableFuture[StreamsGroupInitializeResult] = {
     FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
       s"The old group coordinator does not support ${ApiKeys.STREAMS_GROUP_INITIALIZE.name} API."
     ))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -75,6 +75,7 @@ import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerd
 import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource
 import org.apache.kafka.common.utils.{ImplicitLinkedHashCollection, ProducerIdAndEpoch, SecurityUtils, Utils}
 import org.apache.kafka.coordinator.group.GroupConfig.{CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, CONSUMER_SESSION_TIMEOUT_MS_CONFIG}
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult
 import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfigTest}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
@@ -11184,7 +11185,7 @@ class KafkaApisTest extends Logging {
 
     val requestChannelRequest = buildRequest(new StreamsGroupInitializeRequest.Builder(streamsGroupInitializeRequest, true).build())
 
-    val future = new CompletableFuture[StreamsGroupInitializeResponseData]()
+    val future = new CompletableFuture[StreamsGroupInitializeResult]()
     when(groupCoordinator.streamsGroupInitialize(
       requestChannelRequest.context,
       streamsGroupInitializeRequest
@@ -11195,7 +11196,7 @@ class KafkaApisTest extends Logging {
     )
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
-    val streamsGroupInitializeResponse = new StreamsGroupInitializeResponseData()
+    val streamsGroupInitializeResponse = new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData())
 
     future.complete(streamsGroupInitializeResponse)
     val response = verifyNoThrottling[StreamsGroupInitializeResponse](requestChannelRequest)
@@ -11210,7 +11211,7 @@ class KafkaApisTest extends Logging {
 
     val requestChannelRequest = buildRequest(new StreamsGroupInitializeRequest.Builder(streamsGroupInitializeRequest, true).build())
 
-    val future = new CompletableFuture[StreamsGroupInitializeResponseData]()
+    val future = new CompletableFuture[StreamsGroupInitializeResult]()
     when(groupCoordinator.streamsGroupInitialize(
       requestChannelRequest.context,
       streamsGroupInitializeRequest

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -51,6 +50,7 @@ import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 
@@ -93,10 +93,10 @@ public interface GroupCoordinator {
      * @param context           The request context.
      * @param request           The StreamsGroupInitializeRequest data.
      *
-     * @return  A future yielding the response.
+     * @return  A future yielding the result, which contains the response and all topics to be created.
      *          The error code(s) of the response are set to indicate the error(s) occurred during the execution.
      */
-    CompletableFuture<StreamsGroupInitializeResponseData> streamsGroupInitialize(
+    CompletableFuture<StreamsGroupInitializeResult> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -78,6 +78,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorShardBuilderSuppli
 import org.apache.kafka.coordinator.common.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.record.BrokerCompressionType;
@@ -352,14 +353,14 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * See {@link GroupCoordinator#streamsGroupInitialize(RequestContext, org.apache.kafka.common.message.StreamsGroupInitializeRequestData)}.
      */
     @Override
-    public CompletableFuture<StreamsGroupInitializeResponseData> streamsGroupInitialize(
+    public CompletableFuture<StreamsGroupInitializeResult> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     ) {
         if (!isActive.get()) {
-            return CompletableFuture.completedFuture(new StreamsGroupInitializeResponseData()
+            return CompletableFuture.completedFuture(new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData()
                 .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
-            );
+            ));
         }
 
         return runtime.scheduleWriteOperation(
@@ -371,9 +372,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "streams-group-initialize",
             request,
             exception,
-            (error, message) -> new StreamsGroupInitializeResponseData()
+            (error, message) -> new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData()
                 .setErrorCode(error.code())
-                .setErrorMessage(message),
+                .setErrorMessage(message)),
             log
         ));
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -104,6 +103,7 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.taskassignor.StickyTaskAssignor;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -370,7 +370,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
      * @return A Result containing the StreamsGroupInitialize response and
      *         a list of records to update the state machine.
      */
-    public CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(
+    public CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     ) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.ConsumerProtocolSubscription;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
@@ -60,6 +61,7 @@ import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.TaskIds;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.TaskOffset;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
+import org.apache.kafka.common.message.StreamsGroupInitializeRequestData.Subtopology;
 import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
@@ -135,7 +137,11 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupAssignmentBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
+import org.apache.kafka.coordinator.group.streams.topics.InternalTopicConfig;
+import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.apache.kafka.coordinator.group.taskassignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.image.MetadataDelta;
@@ -167,7 +173,6 @@ import java.util.stream.Stream;
 import static org.apache.kafka.common.protocol.Errors.COORDINATOR_NOT_AVAILABLE;
 import static org.apache.kafka.common.protocol.Errors.ILLEGAL_GENERATION;
 import static org.apache.kafka.common.protocol.Errors.NOT_COORDINATOR;
-import static org.apache.kafka.common.protocol.Errors.STREAMS_INVALID_TOPOLOGY;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_SERVER_ERROR;
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH;
@@ -2564,7 +2569,7 @@ public class GroupMetadataManager {
      * @param subtopologies The list of subtopologies.
      * @return A Result containing the StreamsGroupInitialize response and a list of records to update the state machine.
      */
-    private CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(String groupId,
+    private CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(String groupId,
                                                                                                        String topologyId,
                                                                                                             List<StreamsGroupInitializeRequestData.Subtopology> subtopologies)
         throws ApiException {
@@ -2579,44 +2584,32 @@ public class GroupMetadataManager {
         if (!isTopologyInitializationScheduled(groupId, topologyId)) {
             log.warn("No topology to initialize for group ID {} and topology ID {} found.", groupId, topologyId);
             StreamsGroupInitializeResponseData response = new StreamsGroupInitializeResponseData();
-            return new CoordinatorResult<>(records, response);
+            return new CoordinatorResult<>(records, new StreamsGroupInitializeResult(response));
         }
 
-        // TODO: For the POC, only check if internal topics exist
-        Set<String> missingTopics = new HashSet<>();
-        for (StreamsGroupInitializeRequestData.Subtopology subtopology : subtopologies) {
-            for (StreamsGroupInitializeRequestData.TopicInfo topic : subtopology.stateChangelogTopics()) {
-                if (metadataImage.topics().getTopic(topic.name()) == null) {
-                    missingTopics.add(topic.name());
-                }
-            }
-            for (StreamsGroupInitializeRequestData.TopicInfo topic : subtopology.repartitionSourceTopics()) {
-                if (metadataImage.topics().getTopic(topic.name()) == null) {
-                    missingTopics.add(topic.name());
-                }
-            }
-        }
+        final Map<String, TopicsInfo> subtopologyTopicsInfo =
+            subtopologies.stream().collect(Collectors.toMap(
+                Subtopology::subtopologyId,
+                TopicsInfo::fromInitializationSubtopology
+            ));
+
+        final Map<String, CreatableTopic> missingTopics = InternalTopicManager.configureTopics(
+            logContext, subtopologyTopicsInfo, metadataImage);
 
         cancelStreamsGroupTopologyInitializationTimeout(groupId, topologyId);
 
-        if (!missingTopics.isEmpty()) {
-            StreamsGroupInitializeResponseData response =
-                new StreamsGroupInitializeResponseData()
-                    .setErrorCode(STREAMS_INVALID_TOPOLOGY.code())
-                    .setErrorMessage("Internal topics " + String.join(", ", missingTopics) + " do not exist.");
+        records.add(newStreamsGroupTopologyRecord(groupId, subtopologyTopicsInfo));
 
-            return new CoordinatorResult<>(records, response);
-        } else {
-            records.add(newStreamsGroupTopologyRecord(groupId, subtopologies));
+        final StreamsTopology topology = new StreamsTopology(topologyId, subtopologyTopicsInfo);
 
-            final StreamsTopology topology = new StreamsTopology(topologyId, subtopologies);
-
+        // TODO: This needs to be sorted out, once we merge heartbeat and initialization
+        if (missingTopics.isEmpty()) {
             computeFirstTargetAssignmentAfterTopologyInitialization(group, records, topology);
-
-            StreamsGroupInitializeResponseData response = new StreamsGroupInitializeResponseData();
-
-            return new CoordinatorResult<>(records, response);
         }
+
+        StreamsGroupInitializeResponseData response = new StreamsGroupInitializeResponseData();
+
+        return new CoordinatorResult<>(records, new StreamsGroupInitializeResult(response, missingTopics));
 
     }
 
@@ -4515,7 +4508,7 @@ public class GroupMetadataManager {
      * @return A Result containing the StreamsGroupInitialize response and
      *         a list of records to update the state machine.
      */
-    public CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(
+    public CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     ) throws ApiException {
@@ -4596,8 +4589,9 @@ public class GroupMetadataManager {
             topology.subtopologies().forEach(
                 (subtopologyId, subtopology) -> {
                     newSubscribedTopicNames.addAll(subtopology.sourceTopics());
-                    newSubscribedTopicNames.addAll(subtopology.repartitionSourceTopics().stream()
-                        .map(StreamsGroupTopologyValue.TopicInfo::name).collect(Collectors.toSet()));
+                    newSubscribedTopicNames.addAll(
+                        subtopology.repartitionSourceTopics().values().stream()
+                            .map(InternalTopicConfig::name).collect(Collectors.toSet()));
                 }
             );
             updateGroupsByTopics(groupId, oldSubscribedTopicNames, newSubscribedTopicNames);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -1145,7 +1145,9 @@ public class StreamsGroup implements Group {
             .setGroupEpoch(groupEpoch.get(committedOffset))
             .setGroupState(state.get(committedOffset).toString())
             .setAssignmentEpoch(targetAssignmentEpoch.get(committedOffset))
-            .setTopology(topology.get(committedOffset).map(StreamsTopology::asStreamsGroupDescribeTopology).orElse(null));
+            .setTopology(
+                topology.get(committedOffset).map(StreamsTopology::toStreamsGroupDescribeTopology)
+                    .orElse(null));
         members.entrySet(committedOffset).forEach(
             entry -> describedGroup.members().add(
                 entry.getValue().asStreamsGroupDescribeMember(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
+
+public class StreamsGroupInitializeResult {
+
+    private final StreamsGroupInitializeResponseData data;
+    private final Map<String, CreatableTopic> creatableTopics;
+
+    public StreamsGroupInitializeResult(StreamsGroupInitializeResponseData data, Map<String, CreatableTopic> creatableTopics) {
+        this.data = data;
+        this.creatableTopics = creatableTopics;
+    }
+
+    public StreamsGroupInitializeResult(StreamsGroupInitializeResponseData data) {
+        this.data = data;
+        this.creatableTopics = Collections.emptyMap();
+    }
+
+    public StreamsGroupInitializeResponseData data() {
+        return data;
+    }
+
+    public Map<String, CreatableTopic> creatableTopics() {
+        return creatableTopics;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final StreamsGroupInitializeResult that = (StreamsGroupInitializeResult) o;
+        return Objects.equals(data, that.data) && Objects.equals(creatableTopics,
+            that.creatableTopics);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, creatableTopics);
+    }
+
+    @Override
+    public String toString() {
+        return "StreamsGroupInitializeResult{" +
+            "data=" + data +
+            ", creatableTopics=" + creatableTopics +
+            '}';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.apache.kafka.coordinator.group.taskassignor.TopologyDescriber;
 
 import java.util.Map;
@@ -71,12 +71,12 @@ public class TopologyMetadata implements TopologyDescriber {
      */
     @Override
     public int numPartitions(String subtopologyId) {
-        final Subtopology subtopology = topology.subtopologies().get(subtopologyId);
+        final TopicsInfo subtopology = topology.subtopologies().get(subtopologyId);
         if (subtopology == null) {
             return -1;
         }
         // TODO: We need to validate the validity of the subtopology here or somewhere else
-        final String firstSourceTopic = subtopology.sourceTopics().get(0);
+        final String firstSourceTopic = subtopology.sourceTopics().stream().findFirst().orElse(null);
         if (firstSourceTopic == null) {
             return -1;
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.List;
+import org.apache.kafka.common.utils.LogContext;
+
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ChangelogTopics {
+
+    private final Map<String, TopicsInfo> topicGroups;
+    private final Function<String, Integer> topicPartitionCountProvider;
+    private final Logger log;
+
+    public ChangelogTopics(
+        final LogContext logContext,
+        final Map<String, TopicsInfo> subtopologyToTopicsInfo,
+        final Function<String, Integer> topicPartitionCountProvider) {
+        this.log = logContext.logger(getClass());
+        this.topicGroups = subtopologyToTopicsInfo;
+        this.topicPartitionCountProvider = topicPartitionCountProvider;
+    }
+
+    public Map<String, InternalTopicConfig> setup() {
+        final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
+        for (final Map.Entry<String, TopicsInfo> entry : topicGroups.entrySet()) {
+            final TopicsInfo topicsInfo = entry.getValue();
+            final int maxNumPartitions = maxNumPartitions(topicsInfo.sourceTopics());
+
+            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
+                topicConfig.setNumberOfPartitions(maxNumPartitions);
+                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
+            }
+        }
+
+        log.debug("Creating state changelog topics {} from the requested topology.", changelogTopicMetadata.values());
+
+        return changelogTopicMetadata;
+    }
+
+
+    protected int maxNumPartitions(final List<String> topics) {
+        int maxNumPartitions = 0;
+        for (final String topic : topics) {
+            final Integer topicPartitionCount = topicPartitionCountProvider.apply(topic);
+            if (topicPartitionCount == null) {
+                throw new IllegalStateException("No partition count for topic " + topic);
+            }
+
+            final int numPartitions = topicPartitionCount;
+            if (numPartitions > maxNumPartitions) {
+                maxNumPartitions = numPartitions;
+            }
+        }
+        return maxNumPartitions;
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/CopartitionedTopicsEnforcer.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/CopartitionedTopicsEnforcer.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+public class CopartitionedTopicsEnforcer {
+
+    private final Logger log;
+    private final Function<String, Integer> topicPartitionCountProvider;
+
+    public CopartitionedTopicsEnforcer(final LogContext logContext, final Function<String, Integer> topicPartitionCountProvider) {
+        this.log = logContext.logger(getClass());
+        this.topicPartitionCountProvider = topicPartitionCountProvider;
+    }
+
+    public void enforce(final Set<String> copartitionedTopics,
+        final Map<String, InternalTopicConfig> allRepartitionTopicsNumPartitions) {
+        if (copartitionedTopics.isEmpty()) {
+            return;
+        }
+
+        final Map<Object, InternalTopicConfig> repartitionTopicConfigs =
+            copartitionedTopics.stream()
+                .filter(allRepartitionTopicsNumPartitions::containsKey)
+                .collect(
+                    Collectors.toMap(topic -> topic, allRepartitionTopicsNumPartitions::get));
+
+        final Map<String, Integer> nonRepartitionTopicPartitions =
+            copartitionedTopics.stream().filter(topic -> !allRepartitionTopicsNumPartitions.containsKey(topic))
+                .collect(Collectors.toMap(topic -> topic, topic -> {
+                    final Integer topicPartitionCount = topicPartitionCountProvider.apply(topic);
+                    if (topicPartitionCount == null) {
+                        final String str = String.format("Topic not found: %s", topic);
+                        log.error(str);
+                        throw new IllegalStateException(str);
+                    } else {
+                        return topicPartitionCount;
+                    }
+                }));
+
+        final int numPartitionsToUseForRepartitionTopics;
+        final Collection<InternalTopicConfig> internalTopicConfigs = repartitionTopicConfigs.values();
+
+        if (copartitionedTopics.equals(repartitionTopicConfigs.keySet())) {
+            final Collection<InternalTopicConfig> internalTopicConfigsWithEnforcedNumberOfPartitions = internalTopicConfigs
+                .stream()
+                .filter(x -> x.replicationFactor().isPresent())
+                .collect(Collectors.toList());
+
+            // if there's at least one repartition topic with enforced number of partitions
+            // validate that they all have same number of partitions
+            if (!internalTopicConfigsWithEnforcedNumberOfPartitions.isEmpty()) {
+                numPartitionsToUseForRepartitionTopics = validateAndGetNumOfPartitions(
+                    repartitionTopicConfigs,
+                    internalTopicConfigsWithEnforcedNumberOfPartitions
+                );
+            } else {
+                // If all topics for this co-partition group are repartition topics,
+                // then set the number of partitions to be the maximum of the number of partitions.
+                numPartitionsToUseForRepartitionTopics = getMaxPartitions(repartitionTopicConfigs);
+            }
+        } else {
+            // Otherwise, use the number of partitions from external topics (which must all be the same)
+            numPartitionsToUseForRepartitionTopics = getSamePartitions(nonRepartitionTopicPartitions);
+        }
+
+        // coerce all the repartition topics to use the decided number of partitions.
+        for (final InternalTopicConfig config : internalTopicConfigs) {
+            maybeSetNumberOfPartitionsForInternalTopic(numPartitionsToUseForRepartitionTopics, config);
+
+            final int numberOfPartitionsOfInternalTopic = config
+                .numberOfPartitions()
+                .orElseThrow(emptyNumberOfPartitionsExceptionSupplier(config.name()));
+
+            if (numberOfPartitionsOfInternalTopic != numPartitionsToUseForRepartitionTopics) {
+                final String msg = String.format("Number of partitions [%d] of repartition topic [%s] " +
+                        "doesn't match number of partitions [%d] of the source topic.",
+                    numberOfPartitionsOfInternalTopic,
+                    config.name(),
+                    numPartitionsToUseForRepartitionTopics);
+                throw new StreamsInvalidTopologyException(msg);
+            }
+        }
+    }
+
+    private static void maybeSetNumberOfPartitionsForInternalTopic(final int numPartitionsToUseForRepartitionTopics,
+        final InternalTopicConfig config) {
+        if (!config.numberOfPartitions().isPresent()) {
+            config.setNumberOfPartitions(numPartitionsToUseForRepartitionTopics);
+        }
+    }
+
+    private int validateAndGetNumOfPartitions(final Map<Object, InternalTopicConfig> repartitionTopicConfigs,
+        final Collection<InternalTopicConfig> internalTopicConfigs) {
+        final InternalTopicConfig firstInternalTopicConfig = internalTopicConfigs.iterator().next();
+
+        final int firstNumberOfPartitionsOfInternalTopic = firstInternalTopicConfig
+            .numberOfPartitions()
+            .orElseThrow(emptyNumberOfPartitionsExceptionSupplier(firstInternalTopicConfig.name()));
+
+        for (final InternalTopicConfig internalTopicConfig : internalTopicConfigs) {
+            final Integer numberOfPartitions = internalTopicConfig
+                .numberOfPartitions()
+                .orElseThrow(emptyNumberOfPartitionsExceptionSupplier(internalTopicConfig.name()));
+
+            if (numberOfPartitions != firstNumberOfPartitionsOfInternalTopic) {
+                final Map<Object, Integer> repartitionTopics = repartitionTopicConfigs
+                    .entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(
+                        Entry::getKey, entry -> entry.getValue().numberOfPartitions().get()));
+
+                final String msg = String.format("Following topics do not have the same number of partitions: [%s]",
+                    new TreeMap<>(repartitionTopics));
+                throw new StreamsInvalidTopologyException(msg);
+            }
+        }
+
+        return firstNumberOfPartitionsOfInternalTopic;
+    }
+
+    private static Supplier<StreamsInvalidTopologyException> emptyNumberOfPartitionsExceptionSupplier(final String topic) {
+        return () -> new StreamsInvalidTopologyException("Number of partitions is not set for topic: " + topic);
+    }
+
+    private int getSamePartitions(final Map<String, Integer> nonRepartitionTopicsInCopartitionGroup) {
+        final int partitions = nonRepartitionTopicsInCopartitionGroup.values().iterator().next();
+        for (final Entry<String, Integer> entry : nonRepartitionTopicsInCopartitionGroup.entrySet()) {
+            if (entry.getValue() != partitions) {
+                final TreeMap<String, Integer> sorted = new TreeMap<>(nonRepartitionTopicsInCopartitionGroup);
+                throw new StreamsInvalidTopologyException(
+                    String.format("Topics not co-partitioned: [%s]", sorted)
+                );
+            }
+        }
+        return partitions;
+    }
+
+    private int getMaxPartitions(final Map<Object, InternalTopicConfig> repartitionTopicsInCopartitionGroup) {
+        int maxPartitions = 0;
+
+        for (final InternalTopicConfig config : repartitionTopicsInCopartitionGroup.values()) {
+            final Optional<Integer> partitions = config.numberOfPartitions();
+            maxPartitions = Integer.max(maxPartitions, partitions.orElse(maxPartitions));
+        }
+        if (maxPartitions == 0) {
+            throw new IllegalStateException("Could not validate the copartitioning of topics: " + repartitionTopicsInCopartitionGroup.keySet());
+        }
+        return maxPartitions;
+    }
+
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.internals.Topic;
+
+/**
+ * InternalTopicConfig captures the properties required for configuring
+ * the internal topics we create for change-logs and repartitioning etc.
+ */
+public class InternalTopicConfig {
+
+    private final String name;
+    private final Map<String, String> topicConfigs;
+
+    private Optional<Integer> numberOfPartitions;
+    private Optional<Short> replicationFactor;
+
+    static final Map<String, String> INTERNAL_TOPIC_DEFAULT_OVERRIDES = new HashMap<>();
+    static {
+        INTERNAL_TOPIC_DEFAULT_OVERRIDES.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime");
+    }
+
+    public InternalTopicConfig(final String name) {
+        this.name = Objects.requireNonNull(name, "name can't be null");
+        this.topicConfigs = Collections.emptyMap();
+        this.numberOfPartitions = Optional.empty();
+        this.replicationFactor =  Optional.empty();
+    }
+
+    public InternalTopicConfig(
+        final String name,
+        final Map<String, String> topicConfigs,
+        final Optional<Integer> numberOfPartitions,
+        final Optional<Short> replicationFactor) {
+        this.name = Objects.requireNonNull(name, "name can't be null");
+        Topic.validate(name);
+        numberOfPartitions.ifPresent(InternalTopicConfig::validateNumberOfPartitions);
+        this.topicConfigs = Objects.requireNonNull(topicConfigs, "topicConfigs can't be null");
+        this.numberOfPartitions = numberOfPartitions;
+        this.replicationFactor = replicationFactor;
+    }
+
+    public Map<String, String> topicConfigs() {
+        return topicConfigs;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Optional<Integer> numberOfPartitions() {
+        return numberOfPartitions;
+    }
+
+    public Optional<Short> replicationFactor() {
+        return replicationFactor;
+    }
+
+    public void setNumberOfPartitions(final int numberOfPartitions) {
+        if (this.numberOfPartitions.isPresent() && this.numberOfPartitions.get() != numberOfPartitions) {
+            throw new UnsupportedOperationException(
+                "number of partitions are enforced on topic " + name() + " and can't be altered.");
+        }
+
+        validateNumberOfPartitions(numberOfPartitions);
+
+        this.numberOfPartitions = Optional.of(numberOfPartitions);
+    }
+
+    private static void validateNumberOfPartitions(final int numberOfPartitions) {
+        if (numberOfPartitions < 1) {
+            throw new IllegalArgumentException("Number of partitions must be at least 1.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "InternalTopicConfig(" +
+            "name=" + name +
+            ", topicConfigs=" + topicConfigs +
+            ", numberOfPartitions=" + numberOfPartitions +
+            ", replicationFactor=" + replicationFactor +
+            ")";
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.image.TopicImage;
+
+public class InternalTopicManager {
+
+    public static Map<String, CreatableTopic> configureTopics(LogContext logContext,
+        Map<String, TopicsInfo> subtopologyToTopicsInfo, MetadataImage metadataImage) {
+
+        final Collection<Set<String>> copartitionGroups =
+            subtopologyToTopicsInfo.values().stream()
+                .flatMap(x -> x.copartitionGroups().stream())
+                .collect(Collectors.toList());
+
+        final Function<String, Integer> topicPartitionCountProvider = x -> getPartitionCount(metadataImage, x);
+        final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer = new CopartitionedTopicsEnforcer(
+            logContext, topicPartitionCountProvider);
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(logContext,
+            subtopologyToTopicsInfo, copartitionGroups, copartitionedTopicsEnforcer,
+            topicPartitionCountProvider);
+        final Map<String, InternalTopicConfig> repartitionTopicConfigs = repartitionTopics.setup();
+
+        // Use a topic partition count provider that takes repartitionTopicConfigs into account
+        final Function<String, Integer> topicPartitionCountProviderWithRepartition =
+            x -> getPartitionCount(metadataImage, x, repartitionTopicConfigs);
+        final ChangelogTopics changelogTopics = new ChangelogTopics(logContext,
+            subtopologyToTopicsInfo, topicPartitionCountProviderWithRepartition);
+        final Map<String, InternalTopicConfig> changelogTopicConfigs = changelogTopics.setup();
+
+        final Map<String, CreatableTopic> topicsToCreate = new HashMap<>();
+        repartitionTopicConfigs.values()
+            .forEach(x -> topicsToCreate.put(x.name(), toCreatableTopic(x)));
+        changelogTopicConfigs.values()
+            .forEach(x -> topicsToCreate.put(x.name(), toCreatableTopic(x)));
+
+        // TODO: Validate if existing topics are compatible with the new topics
+        for (String topic : metadataImage.topics().topicsByName().keySet()) {
+            topicsToCreate.remove(topic);
+        }
+
+        return topicsToCreate;
+    }
+
+    private static Integer getPartitionCount(MetadataImage metadataImage, String topic) {
+        final TopicImage topicImage = metadataImage.topics().getTopic(topic);
+        if (topicImage == null) {
+            return null;
+        } else {
+            return topicImage.partitions().size();
+        }
+    }
+
+    private static Integer getPartitionCount(MetadataImage metadataImage, String topic, Map<String, InternalTopicConfig> additionalTopics) {
+        final TopicImage topicImage = metadataImage.topics().getTopic(topic);
+        if (topicImage == null) {
+            if (additionalTopics.containsKey(topic) && additionalTopics.get(topic).numberOfPartitions().isPresent()) {
+                return additionalTopics.get(topic).numberOfPartitions().get();
+            } else {
+                return null;
+            }
+        } else {
+            return topicImage.partitions().size();
+        }
+    }
+
+    private static CreatableTopic toCreatableTopic(final InternalTopicConfig config) {
+
+        final CreatableTopic creatableTopic = new CreatableTopic();
+
+        creatableTopic.setName(config.name());
+
+        if (!config.numberOfPartitions().isPresent()) {
+            throw new IllegalStateException(
+                "Number of partitions must be set for topic " + config.name());
+        } else {
+            creatableTopic.setNumPartitions(config.numberOfPartitions().get());
+        }
+
+        if (config.replicationFactor().isPresent() && config.replicationFactor().get() != 0) {
+            creatableTopic.setReplicationFactor(config.replicationFactor().get());
+        } else {
+            creatableTopic.setReplicationFactor((short) -1);
+        }
+
+        final CreatableTopicConfigCollection topicConfigs = new CreatableTopicConfigCollection();
+
+        config.topicConfigs().forEach((k, v) -> {
+            final CreatableTopicConfig topicConfig = new CreatableTopicConfig();
+            topicConfig.setName(k);
+            topicConfig.setValue(v);
+            topicConfigs.add(topicConfig);
+        });
+
+        creatableTopic.setConfigs(topicConfigs);
+
+        return creatableTopic;
+    }
+
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.List;
+import java.util.function.Function;
+import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
+import org.apache.kafka.common.utils.LogContext;
+
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RepartitionTopics {
+
+    private final Map<String, TopicsInfo> subtopologyToTopicsInfo;
+    private final Collection<Set<String>> copartitionGroups;
+    private final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer;
+    private final Function<String, Integer> topicPartitionCountProvider;
+    private final Logger log;
+
+    private final Map<String, Set<String>> missingInputTopicsBySubtopology = new HashMap<>();
+
+    public RepartitionTopics(final LogContext logContext,
+                             final Map<String, TopicsInfo> subtopologyToTopicsInfo,
+                             final Collection<Set<String>> copartitionGroups,
+                             final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer,
+                             final Function<String, Integer> topicPartitionCountProvider) {
+        this.subtopologyToTopicsInfo = subtopologyToTopicsInfo;
+        this.copartitionGroups = copartitionGroups;
+        this.copartitionedTopicsEnforcer = copartitionedTopicsEnforcer;
+        this.topicPartitionCountProvider = topicPartitionCountProvider;
+        this.log = logContext.logger(getClass());
+    }
+
+    public Map<String, InternalTopicConfig> setup() {
+        final Map<String, InternalTopicConfig> repartitionTopicMetadata = computeRepartitionTopicConfig();
+
+        if (repartitionTopicMetadata.isEmpty()) {
+            if (missingInputTopicsBySubtopology.isEmpty()) {
+                log.info("Skipping the repartition topic validation since there are no repartition topics.");
+            } else {
+                log.info("Skipping the repartition topic validation since all topologies containing repartition"
+                             + "topics are missing external user source topics and cannot be processed.");
+            }
+        } else {
+            // ensure the co-partitioning topics within the group have the same number of partitions,
+            // and enforce the number of partitions for those repartition topics to be the same if they
+            // are co-partitioned as well.
+            ensureCopartitioning(copartitionGroups, repartitionTopicMetadata);
+
+        }
+        return repartitionTopicMetadata;
+    }
+
+    public Queue<StreamsInvalidTopologyException> missingSourceTopicExceptions() {
+        return missingInputTopicsBySubtopology.entrySet().stream().map(entry -> {
+            final Set<String> missingSourceTopics = entry.getValue();
+            final String subtopologyId = entry.getKey();
+
+            return new StreamsInvalidTopologyException(String.format(
+                    "Missing source topics %s for subtopology %s",
+                    missingSourceTopics, subtopologyId));
+        }).collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    private Map<String, InternalTopicConfig> computeRepartitionTopicConfig() {
+        final Set<TopicsInfo> allTopicInfos = new HashSet<>();
+        final Map<String, InternalTopicConfig> allRepartitionTopicConfigs = new HashMap<>();
+
+        final Set<TopicsInfo> topicsInfoForTopology = new HashSet<>();
+        final Set<String> missingSourceTopicsForTopology = new HashSet<>();
+        final Map<String, InternalTopicConfig> repartitionTopicConfigsForTopology = new HashMap<>();
+
+        for (final Map.Entry<String, TopicsInfo> subtopologyEntry : subtopologyToTopicsInfo.entrySet()) {
+            final TopicsInfo topicsInfo = subtopologyEntry.getValue();
+
+            topicsInfoForTopology.add(topicsInfo);
+            repartitionTopicConfigsForTopology.putAll(
+                topicsInfo.repartitionSourceTopics()
+                    .values()
+                    .stream()
+                    .collect(Collectors.toMap(InternalTopicConfig::name, topicConfig -> topicConfig)));
+
+            final Set<String> missingSourceTopicsForSubtopology = computeMissingExternalSourceTopics(
+                topicsInfo);
+            missingSourceTopicsForTopology.addAll(missingSourceTopicsForSubtopology);
+            if (!missingSourceTopicsForSubtopology.isEmpty()) {
+                final String subtopology = subtopologyEntry.getKey();
+                missingInputTopicsBySubtopology.put(subtopology, missingSourceTopicsForSubtopology);
+                log.error("Subtopology {} has missing source topics {} and will be excluded from the current assignment, "
+                    + "this can be due to the consumer client's metadata being stale or because they have "
+                    + "not been created yet. Please verify that you have created all input topics; if they "
+                    + "do exist, you just need to wait for the metadata to be updated, at which time a new "
+                    + "rebalance will be kicked off automatically and the topology will be retried at that time.",
+                    subtopology, missingSourceTopicsForSubtopology);
+            }
+        }
+
+        if (missingSourceTopicsForTopology.isEmpty()) {
+            allRepartitionTopicConfigs.putAll(repartitionTopicConfigsForTopology);
+            allTopicInfos.addAll(topicsInfoForTopology);
+        } else {
+            log.debug("Skipping repartition topic validation for entire topology due to missing source topics {}", missingSourceTopicsForTopology);
+        }
+
+        setRepartitionSourceTopicPartitionCount(allRepartitionTopicConfigs, allTopicInfos);
+
+        return allRepartitionTopicConfigs;
+    }
+
+    private void ensureCopartitioning(final Collection<Set<String>> copartitionGroups,
+                                      final Map<String, InternalTopicConfig> repartitionTopicMetadata) {
+        for (final Set<String> copartitionedTopics : copartitionGroups) {
+            copartitionedTopicsEnforcer.enforce(copartitionedTopics, repartitionTopicMetadata);
+        }
+    }
+
+    private Set<String> computeMissingExternalSourceTopics(final TopicsInfo topicsInfo) {
+        final Set<String> missingExternalSourceTopics = new HashSet<>(topicsInfo.sourceTopics());
+        missingExternalSourceTopics.removeAll(topicsInfo.repartitionSourceTopics().keySet());
+        missingExternalSourceTopics.removeIf(x -> topicPartitionCountProvider.apply(x) != null);
+        return missingExternalSourceTopics;
+    }
+
+    /**
+     * Computes the number of partitions and sets it for each repartition topic in repartitionTopicMetadata
+     */
+    private void setRepartitionSourceTopicPartitionCount(final Map<String, InternalTopicConfig> repartitionTopicMetadata,
+                                                         final Collection<TopicsInfo> topicGroups) {
+        boolean partitionCountNeeded;
+        do {
+            partitionCountNeeded = false;
+            boolean progressMadeThisIteration = false;  // avoid infinitely looping without making any progress on unknown repartitions
+
+            for (final TopicsInfo topicsInfo : topicGroups) {
+                for (final String repartitionSourceTopic : topicsInfo.repartitionSourceTopics()
+                    .keySet()) {
+                    final Optional<Integer> repartitionSourceTopicPartitionCount =
+                        repartitionTopicMetadata.get(repartitionSourceTopic).numberOfPartitions();
+
+                    if (!repartitionSourceTopicPartitionCount.isPresent()) {
+                        final Integer numPartitions = computePartitionCount(
+                            repartitionTopicMetadata,
+                            topicGroups,
+                            repartitionSourceTopic
+                        );
+
+                        if (numPartitions == null) {
+                            partitionCountNeeded = true;
+                            log.trace("Unable to determine number of partitions for {}, another iteration is needed",
+                                repartitionSourceTopic);
+                        } else {
+                            log.trace("Determined number of partitions for {} to be {}", repartitionSourceTopic, numPartitions);
+                            repartitionTopicMetadata.get(repartitionSourceTopic).setNumberOfPartitions(numPartitions);
+                            progressMadeThisIteration = true;
+                        }
+                    }
+                }
+            }
+            if (!progressMadeThisIteration && partitionCountNeeded) {
+                throw new StreamsInvalidTopologyException("Failed to compute number of partitions for all repartition topics, " +
+                    "make sure all user input topics are created and all Pattern subscriptions match at least one topic in the cluster");
+            }
+        } while (partitionCountNeeded);
+    }
+
+    private Integer computePartitionCount(final Map<String, InternalTopicConfig> repartitionTopicMetadata,
+                                          final Collection<TopicsInfo> topicGroups,
+                                          final String repartitionSourceTopic) {
+        Integer partitionCount = null;
+        // try set the number of partitions for this repartition topic if it is not set yet
+        for (final TopicsInfo topicsInfo : topicGroups) {
+            final List<String> repartitionSinkTopics = topicsInfo.repartitionSinkTopics();
+
+            // TODO: Linear search, can be optimized
+            if (repartitionSinkTopics.contains(repartitionSourceTopic)) {
+                // if this topic is one of the sink topics of this topology,
+                // use the maximum of all its source topic partitions as the number of partitions
+                for (final String upstreamSourceTopic : topicsInfo.sourceTopics()) {
+                    Integer numPartitionsCandidate = null;
+                    // It is possible the sourceTopic is another internal topic, i.e,
+                    // map().join().join(map())
+                    if (repartitionTopicMetadata.containsKey(upstreamSourceTopic)) {
+                        if (repartitionTopicMetadata.get(upstreamSourceTopic).numberOfPartitions().isPresent()) {
+                            numPartitionsCandidate =
+                                repartitionTopicMetadata.get(upstreamSourceTopic).numberOfPartitions().get();
+                        }
+                    } else {
+                        final Integer count = topicPartitionCountProvider.apply(upstreamSourceTopic);
+                        if (count == null) {
+                            throw new StreamsInvalidTopologyException(
+                                "No partition count found for source topic "
+                                    + upstreamSourceTopic
+                                    + ", but it should have been."
+                            );
+                        }
+                        numPartitionsCandidate = count;
+                    }
+
+                    if (numPartitionsCandidate != null) {
+                        if (partitionCount == null || numPartitionsCandidate > partitionCount) {
+                            partitionCount = numPartitionsCandidate;
+                        }
+                    }
+                }
+            }
+        }
+        return partitionCount;
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/TopicsInfo.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/TopicsInfo.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
+import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
+
+/**
+ * Internal representation of the topics used by a subtopology.
+ */
+public class TopicsInfo {
+
+    private List<String> repartitionSinkTopics;
+    private List<String> sourceTopics;
+    private List<String> sourceTopicsRegex;
+    private Map<String, InternalTopicConfig> stateChangelogTopics;
+    private Map<String, InternalTopicConfig> repartitionSourceTopics;
+    private Collection<Set<String>> copartitionGroups;
+
+    public TopicsInfo() {
+        this.repartitionSinkTopics = new ArrayList<>();
+        this.sourceTopics = new ArrayList<>();
+        this.sourceTopicsRegex = new ArrayList<>();
+        this.stateChangelogTopics = new HashMap<>();
+        this.repartitionSourceTopics = new HashMap<>();
+        this.copartitionGroups = new ArrayList<>();
+    }
+
+    public TopicsInfo(
+        final List<String> repartitionSinkTopics,
+        final List<String> sourceTopics,
+        final List<String> sourceTopicsRegex,
+        final Map<String, InternalTopicConfig> repartitionSourceTopics,
+        final Map<String, InternalTopicConfig> stateChangelogTopics,
+        final Collection<Set<String>> copartitionGroups
+    ) {
+        this.repartitionSinkTopics = repartitionSinkTopics;
+        this.sourceTopics = sourceTopics;
+        this.sourceTopicsRegex = sourceTopicsRegex;
+        this.stateChangelogTopics = stateChangelogTopics;
+        this.repartitionSourceTopics = repartitionSourceTopics;
+        this.copartitionGroups = copartitionGroups;
+
+        if (this.sourceTopicsRegex != null && !this.sourceTopicsRegex.isEmpty()) {
+            // TODO: Implement support for regular expressions
+            throw new UnsupportedOperationException("Regular expressions are not supported");
+        }
+    }
+
+    public List<String> sourceTopicsRegex() {
+        return sourceTopicsRegex;
+    }
+
+    public List<String> repartitionSinkTopics() {
+        return repartitionSinkTopics;
+    }
+
+    public List<String> sourceTopics() {
+        return sourceTopics;
+    }
+
+    public Map<String, InternalTopicConfig> stateChangelogTopics() {
+        return stateChangelogTopics;
+    }
+
+    public Map<String, InternalTopicConfig> repartitionSourceTopics() {
+        return repartitionSourceTopics;
+    }
+
+    public Collection<Set<String>> copartitionGroups() {
+        return copartitionGroups;
+    }
+
+    public TopicsInfo setRepartitionSinkTopics(final List<String> repartitionSinkTopics) {
+        this.repartitionSinkTopics = repartitionSinkTopics;
+        return this;
+    }
+
+    public TopicsInfo setSourceTopics(final List<String> sourceTopics) {
+        this.sourceTopics = sourceTopics;
+        return this;
+    }
+
+    public TopicsInfo setSourceTopicsRegex(final List<String> sourceTopicsRegex) {
+        this.sourceTopicsRegex = sourceTopicsRegex;
+        return this;
+    }
+
+    public TopicsInfo setStateChangelogTopics(
+        final Map<String, InternalTopicConfig> stateChangelogTopics) {
+        this.stateChangelogTopics = stateChangelogTopics;
+        return this;
+    }
+
+    public TopicsInfo setRepartitionSourceTopics(
+        final Map<String, InternalTopicConfig> repartitionSourceTopics) {
+        this.repartitionSourceTopics = repartitionSourceTopics;
+        return this;
+    }
+
+    public TopicsInfo setCopartitionGroups(final Collection<Set<String>> copartitionGroups) {
+        this.copartitionGroups = copartitionGroups;
+        return this;
+    }
+
+    /**
+     * Returns the config for any changelogs that must be prepared for this topic group, ie
+     * excluding any source topics that are reused as a changelog
+     */
+    public Set<InternalTopicConfig> nonSourceChangelogTopics() {
+        final Set<InternalTopicConfig> topicConfigs = new HashSet<>();
+        for (final Map.Entry<String, InternalTopicConfig> changelogTopicEntry : stateChangelogTopics.entrySet()) {
+            if (!sourceTopics.contains(changelogTopicEntry.getKey())) {
+                topicConfigs.add(changelogTopicEntry.getValue());
+            }
+        }
+        return topicConfigs;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TopicsInfo that = (TopicsInfo) o;
+        return Objects.equals(repartitionSinkTopics, that.repartitionSinkTopics)
+            && Objects.equals(sourceTopics, that.sourceTopics)
+            && Objects.equals(sourceTopicsRegex, that.sourceTopicsRegex)
+            && Objects.equals(stateChangelogTopics, that.stateChangelogTopics)
+            && Objects.equals(repartitionSourceTopics, that.repartitionSourceTopics)
+            && Objects.equals(copartitionGroups, that.copartitionGroups);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repartitionSinkTopics, sourceTopics, sourceTopicsRegex,
+            stateChangelogTopics, repartitionSourceTopics, copartitionGroups);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicsInfo{" +
+            "repartitionSinkTopics=" + repartitionSinkTopics +
+            ", sourceTopics=" + sourceTopics +
+            ", sourceTopicsRegex=" + sourceTopicsRegex +
+            ", stateChangelogTopics=" + stateChangelogTopics +
+            ", repartitionSourceTopics=" + repartitionSourceTopics +
+            ", copartitionGroups=" + copartitionGroups +
+            '}';
+    }
+
+    public static TopicsInfo fromInitializationSubtopology(
+        final StreamsGroupInitializeRequestData.Subtopology subtopology) {
+        return new TopicsInfo(
+            subtopology.repartitionSinkTopics(),
+            subtopology.sourceTopics(),
+            subtopology.sourceTopicRegex(),
+            subtopology.repartitionSourceTopics().stream()
+                .map(TopicsInfo::fromInitializationTopicInfo)
+                .collect(Collectors.toMap(InternalTopicConfig::name, x -> x)),
+            subtopology.stateChangelogTopics().stream()
+                .map(TopicsInfo::fromInitializationTopicInfo)
+                .collect(Collectors.toMap(InternalTopicConfig::name, x -> x)),
+            fromInitializationCopartitionGroups(subtopology)
+        );
+    }
+
+    private static InternalTopicConfig fromInitializationTopicInfo(
+        final StreamsGroupInitializeRequestData.TopicInfo topicInfo) {
+        return new InternalTopicConfig(
+            topicInfo.name(),
+            topicInfo.topicConfigs() != null ? topicInfo.topicConfigs().stream()
+                .collect(Collectors.toMap(StreamsGroupInitializeRequestData.TopicConfig::key,
+                    StreamsGroupInitializeRequestData.TopicConfig::value))
+                : Collections.emptyMap(),
+            topicInfo.partitions() == 0 ? Optional.empty() : Optional.of(topicInfo.partitions()),
+            topicInfo.replicationFactor() == 0 ? Optional.empty()
+                : Optional.of(topicInfo.replicationFactor()));
+    }
+
+    private static Collection<Set<String>> fromInitializationCopartitionGroups(
+        final StreamsGroupInitializeRequestData.Subtopology subtopology) {
+        return subtopology.copartitionGroups().stream().map(copartitionGroup ->
+            Stream.concat(
+                copartitionGroup.sourceTopics().stream()
+                    .map(i -> subtopology.sourceTopics().get(i)),
+                copartitionGroup.repartitionSourceTopics().stream()
+                    .map(i -> subtopology.repartitionSourceTopics().get(i).name())
+            ).collect(Collectors.toSet())
+        ).collect(Collectors.toList());
+    }
+
+    public static TopicsInfo fromPersistedSubtopology(
+        final StreamsGroupTopologyValue.Subtopology subtopology) {
+        return new TopicsInfo(
+            subtopology.repartitionSinkTopics(),
+            subtopology.sourceTopics(),
+            subtopology.sourceTopicRegex(),
+            subtopology.repartitionSourceTopics().stream()
+                .map(TopicsInfo::fromPersistedTopicInfo)
+                .collect(Collectors.toMap(InternalTopicConfig::name, x -> x)),
+            subtopology.stateChangelogTopics().stream()
+                .map(TopicsInfo::fromPersistedTopicInfo)
+                .collect(Collectors.toMap(InternalTopicConfig::name, x -> x)),
+            fromPersistedCopartitionGroups(subtopology)
+        );
+    }
+
+    private static InternalTopicConfig fromPersistedTopicInfo(
+        final StreamsGroupTopologyValue.TopicInfo topicInfo) {
+        return new InternalTopicConfig(
+            topicInfo.name(),
+            topicInfo.topicConfigs() != null ? topicInfo.topicConfigs().stream()
+                .collect(Collectors.toMap(StreamsGroupTopologyValue.TopicConfig::key,
+                    StreamsGroupTopologyValue.TopicConfig::value))
+                : Collections.emptyMap(),
+            topicInfo.partitions() == 0 ? Optional.empty() : Optional.of(topicInfo.partitions()),
+            topicInfo.replicationFactor() == 0 ? Optional.empty()
+                : Optional.of(topicInfo.replicationFactor()));
+    }
+
+    private static Collection<Set<String>> fromPersistedCopartitionGroups(
+        final StreamsGroupTopologyValue.Subtopology subtopology) {
+        return subtopology.copartitionGroups().stream().map(copartitionGroup ->
+            Stream.concat(
+                copartitionGroup.sourceTopics().stream()
+                    .map(i -> subtopology.sourceTopics().get(i)),
+                copartitionGroup.repartitionSourceTopics().stream()
+                    .map(i -> subtopology.repartitionSourceTopics().get(i).name())
+            ).collect(Collectors.toSet())
+        ).collect(Collectors.toList());
+    }
+
+    public static StreamsGroupDescribeResponseData.Subtopology toStreamsGroupDescribeSubtopology(
+        String subtopologyId, TopicsInfo subtopology) {
+        return new StreamsGroupDescribeResponseData.Subtopology()
+            .setSourceTopicRegex(subtopology.sourceTopicsRegex())
+            .setSubtopologyId(subtopologyId)
+            .setSourceTopics(new ArrayList<>(subtopology.sourceTopics()))
+            .setSourceTopicRegex(subtopology.sourceTopicsRegex())
+            .setRepartitionSinkTopics(new ArrayList<>(subtopology.repartitionSinkTopics()))
+            .setRepartitionSourceTopics(
+                subtopology.repartitionSourceTopics().values().stream().map(
+                    TopicsInfo::toStreamsGroupDescribeTopicInfo
+                ).collect(Collectors.toList())
+            )
+            .setStateChangelogTopics(
+                subtopology.stateChangelogTopics().values().stream().map(
+                    TopicsInfo::toStreamsGroupDescribeTopicInfo
+                ).collect(Collectors.toList())
+            );
+    }
+
+    private static StreamsGroupDescribeResponseData.TopicInfo toStreamsGroupDescribeTopicInfo(
+        final InternalTopicConfig internalTopicConfig) {
+        return new StreamsGroupDescribeResponseData.TopicInfo()
+            .setName(internalTopicConfig.name())
+            .setPartitions(internalTopicConfig.numberOfPartitions().isPresent()
+                ? internalTopicConfig.numberOfPartitions().get() : 0)
+            .setReplicationFactor(internalTopicConfig.replicationFactor().isPresent()
+                ? internalTopicConfig.replicationFactor().get() : 0)
+            .setTopicConfigs(
+                internalTopicConfig.topicConfigs() != null ?
+                    internalTopicConfig.topicConfigs().entrySet().stream().map(
+                        y -> new StreamsGroupDescribeResponseData.KeyValue()
+                            .setKey(y.getKey())
+                            .setValue(y.getValue())
+                    ).collect(Collectors.toList()) : null
+            );
+    }
+
+    public static StreamsGroupTopologyValue.Subtopology toStreamsGroupTopologyValueSubtopology(
+        String subtopologyId, TopicsInfo subtopology) {
+
+        final Map<String, Integer> sourceTopicsMap =
+            IntStream.range(0, subtopology.sourceTopics.size())
+                .boxed()
+                .collect(Collectors.toMap(subtopology.sourceTopics::get, i -> i));
+
+        final List<TopicInfo> repartitionSourceTopicList =
+            subtopology.repartitionSourceTopics().values().stream().map(
+                TopicsInfo::toStreamsGroupTopologyValueTopicInfo
+            ).collect(Collectors.toList());
+
+        final Map<String, Integer> repartitionSourceTopicsMap =
+            IntStream.range(0, repartitionSourceTopicList.size())
+                .boxed()
+                .collect(Collectors.toMap(x -> repartitionSourceTopicList.get(x).name(), i -> i));
+
+        return new StreamsGroupTopologyValue.Subtopology()
+            .setSourceTopicRegex(subtopology.sourceTopicsRegex())
+            .setSubtopologyId(subtopologyId)
+            .setSourceTopics(subtopology.sourceTopics)
+            .setSourceTopicRegex(subtopology.sourceTopicsRegex())
+            .setRepartitionSinkTopics(subtopology.repartitionSinkTopics)
+            .setRepartitionSourceTopics(repartitionSourceTopicList)
+            .setStateChangelogTopics(
+                subtopology.stateChangelogTopics().values().stream().map(
+                    TopicsInfo::toStreamsGroupTopologyValueTopicInfo
+                ).collect(Collectors.toList())
+            ).setCopartitionGroups(
+                subtopology.copartitionGroups().stream().map(
+                    x -> toStreamsGroupTopologyValueSubtopologyCopartitionGroup(x, sourceTopicsMap,
+                        repartitionSourceTopicsMap)
+                ).collect(Collectors.toList())
+            );
+    }
+
+    private static StreamsGroupTopologyValue.CopartitionGroup toStreamsGroupTopologyValueSubtopologyCopartitionGroup(
+        final Set<String> topicNames,
+        final Map<String, Integer> sourceTopicsMap,
+        final Map<String, Integer> repartitionSourceTopics) {
+        StreamsGroupTopologyValue.CopartitionGroup copartitionGroup = new StreamsGroupTopologyValue.CopartitionGroup();
+
+        topicNames.forEach(topicName -> {
+            if (sourceTopicsMap.containsKey(topicName)) {
+                copartitionGroup.sourceTopics().add(sourceTopicsMap.get(topicName));
+            } else if (repartitionSourceTopics.containsKey(topicName)) {
+                copartitionGroup.repartitionSourceTopics()
+                    .add(repartitionSourceTopics.get(topicName));
+            } else {
+                throw new IllegalStateException(
+                    "Source topic not found in subtopology: " + topicName);
+            }
+        });
+
+        return copartitionGroup;
+    }
+
+    private static StreamsGroupTopologyValue.TopicInfo toStreamsGroupTopologyValueTopicInfo(
+        final InternalTopicConfig internalTopicConfig) {
+        return new StreamsGroupTopologyValue.TopicInfo()
+            .setName(internalTopicConfig.name())
+            .setPartitions(internalTopicConfig.numberOfPartitions().isPresent()
+                ? internalTopicConfig.numberOfPartitions().get() : 0)
+            .setReplicationFactor(internalTopicConfig.replicationFactor().isPresent()
+                ? internalTopicConfig.replicationFactor().get() : 0)
+            .setTopicConfigs(
+                internalTopicConfig.topicConfigs() != null ?
+                    internalTopicConfig.topicConfigs().entrySet().stream().map(
+                        y -> new StreamsGroupTopologyValue.TopicConfig()
+                            .setKey(y.getKey())
+                            .setValue(y.getValue())
+                    ).collect(Collectors.toList()) : null
+            );
+    }
+    
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
@@ -25,18 +25,29 @@
     { "name":  "Topology", "type": "[]Subtopology", "versions": "0+",
       "about": "The sub-topologies of the streams application.",
       "fields": [
-        { "name": "Subtopology", "type": "string", "versions": "0+",
-          "about": "String to uniquely identify the subtopology." },
+        { "name": "SubtopologyId", "type": "string", "versions": "0+",
+          "about": "String to uniquely identify the sub-topology. Deterministically generated from the topology." },
         { "name": "SourceTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology reads from." },
-        { "name": "SourceTopicRegex", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-          "about": "The regular expressions identifying topics the topology reads from. null if not provided." },
+        { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+          "about": "Regular expressions identifying topics the sub-topology reads from." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of state changelog topics associated with this subtopology. " },
+          "about": "The set of state changelog topics associated with this sub-topology." },
         { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
           "about": "The repartition topics the sub-topology writes to." },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. " }
+          "about": "The set of source topics that are internally created repartition topics." },
+        { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
+          "about": "A subset of source topics that must be copartitioned.",
+          "fields": [
+            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The topics the topology reads from. Index into the array on the subtopology level." },
+            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+              "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
+            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
+          ]
+        }
       ]
     }
   ],
@@ -53,7 +64,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -77,6 +77,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.server.record.BrokerCompressionType;
 import org.apache.kafka.server.util.FutureUtils;
 
@@ -274,14 +275,15 @@ public class GroupCoordinatorServiceTest {
         StreamsGroupInitializeRequestData request = new StreamsGroupInitializeRequestData()
             .setGroupId("foo");
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
 
         assertEquals(
-            new StreamsGroupInitializeResponseData()
-                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()),
+            new StreamsGroupInitializeResult(
+                new StreamsGroupInitializeResponseData()
+                    .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())),
             future.get()
         );
     }
@@ -311,7 +313,7 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupInitializeResponseData()
         ));
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
@@ -362,7 +364,7 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
@@ -371,7 +373,7 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupInitializeResponseData()
                 .setErrorCode(expectedErrorCode)
                 .setErrorMessage(expectedErrorMessage),
-            future.get(5, TimeUnit.SECONDS)
+            future.get(5, TimeUnit.SECONDS).data()
         );
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -63,6 +63,7 @@ import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataValue;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
@@ -150,9 +151,9 @@ public class GroupCoordinatorShardTest {
 
         RequestContext context = requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE);
         StreamsGroupInitializeRequestData request = new StreamsGroupInitializeRequestData();
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = new CoordinatorResult<>(
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = new CoordinatorResult<>(
             Collections.emptyList(),
-            new StreamsGroupInitializeResponseData()
+            new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData())
         );
 
         when(groupMetadataManager.streamsGroupInitialize(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -40,6 +40,9 @@ import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.ConsumerProtocolAssignment;
 import org.apache.kafka.common.message.ConsumerProtocolSubscription;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
 import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
@@ -57,6 +60,7 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
+import org.apache.kafka.common.message.StreamsGroupInitializeRequestData.Subtopology;
 import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupRequestData.SyncGroupRequestAssignment;
@@ -94,8 +98,10 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.CoordinatorStreamsRecordHelpers;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
@@ -521,15 +527,18 @@ public class GroupMetadataManagerTest {
             .setTopologyId(topologyId)
             .setTopology(subtopologies);
 
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response();
+        StreamsGroupInitializeResponseData response = result.response().data();
         assertEquals(Errors.NONE.code(), response.errorCode());
         List<CoordinatorRecord> coordinatorRecords = result.records();
         assertEquals(5, coordinatorRecords.size());
         assertTrue(coordinatorRecords.contains(CoordinatorStreamsRecordHelpers.newStreamsGroupEpochRecord(groupId, 2)));
-        assertTrue(coordinatorRecords.contains(CoordinatorStreamsRecordHelpers.newStreamsGroupTopologyRecord(groupId, subtopologies)));
+        assertTrue(coordinatorRecords.contains(
+            CoordinatorStreamsRecordHelpers.newStreamsGroupTopologyRecord(groupId,
+                subtopologies.stream().collect(Collectors.toMap(Subtopology::subtopologyId,
+                    TopicsInfo::fromInitializationSubtopology)))));
         org.apache.kafka.coordinator.group.streams.TopicMetadata topicMetadata = new org.apache.kafka.coordinator.group.streams.TopicMetadata(
             inputTopicId,
             inputTopicName,
@@ -638,10 +647,10 @@ public class GroupMetadataManagerTest {
             .setTopologyId(wrongTopologyId)
             .setTopology(subtopologies);
 
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response();
+        StreamsGroupInitializeResponseData response = result.response().data();
         assertEquals(Errors.NONE.code(), response.errorCode());
         assertTrue(result.records().isEmpty());
     }
@@ -682,10 +691,10 @@ public class GroupMetadataManagerTest {
             .setTopology(subtopologies);
 
         context.streamsGroupInitialize(initialize);
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response();
+        StreamsGroupInitializeResponseData response = result.response().data();
         assertEquals(Errors.NONE.code(), response.errorCode());
         assertTrue(result.records().isEmpty());
     }
@@ -698,9 +707,12 @@ public class GroupMetadataManagerTest {
         String processId = "process-id";
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "repartition";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(fooTopicId, fooTopicName, 4)
+                .addTopic(barTopicId, barTopicName, 4)
                 .addRacks()
                 .build())
             .build();
@@ -729,6 +741,7 @@ public class GroupMetadataManagerTest {
                     Collections.singletonList(
                         new StreamsGroupInitializeRequestData.TopicInfo()
                             .setName("changelog")
+                            .setReplicationFactor((short) 3)
                             .setTopicConfigs(Collections.singletonList(
                                 new StreamsGroupInitializeRequestData.TopicConfig()
                                     .setKey("config-name2")
@@ -737,7 +750,7 @@ public class GroupMetadataManagerTest {
                     )
                 )
         );
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result =
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result =
             context.streamsGroupInitialize(
                 new StreamsGroupInitializeRequestData()
                     .setGroupId(groupId)
@@ -745,14 +758,31 @@ public class GroupMetadataManagerTest {
                     .setTopology(topology)
             );
 
+        CreatableTopicConfigCollection expectedConfig = new CreatableTopicConfigCollection();
+        expectedConfig.add(
+            new CreatableTopicConfig()
+                .setName("config-name2")
+                .setValue("config-value2")
+        );
+        CreatableTopic expected =
+            new CreatableTopic()
+                .setName("changelog")
+                .setNumPartitions(4)
+                .setReplicationFactor((short) 3)
+                .setConfigs(expectedConfig);
+
         assertEquals(
-            new StreamsGroupInitializeResponseData()
-                .setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code())
-                .setErrorMessage("Internal topics changelog do not exist."),
+            new StreamsGroupInitializeResult(
+                new StreamsGroupInitializeResponseData(),
+                Collections.singletonMap(
+                    "changelog", expected
+                )
+            ),
             result.response()
         );
-        
-        assertTrue(result.records().isEmpty());
+
+        // TODO: Need to check the generated records. Adapt this unit test after merging of
+        //       initilization & heartbeat
     }
 
     private StreamsGroupHeartbeatRequestData buildFirstStreamsGroupHeartbeatRequest(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.network.ClientInformation;
@@ -108,6 +107,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.taskassignor.TaskAssignor;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -720,7 +720,7 @@ public class GroupMetadataManagerTestContext {
     }
 
 
-    public CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(
+    public CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(
         StreamsGroupInitializeRequestData request
     ) {
         RequestContext context = new RequestContext(
@@ -739,7 +739,7 @@ public class GroupMetadataManagerTestContext {
             false
         );
 
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = groupMetadataManager.streamsGroupInitialize(
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = groupMetadataManager.streamsGroupInitialize(
             context,
             request
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
@@ -16,10 +16,13 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import java.util.stream.Collectors;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
+import org.apache.kafka.common.message.StreamsGroupInitializeRequestData.Subtopology;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
 
@@ -64,7 +67,7 @@ class CoordinatorStreamsRecordHelpersTest {
 
         List<StreamsGroupTopologyValue.Subtopology> expectedTopology =
             Collections.singletonList(new StreamsGroupTopologyValue.Subtopology()
-                .setSubtopology("subtopology-id")
+                .setSubtopologyId("subtopology-id")
                 .setRepartitionSinkTopics(Collections.singletonList("foo"))
                 .setSourceTopics(Collections.singletonList("bar"))
                 .setRepartitionSourceTopics(
@@ -104,7 +107,8 @@ class CoordinatorStreamsRecordHelpersTest {
 
         assertEquals(expectedRecord, CoordinatorStreamsRecordHelpers.newStreamsGroupTopologyRecord(
             "group-id",
-            topology
+            topology.stream().collect(Collectors.toMap(Subtopology::subtopologyId,
+                TopicsInfo::fromInitializationSubtopology))
         ));
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsTopologyTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsTopologyTest.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
+import org.apache.kafka.coordinator.group.streams.topics.InternalTopicConfig;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.junit.jupiter.api.Test;
 
 public class StreamsTopologyTest {
@@ -44,9 +44,9 @@ public class StreamsTopologyTest {
 
     @Test
     public void subtopologiesShouldBeCorrect() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology().setSubtopology("subtopology-1")),
-            mkEntry("subtopology-2", new Subtopology().setSubtopology("subtopology-2"))
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()),
+            mkEntry("subtopology-2", new TopicsInfo())
         );
         StreamsTopology topology = new StreamsTopology("topology-id", subtopologies);
         assertEquals(subtopologies, topology.subtopologies());
@@ -54,19 +54,19 @@ public class StreamsTopologyTest {
 
     @Test
     public void topicSubscriptionShouldBeCorrect() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology()
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()
                 .setSourceTopics(Arrays.asList("source-topic-1", "source-topic-2"))
-                .setRepartitionSourceTopics(Arrays.asList(
-                    new TopicInfo().setName("repartition-topic-1"),
-                    new TopicInfo().setName("repartition-topic-2")
+                .setRepartitionSourceTopics(mkMap(
+                    mkEntry("repartition-topic-1", new InternalTopicConfig("repartition-topic-1")),
+                    mkEntry("repartition-topic-2", new InternalTopicConfig("repartition-topic-2"))
                 ))
             ),
-            mkEntry("subtopology-2", new Subtopology()
+            mkEntry("subtopology-2", new TopicsInfo()
                 .setSourceTopics(Arrays.asList("source-topic-3", "source-topic-4"))
-                .setRepartitionSourceTopics(Arrays.asList(
-                    new TopicInfo().setName("repartition-topic-3"),
-                    new TopicInfo().setName("repartition-topic-4")
+                .setRepartitionSourceTopics(mkMap(
+                    mkEntry("repartition-topic-3", new InternalTopicConfig("repartition-topic-3")),
+                    mkEntry("repartition-topic-4", new InternalTopicConfig("repartition-topic-4"))
                 ))
             )
         );
@@ -83,8 +83,8 @@ public class StreamsTopologyTest {
         StreamsGroupTopologyValue record = new StreamsGroupTopologyValue()
             .setTopologyId("topology-id")
             .setTopology(Arrays.asList(
-                new Subtopology().setSubtopology("subtopology-1"),
-                new Subtopology().setSubtopology("subtopology-2")
+                new StreamsGroupTopologyValue.Subtopology().setSubtopologyId("subtopology-1"),
+                new StreamsGroupTopologyValue.Subtopology().setSubtopologyId("subtopology-2")
             ));
         StreamsTopology topology = StreamsTopology.fromRecord(record);
         assertEquals("topology-id", topology.topologyId());
@@ -95,9 +95,9 @@ public class StreamsTopologyTest {
 
     @Test
     public void equalsShouldReturnTrueForEqualTopologies() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology().setSubtopology("subtopology-1")),
-            mkEntry("subtopology-2", new Subtopology().setSubtopology("subtopology-2"))
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()),
+            mkEntry("subtopology-2", new TopicsInfo())
         );
         StreamsTopology topology1 = new StreamsTopology("topology-id", subtopologies);
         StreamsTopology topology2 = new StreamsTopology("topology-id", subtopologies);
@@ -106,11 +106,11 @@ public class StreamsTopologyTest {
 
     @Test
     public void equalsShouldReturnFalseForDifferentTopologies() {
-        Map<String, Subtopology> subtopologies1 = mkMap(
-            mkEntry("subtopology-1", new Subtopology().setSubtopology("subtopology-1"))
+        Map<String, TopicsInfo> subtopologies1 = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo())
         );
-        Map<String, Subtopology> subtopologies2 = mkMap(
-            mkEntry("subtopology-2", new Subtopology().setSubtopology("subtopology-2"))
+        Map<String, TopicsInfo> subtopologies2 = mkMap(
+            mkEntry("subtopology-2", new TopicsInfo())
         );
         StreamsTopology topology1 = new StreamsTopology("topology-id-1", subtopologies1);
         StreamsTopology topology2 = new StreamsTopology("topology-id-2", subtopologies2);
@@ -119,9 +119,9 @@ public class StreamsTopologyTest {
 
     @Test
     public void hashCodeShouldBeConsistentWithEquals() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology().setSubtopology("subtopology-1")),
-            mkEntry("subtopology-2", new Subtopology().setSubtopology("subtopology-2"))
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()),
+            mkEntry("subtopology-2", new TopicsInfo())
         );
         StreamsTopology topology1 = new StreamsTopology("topology-id", subtopologies);
         StreamsTopology topology2 = new StreamsTopology("topology-id", subtopologies);
@@ -130,9 +130,9 @@ public class StreamsTopologyTest {
 
     @Test
     public void toStringShouldReturnCorrectRepresentation() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology().setSubtopology("subtopology-1")),
-            mkEntry("subtopology-2", new Subtopology().setSubtopology("subtopology-2"))
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()),
+            mkEntry("subtopology-2", new TopicsInfo())
         );
         StreamsTopology topology = new StreamsTopology("topology-id", subtopologies);
         String expectedString = "StreamsTopology{topologyId=topology-id, subtopologies=" + subtopologies + "}";
@@ -140,40 +140,36 @@ public class StreamsTopologyTest {
     }
 
     @Test
-    public void asStreamsGroupDescribeTopologyShouldReturnCorrectSubtopologies() {
-        Map<String, Subtopology> subtopologies = mkMap(
-            mkEntry("subtopology-1", new Subtopology()
-                .setSourceTopicRegex("regex-1")
-                .setSubtopology("subtopology-1")
+    public void toStreamsGroupDescribeTopologyShouldReturnCorrectSubtopologies() {
+        Map<String, TopicsInfo> subtopologies = mkMap(
+            mkEntry("subtopology-1", new TopicsInfo()
                 .setSourceTopics(Collections.singletonList("source-topic-1"))
                 .setRepartitionSinkTopics(Collections.singletonList("sink-topic-1"))
                 .setRepartitionSourceTopics(
-                    Collections.singletonList(new TopicInfo().setName("repartition-topic-1")))
+                    Collections.singletonMap("repartition-topic-1", new InternalTopicConfig("repartition-topic-1")))
                 .setStateChangelogTopics(
-                    Collections.singletonList(new TopicInfo().setName("changelog-topic-1")))
+                    Collections.singletonMap("changelog-topic-1", new InternalTopicConfig("changelog-topic-1")))
             ),
-            mkEntry("subtopology-2", new Subtopology()
-                .setSourceTopicRegex("regex-2")
-                .setSubtopology("subtopology-2")
+            mkEntry("subtopology-2", new TopicsInfo()
                 .setSourceTopics(Collections.singletonList("source-topic-2"))
                 .setRepartitionSinkTopics(Collections.singletonList("sink-topic-2"))
                 .setRepartitionSourceTopics(
-                    Collections.singletonList(new TopicInfo().setName("repartition-topic-2")))
+                    Collections.singletonMap("repartition-topic-2", new InternalTopicConfig("repartition-topic-2")))
                 .setStateChangelogTopics(
-                    Collections.singletonList(new TopicInfo().setName("changelog-topic-2")))
+                    Collections.singletonMap("changelog-topic-2", new InternalTopicConfig("changelog-topic-2")))
             )
         );
         StreamsTopology topology = new StreamsTopology("topology-id", subtopologies);
-        List<StreamsGroupDescribeResponseData.Subtopology> result = topology.asStreamsGroupDescribeTopology();
+        List<StreamsGroupDescribeResponseData.Subtopology> result = topology.toStreamsGroupDescribeTopology();
         assertEquals(2, result.size());
-        assertEquals("regex-1", result.get(0).sourceTopicRegex());
-        assertEquals("subtopology-1", result.get(0).subtopology());
+        assertEquals(Collections.emptyList(), result.get(0).sourceTopicRegex());
+        assertEquals("subtopology-1", result.get(0).subtopologyId());
         assertEquals(Collections.singletonList("source-topic-1"), result.get(0).sourceTopics());
         assertEquals(Collections.singletonList("sink-topic-1"), result.get(0).repartitionSinkTopics());
         assertEquals("repartition-topic-1", result.get(0).repartitionSourceTopics().get(0).name());
         assertEquals("changelog-topic-1", result.get(0).stateChangelogTopics().get(0).name());
-        assertEquals("regex-2", result.get(1).sourceTopicRegex());
-        assertEquals("subtopology-2", result.get(1).subtopology());
+        assertEquals(Collections.emptyList(), result.get(1).sourceTopicRegex());
+        assertEquals("subtopology-2", result.get(1).subtopologyId());
         assertEquals(Collections.singletonList("source-topic-2"), result.get(1).sourceTopics());
         assertEquals(Collections.singletonList("sink-topic-2"), result.get(1).repartitionSinkTopics());
         assertEquals("repartition-topic-2", result.get(1).repartitionSourceTopics().get(0).name());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.coordinator.group.streams;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.streams.topics.TopicsInfo;
 import org.apache.kafka.coordinator.group.taskassignor.AssignmentMemberSpec;
 import org.apache.kafka.coordinator.group.taskassignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.taskassignor.GroupSpecImpl;
@@ -116,9 +116,16 @@ public class TargetAssignmentBuilderTest {
                 partitionRacks
             ));
             topicsImageBuilder = topicsImageBuilder.addTopic(topicId, topicName, numTasks);
-            topology.subtopologies().put(subtopologyId, new StreamsGroupTopologyValue.Subtopology()
-                .setSubtopology(subtopologyId)
-                .setSourceTopics(Collections.singletonList(topicId.toString())));
+            topology.subtopologies().put(subtopologyId,
+                new TopicsInfo(
+                    Collections.emptyList(),
+                    Collections.singletonList(topicId.toString()),
+                    Collections.emptyList(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    Collections.emptyList()
+                )
+            );
 
             return subtopologyId;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Collection;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -548,9 +549,39 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                                       final TopologyMetadata topologyMetadata) {
         final InternalTopologyBuilder internalTopologyBuilder = topologyMetadata.lookupBuilderForNamedTopology(null);
 
+        final Map<String, Subtopology> subtopologyMap = initBrokerTopology(config, internalTopologyBuilder);
+
+        return new StreamsAssignmentInterface(
+            processId,
+            endpoint,
+            null,
+            subtopologyMap,
+            config.getClientTags()
+        );
+    }
+
+    private static Map<String, Subtopology> initBrokerTopology(final StreamsConfig config, final InternalTopologyBuilder internalTopologyBuilder) {
+        final Map<String, String> defaultTopicConfigs = new HashMap<>();
+        for (final Map.Entry<String, Object> entry : config.originalsWithPrefix(StreamsConfig.TOPIC_PREFIX).entrySet()) {
+            if (entry.getValue() != null) {
+                defaultTopicConfigs.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        final long windowChangeLogAdditionalRetention = config.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG);
+
         final Map<String, Subtopology> subtopologyMap = new HashMap<>();
+        final Collection<Set<String>> copartitionGroups = internalTopologyBuilder.copartitionGroups();
+
         for (final Map.Entry<TopologyMetadata.Subtopology, TopicsInfo> topicsInfoEntry : internalTopologyBuilder.subtopologyToTopicsInfo()
             .entrySet()) {
+
+            final HashSet<String> allSourceTopics = new HashSet<>(
+                topicsInfoEntry.getValue().sourceTopics);
+            topicsInfoEntry.getValue().repartitionSourceTopics.forEach(
+                (repartitionSourceTopic, repartitionTopicInfo) -> {
+                    allSourceTopics.add(repartitionSourceTopic);
+                });
+
             subtopologyMap.put(
                 String.valueOf(topicsInfoEntry.getKey().nodeGroupId),
                 new Subtopology(
@@ -559,44 +590,28 @@ public class StreamThread extends Thread implements ProcessingThread {
                     topicsInfoEntry.getValue().repartitionSourceTopics.entrySet()
                         .stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, e ->
-                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(), e.getValue().topicConfigs))),
+                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(),
+                                Optional.of(config.getShort(StreamsConfig.REPLICATION_FACTOR_CONFIG)),
+                                e.getValue().properties(defaultTopicConfigs, windowChangeLogAdditionalRetention)))),
                     topicsInfoEntry.getValue().stateChangelogTopics.entrySet()
                         .stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, e ->
-                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(), e.getValue().topicConfigs)))
-
+                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(),
+                                Optional.of(config.getShort(StreamsConfig.REPLICATION_FACTOR_CONFIG)),
+                                e.getValue().properties(defaultTopicConfigs, windowChangeLogAdditionalRetention)))),
+                    copartitionGroups.stream().filter(allSourceTopics::containsAll).collect(
+                        Collectors.toList())
                 )
             );
         }
 
-        // TODO: Which of these are actually needed?
-        // TODO: Maybe we want to split this into assignment properties and internal topic configuration properties
-        final HashMap<String, Object> assignmentProperties = new HashMap<>();
-        assignmentProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, config.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG));
-        assignmentProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, config.getString(StreamsConfig.APPLICATION_SERVER_CONFIG));
-        assignmentProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG));
-        assignmentProperties.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG,
-            config.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG));
-        assignmentProperties.put(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, config.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG));
-        assignmentProperties.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG,
-            config.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG,
-            config.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG,
-            config.getString(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
-            config.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG,
-            config.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG));
+        if (subtopologyMap.values().stream().mapToInt(x -> x.copartitionGroups.size()).sum()
+            != copartitionGroups.size()) {
+            throw new IllegalStateException(
+                "Not all copartition groups were converted to broker topology");
+        }
 
-        return new StreamsAssignmentInterface(
-            processId,
-            endpoint,
-            null,
-            subtopologyMap,
-            assignmentProperties,
-            config.getClientTags()
-        );
+        return subtopologyMap;
     }
 
     private static DefaultTaskManager maybeCreateSchedulingTaskManager(final boolean processingThreadsEnabled,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -126,19 +126,6 @@ public class SmokeTestDriverIntegrationTest extends IntegrationTestHarness {
         }
 
         for (final String topic: new String[]{
-            "SmokeTest-KSTREAM-REDUCE-STATE-STORE-0000000020-changelog",
-            "SmokeTest-minStoreName-changelog",
-            "SmokeTest-cntByCnt-repartition",
-            "SmokeTest-KTABLE-SUPPRESS-STATE-STORE-0000000011-changelog",
-            "SmokeTest-sum-STATE-STORE-0000000050-changelog",
-            "SmokeTest-uwin-cnt-changelog",
-            "SmokeTest-maxStoreName-changelog",
-            "SmokeTest-cntStoreName-changelog",
-            "SmokeTest-KTABLE-SUPPRESS-STATE-STORE-0000000027-changelog",
-            "SmokeTest-win-sum-changelog",
-            "SmokeTest-uwin-max-changelog",
-            "SmokeTest-uwin-min-changelog",
-            "SmokeTest-cntByCnt-changelog",
             "data",
             "echo",
             "max",

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -29,6 +29,7 @@ log4j.logger.org.apache.kafka.clients.consumer=INFO
 log4j.logger.org.apache.kafka.clients.producer=INFO
 log4j.logger.org.apache.kafka.streams=INFO
 log4j.logger.org.apache.kafka.coordinator.group=INFO
+log4j.logger.org.apache.kafka.clients.consumer.internals=INFO
 
 # printing out the configs takes up a huge amount of the allotted characters,
 # and provides little value as we can always figure out the test configs without the logs


### PR DESCRIPTION
First implementation of auto-topic creation of internal topics for KIP-1071. It’s only a sketch, there are some parts missing, unit tests are insufficient, etc. But the draft works end-to-end, automatically creating all required internal topics for a streams application upon initialization, with smoke test integration test passing.

- When initializing the topology, the client sends information about the internal topics required for the application. The key concept is that the topology description being sent to the broker is parametric in the number of partitions -- that is, the broker checks the number of partitions for the input partition, and derives the number of partitions for the internal topic. This logic is ported from the existing streams partition assignor.

- The basic flow is that, upon receiving the initialize RPC, the group coordinator checks for the right ACL permissions, validates if the request is valid, then updates the topology record in the consumer offset topic, determines the right number of partitions for all internal topics and finally triggers a corresponding CreateTopic request. 

- Code for generating and validating internal topic configuration lives inside the group coordinator, but the actual creation of the topics is performed from within KafkaApis.

- Compared to the schema in KIP-1071, I had to add copartition groups to the initialization call. Copartititon groups are not necessarily the same as subtopologies. For example, if we merge two topics, the two topics are in separate copartition groups but the same subtopology. If we join, they are in the same copartition group. So we need to model copartition groups separately in the RPC, otherwise the broker cannot derive the right topic configurations.

- There is a dependency between updating the topology record in the consumer offset topic and creating the internal topics. In case of failures, one could be executed without the other. In this implementation, we update the topology record first, and then create internal topics. The topology record will be the single source of truth. If internal topic creation fails, we need to detect this inside the client. Right now, the heartbeat will respond with error if internal topics are missing. Once we merge the heartbeat and the initialization RPC, we should get the behavior that any attempt to join the group (with a topology description) will also be an attempt to create any missing internal topics.

- Surprising, existing RPCs (TopicMetadata and FindCoordinator) auto-create topics asynchronously — so a create topic request is started, but the result is never checked. I followed the same route for this first version, but I intend to change this. You’d have to check the broker logs if internal topics cannot be created. We can do some validation up-front, but the final confirmation that internal topics were created comes from the response of the internal CreateTopics request, so I would like to only respond to the StreamsGroupInitialize once I have received the result of the CreateTopic RPCs.

- We need some extra logic for revalidating internal topics. With this change, the set of tasks is defined by the TopicsImage in the group coordinator and the partition-parametric topology description. The group epoch needs to be bumped when either changes, we need to make sure to cache the result of validating and instantiating a topology against a current set of input topics, so that we don’t have to redo it on every heartbeat. After fail-over, we need to reconstruct this cache from the topology and subscription records in the offset topic. This is not fully implemented yet.