### PR TITLE
KAFKA-16106: Schedule timeout task to refresh classic group size metric

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -249,6 +249,18 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     static final String GROUP_EXPIRATION_KEY = "expire-group-metadata";
 
     /**
+     * The classic group size counter key to schedule a timer task.
+     *
+     * Visible for testing.
+     */
+    static final String CLASSIC_GROUP_SIZE_COUNTER_KEY = "classic-group-size-counter";
+
+    /**
+     * Hardcoded default value of the interval to update the classic group size counter.
+     */
+    static final int DEFAULT_GROUP_GAUGES_UPDATE_INTERVAL_MS = 60 * 1000;
+
+    /**
      * The logger.
      */
     private final Logger log;
@@ -678,6 +690,30 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     }
 
     /**
+     * Schedules (or reschedules) the group size counter for the classic groups.
+     */
+    private void scheduleClassicGroupSizeCounter() {
+        timer.schedule(
+            CLASSIC_GROUP_SIZE_COUNTER_KEY,
+            DEFAULT_GROUP_GAUGES_UPDATE_INTERVAL_MS,
+            TimeUnit.MILLISECONDS,
+            true,
+            () -> {
+                groupMetadataManager.updateClassicGroupSizeCounter();
+                scheduleClassicGroupSizeCounter();
+                return GroupMetadataManager.EMPTY_RESULT;
+            }
+        );
+    }
+
+    /**
+     * Cancels the group size counter for the classic groups.
+     */
+    private void cancelClassicGroupSizeCounter() {
+        timer.cancel(CLASSIC_GROUP_SIZE_COUNTER_KEY);
+    }
+
+    /**
      * The coordinator has been loaded. This is used to apply any
      * post loading operations (e.g. registering timers).
      *
@@ -692,6 +728,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
 
         groupMetadataManager.onLoaded();
         scheduleGroupMetadataExpiration();
+        scheduleClassicGroupSizeCounter();
     }
 
     @Override
@@ -699,6 +736,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         timer.cancel(GROUP_EXPIRATION_KEY);
         coordinatorMetrics.deactivateMetricsShard(metricsShard);
         groupMetadataManager.onUnloaded();
+        cancelClassicGroupSizeCounter();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3782,6 +3782,7 @@ public class GroupMetadataManager {
                     break;
             }
         });
+        scheduleClassicGroupSizeCounter();
     }
 
     /**
@@ -3841,6 +3842,27 @@ public class GroupMetadataManager {
 
     public static String consumerGroupRebalanceTimeoutKey(String groupId, String memberId) {
         return "rebalance-timeout-" + groupId + "-" + memberId;
+    }
+
+    public static String classicGroupSizeCounterKey() {
+        return "classic-group-size-counter";
+    }
+
+    /**
+     * Schedules (or reschedules) the group size counter for the classic group.
+     */
+    private void scheduleClassicGroupSizeCounter() {
+        timer.schedule(
+            classicGroupSizeCounterKey(),
+            metrics.classicGroupGaugesUpdateIntervalMs(),
+            TimeUnit.MILLISECONDS,
+            true,
+            () -> {
+                metrics.updateClassicGroupGauges(groups);
+                scheduleClassicGroupSizeCounter();
+                return EMPTY_RESULT;
+            }
+        );
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
@@ -103,6 +103,22 @@ public class Utils {
     }
 
     /**
+     * Decrements value by 1; returns null when reaching zero. This helper is
+     * meant to be used with Map#compute.
+     */
+    public static Long decValue(Object key, Long value) {
+        if (value == null) return null;
+        return value == 1 ? null : value - 1;
+    }
+
+    /**
+     * Increments value by 1; This helper is meant to be used with Map#compute.
+     */
+    public static Long incValue(Object key, Long value) {
+        return value == null ? 1 : value + 1;
+    }
+
+    /**
      * @return An Optional containing the provided string if it is not null and not empty,
      *         otherwise an empty Optional.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -38,7 +38,6 @@ import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.GroupCoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -182,24 +181,17 @@ public class ClassicGroup implements Group {
      */
     private boolean newMemberAdded = false;
 
-    /**
-     * Coordinator metrics.
-     */
-    private final GroupCoordinatorMetricsShard metrics;
-
     public ClassicGroup(
         LogContext logContext,
         String groupId,
         ClassicGroupState initialState,
-        Time time,
-        GroupCoordinatorMetricsShard metrics
+        Time time
     ) {
         this(
             logContext,
             groupId,
             initialState,
             time,
-            metrics,
             0,
             Optional.empty(),
             Optional.empty(),
@@ -213,7 +205,6 @@ public class ClassicGroup implements Group {
         String groupId,
         ClassicGroupState initialState,
         Time time,
-        GroupCoordinatorMetricsShard metrics,
         int generationId,
         Optional<String> protocolType,
         Optional<String> protocolName,
@@ -226,7 +217,6 @@ public class ClassicGroup implements Group {
         this.state = Objects.requireNonNull(initialState);
         this.previousState = DEAD;
         this.time = Objects.requireNonNull(time);
-        this.metrics = Objects.requireNonNull(metrics);
         this.generationId = generationId;
         this.protocolType = protocolType;
         this.protocolName = protocolName;
@@ -1377,7 +1367,6 @@ public class ClassicGroup implements Group {
         String leavingMemberId,
         LogContext logContext,
         Time time,
-        GroupCoordinatorMetricsShard metrics,
         MetadataImage metadataImage
     ) {
         ClassicGroup classicGroup = new ClassicGroup(
@@ -1385,7 +1374,6 @@ public class ClassicGroup implements Group {
             consumerGroup.groupId(),
             ClassicGroupState.STABLE,
             time,
-            metrics,
             consumerGroup.groupEpoch(),
             Optional.ofNullable(ConsumerProtocol.PROTOCOL_TYPE),
             Optional.empty(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1013,7 +1013,6 @@ public class ClassicGroup implements Group {
         previousState = state;
         state = groupState;
         currentStateTimestamp = Optional.of(time.milliseconds());
-        metrics.onClassicGroupStateTransition(previousState, state);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -20,23 +20,18 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetricsShard;
-import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.timeline.SnapshotRegistry;
-import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static org.apache.kafka.coordinator.group.Group.GroupType.CLASSIC;
 
 /**
  * This class is mapped to a single {@link org.apache.kafka.coordinator.group.GroupCoordinatorShard}. It will
@@ -48,12 +43,12 @@ import static org.apache.kafka.coordinator.group.Group.GroupType.CLASSIC;
  */
 public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
 
-    private static final Logger log = LoggerFactory.getLogger(GroupCoordinatorMetricsShard.class);
-
     /**
      * Hardcoded default value of the interval to update the classic group size counter.
      */
-    private static final int DEFAULT_GROUP_GAUGES_UPDATE_INTERVAL_MS = 60 * 1000;
+    public static final int DEFAULT_GROUP_GAUGES_UPDATE_INTERVAL_MS = 60 * 1000;
+
+    private static final Logger log = LoggerFactory.getLogger(GroupCoordinatorMetricsShard.class);
 
     /**
      * This class represents a gauge counter for this shard. The TimelineLong object represents a gauge backed by
@@ -75,12 +70,7 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     /**
      * Classic group size gauge counters keyed by the metric name.
      */
-    private final Map<ClassicGroupState, AtomicLong> classicGroupGauges;
-
-    /**
-     * The interval to update classicGroupGauges.
-     */
-    private final long classicGroupGaugesUpdateIntervalMs;
+    private volatile Map<ClassicGroupState, AtomicLong> classicGroupGauges;
 
     /**
      * Consumer group size gauge counters keyed by the metric name.
@@ -121,14 +111,7 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         numOffsetsTimelineGaugeCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
         numClassicGroupsTimelineCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
 
-        this.classicGroupGauges = Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, new AtomicLong(0)),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, new AtomicLong(0)),
-            Utils.mkEntry(ClassicGroupState.STABLE, new AtomicLong(0)),
-            Utils.mkEntry(ClassicGroupState.DEAD, new AtomicLong(0)),
-            Utils.mkEntry(ClassicGroupState.EMPTY, new AtomicLong(0))
-        );
-        this.classicGroupGaugesUpdateIntervalMs = DEFAULT_GROUP_GAUGES_UPDATE_INTERVAL_MS;
+        this.classicGroupGauges = createClassicGroupGauge();
 
         this.consumerGroupGauges = Utils.mkMap(
             Utils.mkEntry(ConsumerGroupState.EMPTY,
@@ -157,23 +140,16 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     }
 
     /**
-     * @return The interval to update classicGroupGauges.
+     * @return An empty ClassicGroupGauges.
      */
-    public long classicGroupGaugesUpdateIntervalMs() {
-        return classicGroupGaugesUpdateIntervalMs;
-    }
-
-    /**
-     * Set the number of classic groups.
-     *
-     * @param state             The classic group state.
-     * @param numClassicGroups  The number of classic groups in the given state.
-     */
-    private void setNumClassicGroups(ClassicGroupState state, AtomicLong numClassicGroups) {
-        AtomicLong counter = classicGroupGauges.get(state);
-        if (counter != null) {
-            counter.getAndSet(numClassicGroups == null ? 0 : numClassicGroups.get());
-        }
+    public static Map<ClassicGroupState, AtomicLong> createClassicGroupGauge() {
+        return Utils.mkMap(
+            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, new AtomicLong(0)),
+            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, new AtomicLong(0)),
+            Utils.mkEntry(ClassicGroupState.STABLE, new AtomicLong(0)),
+            Utils.mkEntry(ClassicGroupState.DEAD, new AtomicLong(0)),
+            Utils.mkEntry(ClassicGroupState.EMPTY, new AtomicLong(0))
+        );
     }
 
     /**
@@ -326,28 +302,14 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     }
 
     /**
-     * The method is called every {@code classicGroupGaugesUpdateIntervalMs}.
-     * It updates the classic group gauges based on the soft state of the groups.
+     * Sets the classicGroupGauges.
      *
-     * @param groups The classic and consumer groups keyed by their name.
+     * @param classicGroupGauges The new classicGroupGauges.
      */
-    public void updateClassicGroupGauges(
-        TimelineHashMap<String, Group> groups
+    public void setClassicGroupGauges(
+        Map<ClassicGroupState, AtomicLong> classicGroupGauges
     ) {
-        Map<String, AtomicLong> groupSizeCounter = new HashMap<>();
-        groups.forEach((__, group) -> {
-            if (group.type() == CLASSIC) {
-                String state = group.stateAsString();
-                groupSizeCounter.computeIfAbsent(state, k -> new AtomicLong(0L))
-                    .incrementAndGet();
-            }
-        });
-
-        setNumClassicGroups(ClassicGroupState.EMPTY, groupSizeCounter.get(ClassicGroupState.EMPTY.toString()));
-        setNumClassicGroups(ClassicGroupState.STABLE, groupSizeCounter.get(ClassicGroupState.STABLE.toString()));
-        setNumClassicGroups(ClassicGroupState.PREPARING_REBALANCE, groupSizeCounter.get(ClassicGroupState.PREPARING_REBALANCE.toString()));
-        setNumClassicGroups(ClassicGroupState.COMPLETING_REBALANCE, groupSizeCounter.get(ClassicGroupState.COMPLETING_REBALANCE.toString()));
-        setNumClassicGroups(ClassicGroupState.DEAD, groupSizeCounter.get(ClassicGroupState.DEAD.toString()));
+        this.classicGroupGauges = classicGroupGauges;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -140,13 +140,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         this.topicPartition = Objects.requireNonNull(topicPartition);
     }
 
-    public void incrementNumClassicGroups(ClassicGroupState state) {
-        AtomicLong counter = classicGroupGauges.get(state);
-        if (counter != null) {
-            counter.incrementAndGet();
-        }
-    }
-
     /**
      * Increment the number of offsets.
      */
@@ -176,18 +169,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     public void decrementNumOffsets() {
         synchronized (numOffsetsTimelineGaugeCounter.timelineLong) {
             numOffsetsTimelineGaugeCounter.timelineLong.decrement();
-        }
-    }
-
-    /**
-     * Decrement the number of classic groups.
-     *
-     * @param state the classic group state.
-     */
-    public void decrementNumClassicGroups(ClassicGroupState state) {
-        AtomicLong counter = classicGroupGauges.get(state);
-        if (counter != null) {
-            counter.decrementAndGet();
         }
     }
 
@@ -306,56 +287,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             }
             gaugeCounter.atomicLong.set(value);
         });
-    }
-
-    /**
-     * Called when a classic group's state has changed. Increment/decrement
-     * the counter accordingly.
-     *
-     * @param oldState The previous state. null value means that it's a new group.
-     * @param newState The next state. null value means that the group has been removed.
-     */
-    public void onClassicGroupStateTransition(
-        ClassicGroupState oldState,
-        ClassicGroupState newState
-    ) {
-        if (newState != null) {
-            switch (newState) {
-                case PREPARING_REBALANCE:
-                    incrementNumClassicGroups(ClassicGroupState.PREPARING_REBALANCE);
-                    break;
-                case COMPLETING_REBALANCE:
-                    incrementNumClassicGroups(ClassicGroupState.COMPLETING_REBALANCE);
-                    break;
-                case STABLE:
-                    incrementNumClassicGroups(ClassicGroupState.STABLE);
-                    break;
-                case DEAD:
-                    incrementNumClassicGroups(ClassicGroupState.DEAD);
-                    break;
-                case EMPTY:
-                    incrementNumClassicGroups(ClassicGroupState.EMPTY);
-            }
-        }
-
-        if (oldState != null) {
-            switch (oldState) {
-                case PREPARING_REBALANCE:
-                    decrementNumClassicGroups(ClassicGroupState.PREPARING_REBALANCE);
-                    break;
-                case COMPLETING_REBALANCE:
-                    decrementNumClassicGroups(ClassicGroupState.COMPLETING_REBALANCE);
-                    break;
-                case STABLE:
-                    decrementNumClassicGroups(ClassicGroupState.STABLE);
-                    break;
-                case DEAD:
-                    decrementNumClassicGroups(ClassicGroupState.DEAD);
-                    break;
-                case EMPTY:
-                    decrementNumClassicGroups(ClassicGroupState.EMPTY);
-            }
-        }
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
@@ -43,7 +43,6 @@ import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.MemberState;
 import org.apache.kafka.coordinator.group.modern.TopicMetadata;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
@@ -89,7 +88,6 @@ import static org.apache.kafka.coordinator.group.GroupCoordinatorRecordHelpers.n
 import static org.apache.kafka.coordinator.group.GroupCoordinatorRecordHelpers.newShareGroupEpochTombstoneRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 public class GroupCoordinatorRecordHelpersTest {
 
@@ -514,8 +512,7 @@ public class GroupCoordinatorRecordHelpersTest {
             new LogContext(),
             "group-id",
             ClassicGroupState.PREPARING_REBALANCE,
-            time,
-            mock(GroupCoordinatorMetricsShard.class)
+            time
         );
 
         Map<String, byte[]> assignment = new HashMap<>();
@@ -585,8 +582,7 @@ public class GroupCoordinatorRecordHelpersTest {
             new LogContext(),
             "group-id",
             ClassicGroupState.PREPARING_REBALANCE,
-            time,
-            mock(GroupCoordinatorMetricsShard.class)
+            time
         );
 
         expectedMembers.forEach(member -> {
@@ -637,8 +633,7 @@ public class GroupCoordinatorRecordHelpersTest {
             new LogContext(),
             "group-id",
             ClassicGroupState.PREPARING_REBALANCE,
-            time,
-            mock(GroupCoordinatorMetricsShard.class)
+            time
         );
 
         expectedMembers.forEach(member -> {
@@ -697,8 +692,7 @@ public class GroupCoordinatorRecordHelpersTest {
             new LogContext(),
             "group-id",
             ClassicGroupState.PREPARING_REBALANCE,
-            time,
-            mock(GroupCoordinatorMetricsShard.class)
+            time
         );
 
         group.initNextGeneration();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -90,8 +90,8 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
 import org.apache.kafka.server.common.MetadataVersion;
-
 import org.apache.kafka.timeline.TimelineHashMap;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
@@ -70,10 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class ClassicGroupTest {
     private final String protocolType = "consumer";
@@ -1260,27 +1257,6 @@ public class ClassicGroupTest {
         assertEquals(Optional.of(Collections.singleton("topic")), group.computeSubscribedTopics());
         assertTrue(group.usesConsumerGroupProtocol());
         assertTrue(group.isSubscribedToTopic("topic"));
-    }
-
-    @Test
-    public void testStateTransitionMetrics() {
-        // Confirm metrics is not updated when a new GenericGroup is created but only when the group transitions
-        // its state.
-        GroupCoordinatorMetricsShard metrics = mock(GroupCoordinatorMetricsShard.class);
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, metrics);
-        verify(metrics, times(0)).onClassicGroupStateTransition(any(), any());
-
-        group.transitionTo(PREPARING_REBALANCE);
-        verify(metrics, times(1)).onClassicGroupStateTransition(EMPTY, PREPARING_REBALANCE);
-
-        group.transitionTo(COMPLETING_REBALANCE);
-        verify(metrics, times(1)).onClassicGroupStateTransition(PREPARING_REBALANCE, COMPLETING_REBALANCE);
-
-        group.transitionTo(STABLE);
-        verify(metrics, times(1)).onClassicGroupStateTransition(COMPLETING_REBALANCE, STABLE);
-
-        group.transitionTo(DEAD);
-        verify(metrics, times(1)).onClassicGroupStateTransition(STABLE, DEAD);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.coordinator.group.classic;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
@@ -39,8 +38,6 @@ import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
 import org.apache.kafka.coordinator.group.OffsetAndMetadata;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
-import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +67,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class ClassicGroupTest {
     private final String protocolType = "consumer";
@@ -81,17 +77,12 @@ public class ClassicGroupTest {
     private final int rebalanceTimeoutMs = 60000;
     private final int sessionTimeoutMs = 10000;
     private final LogContext logContext = new LogContext();
-    private final GroupCoordinatorMetricsShard metrics = new GroupCoordinatorMetricsShard(
-        new SnapshotRegistry(logContext),
-        Collections.emptyMap(),
-        new TopicPartition("__consumer_offsets", 0)
-    );
 
     private ClassicGroup group = null;
 
     @BeforeEach
     public void initialize() {
-        group = new ClassicGroup(logContext, "groupId", EMPTY, Time.SYSTEM, metrics);
+        group = new ClassicGroup(logContext, "groupId", EMPTY, Time.SYSTEM);
     }
 
     @Test
@@ -1122,7 +1113,7 @@ public class ClassicGroupTest {
         OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(15000L, OptionalInt.empty(), "", commitTimestamp, OptionalLong.empty());
         MockTime time = new MockTime();
         long currentStateTimestamp = time.milliseconds();
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, time, mock(GroupCoordinatorMetricsShard.class));
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, time);
 
         // 1. Test no protocol type. Simple consumer case, Base timestamp based off of last commit timestamp.
         Optional<OffsetExpirationCondition> offsetExpirationCondition = group.offsetExpirationCondition();
@@ -1197,7 +1188,7 @@ public class ClassicGroupTest {
 
     @Test
     public void testIsSubscribedToTopic() {
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, mock(GroupCoordinatorMetricsShard.class));
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM);
 
         // 1. group has no protocol type => not subscribed
         assertFalse(group.isSubscribedToTopic("topic"));
@@ -1261,7 +1252,7 @@ public class ClassicGroupTest {
 
     @Test
     public void testIsInStates() {
-        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM, mock(GroupCoordinatorMetricsShard.class));
+        ClassicGroup group = new ClassicGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM);
         assertTrue(group.isInStates(Collections.singleton("empty"), 0));
 
         group.transitionTo(PREPARING_REBALANCE);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -20,9 +20,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.coordinator.group.classic.ClassicGroup;
-import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -34,13 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.stream.IntStream;
 
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.EMPTY;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.PREPARING_REBALANCE;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.STABLE;
 import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.assertGaugeValue;
-import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.metricName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GroupCoordinatorMetricsShardTest {
@@ -96,59 +87,6 @@ public class GroupCoordinatorMetricsShardTest {
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD));
-    }
-
-    @Test
-    public void testGenericGroupStateTransitionMetrics() {
-        MetricsRegistry registry = new MetricsRegistry();
-        Metrics metrics = new Metrics();
-        TopicPartition tp = new TopicPartition("__consumer_offsets", 0);
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
-        GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(new SnapshotRegistry(new LogContext()), tp);
-        coordinatorMetrics.activateMetricsShard(shard);
-
-        LogContext logContext = new LogContext();
-        ClassicGroup group0 = new ClassicGroup(logContext, "groupId0", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group1 = new ClassicGroup(logContext, "groupId1", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group2 = new ClassicGroup(logContext, "groupId2", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group3 = new ClassicGroup(logContext, "groupId3", EMPTY, Time.SYSTEM, shard);
-
-        IntStream.range(0, 4).forEach(__ -> shard.incrementNumClassicGroups(EMPTY));
-
-        assertEquals(4, shard.numClassicGroups());
-
-        group0.transitionTo(PREPARING_REBALANCE);
-        group0.transitionTo(COMPLETING_REBALANCE);
-        group1.transitionTo(PREPARING_REBALANCE);
-        group2.transitionTo(DEAD);
-
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.EMPTY));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.PREPARING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.COMPLETING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.DEAD));
-        assertEquals(0, shard.numClassicGroups(ClassicGroupState.STABLE));
-
-        group0.transitionTo(STABLE);
-        group1.transitionTo(COMPLETING_REBALANCE);
-        group3.transitionTo(DEAD);
-
-        assertEquals(0, shard.numClassicGroups(ClassicGroupState.EMPTY));
-        assertEquals(0, shard.numClassicGroups(ClassicGroupState.PREPARING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.COMPLETING_REBALANCE));
-        assertEquals(2, shard.numClassicGroups(ClassicGroupState.DEAD));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.STABLE));
-
-        assertGaugeValue(
-            metrics,
-            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("protocol", "classic")),
-            4
-        );
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsEmpty"), 0);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsPreparingRebalance"), 0);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsCompletingRebalance"), 1);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsDead"), 2);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsStable"), 1);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -20,14 +20,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.coordinator.group.Group;
-import org.apache.kafka.coordinator.group.classic.ClassicGroup;
-import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.timeline.SnapshotRegistry;
-import org.apache.kafka.timeline.TimelineHashMap;
 
 import com.yammer.metrics.core.MetricsRegistry;
 
@@ -36,13 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.stream.IntStream;
 
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.EMPTY;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.PREPARING_REBALANCE;
-import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.STABLE;
 import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.assertGaugeValue;
-import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.metricName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GroupCoordinatorMetricsShardTest {
@@ -98,67 +87,6 @@ public class GroupCoordinatorMetricsShardTest {
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
         assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD));
-    }
-
-    @Test
-    public void testUpdateClassicGroupGauges() {
-        MetricsRegistry registry = new MetricsRegistry();
-        Metrics metrics = new Metrics();
-        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        TopicPartition tp = new TopicPartition("__consumer_offsets", 0);
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
-        GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(new SnapshotRegistry(new LogContext()), tp);
-        coordinatorMetrics.activateMetricsShard(shard);
-
-        LogContext logContext = new LogContext();
-        TimelineHashMap<String, Group> groups = new TimelineHashMap<>(snapshotRegistry, 5);
-        groups.put("group-0", new ConsumerGroup(snapshotRegistry, "group-0", shard));
-        ClassicGroup group1 = new ClassicGroup(logContext, "group-1", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group2 = new ClassicGroup(logContext, "group-2", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group3 = new ClassicGroup(logContext, "group-3", EMPTY, Time.SYSTEM, shard);
-        ClassicGroup group4 = new ClassicGroup(logContext, "group-4", EMPTY, Time.SYSTEM, shard);
-        groups.put(group1.groupId(), group1);
-        groups.put(group2.groupId(), group2);
-        groups.put(group3.groupId(), group3);
-        groups.put(group4.groupId(), group4);
-
-        shard.updateClassicGroupGauges(groups);
-        assertEquals(4, shard.numClassicGroups());
-
-        group1.transitionTo(PREPARING_REBALANCE);
-        group1.transitionTo(COMPLETING_REBALANCE);
-        group2.transitionTo(PREPARING_REBALANCE);
-        group3.transitionTo(DEAD);
-
-        shard.updateClassicGroupGauges(groups);
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.EMPTY));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.PREPARING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.COMPLETING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.DEAD));
-        assertEquals(0, shard.numClassicGroups(STABLE));
-
-        group1.transitionTo(STABLE);
-        group2.transitionTo(COMPLETING_REBALANCE);
-        group4.transitionTo(DEAD);
-
-        shard.updateClassicGroupGauges(groups);
-        assertEquals(0, shard.numClassicGroups(ClassicGroupState.EMPTY));
-        assertEquals(0, shard.numClassicGroups(ClassicGroupState.PREPARING_REBALANCE));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.COMPLETING_REBALANCE));
-        assertEquals(2, shard.numClassicGroups(ClassicGroupState.DEAD));
-        assertEquals(1, shard.numClassicGroups(ClassicGroupState.STABLE));
-
-        assertGaugeValue(
-            metrics,
-            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("protocol", "classic")),
-            4
-        );
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsEmpty"), 0);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsPreparingRebalance"), 0);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsCompletingRebalance"), 1);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsDead"), 2);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsStable"), 1);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -27,10 +27,10 @@ import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.timeline.SnapshotRegistry;
+import org.apache.kafka.timeline.TimelineHashMap;
 
 import com.yammer.metrics.core.MetricsRegistry;
 
-import org.apache.kafka.timeline.TimelineHashMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME;
@@ -168,18 +167,17 @@ public class GroupCoordinatorMetricsTest {
         coordinatorMetrics.activateMetricsShard(shard1);
 
         shard0.setClassicGroupGauges(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.STABLE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.EMPTY, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.DEAD, new AtomicLong(0))
+            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, 1L),
+            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
+            Utils.mkEntry(ClassicGroupState.STABLE, 1L),
+            Utils.mkEntry(ClassicGroupState.EMPTY, 1L)
         ));
         shard1.setClassicGroupGauges(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.STABLE, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.EMPTY, new AtomicLong(1)),
-            Utils.mkEntry(ClassicGroupState.DEAD, new AtomicLong(1))
+            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, 1L),
+            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
+            Utils.mkEntry(ClassicGroupState.STABLE, 1L),
+            Utils.mkEntry(ClassicGroupState.EMPTY, 1L),
+            Utils.mkEntry(ClassicGroupState.DEAD, 1L)
         ));
 
         IntStream.range(0, 5).forEach(__ -> shard0.incrementNumConsumerGroups(ConsumerGroupState.ASSIGNING));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.Group;
-import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -165,12 +164,6 @@ public class GroupCoordinatorMetricsTest {
         coordinatorMetrics.activateMetricsShard(shard0);
         coordinatorMetrics.activateMetricsShard(shard1);
 
-        IntStream.range(0, 5).forEach(__ -> shard0.incrementNumClassicGroups(ClassicGroupState.PREPARING_REBALANCE));
-        IntStream.range(0, 1).forEach(__ -> shard0.decrementNumClassicGroups(ClassicGroupState.COMPLETING_REBALANCE));
-        IntStream.range(0, 5).forEach(__ -> shard1.incrementNumClassicGroups(ClassicGroupState.STABLE));
-        IntStream.range(0, 4).forEach(__ -> shard1.incrementNumClassicGroups(ClassicGroupState.DEAD));
-        IntStream.range(0, 4).forEach(__ -> shard1.decrementNumClassicGroups(ClassicGroupState.EMPTY));
-
         IntStream.range(0, 5).forEach(__ -> shard0.incrementNumConsumerGroups(ConsumerGroupState.ASSIGNING));
         IntStream.range(0, 5).forEach(__ -> shard1.incrementNumConsumerGroups(ConsumerGroupState.RECONCILING));
         IntStream.range(0, 3).forEach(__ -> shard1.decrementNumConsumerGroups(ConsumerGroupState.DEAD));
@@ -182,15 +175,6 @@ public class GroupCoordinatorMetricsTest {
         IntStream.range(0, 5).forEach(__ -> shard0.incrementNumShareGroups(ShareGroup.ShareGroupState.STABLE));
         IntStream.range(0, 5).forEach(__ -> shard1.incrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY));
         IntStream.range(0, 3).forEach(__ -> shard1.decrementNumShareGroups(ShareGroup.ShareGroupState.DEAD));
-
-        assertEquals(4, shard0.numClassicGroups());
-        assertEquals(5, shard1.numClassicGroups());
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
-        assertGaugeValue(
-            metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("protocol", "classic")),
-            9
-        );
 
         snapshotRegistry0.idempotentCreateSnapshot(1000);
         snapshotRegistry1.idempotentCreateSnapshot(1500);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -28,10 +28,10 @@ import org.apache.kafka.coordinator.group.classic.ClassicGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.timeline.SnapshotRegistry;
+import org.apache.kafka.timeline.TimelineHashMap;
 
 import com.yammer.metrics.core.MetricsRegistry;
 
-import org.apache.kafka.timeline.TimelineHashMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;


### PR DESCRIPTION
In the existing implementation, If an operation modifying the classic group state fails, the group reverts but the group size counter does not. This creates an inconsistency between the group size metric and the actual group size.

Considering that It will be complicated to rely on the `appendFuture` to revert the metrics upon the operation failure, this PR introduces a new implementation. A timeout task will periodically refresh the metrics based on the current `groups` soft state. The refreshing interval is hardcoded to 60 seconds. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
