### PR TITLE
MINOR: Fix MockAdminClient to match the server side update features handling.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1310,7 +1310,7 @@ public class MockAdminClient extends AdminClient {
         for (Map.Entry<String, FeatureUpdate> entry : featureUpdates.entrySet()) {
             KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
             if (error == null) {
-               future.complete(null);
+                future.complete(null);
                 if (!options.validateOnly()) {
                     featureLevels.put(entry.getKey(), entry.getValue().maxVersionLevel());
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1259,15 +1259,14 @@ public class MockAdminClient extends AdminClient {
         Map<String, FeatureUpdate> featureUpdates,
         UpdateFeaturesOptions options
     ) {
-        Map<String, KafkaFuture<Void>> results = new HashMap<>();
+        Throwable error = null;
         for (Map.Entry<String, FeatureUpdate> entry : featureUpdates.entrySet()) {
-            KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
             String feature = entry.getKey();
+            short cur = featureLevels.getOrDefault(feature, (short) 0);
+            short next = entry.getValue().maxVersionLevel();
+            short min = minSupportedFeatureLevels.getOrDefault(feature, (short) 0);
+            short max = maxSupportedFeatureLevels.getOrDefault(feature, (short) 0);
             try {
-                short cur = featureLevels.getOrDefault(feature, (short) 0);
-                short next = entry.getValue().maxVersionLevel();
-                short min = minSupportedFeatureLevels.getOrDefault(feature, (short) 0);
-                short max = maxSupportedFeatureLevels.getOrDefault(feature, (short) 0);
                 switch (entry.getValue().upgradeType()) {
                     case UNKNOWN:
                         throw new InvalidRequestException("Invalid upgrade type.");
@@ -1302,16 +1301,30 @@ public class MockAdminClient extends AdminClient {
                 if (next > max) {
                     throw new InvalidUpdateVersionException("Can't upgrade above " + max);
                 }
-                if (!options.validateOnly()) {
-                    featureLevels.put(feature, next);
-                }
-                future.complete(null);
             } catch (Exception e) {
-                future.completeExceptionally(e);
+                error = invalidUpdateVersion(feature, next, e.getMessage());
+                break;
             }
-            results.put(feature, future);
         }
+        Map<String, KafkaFuture<Void>> results = new HashMap<>();
+        for (Map.Entry<String, FeatureUpdate> entry : featureUpdates.entrySet()) {
+            KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+            if (error == null) {
+               future.complete(null);
+                if (!options.validateOnly()) {
+                    featureLevels.put(entry.getKey(), entry.getValue().maxVersionLevel());
+                }
+            } else {
+                future.completeExceptionally(error);
+            }
+            results.put(entry.getKey(), future);
+        }
+
         return new UpdateFeaturesResult(results);
+    }
+
+    private InvalidRequestException invalidUpdateVersion(String feature, short version, String message) {
+        return new InvalidRequestException(String.format("Invalid update version %d for feature %s. %s", version, feature, message));
     }
 
     @Override

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -212,10 +212,10 @@ public class FeatureCommandTest {
         namespace.put("dry_run", false);
         String upgradeOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleUpgrade(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 2 operation(s) failed."));
+            assertTrue(t.getMessage().contains("2 out of 2 operation(s) failed."));
         });
-        assertEquals(format("foo.bar was upgraded to 6.%n" +
-            "Could not upgrade metadata.version to 5. Can't upgrade to lower version."), upgradeOutput);
+        assertEquals(format("Could not upgrade foo.bar to 6. Invalid update version 5 for feature metadata.version. Can't upgrade to lower version.%n" +
+            "Could not upgrade metadata.version to 5. Invalid update version 5 for feature metadata.version. Can't upgrade to lower version."), upgradeOutput);
     }
 
     @Test
@@ -226,10 +226,10 @@ public class FeatureCommandTest {
         namespace.put("dry_run", true);
         String upgradeOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleUpgrade(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 2 operation(s) failed."));
+            assertTrue(t.getMessage().contains("2 out of 2 operation(s) failed."));
         });
-        assertEquals(format("foo.bar can be upgraded to 6.%n" +
-            "Can not upgrade metadata.version to 5. Can't upgrade to lower version."), upgradeOutput);
+        assertEquals(format("Can not upgrade foo.bar to 6. Invalid update version 5 for feature metadata.version. Can't upgrade to lower version.%n" +
+            "Can not upgrade metadata.version to 5. Invalid update version 5 for feature metadata.version. Can't upgrade to lower version."), upgradeOutput);
     }
 
     @Test
@@ -240,10 +240,10 @@ public class FeatureCommandTest {
         namespace.put("dry_run", false);
         String downgradeOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleDowngrade(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 2 operation(s) failed."));
+            assertTrue(t.getMessage().contains("2 out of 2 operation(s) failed."));
         });
-        assertEquals(format("foo.bar was downgraded to 1.%n" +
-            "Could not downgrade metadata.version to 7. Can't downgrade to newer version."), downgradeOutput);
+        assertEquals(format("Could not downgrade foo.bar to 1. Invalid update version 7 for feature metadata.version. Can't downgrade to newer version.%n" +
+            "Could not downgrade metadata.version to 7. Invalid update version 7 for feature metadata.version. Can't downgrade to newer version."), downgradeOutput);
     }
 
     @Test
@@ -254,10 +254,10 @@ public class FeatureCommandTest {
         namespace.put("dry_run", true);
         String downgradeOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleDowngrade(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 2 operation(s) failed."));
+            assertTrue(t.getMessage().contains("2 out of 2 operation(s) failed."));
         });
-        assertEquals(format("foo.bar can be downgraded to 1.%n" +
-            "Can not downgrade metadata.version to 7. Can't downgrade to newer version."), downgradeOutput);
+        assertEquals(format("Can not downgrade foo.bar to 1. Invalid update version 7 for feature metadata.version. Can't downgrade to newer version.%n" +
+            "Can not downgrade metadata.version to 7. Invalid update version 7 for feature metadata.version. Can't downgrade to newer version."), downgradeOutput);
     }
 
     @Test
@@ -267,11 +267,11 @@ public class FeatureCommandTest {
         namespace.put("dry_run", false);
         String disableOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleDisable(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 3 operation(s) failed."));
+            assertTrue(t.getMessage().contains("3 out of 3 operation(s) failed."));
         });
-        assertEquals(format("foo.bar was disabled.%n" +
-            "Could not disable metadata.version. Can't downgrade below 4%n" +
-            "quux was disabled."), disableOutput);
+        assertEquals(format("Could not disable foo.bar. Invalid update version 0 for feature metadata.version. Can't downgrade below 4%n" +
+            "Could not disable metadata.version. Invalid update version 0 for feature metadata.version. Can't downgrade below 4%n" +
+            "Could not disable quux. Invalid update version 0 for feature metadata.version. Can't downgrade below 4"), disableOutput);
     }
 
     @Test
@@ -281,11 +281,11 @@ public class FeatureCommandTest {
         namespace.put("dry_run", true);
         String disableOutput = ToolsTestUtils.captureStandardOut(() -> {
             Throwable t = assertThrows(TerseException.class, () -> FeatureCommand.handleDisable(new Namespace(namespace), buildAdminClient()));
-            assertTrue(t.getMessage().contains("1 out of 3 operation(s) failed."));
+            assertTrue(t.getMessage().contains("3 out of 3 operation(s) failed."));
         });
-        assertEquals(format("foo.bar can be disabled.%n" +
-            "Can not disable metadata.version. Can't downgrade below 4%n" +
-            "quux can be disabled."), disableOutput);
+        assertEquals(format("Can not disable foo.bar. Invalid update version 0 for feature metadata.version. Can't downgrade below 4%n" +
+            "Can not disable metadata.version. Invalid update version 0 for feature metadata.version. Can't downgrade below 4%n" +
+            "Can not disable quux. Invalid update version 0 for feature metadata.version. Can't downgrade below 4"), disableOutput);
     }
 
     @Test


### PR DESCRIPTION
https://github.com/apache/kafka/commit/49d7ea6c6a2afe4620d089625b3473f913a3f11e updated the behavior of the UpdateFeaturesRequest/Response, but the MockAdminClient did not reflect those changes. 

Now if any feature fails, all the features fail and the correct message is written in the result. Also only update the features if all features are successful and the command is not validate only. 
