### PR TITLE
KAFKA-17673 Switch back to statuses API

### DIFF
--- a/.github/actions/gh-api-update-status/action.yml
+++ b/.github/actions/gh-api-update-status/action.yml
@@ -16,8 +16,8 @@
 # under the License.
 #
 ---
-name: "Update Check Run"
-description: "Update the status of a commit check using the GH CLI. See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run"
+name: "Update Commit Status Check"
+description: "Update the status of a commit check using the GH CLI"
 inputs:
   # Composite actions do not support typed parameters. Everything is treated as a string
   # See: https://github.com/actions/runner/issues/2238
@@ -39,43 +39,23 @@ inputs:
     description: "The text to display next to the check"
     default: ""
     required: false
-  title:
-    description: "The title of the status check"
+  context:
+    description: "The name of the status check"
     required: true
-  status:
-    description: "The status of the check. Can be one of: queued, in_progress, completed, waiting, requested, pending"
+  state:
+    description: "The state of the check. Can be one of: error, failure, pending, success"
     required: true
-  conclusion:
-    description: "Required if status is 'completed'. Can be one of: action_required, cancelled, failure, neutral, success, skipped, stale, timed_out"
-    required: false
 
 runs:
   using: "composite"
   steps:
-    - if: inputs.conclusion == ''
+    - name: Update Check
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/${{ inputs.repository }}/check-runs \
-        -f "head_sha=${{ inputs.commit_sha }}" \
-        -f "status=${{ inputs.status }}" \
-        -f "details_url=${{ inputs.url }}" \
-        -f "output[title]=${{ inputs.title }}" \
-        -f "output[summary]=${{ inputs.description }}" \
-        -f "name=${{ inputs.title }}"
-    - if: inputs.conclusion != ''
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.gh-token }}
-      run: |
-        gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/${{ inputs.repository }}/check-runs \
-        -f "head_sha=${{ inputs.commit_sha }}" \
-        -f "status=${{ inputs.status }}" \
-        -f "conclusion=${{ inputs.conclusion }}" \
-        -f "details_url=${{ inputs.url }}" \
-        -f "output[title]=${{ inputs.title }}" \
-        -f "output[summary]=${{ inputs.description }}" \
-        -f "name=${{ inputs.title }}"
+        /repos/${{ inputs.repository }}/statuses/${{ inputs.commit_sha }} \
+        -f "state=${{ inputs.state }}" -f "target_url=${{ inputs.url }}" \
+        -f "description=${{ inputs.description }}" \
+        -f "context=${{ inputs.context }}"

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -70,16 +70,15 @@ jobs:
           path: ~/.gradle/build-scan-data  # This is where Gradle buffers unpublished build scan data when --no-scan is given
       - name: Handle missing scan
         if: ${{ steps.download-build-scan.outcome == 'failure' }}
-        uses: ./.github/actions/gh-api-update-check
+        uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
-          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          status: 'completed'
-          conclusion: 'skipped'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          state: 'error'
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}
@@ -99,25 +98,23 @@ jobs:
           fi
       - name: Handle failed publish
         if: ${{ failure() && steps.publish-build-scan.outcome == 'failure' }}
-        uses: ./.github/actions/gh-api-update-check
+        uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
           description: 'The build scan failed to be published'
-          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          status: 'completed'
-          conclusion: 'failure'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          state: 'error'
       - name: Update Status Check
         if: ${{ steps.publish-build-scan.outcome == 'success' }}
-        uses: ./.github/actions/gh-api-update-check
+        uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'
-          title: 'Gradle Build Scan / Java ${{ matrix.java }}'
-          status: 'completed'
-          conclusion: 'success'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          state: 'success'


### PR DESCRIPTION
The Checks API is apparently only meant for use with GitHub Apps, not Actions. This patch switches us back to the statuses API.

GitHub staff mentioning that some aspects of the Checks won't work from a GitHub Action: https://github.com/orgs/community/discussions/26757#discussioncomment-3253274

Docs: https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28