### PR TITLE
KAFKA-17674: Fix bug on update positions of newly added partitions

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -769,7 +769,6 @@ public class OffsetsRequestManagerTest {
         verify(commitRequestManager).fetchOffsets(initPartitions1, internalFetchCommittedTimeout);
         clearInvocations(commitRequestManager);
 
-
         // tp2 added to the assignment when the Offset Fetch request is already sent including tp1 only
         TopicPartition tp2 = new TopicPartition("topic2", 2);
         Set<TopicPartition> initPartitions2 = new HashSet<>(Arrays.asList(tp1, tp2));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -76,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -745,6 +747,47 @@ public class OffsetsRequestManagerTest {
         when(subscriptionState.initializingPartitions()).thenReturn(Collections.emptySet());
         fetchResult.complete(Collections.singletonMap(tp1, new OffsetAndMetadata(5)));
         verify(subscriptionState, never()).seekUnvalidated(any(), any());
+    }
+
+    // This test ensures that we don't reset positions to the partition offsets for a partition assigned while the
+    // updateFetchPositions is running (after the OffsetFetch request has been sent).
+    @Test
+    public void testUpdatePositionsDoesNotResetPositionBeforeRetrievingOffsetsForNewlyAddedPartition() {
+        long internalFetchCommittedTimeout = time.milliseconds() + DEFAULT_API_TIMEOUT_MS;
+        TopicPartition tp1 = new TopicPartition("topic1", 1);
+        Set<TopicPartition> initPartitions1 = Collections.singleton(tp1);
+        Metadata.LeaderAndEpoch leaderAndEpoch = testLeaderEpoch(LEADER_1, Optional.of(1));
+
+        // tp1 assigned and requires a position
+        mockAssignedPartitionsMissingPositions(initPartitions1, initPartitions1, leaderAndEpoch);
+
+        // call to updateFetchPositions will trigger an OffsetFetch request for tp1 (won't complete just yet)
+        CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> fetchResult = new CompletableFuture<>();
+        when(commitRequestManager.fetchOffsets(initPartitions1, internalFetchCommittedTimeout)).thenReturn(fetchResult);
+        CompletableFuture<Boolean> updatePositions1 = requestManager.updateFetchPositions(time.milliseconds());
+        assertFalse(updatePositions1.isDone());
+        verify(commitRequestManager).fetchOffsets(initPartitions1, internalFetchCommittedTimeout);
+        clearInvocations(commitRequestManager);
+
+
+        // tp2 added to the assignment when the Offset Fetch request is already sent including tp1 only
+        TopicPartition tp2 = new TopicPartition("topic2", 2);
+        Set<TopicPartition> initPartitions2 = new HashSet<>(Arrays.asList(tp1, tp2));
+        mockAssignedPartitionsMissingPositions(initPartitions2, initPartitions2, leaderAndEpoch);
+
+        // tp2 requires a position, but shouldn't be reset after receiving the offset fetch response that will only
+        // include the requested partition tp1
+        when(subscriptionState.initializingPartitions()).thenReturn(initPartitions2);
+        OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(10, Optional.empty(), "");
+        fetchResult.complete(Collections.singletonMap(tp1, offsetAndMetadata));
+
+        // Position should have been updated for tp1 using the committed offset
+        SubscriptionState.FetchPosition expectedPosition = new SubscriptionState.FetchPosition(
+            offsetAndMetadata.offset(), offsetAndMetadata.leaderEpoch(), leaderAndEpoch);
+        verify(subscriptionState).seekUnvalidated(tp1, expectedPosition);
+
+        // Reset positions shouldn't include tp2
+        verify(subscriptionState).resetInitializingPositions(argThat(p -> !p.test(tp2)));
     }
 
     @Test


### PR DESCRIPTION
Fix to ensure that we keep the same set of initialization partitions within a single run of updateFetchPositions. This ensures that we don't reset positions using partition offsets for partitions that may be assigned while the updateFetchPositions is half-way (ie. after retrieving committed offsets but before the call to resetPositions). 

Before this PR, we could mistakenly reset positions to the partition offsets for a partition assigned that had committed offsets: fetch committed (not including the partition that wasn't assigned yet) + partition assigned + resetPositions(would include the partition that has been assigned and requires a position). 
