### PR TITLE
MINOR: Revert ducktape version until issues with latest version fixed.

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.11.4", "requests==2.31.0"],
+      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
There's an issue with running branch builder with the latest version of ducktape.  This PR reverts ducktape to the previous version to unblock running system tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
