### PR TITLE
KAFKA-17658: Move `BootstrapControllersIntegrationTest` to kafka.server

### DIFF
--- a/core/src/test/java/kafka/server/BootstrapControllersIntegrationTest.java
+++ b/core/src/test/java/kafka/server/BootstrapControllersIntegrationTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package kafka.test.server;
+package kafka.server;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;


### PR DESCRIPTION
As titled, please check [KAFKA-17658](https://issues.apache.org/jira/browse/KAFKA-17658) for details, it's based on the change of https://github.com/apache/kafka/pull/17337 . Please take a look.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)