### PR TITLE
MINOR: Small cleanup in ToolsUtils

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
@@ -19,7 +19,6 @@ package org.apache.kafka.tools;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.server.util.CommandLineUtils;
 
 import java.io.PrintStream;
 import java.util.Arrays;
@@ -29,8 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-
-import joptsimple.OptionParser;
 
 public class ToolsUtils {
     /**
@@ -44,7 +41,7 @@ public class ToolsUtils {
             for (Metric metric : metrics.values()) {
                 MetricName mName = metric.metricName();
                 String mergedName = mName.group() + ":" + mName.name() + ":" + mName.tags();
-                maxLengthOfDisplayName = maxLengthOfDisplayName < mergedName.length() ? mergedName.length() : maxLengthOfDisplayName;
+                maxLengthOfDisplayName = Math.max(maxLengthOfDisplayName, mergedName.length());
                 sortedMetrics.put(mergedName, metric.metricValue());
             }
             String doubleOutputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
@@ -156,18 +153,5 @@ public class ToolsUtils {
         for (T t : toRemove)
             res.remove(t);
         return res;
-    }
-
-    /**
-     * This is a simple wrapper around `CommandLineUtils.printUsageAndExit`.
-     * It is needed for tools migration (KAFKA-14525), as there is no Java equivalent for return type `Nothing`.
-     * Can be removed once [[kafka.tools.ConsoleConsumer]] are migrated.
-     *
-     * @param parser Command line options parser.
-     * @param message Error message.
-     */
-    public static void printUsageAndExit(OptionParser parser, String message) {
-        CommandLineUtils.printUsageAndExit(parser, message);
-        throw new AssertionError("printUsageAndExit should not return, but it did.");
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -48,7 +48,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandLineUtils;
-import org.apache.kafka.tools.ToolsUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -435,7 +434,7 @@ public class ConsumerGroupCommand {
                     String format = "\n%" + -coordinatorColLen + "s %-25s %-20s %-15s %s";
 
                     System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS");
-                    System.out.printf(format, state.group, coordinator, state.assignmentStrategy, state.state.toString(), state.numMembers);
+                    System.out.printf(format, state.group, coordinator, state.assignmentStrategy, state.state, state.numMembers);
                     System.out.println();
                 }
             });
@@ -1002,8 +1001,7 @@ public class ConsumerGroupCommand {
                     LogOffsetResult logOffsetResult = logStartOffsets.get(topicPartition);
 
                     if (!(logOffsetResult instanceof LogOffset)) {
-                        ToolsUtils.printUsageAndExit(opts.parser, "Error getting starting offset of topic partition: " + topicPartition);
-                        return null;
+                        CommandLineUtils.printUsageAndExit(opts.parser, "Error getting starting offset of topic partition: " + topicPartition);
                     }
 
                     return new OffsetAndMetadata(((LogOffset) logOffsetResult).value);
@@ -1014,8 +1012,7 @@ public class ConsumerGroupCommand {
                     LogOffsetResult logOffsetResult = logEndOffsets.get(topicPartition);
 
                     if (!(logOffsetResult instanceof LogOffset)) {
-                        ToolsUtils.printUsageAndExit(opts.parser, "Error getting ending offset of topic partition: " + topicPartition);
-                        return null;
+                        CommandLineUtils.printUsageAndExit(opts.parser, "Error getting ending offset of topic partition: " + topicPartition);
                     }
 
                     return new OffsetAndMetadata(((LogOffset) logOffsetResult).value);
@@ -1042,8 +1039,7 @@ public class ConsumerGroupCommand {
                         LogOffsetResult logTimestampOffset = logTimestampOffsets.get(topicPartition);
 
                         if (!(logTimestampOffset instanceof LogOffset)) {
-                            ToolsUtils.printUsageAndExit(opts.parser, "Error getting offset by timestamp of topic partition: " + topicPartition);
-                            return null;
+                            CommandLineUtils.printUsageAndExit(opts.parser, "Error getting offset by timestamp of topic partition: " + topicPartition);
                         }
 
                         return new OffsetAndMetadata(((LogOffset) logTimestampOffset).value);
@@ -1062,8 +1058,7 @@ public class ConsumerGroupCommand {
                     LogOffsetResult logTimestampOffset = logTimestampOffsets.get(topicPartition);
 
                     if (!(logTimestampOffset instanceof LogOffset)) {
-                        ToolsUtils.printUsageAndExit(opts.parser, "Error getting offset by timestamp of topic partition: " + topicPartition);
-                        return null;
+                        CommandLineUtils.printUsageAndExit(opts.parser, "Error getting offset by timestamp of topic partition: " + topicPartition);
                     }
 
                     return new OffsetAndMetadata(((LogOffset) logTimestampOffset).value);
@@ -1110,8 +1105,7 @@ public class ConsumerGroupCommand {
                 Map<TopicPartition, OffsetAndMetadata> preparedOffsetsForPartitionsWithoutCommittedOffset = getLogEndOffsets(partitionsToResetWithoutCommittedOffset)
                     .entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
                         if (!(e.getValue() instanceof LogOffset)) {
-                            ToolsUtils.printUsageAndExit(opts.parser, "Error getting ending offset of topic partition: " + e.getKey());
-                            return null;
+                            CommandLineUtils.printUsageAndExit(opts.parser, "Error getting ending offset of topic partition: " + e.getKey());
                         }
 
                         return new OffsetAndMetadata(((LogOffset) e.getValue()).value);
@@ -1122,7 +1116,7 @@ public class ConsumerGroupCommand {
                 return preparedOffsetsForPartitionsWithCommittedOffset;
             }
 
-            ToolsUtils.printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
+            CommandLineUtils.printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
             return null;
         }
 


### PR DESCRIPTION
We can now delete `ToolsUtils.printUsageAndExit()` since we migrated both console consumer and producer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
