### PR TITLE
KAFKA-17348: Add custom produce request parsers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DefaultFetchResponseParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DefaultFetchResponseParser.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.message.FetchResponseData;
+
+public class DefaultFetchResponseParser implements FetchResponseParser {
+    public FetchResponse parse(ByteBuffer buffer, short version) {
+        return new FetchResponse(new FetchResponseData(new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceRequestParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceRequestParser.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.message.ProduceRequestData;
+
+public class DefaultProduceRequestParser implements ProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version) {
+        return new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceResponseParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DefaultProduceResponseParser.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.message.ProduceResponseData;
+
+public class DefaultProduceResponseParser implements ProduceResponseParser {
+    public ProduceResponse parse(ByteBuffer buffer, short version) {
+        return new ProduceResponse(new ProduceResponseData(new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -72,6 +72,8 @@ public class FetchResponse extends AbstractResponse {
     public static final long INVALID_LOG_START_OFFSET = -1L;
     public static final int INVALID_PREFERRED_REPLICA_ID = -1;
 
+    private static FetchResponseParser fetchResponseParser = FetchResponseParserFactory.getFetchResponseParser();
+
     private final FetchResponseData data;
 
     @Override
@@ -139,7 +141,7 @@ public class FetchResponse extends AbstractResponse {
     }
 
     public static FetchResponse parse(ByteBuffer buffer, short version) {
-        return new FetchResponse(new FetchResponseData(new ByteBufferAccessor(buffer), version));
+        return fetchResponseParser.parse(buffer, version);
     }
 
     // Fetch versions 13 and above should have topic IDs for all topics.

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.record.MemoryRecords;

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponseParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponseParser.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+public interface FetchResponseParser {
+    public FetchResponse parse(ByteBuffer buffer, short version);
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponseParserFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponseParserFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+
+import java.util.Properties;
+import java.io.InputStream;
+import java.io.FileInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetchResponseParserFactory {
+    public static final Logger log = LoggerFactory.getLogger(FetchResponseParserFactory.class);
+
+    public static final String FETCH_RESPONSE_PARSER_PROPERTY = "org.apache.kafka.common.requests.FetchResponseParser";
+    public static final String FETCH_RESPONSE_PARSER_ENV = "KAFKA_FETCH_RESPONSE_PARSER";
+    public static final String FETCH_RESPONSE_PARSER_DEFAULT = "org.apache.kafka.common.requests.DefaultFetchResponseParser";
+
+    private static String getFetchResponseParserClassName() {
+        String fetchResponseParserClassName = System.getProperty(FETCH_RESPONSE_PARSER_PROPERTY);
+        if (null != fetchResponseParserClassName) {
+            log.info("FetchResponseParser class {} from property {}", fetchResponseParserClassName, FETCH_RESPONSE_PARSER_PROPERTY);
+            return fetchResponseParserClassName;
+        }
+
+        fetchResponseParserClassName = System.getenv(FETCH_RESPONSE_PARSER_ENV);
+        if (null != fetchResponseParserClassName) {
+            log.info("FetchResponseParser class {} from env {}", fetchResponseParserClassName, FETCH_RESPONSE_PARSER_ENV);
+            return fetchResponseParserClassName;
+        }
+
+        fetchResponseParserClassName = getFetchResponseParserClassNameFromConfigFile();
+        if (null != fetchResponseParserClassName) {
+            return fetchResponseParserClassName;
+        }
+
+        fetchResponseParserClassName = FETCH_RESPONSE_PARSER_DEFAULT;
+        log.info("FetchResponseParser class {} from default {}", fetchResponseParserClassName, FETCH_RESPONSE_PARSER_DEFAULT);
+        return fetchResponseParserClassName;
+    }
+
+    private static String getFetchResponseParserClassNameFromConfigFile() {
+        String commandLine = System.getProperty("sun.java.command");
+        if(null == commandLine) {
+            return null;
+        }
+
+        String[] commandLineArgs = commandLine.split("\\s+");
+        String configFileName = null;
+        if(commandLineArgs.length < 2) {
+            return null;
+        }
+
+        configFileName = commandLineArgs[1];
+        if(null == configFileName) {
+            return null;
+        }
+
+        Properties properties = new Properties();
+        try {
+            InputStream inputStream = new FileInputStream(configFileName);
+            properties.load(inputStream);
+            inputStream.close();
+            inputStream = null;
+        } catch(Exception e) {
+            log.trace("Failed to load {}", configFileName, e);
+            return null;
+        }
+
+        String fetchResponseParserClassName = null;
+        try {
+            fetchResponseParserClassName = properties.getProperty(FETCH_RESPONSE_PARSER_PROPERTY);
+        } catch(Exception e) {
+            log.trace("{} not found in {}", FETCH_RESPONSE_PARSER_PROPERTY, configFileName, e);
+            return null;
+        }
+
+        if(null == fetchResponseParserClassName) {
+            return null;
+        }
+
+        log.info("FetchResponseParser class {} from config {}", fetchResponseParserClassName, configFileName);
+        return fetchResponseParserClassName;
+    }
+
+
+    public static FetchResponseParser getFetchResponseParser() {
+        try {
+            String fetchResponseParserClassName = getFetchResponseParserClassName();
+            return (FetchResponseParser) Class.forName(fetchResponseParserClassName).getConstructor().newInstance();
+        } catch (Exception e) {
+            String message = "Failed to initialize";
+            log.error(message, e);
+            throw new InvalidConfigurationException(message, e);
+        }
+    }
+}
+

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.errors.UnsupportedCompressionTypeException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.CompressionType;
@@ -39,7 +38,13 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.requests.ProduceResponse.INVALID_OFFSET;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ProduceRequest extends AbstractRequest {
+    public static final Logger log = LoggerFactory.getLogger(ProduceRequest.class);
+
+    private static ProduceRequestParser produceRequestParser = ProduceRequestParserFactory.getProduceRequestParser();
 
     public static Builder forMagic(byte magic, ProduceRequestData data) {
         // Message format upgrades correspond with a bump in the produce request version. Older
@@ -252,7 +257,7 @@ public class ProduceRequest extends AbstractRequest {
     }
 
     public static ProduceRequest parse(ByteBuffer buffer, short version) {
-        return new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version);
+        return produceRequestParser.parse(buffer, version);
     }
 
     public static byte requiredMagicForVersion(short produceRequestVersion) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -38,12 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.requests.ProduceResponse.INVALID_OFFSET;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ProduceRequest extends AbstractRequest {
-    public static final Logger log = LoggerFactory.getLogger(ProduceRequest.class);
-
     private static ProduceRequestParser produceRequestParser = ProduceRequestParserFactory.getProduceRequestParser();
 
     public static Builder forMagic(byte magic, ProduceRequestData data) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+public interface ProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version);
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParserFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParserFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+
+import java.util.Properties;
+import java.io.InputStream;
+import java.io.FileInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProduceRequestParserFactory {
+    public static final Logger log = LoggerFactory.getLogger(ProduceRequestParserFactory.class);
+
+    public static final String PRODUCE_REQUEST_PARSER_PROPERTY = "org.apache.kafka.common.requests.ProduceRequestParser";
+    public static final String PRODUCE_REQUEST_PARSER_ENV = "KAFKA_PRODUCE_REQUEST_PARSER";
+    public static final String PRODUCE_REQUEST_PARSER_DEFAULT = "org.apache.kafka.common.requests.DefaultProduceRequestParser";
+
+    private static String getProduceRequestParserClassName() {
+        String produceRequestParserClassName = System.getProperty(PRODUCE_REQUEST_PARSER_PROPERTY);
+        if (null != produceRequestParserClassName) {
+            log.info("ProduceRequestParser class {} from property {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_PROPERTY);
+            return produceRequestParserClassName;
+        }
+
+        produceRequestParserClassName = System.getenv(PRODUCE_REQUEST_PARSER_ENV);
+        if (null != produceRequestParserClassName) {
+            log.info("ProduceRequestParser class {} from env {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_ENV);
+            return produceRequestParserClassName;
+        }
+
+        produceRequestParserClassName = getProduceRequestParserClassNameFromConfigFile();
+        if (null != produceRequestParserClassName) {
+            return produceRequestParserClassName;
+        }
+
+        produceRequestParserClassName = PRODUCE_REQUEST_PARSER_DEFAULT;
+        log.info("ProduceRequestParser class {} from default {}", produceRequestParserClassName, PRODUCE_REQUEST_PARSER_DEFAULT);
+        return produceRequestParserClassName;
+    }
+
+    private static String getProduceRequestParserClassNameFromConfigFile() {
+        String commandLine = System.getProperty("sun.java.command");
+        if(null == commandLine) {
+            return null;
+        }
+
+        String[] commandLineArgs = commandLine.split("\\s+");
+        String configFileName = null;
+        if(commandLineArgs.length < 2) {
+            return null;
+        }
+
+        configFileName = commandLineArgs[1];
+        if(null == configFileName) {
+            return null;
+        }
+
+        Properties properties = new Properties();
+        try {
+            InputStream inputStream = new FileInputStream(configFileName);
+            properties.load(inputStream);
+            inputStream.close();
+            inputStream = null;
+        } catch(Exception e) {
+            log.trace("Failed to load {}", configFileName, e);
+            return null;
+        }
+
+        String produceRequestParserClassName = null;
+        try {
+            produceRequestParserClassName = properties.getProperty(PRODUCE_REQUEST_PARSER_PROPERTY);
+        } catch(Exception e) {
+            log.trace("{} not found in {}", PRODUCE_REQUEST_PARSER_PROPERTY, configFileName, e);
+            return null;
+        }
+
+        if(null == produceRequestParserClassName) {
+            return null;
+        }
+
+        log.info("ProduceRequestParser class {} from config {}", produceRequestParserClassName, configFileName);
+        return produceRequestParserClassName;
+    }
+
+
+    public static ProduceRequestParser getProduceRequestParser() {
+        try {
+            String produceRequestParserClassName = getProduceRequestParserClassName();
+            return (ProduceRequestParser) Class.forName(produceRequestParserClassName).getConstructor().newInstance();
+        } catch (Exception e) {
+            String message = "Failed to initialize";
+            log.error(message, e);
+            throw new InvalidConfigurationException(message, e);
+        }
+    }
+}
+

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -60,6 +60,8 @@ public class ProduceResponse extends AbstractResponse {
     public static final long INVALID_OFFSET = -1L;
     private final ProduceResponseData data;
 
+    private static ProduceResponseParser produceResponseParser = ProduceResponseParserFactory.getProduceResponseParser();
+
     public ProduceResponse(ProduceResponseData produceResponseData) {
         super(ApiKeys.PRODUCE);
         this.data = produceResponseData;
@@ -296,7 +298,7 @@ public class ProduceResponse extends AbstractResponse {
     }
 
     public static ProduceResponse parse(ByteBuffer buffer, short version) {
-        return new ProduceResponse(new ProduceResponseData(new ByteBufferAccessor(buffer), version));
+        return produceResponseParser.parse(buffer, version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ProduceResponseData.LeaderIdAndEpoch;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponseParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponseParser.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+public interface ProduceResponseParser {
+    public ProduceResponse parse(ByteBuffer buffer, short version);
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponseParserFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponseParserFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+
+import java.util.Properties;
+import java.io.InputStream;
+import java.io.FileInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProduceResponseParserFactory {
+    public static final Logger log = LoggerFactory.getLogger(ProduceResponseParserFactory.class);
+
+    public static final String PRODUCE_RESPONSE_PARSER_PROPERTY = "org.apache.kafka.common.requests.ProduceResponseParser";
+    public static final String PRODUCE_RESPONSE_PARSER_ENV = "KAFKA_PRODUCE_RESPONSE_PARSER";
+    public static final String PRODUCE_RESPONSE_PARSER_DEFAULT = "org.apache.kafka.common.requests.DefaultProduceResponseParser";
+
+    private static String getProduceResponseParserClassName() {
+        String produceResponseParserClassName = System.getProperty(PRODUCE_RESPONSE_PARSER_PROPERTY);
+        if (null != produceResponseParserClassName) {
+            log.info("ProduceResponseParser class {} from property {}", produceResponseParserClassName, PRODUCE_RESPONSE_PARSER_PROPERTY);
+            return produceResponseParserClassName;
+        }
+
+        produceResponseParserClassName = System.getenv(PRODUCE_RESPONSE_PARSER_ENV);
+        if (null != produceResponseParserClassName) {
+            log.info("ProduceResponseParser class {} from env {}", produceResponseParserClassName, PRODUCE_RESPONSE_PARSER_ENV);
+            return produceResponseParserClassName;
+        }
+
+        produceResponseParserClassName = getProduceResponseParserClassNameFromConfigFile();
+        if (null != produceResponseParserClassName) {
+            return produceResponseParserClassName;
+        }
+
+        produceResponseParserClassName = PRODUCE_RESPONSE_PARSER_DEFAULT;
+        log.info("ProduceResponseParser class {} from default {}", produceResponseParserClassName, PRODUCE_RESPONSE_PARSER_DEFAULT);
+        return produceResponseParserClassName;
+    }
+
+    private static String getProduceResponseParserClassNameFromConfigFile() {
+        String commandLine = System.getProperty("sun.java.command");
+        if(null == commandLine) {
+            return null;
+        }
+
+        String[] commandLineArgs = commandLine.split("\\s+");
+        String configFileName = null;
+        if(commandLineArgs.length < 2) {
+            return null;
+        }
+
+        configFileName = commandLineArgs[1];
+        if(null == configFileName) {
+            return null;
+        }
+
+        Properties properties = new Properties();
+        try {
+            InputStream inputStream = new FileInputStream(configFileName);
+            properties.load(inputStream);
+            inputStream.close();
+            inputStream = null;
+        } catch(Exception e) {
+            log.trace("Failed to load {}", configFileName, e);
+            return null;
+        }
+
+        String produceResponseParserClassName = null;
+        try {
+            produceResponseParserClassName = properties.getProperty(PRODUCE_RESPONSE_PARSER_PROPERTY);
+        } catch(Exception e) {
+            log.trace("{} not found in {}", PRODUCE_RESPONSE_PARSER_PROPERTY, configFileName, e);
+            return null;
+        }
+
+        if(null == produceResponseParserClassName) {
+            return null;
+        }
+
+        log.info("ProduceResponseParser class {} from config {}", produceResponseParserClassName, configFileName);
+        return produceResponseParserClassName;
+    }
+
+
+    public static ProduceResponseParser getProduceResponseParser() {
+        try {
+            String produceResponseParserClassName = getProduceResponseParserClassName();
+            return (ProduceResponseParser) Class.forName(produceResponseParserClassName).getConstructor().newInstance();
+        } catch (Exception e) {
+            String message = "Failed to initialize";
+            log.error(message, e);
+            throw new InvalidConfigurationException(message, e);
+        }
+    }
+}
+

--- a/clients/src/test/java/org/apache/kafka/common/requests/TestCustomFailingProduceRequestParser.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TestCustomFailingProduceRequestParser.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.errors.InvalidRequestException;
+
+public class TestCustomFailingProduceRequestParser implements ProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version) {
+        throw new InvalidRequestException("Testing custom parser failure handling");
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/TestCustomProduceRequestParser.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TestCustomProduceRequestParser.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+public class TestCustomProduceRequestParser extends DefaultProduceRequestParser {
+    public ProduceRequest parse(ByteBuffer buffer, short version) {
+        return super.parse(buffer, version);
+    }
+}

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -302,6 +302,21 @@
       <tr><th>Default Value:</th><td>com.sun.security.auth.module.JndiLoginModule</td></tr>
       </tbody></table>
     </li>
+    <li>
+      <h4><a id="org.apache.kafka.common.requests.ProduceRequestParser"></a><a id="systemproperties_org.apache.kafka.common.requests.ProduceRequestParser" href="#systemproperties_org.apache.kafka.common.requests.ProduceRequestParser">org.apache.kafka.common.requests.ProduceRequestParser</a></h4>
+      <p>Can be configured via server.properties, a system property, or an environment variable, and is used to specify a custom ProduceRequest parser. By default <b>org.apache.kafka.common.requests.DefaultProduceRequestParser</b> is used.
+      <p>In server.properties:
+      <p><pre><code class="language-bash">org.apache.kafka.common.requests.ProduceRequestParser=org.example.kafka.requests.CustomProduceRequestParser</code></pre>
+      <p>In system properties:
+      <p><pre><code class="language-bash">-Dorg.apache.kafka.common.requests.ProduceRequestParser=org.example.kafka.requests.CustomProduceRequestParser</code></pre>
+      <p>In environment:
+      <p><pre><code class="language-bash">export KAFKA_PRODUCE_REQUEST_PARSER=org.example.kafka.requests.CustomProduceRequestParser</code></pre>
+      <p>Where <b>org.example.kafka.requests.CustomProduceRequestParser</b> implements <b>org.apache.kafka.common.requests.ProduceRequestParser</b> interface.
+      <table><tbody>
+      <tr><th>Since:</th><td>4.0.0</td></tr>
+      <tr><th>Default Value:</th><td>org.apache.kafka.common.requests.DefaultProduceRequestParser</td></tr>
+      </tbody></table>
+    </li>
   </ul>
 
   <h3 class="anchor-heading"><a id="tieredstorageconfigs" class="anchor-link"></a><a href="#tieredstorageconfigs">3.10 Tiered Storage Configs</a></h3>


### PR DESCRIPTION
This PR adds ability to specify a custom produce request parser. A custom produce request parser would allow to intercept all incoming messages before they get into the broker and apply broker wide logic to the messages. This could be a trace , a filter, or a transform(such as lineage).
The inline new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version) was moved out of [ProduceRequest.java](https://app.slack.com/client/EAZPKTY6A/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java) into its own class [ProduceRequestParser.java](https://app.slack.com/client/EAZPKTY6A/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequestParser.java), and ProduceRequest class was augmented with the dynamic loading of a specified parser class. When no class is specified, the default one is loaded maintaining full backward compatibilty.

JIRA: [KAFKA-17348](https://issues.apache.org/jira/browse/KAFKA-17348)
KIP: [KIP-1086](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=318606528)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

Replaces closed PR #16812 