### PR TITLE
KAFKA-17654 Fix flaky ProducerIdManagerTest#testUnrecoverableErrors

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -217,7 +217,7 @@ class RPCProducerIdManager(brokerId: Int,
       // Send a request only if we reached the retry deadline, or if no deadline was set.
 
       if (nextProducerIdBlock.get == null &&
-        requestInFlight.compareAndSet(false, true) ) {
+        requestInFlight.compareAndSet(false, true)) {
 
         sendRequest()
         // Reset backoff after a successful send.

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -235,7 +235,7 @@ class ProducerIdManagerTest {
     }, "Expected failure")
     manager.capturedFailure.set(false)
   }
-  
+
   private def verifyNewBlockAndProducerId(manager: MockProducerIdManager,
                                           expectedBlock: ProducerIdsBlock,
                                           expectedPid: Long): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -181,10 +181,8 @@ class ProducerIdManagerTest {
     val time = new MockTime()
     val manager = new MockProducerIdManager(0, 0, 1, errorQueue = queue(Errors.NONE, error), time = time)
 
-    Thread.sleep(1000)
     verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 0, 1), 0)
-    Thread.sleep(1000)
-    verifyFailure(manager)
+    verifyFailureWithoutGenerateProducerId(manager)
 
     time.sleep(RetryBackoffMs)
     verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 1, 1), 1)
@@ -224,6 +222,10 @@ class ProducerIdManagerTest {
 
   private def verifyFailure(manager: MockProducerIdManager): Unit = {
     assertCoordinatorLoadInProgressExceptionFailure(manager.generateProducerId())
+    verifyFailureWithoutGenerateProducerId(manager)
+  }  
+  
+  private def verifyFailureWithoutGenerateProducerId(manager: MockProducerIdManager): Unit = {
     TestUtils.waitUntilTrue(() => {
       manager synchronized {
         manager.capturedFailure.get

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -180,7 +180,9 @@ class ProducerIdManagerTest {
   def testUnrecoverableErrors(error: Errors): Unit = {
     val time = new MockTime()
     val manager = new MockProducerIdManager(0, 0, 1, errorQueue = queue(Errors.NONE, error), time = time)
-
+    // two block requests are sent in this case:
+    // 1. the first generateProducerId(), there is no Producer ID available.
+    // 2. the second generateProducerId(), the second block request will fail.
     verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 0, 1), 0)
     verifyFailureWithoutGenerateProducerId(manager)
 
@@ -233,7 +235,7 @@ class ProducerIdManagerTest {
     }, "Expected failure")
     manager.capturedFailure.set(false)
   }
-
+  
   private def verifyNewBlockAndProducerId(manager: MockProducerIdManager,
                                           expectedBlock: ProducerIdsBlock,
                                           expectedPid: Long): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -181,8 +181,9 @@ class ProducerIdManagerTest {
     val time = new MockTime()
     val manager = new MockProducerIdManager(0, 0, 1, errorQueue = queue(Errors.NONE, error), time = time)
 
+    Thread.sleep(1000)
     verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 0, 1), 0)
-
+    Thread.sleep(1000)
     verifyFailure(manager)
 
     time.sleep(RetryBackoffMs)


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17654
There are two flaky scenarios:
1. AssertionFailedError: failed to generate block: 
The failure occurs at the second `verifyNewBlockAndProducerId` because this method is supposed to test a scenario where `Errors` is null. However, the `brokerToControllerRequestExecutor` thread executes too slowly, and instead of `Errors` being null, this method ends up testing where Errors is INVALID_REQUEST. As a result, `manager.nextProducerIdBlock.get` always returns null, causing the failure.
there is my local log
```text
[2024-10-03 08:55:07,672] WARN pool-1-thread-1 start submit error: NONE
Test worker manager.nextProducerIdBlock.get: null
[2024-10-03 08:55:07,779] WARN pool-1-thread-1 Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
[2024-10-03 08:55:07,780] WARN [RPC ProducerId Manager 0]: pool-1-thread-1  Got next producer ID block from controller AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
Test worker manager.nextProducerIdBlock.get: null
Test worker manager.nextProducerIdBlock.get: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=0, size=1)
[2024-10-03 08:55:07,780] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
[2024-10-03 08:55:07,781] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: null
Test worker manager.capturedFailure.get: true
[2024-10-03 08:55:07,781] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in response: 0
Test worker manager.capturedFailure.get: true
Test worker manager.nextProducerIdBlock.get: null
[2024-10-03 08:55:07,781] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in idStart: 1
[2024-10-03 08:55:07,782] WARN pool-1-thread-1 start submit error: INVALID_REQUEST
[2024-10-03 08:55:07,782] WARN pool-1-thread-1  Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0)
[2024-10-03 08:55:07,782] WARN [RPC ProducerId Manager 0]: pool-1-thread-1  Received an unexpected error code from the controller: INVALID_REQUEST
[2024-10-03 08:55:07,783] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0)
[2024-10-03 08:55:07,783] WARN pool-1-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: null
Test worker manager.nextProducerIdBlock.get: null
Test worker manager.nextProducerIdBlock.get: null
```

2. AssertionFailedError: Expected failure: This fails at `verifyFailure`. In this scenario, the test thread runs too fast. When the `brokerToControllerRequestExecutor` executes `handleAllocateProducerIdsResponse`, it hasn't yet reached `capturedFailure.set(nextProducerIdBlock.get == null)`. Therefore, when the main thread reaches [1], it will returns false,
then `brokerToControllerRequestExecutor` will do next `Errors` is null, I will retuen `ProducerIdsBlock(assignedBrokerId=0, firstProducerId=1, size=1)`, thus `capturedFailure.set(nextProducerIdBlock.get == null)` will always return false, This test case fail.
```text
[2024-10-03 08:58:48,622] WARN pool-2-thread-1 start submit error: NONE
[2024-10-03 08:58:48,622] WARN pool-2-thread-1 Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
[2024-10-03 08:58:48,623] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Got next producer ID block from controller AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1)
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=0, size=1)
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: 0
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in idStart: 1
Test worker manager.nextProducerIdBlock.get: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=0, size=1)
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 start submit error: INVALID_REQUEST
[2024-10-03 08:58:48,623] WARN pool-2-thread-1  Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0)
[2024-10-03 08:58:48,623] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Received an unexpected error code from the controller: INVALID_REQUEST
[2024-10-03 08:58:48,623] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0)
Test worker manager.capturedFailure.get: false
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: null
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 start submit error: null
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1)
[2024-10-03 08:58:48,624] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Got next producer ID block from controller AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1)
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1)
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=1, size=1)
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: 1
[2024-10-03 08:58:48,624] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in idStart: 2
Test worker manager.capturedFailure.get: false
Test worker manager.capturedFailure.get: false
Test worker manager.capturedFailure.get: false
Test worker manager.capturedFailure.get: false
```

[1] https://github.com/apache/kafka/blob/1962917436f463541f9bb63791b7ed55c23ce8c1/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala#L78

The standard scenrio  is below:
```
Test worker manager.nextProducerIdBlock.get: null
[2024-10-03 12:05:51,640] WARN pool-2-thread-1 start submit error: NONE 
[2024-10-03 12:05:51,640] WARN pool-2-thread-1  Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1) 
[2024-10-03 12:05:51,640] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Got next producer ID block from controller AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1) 
[2024-10-03 12:05:51,640] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=0, producerIdLen=1) 
[2024-10-03 12:05:51,640] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=0, size=1) 
[2024-10-03 12:05:51,641] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: 0 
[2024-10-03 12:05:51,641] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in idStart: 1 
Test worker manager.nextProducerIdBlock.get: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=0, size=1)
[2024-10-03 12:05:51,741] WARN pool-2-thread-1 start submit error: INVALID_REQUEST 
[2024-10-03 12:05:51,741] WARN pool-2-thread-1  Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0) 
[2024-10-03 12:05:51,741] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Received an unexpected error code from the controller: INVALID_REQUEST 
[2024-10-03 12:05:51,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=42, producerIdStart=0, producerIdLen=0) 
[2024-10-03 12:05:51,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: null 
Test worker manager.capturedFailure.get: true 
Test worker manager.nextProducerIdBlock.get: null
[2024-10-03 12:05:52,741] WARN pool-2-thread-1 start submit error: null 
[2024-10-03 12:05:52,741] WARN pool-2-thread-1  Received AllocateProducerIds response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1) 
[2024-10-03 12:05:52,741] WARN [RPC ProducerId Manager 0]: pool-2-thread-1  Got next producer ID block from controller AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1) 
[2024-10-03 12:05:52,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: AllocateProducerIdsResponseData(throttleTimeMs=0, errorCode=0, producerIdStart=1, producerIdLen=1) 
[2024-10-03 12:05:52,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in nextProducerIdBlock: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=1, size=1) 
[2024-10-03 12:05:52,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in response: 1 
[2024-10-03 12:05:52,741] WARN pool-2-thread-1 handleAllocateProducerIdsResponse in idStart: 
Test worker manager.nextProducerIdBlock.get: ProducerIdsBlock(assignedBrokerId=0, firstProducerId=1, size=1)
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
