### PR TITLE
KAFKA-17428: Add retry mechanism for cleaning up dangling remote segments

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -956,7 +956,7 @@ public class RemoteLogManager implements Closeable {
             try {
                 customMetadata = remoteLogStorageManager.copyLogSegmentData(copySegmentStartedRlsm, segmentData);
             } catch (RemoteStorageException e) {
-                logger.error("Copy failed, cleaning segment {}", copySegmentStartedRlsm.remoteLogSegmentId());
+                logger.info("Copy failed, cleaning segment {}", copySegmentStartedRlsm.remoteLogSegmentId());
                 try {
                     deleteRemoteLogSegment(
                         copySegmentStartedRlsm,
@@ -981,7 +981,7 @@ public class RemoteLogManager implements Closeable {
                 long customMetadataSize = customMetadata.get().value().length;
                 if (customMetadataSize > this.customMetadataSizeLimit) {
                     CustomMetadataSizeLimitExceededException e = new CustomMetadataSizeLimitExceededException();
-                    logger.error("Custom metadata size {} exceeds configured limit {}." +
+                    logger.info("Custom metadata size {} exceeds configured limit {}." +
                                     " Copying will be stopped and copied segment will be attempted to clean." +
                                     " Original metadata: {}",
                             customMetadataSize, this.customMetadataSizeLimit, copySegmentStartedRlsm, e);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1257,8 +1257,8 @@ public class RemoteLogManager implements Closeable {
                         canProcess = false;
                         continue;
                     }
-                    // This works as retry mechanism for failed deletion remote segments. Rather than waiting for the 
-                    // retention to kick in, we cleanup early to avoid polluting the cache and possibly waste remote storage.
+                    // This works as retry mechanism for dangling remote segments that failed the deletion in previous attempts.
+                    // Rather than waiting for the retention to kick in, we cleanup early to avoid polluting the cache and possibly waste remote storage.
                     if (RemoteLogSegmentState.DELETE_SEGMENT_STARTED.equals(metadata.state())) {
                         segmentsToDelete.add(metadata);
                         continue;
@@ -1392,8 +1392,8 @@ public class RemoteLogManager implements Closeable {
                     while (segmentsIterator.hasNext()) {
                         RemoteLogSegmentMetadata segmentMetadata = segmentsIterator.next();
                         // Count only the size of segments in "COPY_SEGMENT_FINISHED" state because 
-                        // "COPY_SEGMENT_STARTED" means copy didn't complete and we will count them later, 
-                        // "DELETE_SEGMENT_STARTED" means deletion failed and we will retry later,
+                        // "COPY_SEGMENT_STARTED" means copy didn't complete and we will count them later,
+                        // "DELETE_SEGMENT_STARTED" means deletion failed in the previous attempt and we will retry later,
                         // "DELETE_SEGMENT_FINISHED" means deletion completed, so there is nothing to count.
                         if (segmentMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
                             RemoteLogSegmentId segmentId = segmentMetadata.remoteLogSegmentId();

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -952,14 +952,24 @@ public class RemoteLogManager implements Closeable {
             brokerTopicStats.topicStats(log.topicPartition().topic()).remoteCopyRequestRate().mark();
             brokerTopicStats.allTopicsStats().remoteCopyRequestRate().mark();
             Optional<CustomMetadata> customMetadata = Optional.empty();
+            
             try {
                 customMetadata = remoteLogStorageManager.copyLogSegmentData(copySegmentStartedRlsm, segmentData);
             } catch (RemoteStorageException e) {
+                logger.warn("Cleaning after failing to copy segment {}", copySegmentStartedRlsm.remoteLogSegmentId());
                 try {
-                    remoteLogStorageManager.deleteLogSegmentData(copySegmentStartedRlsm);
-                    logger.info("Successfully cleaned segment {} after failing to copy segment", segmentId);
+                    deleteRemoteLogSegment(
+                        copySegmentStartedRlsm,
+                        ignored -> !isCancelled(),
+                        remoteLogMetadataManager,
+                        remoteLogStorageManager,
+                        brokerTopicStats,
+                        time,
+                        brokerId
+                    );
+                    LOGGER.info("Successfully cleaned dangling segment {}", copySegmentStartedRlsm.remoteLogSegmentId());
                 } catch (RemoteStorageException e1) {
-                    logger.error("Error while cleaning segment {}, consider cleaning manually", segmentId, e1);
+                    LOGGER.warn("Error while cleaning dangling segment {}: {}", copySegmentStartedRlsm.remoteLogSegmentId(), e1.getMessage());
                 }
                 throw e;
             }
@@ -1038,7 +1048,6 @@ public class RemoteLogManager implements Closeable {
 
         @Override
         protected void execute(UnifiedLog log) throws InterruptedException, RemoteStorageException, ExecutionException {
-            // Cleanup/delete expired remote log segments
             cleanupExpiredRemoteLogSegments();
         }
 
@@ -1128,8 +1137,16 @@ public class RemoteLogManager implements Closeable {
             private boolean deleteLogSegmentsDueToLeaderEpochCacheTruncation(EpochEntry earliestEpochEntry,
                                                                              RemoteLogSegmentMetadata metadata)
                     throws RemoteStorageException, ExecutionException, InterruptedException {
-                boolean isSegmentDeleted = deleteRemoteLogSegment(metadata, ignored ->
-                        metadata.segmentLeaderEpochs().keySet().stream().allMatch(epoch -> epoch < earliestEpochEntry.epoch));
+                boolean isSegmentDeleted = deleteRemoteLogSegment(
+                    metadata, 
+                    ignored -> metadata.segmentLeaderEpochs().keySet()
+                        .stream().allMatch(epoch -> epoch < earliestEpochEntry.epoch),
+                    remoteLogMetadataManager,
+                    remoteLogStorageManager,
+                    brokerTopicStats,
+                    time,
+                    brokerId
+                );
                 if (isSegmentDeleted) {
                     logger.info("Deleted remote log segment {} due to leader-epoch-cache truncation. " +
                                     "Current earliest-epoch-entry: {}, segment-end-offset: {} and segment-epochs: {}",
@@ -1138,41 +1155,6 @@ public class RemoteLogManager implements Closeable {
                 // No need to update the log-start-offset as these epochs/offsets are earlier to that value.
                 return isSegmentDeleted;
             }
-
-            private boolean deleteRemoteLogSegment(RemoteLogSegmentMetadata segmentMetadata, Predicate<RemoteLogSegmentMetadata> predicate)
-                    throws RemoteStorageException, ExecutionException, InterruptedException {
-                if (predicate.test(segmentMetadata)) {
-                    logger.debug("Deleting remote log segment {}", segmentMetadata.remoteLogSegmentId());
-
-                    String topic = segmentMetadata.topicIdPartition().topic();
-
-                    // Publish delete segment started event.
-                    remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
-                            new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId)).get();
-
-                    brokerTopicStats.topicStats(topic).remoteDeleteRequestRate().mark();
-                    brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().mark();
-
-                    // Delete the segment in remote storage.
-                    try {
-                        remoteLogStorageManager.deleteLogSegmentData(segmentMetadata);
-                    } catch (RemoteStorageException e) {
-                        brokerTopicStats.topicStats(topic).failedRemoteDeleteRequestRate().mark();
-                        brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().mark();
-                        throw e;
-                    }
-
-                    // Publish delete segment finished event.
-                    remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
-                            new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId)).get();
-                    logger.debug("Deleted remote log segment {}", segmentMetadata.remoteLogSegmentId());
-                    return true;
-                }
-                return false;
-            }
-
         }
 
         private void updateMetadataCountAndLogSizeWith(int metadataCount, long remoteLogSizeBytes) {
@@ -1189,6 +1171,7 @@ public class RemoteLogManager implements Closeable {
             brokerTopicStats.recordRemoteDeleteLagBytes(topic, partition, sizeOfDeletableSegmentsBytes);
         }
 
+        /** Cleanup expired and dangling remote log segments. */
         void cleanupExpiredRemoteLogSegments() throws RemoteStorageException, ExecutionException, InterruptedException {
             if (isCancelled()) {
                 logger.info("Returning from remote log segments cleanup as the task state is changed");
@@ -1265,6 +1248,26 @@ public class RemoteLogManager implements Closeable {
                         canProcess = false;
                         continue;
                     }
+                    // This works as retry mechanism for dangling remote segments.
+                    // A dangling remote segment is one that failed the copy to remote storage and the following cleanup.
+                    // Rather than waiting for the retention to kick in, we cleanup early to avoid polluting the cache and possibly waste remote storage.
+                    if (RemoteLogSegmentState.DELETE_SEGMENT_STARTED.equals(metadata.state())) {
+                        LOGGER.info("Cleaning dangling segment {}", metadata.remoteLogSegmentId());
+                        try {
+                            deleteRemoteLogSegment(
+                                metadata,
+                                ignored -> !isCancelled(),
+                                remoteLogMetadataManager,
+                                remoteLogStorageManager,
+                                brokerTopicStats,
+                                time,
+                                brokerId
+                            );
+                            LOGGER.info("Successfully cleaned dangling segment {}", metadata.remoteLogSegmentId());
+                        } catch (RemoteStorageException e1) {
+                            LOGGER.warn("Error while cleaning dangling segment {}: {}", metadata.remoteLogSegmentId(), e1.getMessage());
+                        }
+                    }
                     if (RemoteLogSegmentState.DELETE_SEGMENT_FINISHED.equals(metadata.state())) {
                         continue;
                     }
@@ -1311,7 +1314,14 @@ public class RemoteLogManager implements Closeable {
             updateRemoteDeleteLagWith(segmentsLeftToDelete, sizeOfDeletableSegmentsBytes);
             List<String> undeletedSegments = new ArrayList<>();
             for (RemoteLogSegmentMetadata segmentMetadata : segmentsToDelete) {
-                if (!remoteLogRetentionHandler.deleteRemoteLogSegment(segmentMetadata, x -> !isCancelled())) {
+                if (!deleteRemoteLogSegment(
+                    segmentMetadata, x -> !isCancelled(),
+                    remoteLogMetadataManager,
+                    remoteLogStorageManager,
+                    brokerTopicStats,
+                    time,
+                    brokerId
+                )) {
                     undeletedSegments.add(segmentMetadata.remoteLogSegmentId().toString());
                 } else {
                     sizeOfDeletableSegmentsBytes -= segmentMetadata.segmentSizeInBytes();
@@ -1385,13 +1395,11 @@ public class RemoteLogManager implements Closeable {
                     Iterator<RemoteLogSegmentMetadata> segmentsIterator = remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition, epoch);
                     while (segmentsIterator.hasNext()) {
                         RemoteLogSegmentMetadata segmentMetadata = segmentsIterator.next();
-                        // Only count the size of "COPY_SEGMENT_FINISHED" and "DELETE_SEGMENT_STARTED" state segments
-                        // because "COPY_SEGMENT_STARTED" means copy didn't complete, and "DELETE_SEGMENT_FINISHED" means delete did complete.
-                        // Note: there might be some "COPY_SEGMENT_STARTED" segments not counted here.
-                        // Either they are being copied and will be counted next time or they are dangling and will be cleaned elsewhere,
-                        // either way, this won't cause more segment deletion.
-                        if (segmentMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED) ||
-                                segmentMetadata.state().equals(RemoteLogSegmentState.DELETE_SEGMENT_STARTED)) {
+                        // Count only the size of segments in "COPY_SEGMENT_FINISHED" state because 
+                        // "COPY_SEGMENT_STARTED" means copy didn't complete and we will count them later, 
+                        // "DELETE_SEGMENT_STARTED" means deletion failed and we will retry later,
+                        // "DELETE_SEGMENT_FINISHED" means deletion completed, so there is nothing to count.
+                        if (segmentMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
                             RemoteLogSegmentId segmentId = segmentMetadata.remoteLogSegmentId();
                             if (!visitedSegmentIds.contains(segmentId) && isRemoteSegmentWithinLeaderEpochs(segmentMetadata, logEndOffset, epochEntries)) {
                                 remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
@@ -1430,6 +1438,46 @@ public class RemoteLogManager implements Closeable {
             // are not deleted before they are copied to remote storage.
             log.updateHighestOffsetInRemoteStorage(offsetAndEpoch.offset());
         }
+    }
+    
+    private static boolean deleteRemoteLogSegment(
+        RemoteLogSegmentMetadata segmentMetadata,
+        Predicate<RemoteLogSegmentMetadata> predicate,
+        RemoteLogMetadataManager remoteLogMetadataManager,
+        RemoteStorageManager remoteLogStorageManager,
+        BrokerTopicStats brokerTopicStats,
+        Time time,
+        int brokerId
+    ) throws RemoteStorageException, ExecutionException, InterruptedException {
+        if (predicate.test(segmentMetadata)) {
+            LOGGER.debug("Deleting remote log segment {}", segmentMetadata.remoteLogSegmentId());
+            String topic = segmentMetadata.topicIdPartition().topic();
+
+            // Publish delete segment started event.
+            remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
+                new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
+                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId)).get();
+
+            brokerTopicStats.topicStats(topic).remoteDeleteRequestRate().mark();
+            brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().mark();
+
+            // Delete the segment in remote storage.
+            try {
+                remoteLogStorageManager.deleteLogSegmentData(segmentMetadata);
+            } catch (RemoteStorageException e) {
+                brokerTopicStats.topicStats(topic).failedRemoteDeleteRequestRate().mark();
+                brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().mark();
+                throw e;
+            }
+
+            // Publish delete segment finished event.
+            remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
+                new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
+                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId)).get();
+            LOGGER.debug("Deleted remote log segment {}", segmentMetadata.remoteLogSegmentId());
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -744,6 +744,7 @@ public class RemoteLogManagerTest {
         dummyFuture.complete(null);
         when(remoteLogMetadataManager.addRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadata.class))).thenReturn(dummyFuture);
         when(rlmCopyQuotaManager.getThrottleTimeMs()).thenReturn(quotaAvailableThrottleTime);
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class))).thenReturn(dummyFuture);
 
         // throw exception when copyLogSegmentData
         when(remoteStorageManager.copyLogSegmentData(any(RemoteLogSegmentMetadata.class), any(LogSegmentData.class)))
@@ -756,8 +757,8 @@ public class RemoteLogManagerTest {
         // verify the segment is deleted
         verify(remoteStorageManager, times(1)).deleteLogSegmentData(eq(remoteLogSegmentMetadataArg.getValue()));
 
-        // The metadata update should not be posted.
-        verify(remoteLogMetadataManager, never()).updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class));
+        // verify deletion state update
+        verify(remoteLogMetadataManager, times(2)).updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class));
 
         // Verify the metrics
         assertEquals(1, brokerTopicStats.topicStats(leaderTopicIdPartition.topic()).remoteCopyRequestRate().count());
@@ -2422,16 +2423,16 @@ public class RemoteLogManagerTest {
         when(mockLog.logEndOffset()).thenReturn(2000L);
 
         // creating remote log metadata list:
-        // s1. One segment with "COPY_SEGMENT_STARTED" state to simulate the segment was failing on copying to remote storage.
+        // s1. One segment with "COPY_SEGMENT_STARTED" state to simulate the segment was failing on copying to remote storage (dangling).
         //     it should be ignored for both remote log size calculation, but get deleted in the 1st run.
         // s2. One segment with "DELETE_SEGMENT_FINISHED" state to simulate the remoteLogMetadataManager doesn't filter it out and returned.
         //     We should filter it out when calculating remote storage log size and deletion
-        // s3. One segment with "DELETE_SEGMENT_STARTED" state to simulate the segment was failing on deleting remote log.
-        //     We should count it in when calculating remote storage log size.
+        // s3. One segment with "DELETE_SEGMENT_STARTED" state to simulate the segment was failing on deleting remote log (dangling).
+        //     We should NOT count it when calculating remote storage log size and we should retry deletion.
         // s4. Another segment with "COPY_SEGMENT_STARTED" state to simulate the segment is copying to remote storage.
         //     The segment state will change to "COPY_SEGMENT_FINISHED" state before checking deletion.
         //     In the 1st run, this segment should be skipped when calculating remote storage size.
-        //     In the 2nd run, we should count it in when calculating remote storage log size.
+        //     In the 2nd run, we should count it in when calculating remote storage size.
         // s5. 11 segments with "COPY_SEGMENT_FINISHED" state. These are expected to be counted in when calculating remote storage log size
         //
         // Expected results (retention.size is 10240 (10 segments)):
@@ -2469,7 +2470,7 @@ public class RemoteLogManagerTest {
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         task.cleanupExpiredRemoteLogSegments();
         verify(remoteStorageManager, times(2)).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
-        verify(remoteStorageManager).deleteLogSegmentData(s1);
+        verify(remoteStorageManager).deleteLogSegmentData(s1); 
         // make sure the s2 segment with "DELETE_SEGMENT_FINISHED" state is not invoking "deleteLogSegmentData"
         verify(remoteStorageManager, never()).deleteLogSegmentData(s2);
         verify(remoteStorageManager).deleteLogSegmentData(s3);

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2437,10 +2437,9 @@ public class RemoteLogManagerTest {
         // s5. 11 segments with "COPY_SEGMENT_FINISHED" state. These are expected to be counted in when calculating remote storage log size
         //
         // Expected results (retention.size is 10240 (10 segments)):
-        // In the 1st run, the total remote storage size should be 1024 * 11 (s5), so 2 segments (s1, s3) will be deleted
-        // because they are dangling segments (s1 case should not happen as we always attempt a deletion when copy fails).
-        // In the 2nd run, the total remote storage size should be 1024 * 12 (s4, s5), so 2 segments (s4, s5[0]) will be deleted 
-        // because of retention size breach.
+        // In the 1st run, the total remote storage size should be 1024 * 11 (s5) and 2 segments (s1, s3) will be deleted because they are dangling segments.
+        // Note: segments being copied are filtered out by the expiration logic, so s1 may be the result of an old failed copy cleanup where we weren't updating the state.
+        // In the 2nd run, the total remote storage size should be 1024 * 12 (s4, s5) and 2 segments (s4, s5[0]) will be deleted because of retention size breach.
         RemoteLogSegmentMetadata s1 = createRemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
                 0, 99, segmentSize, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_STARTED);
         RemoteLogSegmentMetadata s2 = createRemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2437,11 +2437,10 @@ public class RemoteLogManagerTest {
         // s5. 11 segments with "COPY_SEGMENT_FINISHED" state. These are expected to be counted in when calculating remote storage log size
         //
         // Expected results (retention.size is 10240 (10 segments)):
-        // In the 1st run, the total remote storage size should be 1024 * 12 (s3, s5), so 2 segments (s1, s3) will be deleted
-        // due to retention size breached. s1 will be deleted even though it is not included in size calculation. But it's fine.
-        // The segment intended to be deleted will be deleted in the next run.
-        // In the 2nd run, the total remote storage size should be 1024 * 12 (s4, s5)
-        // so 2 segments (s4, s5[0]) will be deleted due to retention size breached.
+        // In the 1st run, the total remote storage size should be 1024 * 11 (s5), so 2 segments (s1, s3) will be deleted
+        // because they are dangling segments (s1 case should not happen as we always attempt a deletion when copy fails).
+        // In the 2nd run, the total remote storage size should be 1024 * 12 (s4, s5), so 2 segments (s4, s5[0]) will be deleted 
+        // because of retention size breach.
         RemoteLogSegmentMetadata s1 = createRemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
                 0, 99, segmentSize, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_STARTED);
         RemoteLogSegmentMetadata s2 = createRemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
@@ -71,20 +71,18 @@ public interface RemoteLogMetadataManager extends Configurable, Closeable {
      * state based on the life cycle of the segment. It can go through the below state transitions described in {@link RemoteLogSegmentState}.
      *
      * <ul><li>{@link RemoteLogSegmentState#COPY_SEGMENT_STARTED} - This state indicates that the segment copying to remote storage is started but not yet finished.</li>
-     * <li>{@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED} - This state indicates that the segment copying to remote storage is finished.</li>
-     * <li>{@link RemoteLogSegmentState#DANGLING} - This state indicates that the segment copy failed and the broker will attempt to clean any uploaded data.</li></ul>
+     * <li>{@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED} - This state indicates that the segment copying to remote storage is finished.</li></ul>
      * The leader broker copies the log segments to the remote storage and puts the remote log segment metadata with the
      * state as “COPY_SEGMENT_STARTED” and updates the state as “COPY_SEGMENT_FINISHED” once the copy is successful.
      * If the copy fails, the leader broker updates the remote segment state to "DANGLING" and tries to delete it immediately.
      * If it fails to delete immediately, the copy task will retry in the following iterations.
-     * <br><br>
+     * 
      * <ul><li>{@link RemoteLogSegmentState#DELETE_SEGMENT_STARTED} - This state indicates that the segment deletion is started but not yet finished.</li>
      * <li>{@link RemoteLogSegmentState#DELETE_SEGMENT_FINISHED} - This state indicates that the segment is deleted successfully.</li></ul>
      * Leader partitions publish both the above delete segment events when remote log retention is reached for the
      * respective segments. Remote Partition Removers also publish these events when a segment is deleted as part of
      * the remote partition deletion.
-     * <br/><br/>
-     * 
+     *
      * @param remoteLogSegmentMetadataUpdate update of the remote log segment metadata.
      * @throws RemoteStorageException          if there are any storage related errors occurred.
      * @throws RemoteResourceNotFoundException when there are no resources associated with the given remoteLogSegmentMetadataUpdate.


### PR DESCRIPTION
This change introduces a retry mechanism for cleanig up remote segments that failed the copy to remote storage. It also makes sure that we always update the remote segment state whenever we attempt a deletion.

When a segment copy fails, we immediately try to delete the segment, but this can also fail. The RLMExpirationTask is now also responsible for retrying dangling segments cleanup.

This is how a segment state is updated in the above case:

1. COPY_SEGMENT_STARTED (copy task fails)
2. DELETE_SEGMENT_STARTED (copy task cleanup also fails)
3. DELETE_SEGMENT_STARTED (expiration task retries; self state transition)
4. DELETE_SEGMENT_FINISHED (expiration task completes)
5. COPY_SEGMENT_STARTED (copy task retries)
6. COPY_SEGMENT_FINISHED (copy task completes)
