### PR TITLE
KAFKA-15859: Fixed the Unsupported version error when new admin connects to old broker

### DIFF
--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -63,7 +63,7 @@
           "about": "The maximum number of offsets to report." }
       ]}
     ]},
-    { "name": "TimeoutMs", "type": "int32", "versions": "10+",
+    { "name": "TimeoutMs", "type": "int32", "versions": "10+", "ignorable": true,
       "about": "The timeout to await a response in milliseconds for requests that require reading from remote storage for topics enabled with tiered storage." }
   ]
 }


### PR DESCRIPTION
Fixed the Unsupported version error when new admin tries to connect to old broker:
```
org.apache.kafka.common.errors.UnsupportedVersionException: Attempted to write a non-default timeoutMs at version 8
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
