### PR TITLE
MINOR Add a step to integrate a PR into trunk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
   integrate:
-    if: is-public-fork
+    if: inputs.is-public-fork
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Merge, Compile, and validate
         run: |
+          git fetch origin trunk
           git checkout -b trunk-integration-${{ github.run_id }} trunk
           git merge --squash ${{ github.ref }} -m ''
           ./gradlew --build-cache --info --no-scan check -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,32 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
+  integrate:
+    if: is-public-fork
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 21, 17, 11, 8 ]
+    name: Integrate with trunk, compile, and check Java ${{ matrix.java }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: true
+          gradle-cache-write-only: false
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+      - name: Merge, Compile, and validate
+        run: |
+          git checkout -b trunk-integration-${{ github.run_id }} trunk
+          git merge --squash ${{ github.ref }} -m ''
+          ./gradlew --build-cache --info --no-scan check -x test
+
   test:
     needs: validate
     if: ${{ ! needs.validate.outputs.is-draft }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
@@ -116,8 +115,7 @@ jobs:
       - name: Merge, Compile, and validate
         run: |
           git fetch origin trunk
-          git checkout -b trunk-integration-${{ github.run_id }} origin/trunk
-          git merge --squash ${{ github.ref }} -m ''
+          git merge origin/trunk
           ./gradlew --build-cache --info --no-scan check -x test
 
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Merge, Compile, and validate
         run: |
           git fetch origin trunk
-          git checkout -b trunk-integration-${{ github.run_id }} trunk
+          git checkout -b trunk-integration-${{ github.run_id }} origin/trunk
           git merge --squash ${{ github.ref }} -m ''
           ./gradlew --build-cache --info --no-scan check -x test
 


### PR DESCRIPTION
This patch adds a step to integrate a PR into trunk and run `check -x test`. This adds a bit of validation that a PR may otherwise lack if it has not been updated with trunk recently.