### PR TITLE
KAFKA-17646: Fix flaky KafkaStreamsTest.testStateGlobalThreadClose

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -544,18 +544,14 @@ public class KafkaStreamsTest {
 
             // shutting down the global thread from "external" will yield an error in KafkaStreams
             waitForCondition(
-                () -> streams.state() == KafkaStreams.State.PENDING_ERROR,
-                "Thread never stopped."
-            );
-
-            waitForCondition(
                 () -> streams.state() == KafkaStreams.State.ERROR,
                 "Thread never stopped."
             );
 
             streams.close();
             assertEquals(streams.state(), KafkaStreams.State.ERROR, "KafkaStreams should remain in ERROR state after close.");
-            assertThat(appender.getMessages(), hasItem(containsString("ERROR")));
+            assertThat(appender.getMessages(), hasItem(containsString("State transition from RUNNING to PENDING_ERROR")));
+            assertThat(appender.getMessages(), hasItem(containsString("State transition from PENDING_ERROR to ERROR")));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -547,13 +547,14 @@ public class KafkaStreamsTest {
                 () -> streams.state() == KafkaStreams.State.PENDING_ERROR,
                 "Thread never stopped."
             );
-            streams.close();
 
             waitForCondition(
                 () -> streams.state() == KafkaStreams.State.ERROR,
                 "Thread never stopped."
             );
 
+            streams.close();
+            assertEquals(streams.state(), KafkaStreams.State.ERROR, "KafkaStreams should remain in ERROR state after close.");
             assertThat(appender.getMessages(), hasItem(containsString("ERROR")));
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -540,7 +540,6 @@ public class KafkaStreamsTest {
             waitForCondition(
                 () -> globalStreamThread.state() == GlobalStreamThread.State.DEAD,
                 "Thread never stopped.");
-            globalStreamThread.join();
 
             // shutting down the global thread from "external" will yield an error in KafkaStreams
             waitForCondition(
@@ -552,6 +551,7 @@ public class KafkaStreamsTest {
             assertEquals(streams.state(), KafkaStreams.State.ERROR, "KafkaStreams should remain in ERROR state after close.");
             assertThat(appender.getMessages(), hasItem(containsString("State transition from RUNNING to PENDING_ERROR")));
             assertThat(appender.getMessages(), hasItem(containsString("State transition from PENDING_ERROR to ERROR")));
+            assertThat(appender.getMessages(), hasItem(containsString("Streams client is already in the terminal ERROR state")));
         }
     }
 


### PR DESCRIPTION
It's regarding [KAFKA-17646](https://issues.apache.org/jira/browse/KAFKA-17646).

Two issues found in the flaky test:
1. Racing between `streams.close()` and `shutdownHelper()` threads: Resolved it by moving the `streams.close()`  call after confirming the KafkaStreams state is in `ERROR` state.
2. Checking for short-lived `PENDING_ERROR` state: Resolved it by changing the assertion to check the log content `State transition from RUNNING to PENDING_ERROR`.

Put the verbose explanation under Jira comment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
