### PR TITLE
KAFKA-4566: multiple changes $(dirname "$0.. to $(dirname "$(readlink -f "$0..

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"

--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -20,7 +20,7 @@ then
         exit 1
 fi
 
-base_dir=$(dirname $0)
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"
+exec "$base_dir"/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"

--- a/bin/connect-mirror-maker.sh
+++ b/bin/connect-mirror-maker.sh
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.mirror.MirrorMaker "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.mirror.MirrorMaker "$@"

--- a/bin/connect-mirror-maker.sh
+++ b/bin/connect-mirror-maker.sh
@@ -20,7 +20,7 @@ then
         exit 1
 fi
 
-base_dir=$(dirname $0)
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.mirror.MirrorMaker "$@"
+exec "$base_dir"/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.mirror.MirrorMaker "$@"

--- a/bin/connect-plugin-path.sh
+++ b/bin/connect-plugin-path.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
   export KAFKA_HEAP_OPTS="-Xms256M -Xmx2G"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ConnectPluginPath "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ConnectPluginPath "$@"

--- a/bin/connect-plugin-path.sh
+++ b/bin/connect-plugin-path.sh
@@ -18,4 +18,4 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
   export KAFKA_HEAP_OPTS="-Xms256M -Xmx2G"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ConnectPluginPath "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ConnectPluginPath "$@"

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -20,7 +20,7 @@ then
         exit 1
 fi
 
-base_dir=$(dirname $0)
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
@@ -42,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"
+exec "$base_dir"/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"

--- a/bin/kafka-acls.sh
+++ b/bin/kafka-acls.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.AclCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh kafka.admin.AclCommand "$@"

--- a/bin/kafka-acls.sh
+++ b/bin/kafka-acls.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.AclCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.AclCommand "$@"

--- a/bin/kafka-broker-api-versions.sh
+++ b/bin/kafka-broker-api-versions.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.BrokerApiVersionsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.BrokerApiVersionsCommand "$@"

--- a/bin/kafka-broker-api-versions.sh
+++ b/bin/kafka-broker-api-versions.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.BrokerApiVersionsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.BrokerApiVersionsCommand "$@"

--- a/bin/kafka-client-metrics.sh
+++ b/bin/kafka-client-metrics.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ClientMetricsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ClientMetricsCommand "$@"

--- a/bin/kafka-client-metrics.sh
+++ b/bin/kafka-client-metrics.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ClientMetricsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ClientMetricsCommand "$@"

--- a/bin/kafka-cluster.sh
+++ b/bin/kafka-cluster.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ClusterTool "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ClusterTool "$@"

--- a/bin/kafka-cluster.sh
+++ b/bin/kafka-cluster.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ClusterTool "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ClusterTool "$@"

--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConfigCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.ConfigCommand "$@"

--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.ConfigCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh kafka.admin.ConfigCommand "$@"

--- a/bin/kafka-console-consumer.sh
+++ b/bin/kafka-console-consumer.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleConsumer "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleConsumer "$@"

--- a/bin/kafka-console-consumer.sh
+++ b/bin/kafka-console-consumer.sh
@@ -18,4 +18,4 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleConsumer "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleConsumer "$@"

--- a/bin/kafka-console-producer.sh
+++ b/bin/kafka-console-producer.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"
+exec "$base_dir"/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"

--- a/bin/kafka-console-producer.sh
+++ b/bin/kafka-console-producer.sh
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"
+
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"

--- a/bin/kafka-console-share-consumer.sh
+++ b/bin/kafka-console-share-consumer.sh
@@ -18,4 +18,4 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleShareConsumer "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleShareConsumer "$@"

--- a/bin/kafka-console-share-consumer.sh
+++ b/bin/kafka-console-share-consumer.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleShareConsumer "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleShareConsumer "$@"

--- a/bin/kafka-consumer-groups.sh
+++ b/bin/kafka-consumer-groups.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ConsumerGroupCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ConsumerGroupCommand "$@"

--- a/bin/kafka-consumer-groups.sh
+++ b/bin/kafka-consumer-groups.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ConsumerGroupCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ConsumerGroupCommand "$@"

--- a/bin/kafka-consumer-perf-test.sh
+++ b/bin/kafka-consumer-perf-test.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ConsumerPerformance "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ConsumerPerformance "$@"

--- a/bin/kafka-consumer-perf-test.sh
+++ b/bin/kafka-consumer-perf-test.sh
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ConsumerPerformance "$@"
+
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ConsumerPerformance "$@"

--- a/bin/kafka-delegation-tokens.sh
+++ b/bin/kafka-delegation-tokens.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.DelegationTokenCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.DelegationTokenCommand "$@"

--- a/bin/kafka-delegation-tokens.sh
+++ b/bin/kafka-delegation-tokens.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.DelegationTokenCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.DelegationTokenCommand "$@"

--- a/bin/kafka-delete-records.sh
+++ b/bin/kafka-delete-records.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.DeleteRecordsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.DeleteRecordsCommand "$@"

--- a/bin/kafka-delete-records.sh
+++ b/bin/kafka-delete-records.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.DeleteRecordsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.DeleteRecordsCommand "$@"

--- a/bin/kafka-dump-log.sh
+++ b/bin/kafka-dump-log.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"

--- a/bin/kafka-dump-log.sh
+++ b/bin/kafka-dump-log.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"

--- a/bin/kafka-e2e-latency.sh
+++ b/bin/kafka-e2e-latency.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.EndToEndLatency "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.EndToEndLatency "$@"

--- a/bin/kafka-e2e-latency.sh
+++ b/bin/kafka-e2e-latency.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.EndToEndLatency "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.EndToEndLatency "$@"

--- a/bin/kafka-features.sh
+++ b/bin/kafka-features.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.FeatureCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.FeatureCommand "$@"

--- a/bin/kafka-features.sh
+++ b/bin/kafka-features.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.FeatureCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.FeatureCommand "$@"

--- a/bin/kafka-get-offsets.sh
+++ b/bin/kafka-get-offsets.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.GetOffsetShell "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.GetOffsetShell "$@"

--- a/bin/kafka-get-offsets.sh
+++ b/bin/kafka-get-offsets.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.GetOffsetShell "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.GetOffsetShell "$@"

--- a/bin/kafka-jmx.sh
+++ b/bin/kafka-jmx.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.JmxTool "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.JmxTool "$@"

--- a/bin/kafka-jmx.sh
+++ b/bin/kafka-jmx.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.JmxTool "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.JmxTool "$@"

--- a/bin/kafka-leader-election.sh
+++ b/bin/kafka-leader-election.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.LeaderElectionCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.LeaderElectionCommand "$@"

--- a/bin/kafka-leader-election.sh
+++ b/bin/kafka-leader-election.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.LeaderElectionCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.LeaderElectionCommand "$@"

--- a/bin/kafka-log-dirs.sh
+++ b/bin/kafka-log-dirs.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.LogDirsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.LogDirsCommand "$@"

--- a/bin/kafka-log-dirs.sh
+++ b/bin/kafka-log-dirs.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.LogDirsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.LogDirsCommand "$@"

--- a/bin/kafka-metadata-quorum.sh
+++ b/bin/kafka-metadata-quorum.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.MetadataQuorumCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.MetadataQuorumCommand "$@"

--- a/bin/kafka-metadata-quorum.sh
+++ b/bin/kafka-metadata-quorum.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.MetadataQuorumCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.MetadataQuorumCommand "$@"

--- a/bin/kafka-metadata-shell.sh
+++ b/bin/kafka-metadata-shell.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.shell.MetadataShell "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.shell.MetadataShell "$@"

--- a/bin/kafka-metadata-shell.sh
+++ b/bin/kafka-metadata-shell.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.shell.MetadataShell "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.shell.MetadataShell "$@"

--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"

--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"
+
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"

--- a/bin/kafka-reassign-partitions.sh
+++ b/bin/kafka-reassign-partitions.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.reassign.ReassignPartitionsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.reassign.ReassignPartitionsCommand "$@"

--- a/bin/kafka-reassign-partitions.sh
+++ b/bin/kafka-reassign-partitions.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.reassign.ReassignPartitionsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.reassign.ReassignPartitionsCommand "$@"

--- a/bin/kafka-replica-verification.sh
+++ b/bin/kafka-replica-verification.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ReplicaVerificationTool "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ReplicaVerificationTool "$@"

--- a/bin/kafka-replica-verification.sh
+++ b/bin/kafka-replica-verification.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.ReplicaVerificationTool "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.ReplicaVerificationTool "$@"

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -46,7 +46,7 @@ should_include_file() {
   fi
 }
 
-base_dir=$(dirname $0)/..
+base_dir=$(dirname "$(readlink -f "$0")")/..
 
 if [ -z "$SCALA_VERSION" ]; then
   SCALA_VERSION=2.13.15
@@ -76,9 +76,9 @@ do
 done
 
 if [ -z "$UPGRADE_KAFKA_STREAMS_TEST_VERSION" ]; then
-  clients_lib_dir=$(dirname $0)/../clients/build/libs
-  streams_lib_dir=$(dirname $0)/../streams/build/libs
-  streams_dependant_clients_lib_dir=$(dirname $0)/../streams/build/dependant-libs-${SCALA_VERSION}
+  clients_lib_dir="$base_dir"/clients/build/libs
+  streams_lib_dir="$base_dir"/streams/build/libs
+  streams_dependant_clients_lib_dir="$base_dir"/streams/build/dependant-libs-${SCALA_VERSION}
 else
   clients_lib_dir=/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs
   streams_lib_dir=$clients_lib_dir
@@ -344,7 +344,7 @@ CLASSPATH=${CLASSPATH#:}
 # It expects the Kafka executable binary to be present at $base_dir/kafka.Kafka.
 # This is specifically used to run system tests on native Kafka - by bringing up Kafka in the native mode.
 if [[ "x$KAFKA_MODE" == "xnative" ]] && [[ "$*" == *"kafka.Kafka"* ]]; then
-  exec $base_dir/kafka.Kafka start --config "$2"  $KAFKA_LOG4J_CMD_OPTS $KAFKA_JMX_OPTS $KAFKA_OPTS
+  exec "$base_dir"/kafka.Kafka start --config "$2"  $KAFKA_LOG4J_CMD_OPTS $KAFKA_JMX_OPTS $KAFKA_OPTS
 else
   # Launch mode
   if [ "x$DAEMON_MODE" = "xtrue" ]; then

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -19,7 +19,8 @@ then
 	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
 	exit 1
 fi
-base_dir=$(dirname $0)
+
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
@@ -41,4 +42,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"
+exec "$base_dir"/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -41,4 +41,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"

--- a/bin/kafka-share-groups.sh
+++ b/bin/kafka-share-groups.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ShareGroupCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ShareGroupCommand "$@"

--- a/bin/kafka-share-groups.sh
+++ b/bin/kafka-share-groups.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ShareGroupCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.consumer.group.ShareGroupCommand "$@"

--- a/bin/kafka-storage.sh
+++ b/bin/kafka-storage.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.StorageTool "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh kafka.tools.StorageTool "$@"

--- a/bin/kafka-storage.sh
+++ b/bin/kafka-storage.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.StorageTool "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.tools.StorageTool "$@"

--- a/bin/kafka-streams-application-reset.sh
+++ b/bin/kafka-streams-application-reset.sh
@@ -18,4 +18,4 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.StreamsResetter "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.StreamsResetter "$@"

--- a/bin/kafka-streams-application-reset.sh
+++ b/bin/kafka-streams-application-reset.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.StreamsResetter "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.StreamsResetter "$@"

--- a/bin/kafka-topics.sh
+++ b/bin/kafka-topics.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.TopicCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.TopicCommand "$@"

--- a/bin/kafka-topics.sh
+++ b/bin/kafka-topics.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.TopicCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.TopicCommand "$@"

--- a/bin/kafka-transactions.sh
+++ b/bin/kafka-transactions.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.TransactionsCommand "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.TransactionsCommand "$@"

--- a/bin/kafka-transactions.sh
+++ b/bin/kafka-transactions.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.TransactionsCommand "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.TransactionsCommand "$@"

--- a/bin/kafka-verifiable-consumer.sh
+++ b/bin/kafka-verifiable-consumer.sh
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"
+
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"

--- a/bin/kafka-verifiable-consumer.sh
+++ b/bin/kafka-verifiable-consumer.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"

--- a/bin/kafka-verifiable-producer.sh
+++ b/bin/kafka-verifiable-producer.sh
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"
+
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"

--- a/bin/kafka-verifiable-producer.sh
+++ b/bin/kafka-verifiable-producer.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_dir=$(dirname "$(readlink -f "$0")")
+
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"
+exec "$base_dir"/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"

--- a/bin/trogdor.sh
+++ b/bin/trogdor.sh
@@ -47,4 +47,4 @@ case ${action} in
 esac
 
 export INCLUDE_TEST_JARS=1
-exec $(dirname $0)/kafka-run-class.sh "${CLASS}" "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh "${CLASS}" "$@"

--- a/bin/zookeeper-security-migration.sh
+++ b/bin/zookeeper-security-migration.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"

--- a/bin/zookeeper-security-migration.sh
+++ b/bin/zookeeper-security-migration.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"

--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -41,4 +41,4 @@ case $COMMAND in
      ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"

--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -19,7 +19,8 @@ then
 	echo "USAGE: $0 [-daemon] zookeeper.properties"
 	exit 1
 fi
-base_dir=$(dirname $0)
+
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
@@ -41,4 +42,4 @@ case $COMMAND in
      ;;
 esac
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"
+exec "$base_dir"/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -20,4 +20,6 @@ then
 	exit 1
 fi
 
-exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"
+base_dir=$(dirname "$(readlink -f "$0")")
+
+exec "$base_dir"/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -20,4 +20,4 @@ then
 	exit 1
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"
+exec $(dirname "$(readlink -f "$0")")/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"

--- a/examples/bin/exactly-once-demo.sh
+++ b/examples/bin/exactly-once-demo.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-base_dir=$(dirname $0)/../..
+base_dir=$(dirname "$(readlink -f "$0")")/../..
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $base_dir/bin/kafka-run-class.sh kafka.examples.KafkaExactlyOnceDemo $@
+exec "$base_dir"/bin/kafka-run-class.sh kafka.examples.KafkaExactlyOnceDemo $@

--- a/examples/bin/java-producer-consumer-demo.sh
+++ b/examples/bin/java-producer-consumer-demo.sh
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-base_dir=$(dirname $0)/../..
+base_dir=$(dirname "$(readlink -f "$0")")/../..
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $base_dir/bin/kafka-run-class.sh kafka.examples.KafkaConsumerProducerDemo $@
+
+exec "$base_dir"/bin/kafka-run-class.sh kafka.examples.KafkaConsumerProducerDemo $@

--- a/jmh-benchmarks/jmh.sh
+++ b/jmh-benchmarks/jmh.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-base_dir=$(dirname $0)
+base_dir=$(dirname "$(readlink -f "$0")")
 jmh_project_name="jmh-benchmarks"
 
-if [ ${base_dir} == "." ]; then
+if [ "$base_dir" == "." ]; then
      gradlew_dir=".."
-elif [ ${base_dir##./} == "${jmh_project_name}" ]; then
+elif [ "${base_dir##./}" == "${jmh_project_name}" ]; then
      gradlew_dir="."
 else
     echo "JMH Benchmarks need to be run from the root of the kafka repository or the 'jmh-benchmarks' directory"
@@ -27,7 +27,7 @@ else
 fi
 
 gradleCmd="${gradlew_dir}/gradlew"
-libDir="${base_dir}/build/libs"
+libDir="$base_dir/build/libs"
 
 echo "running gradlew :jmh-benchmarks:clean :jmh-benchmarks:shadowJar"
 

--- a/raft/bin/test-kraft-server-start.sh
+++ b/raft/bin/test-kraft-server-start.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-base_dir=$(dirname $0)
+base_dir=$(dirname "$(readlink -f "$0")")
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/kraft-log4j.properties"
@@ -36,4 +36,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $base_dir/../../bin/kafka-run-class.sh $EXTRA_ARGS kafka.tools.TestRaftServer "$@"
+exec "$base_dir"/../../bin/kafka-run-class.sh $EXTRA_ARGS kafka.tools.TestRaftServer "$@"

--- a/tests/bootstrap-test-env.sh
+++ b/tests/bootstrap-test-env.sh
@@ -20,7 +20,7 @@ export GREP_OPTIONS='--color=never'
 # Helper function which prints version numbers so they can be compared lexically or numerically
 function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
-base_dir=`dirname $0`/..
+base_dir=$(dirname "$(readlink -f "$0")")/..
 cd $base_dir
 
 echo "Checking Virtual Box installation..."

--- a/vagrant/aws/aws-init.sh
+++ b/vagrant/aws/aws-init.sh
@@ -55,7 +55,7 @@ done
 
 # Create Vagrantfile.local as a convenience
 if [ ! -e "$base_dir/Vagrantfile.local" ]; then
-    cp $base_dir/vagrant/aws/aws-example-Vagrantfile.local $base_dir/Vagrantfile.local
+    cp "$base_dir"/vagrant/aws/aws-example-Vagrantfile.local "$base_dir"/Vagrantfile.local
 fi
 
 gradle="gradle-2.2.1"


### PR DESCRIPTION
This PR allows people to symlink to e.g. /opt/kafka/bin/kafka-console-consumer.sh and when they execute the script it does not fail due to exec $(dirname $0.. when the directory of the symlink is not the same i.e. the symlink is in a separate directory so that binaries don't have to be cloned when a separate directory is used for e.g. configuration. This was raised as a bug in 2016 and was never fixed since the original proposal was not platform agnostic (MacOS vs Linux) and further proposals were heavy-handed. However, "readlink -f" is platform portable (across MacOS and Linux i.e. official docker container) and neatly solves the problem with symlinking to /opt/kafka/bin scripts.
This is my original work and I license this work to the project under the project's open source license.