### PR TITLE
KAFKA-17706 Allow all imports for test-common and test-common-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1560,7 +1560,7 @@ project(':test-common') {
   }
 
   checkstyle {
-    sourceSets = []
+    configProperties = checkstyleConfigProperties("import-control-test-common.xml")
   }
 
   javadoc {
@@ -1603,7 +1603,7 @@ project(':test-common:test-common-api') {
   }
 
   checkstyle {
-    sourceSets = []
+    configProperties = checkstyleConfigProperties("import-control-test-common-api.xml")
   }
 
   javadoc {

--- a/checkstyle/import-control-test-common-api.xml
+++ b/checkstyle/import-control-test-common-api.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.1//EN"
+        "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<import-control pkg="org.apache.kafka">
+    <allow pkg="java" />
+    <allow pkg="org" />
+    <allow pkg="kafka" />
+    <allow pkg="scala" />
+</import-control>

--- a/checkstyle/import-control-test-common.xml
+++ b/checkstyle/import-control-test-common.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.1//EN"
+        "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<import-control pkg="org.apache.kafka">
+
+    <allow pkg="java" />
+    <allow pkg="org" />
+    <allow pkg="kafka" />
+</import-control>


### PR DESCRIPTION
Both modules are being refactored ([KAFKA-17690](https://issues.apache.org/jira/browse/KAFKA-17690) and [KAFKA-17682](https://issues.apache.org/jira/browse/KAFKA-17682)), so this JIRA will temporarily allow all imports for now.

Additionally, this PR fix the error for following tasks.
```
./gradlew checkstyleMain checkstyleTest
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
