### PR TITLE
KAFKA-17684 Update our java build versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ 21, 17, 11, 8 ]
-    name: Compile and Check Java ${{ matrix.java }}
+    name: Compile and Check Java
     outputs:
       is-draft: ${{ steps.check-draft-pr.outputs.is-draft }}
     steps:
@@ -62,7 +58,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 21
           gradle-cache-read-only: ${{ inputs.gradle-cache-read-only }}
           gradle-cache-write-only: ${{ inputs.gradle-cache-write-only }}
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -80,20 +76,20 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: check-reports-${{ matrix.java }}
+          name: check-reports
           path: |
             **/build/**/*.html
           compression-level: 9
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
         # Avoid duplicate annotations, only run on java 21
-        if: ${{ failure() && matrix.java == '21' }}
+        if: failure()
         run: python .github/scripts/checkstyle.py
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
       - name: Annotate Rat errors
         # Avoid duplicate annotations, only run on java 21
-        if: ${{ failure() && matrix.java == '21' }}
+        if: failure()
         run: python .github/scripts/rat.py
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -105,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 11 ]  # If we change these, make sure to adjust ci-complete.yml
+        java: [ 21, 11 ]  # If we change these, make sure to adjust ci-complete.yml
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 11 ]
+        java: [ 21, 11 ]
     steps:
       - name: Env
         run: printenv


### PR DESCRIPTION
This updates the versions of Java we test on from 8 and 21 to 11 and 21. This also removes unnecessary Check and Compile Java variations.