### PR TITLE
KAFKA-17248: Add reporter for getting client metrics into telemetry pipeline and test [3/N]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.FeatureUpdateFailedException;
 import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.kafka.common.requests.LeaveGroupResponse;
@@ -1822,6 +1823,41 @@ public interface Admin extends AutoCloseable {
     default ListShareGroupsResult listShareGroups() {
         return listShareGroups(new ListShareGroupsOptions());
     }
+
+
+    /**
+     * Add the provided application metric for subscription.
+     * This metric will be added to this client's metrics
+     * that are available for subscription and sent as
+     * telemetry data to the broker.
+     * The provided metric must map to an OTLP metric data point
+     * type in the OpenTelemetry v1 metrics protobuf message types.
+     * Specifically, the metric should be one of the following:
+     * <ul>
+     *  <li>
+     *     `Sum`: Monotonic total count meter (Counter). Suitable for metrics like total number of X, e.g., total bytes sent.
+     *  </li>
+     *  <li>
+     *     `Gauge`: Non-monotonic current value meter (UpDownCounter). Suitable for metrics like current value of Y, e.g., current queue count.
+     *  </li>
+     * </ul>
+     * Metrics not matching these types are silently ignored.
+     * Executing this method for a previously registered metric is a benign operation and results in updating that metrics entry.
+     *
+     * @param metric The application metric to register
+     */
+    void registerMetricForSubscription(KafkaMetric metric);
+
+    /**
+     * Remove the provided application metric for subscription.
+     * This metric is removed from this client's metrics
+     * and will not be available for subscription any longer.
+     * Executing this method with a metric that has not been registered is a
+     * benign operation and does not result in any action taken (no-op).
+     *
+     * @param metric The application metric to remove
+     */
+    void unregisterMetricFromSubscription(KafkaMetric metric);
 
     /**
      * Get the metrics kept by the adminClient

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 
@@ -306,6 +307,16 @@ public class ForwardingAdmin implements Admin {
     @Override
     public ListShareGroupsResult listShareGroups(ListShareGroupsOptions options) {
         return delegate.listShareGroups(options);
+    }
+
+    @Override
+    public void registerMetricForSubscription(KafkaMetric metric) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(KafkaMetric metric) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -165,6 +165,7 @@ import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.UnregisterBrokerRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData.UpdatableFeatureResult;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -4132,6 +4133,16 @@ public class KafkaAdminClient extends AdminClient {
         });
 
         return future;
+    }
+
+    @Override
+    public void registerMetricForSubscription(KafkaMetric metric) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(KafkaMetric metric) {
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
@@ -93,6 +94,7 @@ public class MockAdminClient extends AdminClient {
     private final Map<String, Map<String, String>> clientMetricsConfigs;
     private final Map<String, Map<String, String>> groupConfigs;
     private final Map<String, String> defaultGroupConfigs;
+    private final List<KafkaMetric> addedMetrics = new ArrayList<>();
 
     private Node controller;
     private int timeoutNextRequests = 0;
@@ -1496,5 +1498,19 @@ public class MockAdminClient extends AdminClient {
 
     public synchronized Node broker(int index) {
         return brokers.get(index);
+    }
+
+    public List<KafkaMetric> addedMetrics() {
+        return Collections.unmodifiableList(addedMetrics);
+    }
+
+    @Override
+    public void registerMetricForSubscription(KafkaMetric metric) {
+        addedMetrics.add(metric);
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(KafkaMetric metric) {
+        addedMetrics.remove(metric);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
@@ -33,9 +33,9 @@ public class StreamsClientMetricsDelegatingReporter implements MetricsReporter {
     private static final Logger log = LoggerFactory.getLogger(StreamsClientMetricsDelegatingReporter.class);
     private final Admin adminClient;
 
-    public StreamsClientMetricsDelegatingReporter(final Admin adminClient, final String adminClientId) {
+    public StreamsClientMetricsDelegatingReporter(final Admin adminClient, final String streamsClientId) {
         this.adminClient = Objects.requireNonNull(adminClient);
-        log.debug("Creating Client Metrics reporter for client {}", adminClientId);
+        log.debug("Creating Client Metrics reporter for streams client {}", streamsClientId);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
@@ -33,9 +33,9 @@ public class StreamsClientMetricsDelegatingReporter implements MetricsReporter {
     private static final Logger log = LoggerFactory.getLogger(StreamsClientMetricsDelegatingReporter.class);
     private final Admin adminClient;
 
-    public StreamsClientMetricsDelegatingReporter(final Admin adminClient) {
+    public StreamsClientMetricsDelegatingReporter(final Admin adminClient, final String adminClientId) {
         this.adminClient = Objects.requireNonNull(adminClient);
-        log.debug("Creating Client Metrics reporter for admin client {}", adminClient);
+        log.debug("Creating Client Metrics reporter for client {}", adminClientId);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class StreamsClientMetricsDelegatingReporter implements MetricsReporter {
     private boolean isStreamsClientMetric(final KafkaMetric metric) {
         final boolean shouldInclude = metric.metricName().group().equals("stream-metrics");
         if (!shouldInclude) {
-            log.debug("Rejecting thread metric {}", metric.metricName());
+            log.trace("Rejecting thread metric {}", metric.metricName());
         }
         return shouldInclude;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.internals.metrics;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class StreamsClientMetricsDelegatingReporter implements MetricsReporter {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamsClientMetricsDelegatingReporter.class);
+    private final Admin adminClient;
+
+    public StreamsClientMetricsDelegatingReporter(final Admin adminClient) {
+        this.adminClient = Objects.requireNonNull(adminClient);
+        log.debug("Creating Client Metrics reporter for admin client {}", adminClient);
+    }
+
+    @Override
+    public void init(final List<KafkaMetric> metrics) {
+        metrics.forEach(this::metricChange);
+    }
+
+    @Override
+    public void metricChange(final KafkaMetric metric) {
+        if (isStreamsClientMetric(metric)) {
+            log.debug("Registering metric {}", metric.metricName());
+            adminClient.registerMetricForSubscription(metric);
+        }
+    }
+
+    private boolean isStreamsClientMetric(final KafkaMetric metric) {
+        final boolean shouldInclude = metric.metricName().group().equals("stream-metrics");
+        if (!shouldInclude) {
+            log.debug("Rejecting thread metric {}", metric.metricName());
+        }
+        return shouldInclude;
+    }
+
+    @Override
+    public void metricRemoval(final KafkaMetric metric) {
+        if (isStreamsClientMetric(metric)) {
+            log.debug("Unregistering metric {}", metric.metricName());
+            adminClient.unregisterMetricFromSubscription(metric);
+        }
+    }
+
+    @Override
+    public void close() {
+        // No op
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        // No op
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -419,6 +419,16 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     }
 
     @Override
+    public void registerMetricForSubscription(final KafkaMetric metric) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(final KafkaMetric metric) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return adminDelegate.metrics();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.internals.metrics;
+
+import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StreamsClientMetricsDelegatingReporterTest {
+
+    private MockAdminClient mockAdminClient;
+    private StreamsClientMetricsDelegatingReporter streamsClientMetricsDelegatingReporter;
+
+    private KafkaMetric streamClientMetricOne;
+    private KafkaMetric streamClientMetricTwo;
+    private KafkaMetric streamClientMetricThree;
+    private KafkaMetric kafkaMetricWithThreadIdTag;
+    private final Object lock = new Object();
+    private final MetricConfig metricConfig = new MetricConfig();
+
+
+    @BeforeEach
+    public void setup() {
+        mockAdminClient = new MockAdminClient();
+        streamsClientMetricsDelegatingReporter = new StreamsClientMetricsDelegatingReporter(mockAdminClient);
+
+        final Map<String, String> threadIdTagMap = new HashMap<>();
+        final String threadId = "abcxyz-StreamThread-1";
+        threadIdTagMap.put("thread-id", threadId);
+
+        final MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new HashMap<>());
+        final MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new HashMap<>());
+        final MetricName metricNameThree = new MetricName("metricThree", "stream-metrics", "description for metric three", new HashMap<>());
+        final MetricName metricNameFour = new MetricName("metricThree", "thread-metrics", "description for metric three", threadIdTagMap);
+
+        streamClientMetricOne = new KafkaMetric(lock, metricNameOne, (Measurable) (m, now) -> 1.0, metricConfig, Time.SYSTEM);
+        streamClientMetricTwo = new KafkaMetric(lock, metricNameTwo, (Measurable) (m, now) -> 2.0, metricConfig, Time.SYSTEM);
+        streamClientMetricThree = new KafkaMetric(lock, metricNameThree, (Measurable) (m, now) -> 3.0, metricConfig, Time.SYSTEM);
+        kafkaMetricWithThreadIdTag = new KafkaMetric(lock, metricNameFour, (Measurable) (m, now) -> 4.0, metricConfig, Time.SYSTEM);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockAdminClient.close();
+    }
+
+    @Test
+    @DisplayName("Should register metrics from init method")
+    public void shouldInitMetrics() {
+        final List<KafkaMetric> metrics = Arrays.asList(streamClientMetricOne, streamClientMetricTwo, streamClientMetricThree, kafkaMetricWithThreadIdTag);
+        streamsClientMetricsDelegatingReporter.init(metrics);
+        final List<KafkaMetric> expectedMetrics = Arrays.asList(streamClientMetricOne, streamClientMetricTwo, streamClientMetricThree);
+        assertEquals(expectedMetrics, mockAdminClient.addedMetrics());
+    }
+
+    @Test
+    @DisplayName("Should register client instance metrics only")
+    public void shouldRegisterCorrectMetrics() {
+        streamsClientMetricsDelegatingReporter.metricChange(kafkaMetricWithThreadIdTag);
+        assertEquals(0, mockAdminClient.addedMetrics().size());
+
+        streamsClientMetricsDelegatingReporter.metricChange(streamClientMetricOne);
+        assertEquals(1, mockAdminClient.addedMetrics().size());
+    }
+
+    @Test
+    @DisplayName("Should remove client instance metrics")
+    public void metricRemoval() {
+        streamsClientMetricsDelegatingReporter.metricChange(streamClientMetricOne);
+        streamsClientMetricsDelegatingReporter.metricChange(streamClientMetricTwo);
+        streamsClientMetricsDelegatingReporter.metricChange(streamClientMetricThree);
+        assertEquals(3, mockAdminClient.addedMetrics().size());
+
+        streamsClientMetricsDelegatingReporter.metricRemoval(streamClientMetricOne);
+        assertEquals(2, mockAdminClient.addedMetrics().size());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
@@ -52,7 +52,7 @@ class StreamsClientMetricsDelegatingReporterTest {
     @BeforeEach
     public void setup() {
         mockAdminClient = new MockAdminClient();
-        streamsClientMetricsDelegatingReporter = new StreamsClientMetricsDelegatingReporter(mockAdminClient);
+        streamsClientMetricsDelegatingReporter = new StreamsClientMetricsDelegatingReporter(mockAdminClient, "adminClientId");
 
         final Map<String, String> threadIdTagMap = new HashMap<>();
         final String threadId = "abcxyz-StreamThread-1";


### PR DESCRIPTION
This PR adds a Reporter instance that will add streams client metrics to the telemetry pipeline.

For testing, the PR adds a unit test.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
