### PR TITLE
KAFKA-17656: Replace string concatenation with parameterized logging for PartitionChangeBuilder

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -297,14 +297,13 @@ public class PartitionChangeBuilder {
 
     private boolean canElectLastKnownLeader() {
         if (!eligibleLeaderReplicasEnabled || !useLastKnownLeaderInBalancedRecovery) {
-            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
-                " but elrEnabled=" + eligibleLeaderReplicasEnabled + ", useLastKnownLeaderInBalancedRecovery=" +
-                useLastKnownLeaderInBalancedRecovery);
+            log.trace("Try to elect last known leader for {}-{} but elrEnabled={}, useLastKnownLeaderInBalancedRecovery={}",
+                    topicId, partitionId, eligibleLeaderReplicasEnabled, useLastKnownLeaderInBalancedRecovery);
             return false;
         }
         if (!targetElr.isEmpty() || !targetIsr.isEmpty()) {
-            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
-                " but ELR/ISR is not empty. ISR=" + targetIsr + ", ELR=" + targetElr);
+            log.trace("Try to elect last known leader for {}-{} but ELR/ISR is not empty. ISR={}, ELR={}",
+                    topicId, partitionId, targetIsr, targetElr);
             return false;
         }
 
@@ -316,14 +315,13 @@ public class PartitionChangeBuilder {
         //    in the field even if useLastKnownLeaderInBalancedRecovery is set to true again. In this case, we can't
         //    refer to the lastKnownElr.
         if (partition.lastKnownElr.length != 1) {
-            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
-                " but lastKnownElr does not only have 1 member. lastKnownElr=" +
-                Arrays.toString(partition.lastKnownElr));
+            log.trace("Try to elect last known leader for {}-{} but lastKnownElr does not only have 1 member. lastKnownElr={}",
+                    topicId, partitionId, Arrays.toString(partition.lastKnownElr));
             return false;
         }
         if (isAcceptableLeader.test(partition.lastKnownElr[0])) {
-            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
-                " but last known leader is not alive. last known leader=" + partition.lastKnownElr[0]);
+            log.trace("Try to elect last known leader for {}-{} but last known leader is not alive. last known leader={}",
+                    topicId, partitionId, partition.lastKnownElr[0]);
         }
         return true;
     }
@@ -463,7 +461,7 @@ public class PartitionChangeBuilder {
             !targetIsr.equals(Replicas.toList(partition.isr))) {
             // Set the new ISR if it is different from the current ISR and unclean leader election didn't already set it.
             if (targetIsr.isEmpty()) {
-                log.debug("A partition will have an empty ISR. " + this);
+                log.debug("A partition will have an empty ISR. {}", this);
             }
             record.setIsr(targetIsr);
         }


### PR DESCRIPTION
Replace string concatenation with parameterized logging to defer evaluation when it actually needed for better performance and readibility.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
