### PR TITLE
KAFKA-17697: Fix flaky DefaultStateUpdaterTest.shouldRestoreSingleActiveStatefulTask

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -324,14 +324,15 @@ class DefaultStateUpdaterTest {
     public void shouldRestoreSingleActiveStatefulTask() throws Exception {
         final StreamTask task =
             statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+        final AtomicBoolean allChangelogCompleted = new AtomicBoolean(false);
         when(changelogReader.completedChangelogs())
             .thenReturn(Collections.emptySet())
             .thenReturn(Set.of(TOPIC_PARTITION_A_0))
-            .thenReturn(Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0));
-        when(changelogReader.allChangelogsCompleted())
-            .thenReturn(false)
-            .thenReturn(false)
-            .thenReturn(true);
+            .thenAnswer(invocation -> {
+                allChangelogCompleted.set(true);
+                return Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0);
+            });
+        when(changelogReader.allChangelogsCompleted()).thenReturn(allChangelogCompleted.get());
         stateUpdater.start();
 
         stateUpdater.add(task);


### PR DESCRIPTION
It's regarding [KAFKA-17697.](https://issues.apache.org/jira/browse/KAFKA-17697) 

In `DefaultStateUpdaterTest.shouldRestoreSingleActiveStatefulTask`, racing occurs between test and StateUpdaterThread threads. Put the detailed explanation in Jira.

To solve the racing issue, rewrite the mock of `changelogReader.allChangelogsCompleted()`, only return true if `changelogReader.completedChangelogs()` returned the last result.

It's referenced from the similar test `shouldRestoreMultipleActiveStatefulTasks`.

https://github.com/apache/kafka/blob/0edf5dbd204df9eb62bfea1b56993e95737df5a3/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java#L352-L366

Tested without error for 1000 loops in my local env. (Before this PR the issue occurs within 20 loops.)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
