### PR TITLE
Complete topic metadata for automatic topic creation 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,11 +42,7 @@ public class StreamsAssignmentInterface {
 
     private Optional<HostInfo> endpoint;
 
-    private String assignor;
-
     private Map<String, Subtopology> subtopologyMap;
-
-    private Map<String, Object> assignmentConfiguration;
 
     private Map<TaskId, Long> taskLags;
 
@@ -66,16 +63,8 @@ public class StreamsAssignmentInterface {
         return endpoint;
     }
 
-    public String assignor() {
-        return assignor;
-    }
-
     public Map<String, Subtopology> subtopologyMap() {
         return subtopologyMap;
-    }
-
-    public Map<String, Object> assignmentConfiguration() {
-        return assignmentConfiguration;
     }
 
     // TODO: This needs to be used somewhere
@@ -190,11 +179,14 @@ public class StreamsAssignmentInterface {
     public static class TopicInfo {
 
         public final Optional<Integer> numPartitions;
+        public final Optional<Short> replicationFactor;
         public final Map<String, String> topicConfigs;
 
         public TopicInfo(final Optional<Integer> numPartitions,
+                         final Optional<Short> replicationFactor,
                          final Map<String, String> topicConfigs) {
             this.numPartitions = numPartitions;
+            this.replicationFactor = replicationFactor;
             this.topicConfigs = topicConfigs;
         }
 
@@ -202,10 +194,10 @@ public class StreamsAssignmentInterface {
         public String toString() {
             return "TopicInfo{" +
                 "numPartitions=" + numPartitions +
+                ", replicationFactor=" + replicationFactor +
                 ", topicConfigs=" + topicConfigs +
                 '}';
         }
-
     }
 
     public static class TaskId {
@@ -241,15 +233,19 @@ public class StreamsAssignmentInterface {
         public final Set<String> sinkTopics;
         public final Map<String, TopicInfo> stateChangelogTopics;
         public final Map<String, TopicInfo> repartitionSourceTopics;
+        public final Collection<Set<String>> copartitionGroups;
 
         public Subtopology(final Set<String> sourceTopics,
                            final Set<String> sinkTopics,
                            final Map<String, TopicInfo> repartitionSourceTopics,
-                           final Map<String, TopicInfo> stateChangelogTopics) {
+                           final Map<String, TopicInfo> stateChangelogTopics,
+                           final Collection<Set<String>> copartitionGroups
+        ) {
             this.sourceTopics = sourceTopics;
             this.sinkTopics = sinkTopics;
             this.stateChangelogTopics = stateChangelogTopics;
             this.repartitionSourceTopics = repartitionSourceTopics;
+            this.copartitionGroups = copartitionGroups;
         }
 
         @Override
@@ -259,22 +255,19 @@ public class StreamsAssignmentInterface {
                 ", sinkTopics=" + sinkTopics +
                 ", stateChangelogTopics=" + stateChangelogTopics +
                 ", repartitionSourceTopics=" + repartitionSourceTopics +
+                ", copartitionGroups=" + copartitionGroups +
                 '}';
         }
     }
 
     public StreamsAssignmentInterface(UUID processId,
                                       Optional<HostInfo> endpoint,
-                                      String assignor,
                                       Map<String, Subtopology> subtopologyMap,
-                                      Map<String, Object> assignmentConfiguration,
                                       Map<String, String> clientTags
     ) {
         this.processId = processId;
         this.endpoint = endpoint;
-        this.assignor = assignor;
         this.subtopologyMap = subtopologyMap;
-        this.assignmentConfiguration = assignmentConfiguration;
         this.taskLags = new HashMap<>();
         this.shutdownRequested = new AtomicBoolean(false);
         this.clientTags = clientTags;
@@ -285,9 +278,7 @@ public class StreamsAssignmentInterface {
         return "StreamsAssignmentMetadata{" +
             "processID=" + processId +
             ", endpoint='" + endpoint + '\'' +
-            ", assignor='" + assignor + '\'' +
             ", subtopologyMap=" + subtopologyMap +
-            ", assignmentConfiguration=" + assignmentConfiguration +
             ", taskLags=" + taskLags +
             ", clientTags=" + clientTags +
             '}';

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManager.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
+import org.apache.kafka.common.message.StreamsGroupInitializeRequestData.CopartitionGroup;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.StreamsGroupInitializeRequest;
 import org.apache.kafka.common.requests.StreamsGroupInitializeResponse;
@@ -27,9 +28,14 @@ import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class StreamsGroupInitializeRequestManager implements RequestManager {
 
@@ -72,9 +78,8 @@ public class StreamsGroupInitializeRequestManager implements RequestManager {
         streamsGroupInitializeRequestData.setTopologyId(streamsAssignmentInterface.topologyId());
         final List<StreamsGroupInitializeRequestData.Subtopology> topology = getTopologyFromStreams();
         streamsGroupInitializeRequestData.setTopology(topology);
-        final StreamsGroupInitializeRequest.Builder streamsGroupInitializeRequestBuilder = new StreamsGroupInitializeRequest.Builder(
-            streamsGroupInitializeRequestData
-        );
+        final StreamsGroupInitializeRequest.Builder streamsGroupInitializeRequestBuilder =
+            new StreamsGroupInitializeRequest.Builder(streamsGroupInitializeRequestData);
         return new NetworkClientDelegate.UnsentRequest(
             streamsGroupInitializeRequestBuilder,
             coordinatorRequestManager.coordinator()
@@ -95,10 +100,56 @@ public class StreamsGroupInitializeRequestManager implements RequestManager {
         final StreamsGroupInitializeRequestData.Subtopology subtopologyData = new StreamsGroupInitializeRequestData.Subtopology();
         subtopologyData.setSubtopologyId(subtopologyName);
         subtopologyData.setSourceTopics(new ArrayList<>(subtopology.sourceTopics));
+        Collections.sort(subtopologyData.sourceTopics());
         subtopologyData.setRepartitionSinkTopics(new ArrayList<>(subtopology.sinkTopics));
+        Collections.sort(subtopologyData.repartitionSinkTopics());
         subtopologyData.setRepartitionSourceTopics(getRepartitionTopicsInfoFromStreams(subtopology));
         subtopologyData.setStateChangelogTopics(getChangelogTopicsInfoFromStreams(subtopology));
+        subtopologyData.setCopartitionGroups(
+            getCopartitionGroupsFromStreams(subtopology.copartitionGroups, subtopologyData));
         return subtopologyData;
+    }
+
+    private static List<CopartitionGroup> getCopartitionGroupsFromStreams(
+        final Collection<Set<String>> copartitionGroups,
+        final StreamsGroupInitializeRequestData.Subtopology subtopologyData) {
+
+        final Map<String, Integer> sourceTopicsMap =
+            IntStream.range(0, subtopologyData.sourceTopics().size())
+                .boxed()
+                .collect(Collectors.toMap(subtopologyData.sourceTopics()::get, i -> i));
+
+        final Map<String, Integer> repartitionSourceTopics =
+            IntStream.range(0, subtopologyData.repartitionSourceTopics().size())
+                .boxed()
+                .collect(
+                    Collectors.toMap(x -> subtopologyData.repartitionSourceTopics().get(x).name(),
+                        i -> i));
+
+        return copartitionGroups.stream()
+            .map(x -> getCopartitionGroupFromStreams(x, sourceTopicsMap, repartitionSourceTopics))
+            .collect(Collectors.toList());
+    }
+
+    private static CopartitionGroup getCopartitionGroupFromStreams(
+        final Set<String> topicNames,
+        final Map<String, Integer> sourceTopicsMap,
+        final Map<String, Integer> repartitionSourceTopics) {
+        CopartitionGroup copartitionGroup = new CopartitionGroup();
+
+        topicNames.forEach(topicName -> {
+            if (sourceTopicsMap.containsKey(topicName)) {
+                copartitionGroup.sourceTopics().add(sourceTopicsMap.get(topicName));
+            } else if (repartitionSourceTopics.containsKey(topicName)) {
+                copartitionGroup.repartitionSourceTopics()
+                    .add(repartitionSourceTopics.get(topicName));
+            } else {
+                throw new IllegalStateException(
+                    "Source topic not found in subtopology: " + topicName);
+            }
+        });
+
+        return copartitionGroup;
     }
 
     private static List<StreamsGroupInitializeRequestData.TopicInfo> getRepartitionTopicsInfoFromStreams(final StreamsAssignmentInterface.Subtopology subtopologyDataFromStreams) {
@@ -107,6 +158,7 @@ public class StreamsGroupInitializeRequestManager implements RequestManager {
             final StreamsGroupInitializeRequestData.TopicInfo repartitionTopicInfo = new StreamsGroupInitializeRequestData.TopicInfo();
             repartitionTopicInfo.setName(repartitionTopic.getKey());
             repartitionTopic.getValue().numPartitions.ifPresent(repartitionTopicInfo::setPartitions);
+            repartitionTopic.getValue().replicationFactor.ifPresent(repartitionTopicInfo::setReplicationFactor);
             repartitionTopicsInfo.add(repartitionTopicInfo);
         }
         return repartitionTopicsInfo;
@@ -117,11 +169,12 @@ public class StreamsGroupInitializeRequestManager implements RequestManager {
         for (final Map.Entry<String, StreamsAssignmentInterface.TopicInfo> changelogTopic : subtopologyDataFromStreams.stateChangelogTopics.entrySet()) {
             final StreamsGroupInitializeRequestData.TopicInfo changelogTopicInfo = new StreamsGroupInitializeRequestData.TopicInfo();
             changelogTopicInfo.setName(changelogTopic.getKey());
+            changelogTopic.getValue().replicationFactor.ifPresent(changelogTopicInfo::setReplicationFactor);
             changelogTopicsInfo.add(changelogTopicInfo);
         }
         return changelogTopicsInfo;
     }
-    
+
     private void onResponse(final ClientResponse response, final Throwable exception) {
         if (exception != null) {
             // todo: handle error

--- a/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
@@ -52,14 +52,14 @@
               "about": "String to uniquely identify the subtopology. Deterministically generated from the topology." },
             { "name": "SourceTopics", "type": "[]string", "versions": "0+",
               "about": "The topics the topology reads from." },
-            { "name": "SourceTopicRegex", "type": "string", "versions": "0+",
-              "about": "The regular expressions identifying topics the topology reads from." },
             { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
               "about": "The repartition topics the topology writes to." },
+            { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+              "about": "Regular expressions identifying topics the subtopology reads from." },
             { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
               "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
             { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-              "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+              "about": "The set of source topics that are internally created repartition topics." }
           ]
         },
         { "name": "Members", "type": "[]Member", "versions": "0+",
@@ -143,7 +143,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]KeyValue", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]KeyValue", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
@@ -32,14 +32,25 @@
           "about": "String to uniquely identify the subtopology. Deterministically generated from the topology." },
         { "name": "SourceTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology reads from." },
-        { "name": "SourceTopicRegex", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-          "about": "The regular expressions identifying topics the subtopology reads from." },
+        { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+          "about": "Regular expressions identifying topics the subtopology reads from." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
           "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
         { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
           "about": "The repartition topics the subtopology writes to." },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. Created automatically." }
+          "about": "The set of source topics that are internally created repartition topics. Created automatically." },
+        { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
+          "about": "A subset of source topics that must be copartitioned.",
+          "fields": [
+            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The topics the topology reads from. Index into the array on the subtopology level." },
+            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+              "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
+            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
+          ]
+        }
       ]
     }
   ],
@@ -56,7 +67,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupInitializeRequest.json
@@ -43,11 +43,11 @@
         { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
           "about": "A subset of source topics that must be copartitioned.",
           "fields": [
-            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+            { "name": "SourceTopics", "type": "[]int16", "versions": "0+",
               "about": "The topics the topology reads from. Index into the array on the subtopology level." },
-            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+            { "name": "SourceTopicRegex", "type": "[]int16", "versions": "0+",
               "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
-            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+            { "name": "RepartitionSourceTopics", "type": "[]int16", "versions": "0+",
               "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
           ]
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -107,11 +107,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
 
     private final StreamsAssignmentInterface.HostInfo endPoint = new StreamsAssignmentInterface.HostInfo("localhost", 8080);
 
-    private final String assignor = "test";
-
     private final Map<String, Subtopology> subtopologyMap = new HashMap<>();
-
-    private final Map<String, Object> assignmentConfiguration = new HashMap<>();
 
     private final Map<String, String> clientTags = new HashMap<>();
 
@@ -122,15 +118,12 @@ class StreamsGroupHeartbeatRequestManagerTest {
         config = config();
 
         subtopologyMap.clear();
-        assignmentConfiguration.clear();
         clientTags.clear();
         streamsAssignmentInterface =
             new StreamsAssignmentInterface(
                 processID,
                 Optional.of(endPoint),
-                assignor,
                 subtopologyMap,
-                assignmentConfiguration,
                 clientTags
             );
         LogContext logContext = new LogContext("test");
@@ -205,7 +198,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
     @Test
     void testFullStaticInformationWhenJoining() {
         mockJoiningState();
-        assignmentConfiguration.put("config1", "value1");
         clientTags.put("clientTag1", "value2");
 
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
@@ -245,7 +237,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
         final Uuid uuid0 = Uuid.randomUuid();
         final Uuid uuid1 = Uuid.randomUuid();
 
-        final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Collections.emptyMap());
+        final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Optional.empty(), Collections.emptyMap());
 
         when(metadata.topicIds()).thenReturn(
             mkMap(
@@ -258,21 +250,24 @@ class StreamsGroupHeartbeatRequestManagerTest {
                 Collections.singleton("source0"),
                 Collections.singleton("sink0"),
                 Collections.singletonMap("repartition0", emptyTopicInfo),
-                Collections.singletonMap("changelog0", emptyTopicInfo)
+                Collections.singletonMap("changelog0", emptyTopicInfo),
+                Collections.singletonList(mkSet("source0", "repartition0"))
             ));
         streamsAssignmentInterface.subtopologyMap().put("1",
             new Subtopology(
                 Collections.singleton("source1"),
                 Collections.singleton("sink1"),
                 Collections.singletonMap("repartition1", emptyTopicInfo),
-                Collections.singletonMap("changelog1", emptyTopicInfo)
+                Collections.singletonMap("changelog1", emptyTopicInfo),
+                Collections.singletonList(mkSet("source1", "repartition1"))
             ));
         streamsAssignmentInterface.subtopologyMap().put("2",
             new Subtopology(
                 Collections.singleton("source2"),
                 Collections.singleton("sink2"),
                 Collections.singletonMap("repartition2", emptyTopicInfo),
-                Collections.singletonMap("changelog2", emptyTopicInfo)
+                Collections.singletonMap("changelog2", emptyTopicInfo),
+                Collections.singletonList(mkSet("source2", "repartition2"))
             ));
 
         StreamsGroupHeartbeatResponseData data = new StreamsGroupHeartbeatResponseData()

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupInitializeRequestManagerTest.java
@@ -140,10 +140,10 @@ class StreamsGroupInitializeRequestManagerTest {
 
         assertEquals(2, subtopology.copartitionGroups().size());
         final StreamsGroupInitializeRequestData.CopartitionGroup copartitionGroupData1 = subtopology.copartitionGroups().get(0);
-        assertEquals(Collections.singletonList(0), copartitionGroupData1.sourceTopics());
-        assertEquals(Collections.singletonList(1), copartitionGroupData1.repartitionSourceTopics());
+        assertEquals(Collections.singletonList((short) 0), copartitionGroupData1.sourceTopics());
+        assertEquals(Collections.singletonList((short) 1), copartitionGroupData1.repartitionSourceTopics());
         final StreamsGroupInitializeRequestData.CopartitionGroup copartitionGroupData2 = subtopology.copartitionGroups().get(1);
-        assertEquals(Collections.singletonList(1), copartitionGroupData2.sourceTopics());
-        assertEquals(Collections.singletonList(0), copartitionGroupData2.repartitionSourceTopics());
+        assertEquals(Collections.singletonList((short) 1), copartitionGroupData2.sourceTopics());
+        assertEquals(Collections.singletonList((short) 0), copartitionGroupData2.repartitionSourceTopics());
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -205,6 +205,7 @@ import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CONSUMER_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.STREAMS_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember.hasAssignedPartitionsChanged;
+import static org.apache.kafka.coordinator.group.streams.CoordinatorStreamsRecordHelpers.convertToStreamsGroupTopologyRecord;
 import static org.apache.kafka.coordinator.group.streams.CoordinatorStreamsRecordHelpers.newStreamsGroupCurrentAssignmentRecord;
 import static org.apache.kafka.coordinator.group.streams.CoordinatorStreamsRecordHelpers.newStreamsGroupCurrentAssignmentTombstoneRecord;
 import static org.apache.kafka.coordinator.group.streams.CoordinatorStreamsRecordHelpers.newStreamsGroupEpochRecord;
@@ -2597,6 +2598,8 @@ public class GroupMetadataManager {
             }
         }
 
+        StreamsGroupTopologyValue recordValue = convertToStreamsGroupTopologyRecord(subtopologies);
+
         cancelStreamsGroupTopologyInitializationTimeout(groupId, topologyId);
 
         if (!missingTopics.isEmpty()) {
@@ -2607,9 +2610,12 @@ public class GroupMetadataManager {
 
             return new CoordinatorResult<>(records, response);
         } else {
-            records.add(newStreamsGroupTopologyRecord(groupId, subtopologies));
+            records.add(newStreamsGroupTopologyRecord(groupId, recordValue));
 
-            final StreamsTopology topology = new StreamsTopology(topologyId, subtopologies);
+            final Map<String, StreamsGroupTopologyValue.Subtopology> subtopologyMap = recordValue.topology().stream()
+                .collect(Collectors.toMap(StreamsGroupTopologyValue.Subtopology::subtopologyId, x -> x));
+
+            final StreamsTopology topology = new StreamsTopology(topologyId, subtopologyMap);
 
             computeFirstTargetAssignmentAfterTopologyInitialization(group, records, topology);
 

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
@@ -29,14 +29,25 @@
           "about": "String to uniquely identify the subtopology. Deterministically generated from the topology." },
         { "name": "SourceTopics", "type": "[]string", "versions": "0+",
           "about": "The topics the topology reads from." },
-        { "name": "SourceTopicRegex", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-          "about": "The regular expressions identifying topics the topology reads from. null if not provided." },
+        { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
+          "about": "Regular expressions identifying topics the sub-topology reads from." },
         { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of state changelog topics associated with this subtopology. " },
+          "about": "The set of state changelog topics associated with this sub-topology." },
         { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
           "about": "The repartition topics the subtopology writes to." },
         { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
-          "about": "The set of source topics that are internally created repartition topics. " }
+          "about": "The set of source topics that are internally created repartition topics." },
+        { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
+          "about": "A subset of source topics that must be copartitioned.",
+          "fields": [
+            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The topics the topology reads from. Index into the array on the subtopology level." },
+            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+              "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
+            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+              "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
+          ]
+        }
       ]
     }
   ],
@@ -53,7 +64,9 @@
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },
-      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      { "name": "ReplicationFactor", "type": "int16", "versions": "0+",
+        "about": "The replication factor of the topic. Can be 0 if the default replication factor should be used." },
+      { "name": "TopicConfigs", "type": "[]TopicConfig", "versions": "0+",
         "about": "Topic-level configurations as key-value pairs."
       }
     ]}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTopologyValue.json
@@ -40,11 +40,11 @@
         { "name": "CopartitionGroups", "type": "[]CopartitionGroup", "versions": "0+",
           "about": "A subset of source topics that must be copartitioned.",
           "fields": [
-            { "name": "SourceTopics", "type": "[]int32", "versions": "0+",
+            { "name": "SourceTopics", "type": "[]int16", "versions": "0+",
               "about": "The topics the topology reads from. Index into the array on the subtopology level." },
-            { "name": "SourceTopicRegex", "type": "[]int32", "versions": "0+",
+            { "name": "SourceTopicRegex", "type": "[]int16", "versions": "0+",
               "about": "Regular expressions identifying topics the subtopology reads from. Index into the array on the subtopology level." },
-            { "name": "RepartitionSourceTopics", "type": "[]int32", "versions": "0+",
+            { "name": "RepartitionSourceTopics", "type": "[]int16", "versions": "0+",
               "about": "The set of source topics that are internally created repartition topics. Index into the array on the subtopology level." }
           ]
         }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,11 +39,13 @@ class CoordinatorStreamsRecordHelpersTest {
                 .setSubtopologyId("subtopology-id")
                 .setRepartitionSinkTopics(Collections.singletonList("foo"))
                 .setSourceTopics(Collections.singletonList("bar"))
+                .setSourceTopicRegex(Collections.singletonList("regex"))
                 .setRepartitionSourceTopics(
                     Collections.singletonList(
                         new StreamsGroupInitializeRequestData.TopicInfo()
                             .setName("repartition")
                             .setPartitions(4)
+                            .setReplicationFactor((short) 3)
                             .setTopicConfigs(Collections.singletonList(
                                 new StreamsGroupInitializeRequestData.TopicConfig()
                                     .setKey("config-name1")
@@ -54,6 +57,7 @@ class CoordinatorStreamsRecordHelpersTest {
                     Collections.singletonList(
                         new StreamsGroupInitializeRequestData.TopicInfo()
                             .setName("changelog")
+                            .setReplicationFactor((short) 2)
                             .setTopicConfigs(Collections.singletonList(
                                 new StreamsGroupInitializeRequestData.TopicConfig()
                                     .setKey("config-name2")
@@ -61,6 +65,13 @@ class CoordinatorStreamsRecordHelpersTest {
                             ))
                     )
                 )
+                .setCopartitionGroups(Arrays.asList(
+                    new StreamsGroupInitializeRequestData.CopartitionGroup()
+                        .setSourceTopics(Collections.singletonList(0))
+                        .setRepartitionSourceTopics(Collections.singletonList(0)),
+                    new StreamsGroupInitializeRequestData.CopartitionGroup()
+                        .setSourceTopicRegex(Collections.singletonList(0))
+                ))
             );
 
         List<StreamsGroupTopologyValue.Subtopology> expectedTopology =
@@ -68,11 +79,13 @@ class CoordinatorStreamsRecordHelpersTest {
                 .setSubtopologyId("subtopology-id")
                 .setRepartitionSinkTopics(Collections.singletonList("foo"))
                 .setSourceTopics(Collections.singletonList("bar"))
+                .setSourceTopicRegex(Collections.singletonList("regex"))
                 .setRepartitionSourceTopics(
                     Collections.singletonList(
                         new StreamsGroupTopologyValue.TopicInfo()
                             .setName("repartition")
                             .setPartitions(4)
+                            .setReplicationFactor((short) 3)
                             .setTopicConfigs(Collections.singletonList(
                                 new StreamsGroupTopologyValue.TopicConfig()
                                     .setKey("config-name1")
@@ -84,6 +97,7 @@ class CoordinatorStreamsRecordHelpersTest {
                     Collections.singletonList(
                         new StreamsGroupTopologyValue.TopicInfo()
                             .setName("changelog")
+                            .setReplicationFactor((short) 2)
                             .setTopicConfigs(Collections.singletonList(
                                 new StreamsGroupTopologyValue.TopicConfig()
                                     .setKey("config-name2")
@@ -91,6 +105,13 @@ class CoordinatorStreamsRecordHelpersTest {
                             ))
                     )
                 )
+                .setCopartitionGroups(Arrays.asList(
+                    new StreamsGroupTopologyValue.CopartitionGroup()
+                        .setSourceTopics(Collections.singletonList(0))
+                        .setRepartitionSourceTopics(Collections.singletonList(0)),
+                    new StreamsGroupTopologyValue.CopartitionGroup()
+                        .setSourceTopicRegex(Collections.singletonList(0))
+                ))
             );
 
         CoordinatorRecord expectedRecord = new CoordinatorRecord(
@@ -108,4 +129,5 @@ class CoordinatorStreamsRecordHelpersTest {
             topology
         ));
     }
+
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CoordinatorStreamsRecordHelpersTest.java
@@ -67,10 +67,10 @@ class CoordinatorStreamsRecordHelpersTest {
                 )
                 .setCopartitionGroups(Arrays.asList(
                     new StreamsGroupInitializeRequestData.CopartitionGroup()
-                        .setSourceTopics(Collections.singletonList(0))
-                        .setRepartitionSourceTopics(Collections.singletonList(0)),
+                        .setSourceTopics(Collections.singletonList((short) 0))
+                        .setRepartitionSourceTopics(Collections.singletonList((short) 0)),
                     new StreamsGroupInitializeRequestData.CopartitionGroup()
-                        .setSourceTopicRegex(Collections.singletonList(0))
+                        .setSourceTopicRegex(Collections.singletonList((short) 0))
                 ))
             );
 
@@ -107,10 +107,10 @@ class CoordinatorStreamsRecordHelpersTest {
                 )
                 .setCopartitionGroups(Arrays.asList(
                     new StreamsGroupTopologyValue.CopartitionGroup()
-                        .setSourceTopics(Collections.singletonList(0))
-                        .setRepartitionSourceTopics(Collections.singletonList(0)),
+                        .setSourceTopics(Collections.singletonList((short) 0))
+                        .setRepartitionSourceTopics(Collections.singletonList((short) 0)),
                     new StreamsGroupTopologyValue.CopartitionGroup()
-                        .setSourceTopicRegex(Collections.singletonList(0))
+                        .setSourceTopicRegex(Collections.singletonList((short) 0))
                 ))
             );
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsTopologyTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsTopologyTest.java
@@ -145,40 +145,60 @@ public class StreamsTopologyTest {
     public void asStreamsGroupDescribeTopologyShouldReturnCorrectSubtopologies() {
         Map<String, Subtopology> subtopologies = mkMap(
             mkEntry("subtopology-1", new Subtopology()
-                .setSourceTopicRegex("regex-1")
+                .setSourceTopicRegex(Collections.singletonList("regex-1"))
                 .setSubtopologyId("subtopology-1")
                 .setSourceTopics(Collections.singletonList("source-topic-1"))
                 .setRepartitionSinkTopics(Collections.singletonList("sink-topic-1"))
                 .setRepartitionSourceTopics(
-                    Collections.singletonList(new TopicInfo().setName("repartition-topic-1")))
+                    Collections.singletonList(new TopicInfo()
+                        .setName("repartition-topic-1")
+                        .setReplicationFactor((short) 3)
+                        .setPartitions(2)))
                 .setStateChangelogTopics(
-                    Collections.singletonList(new TopicInfo().setName("changelog-topic-1")))
+                    Collections.singletonList(new TopicInfo()
+                        .setName("changelog-topic-1")
+                        .setReplicationFactor((short) 2)
+                        .setPartitions(1)))
             ),
             mkEntry("subtopology-2", new Subtopology()
-                .setSourceTopicRegex("regex-2")
+                .setSourceTopicRegex(Collections.singletonList("regex-2"))
                 .setSubtopologyId("subtopology-2")
                 .setSourceTopics(Collections.singletonList("source-topic-2"))
                 .setRepartitionSinkTopics(Collections.singletonList("sink-topic-2"))
                 .setRepartitionSourceTopics(
-                    Collections.singletonList(new TopicInfo().setName("repartition-topic-2")))
+                    Collections.singletonList(new TopicInfo()
+                        .setName("repartition-topic-2")
+                        .setReplicationFactor((short) 3)
+                        .setPartitions(2)))
                 .setStateChangelogTopics(
-                    Collections.singletonList(new TopicInfo().setName("changelog-topic-2")))
+                    Collections.singletonList(new TopicInfo()
+                        .setName("changelog-topic-2")
+                        .setReplicationFactor((short) 2)
+                        .setPartitions(1)))
             )
         );
         StreamsTopology topology = new StreamsTopology("topology-id", subtopologies);
         List<StreamsGroupDescribeResponseData.Subtopology> result = topology.asStreamsGroupDescribeTopology();
         assertEquals(2, result.size());
-        assertEquals("regex-1", result.get(0).sourceTopicRegex());
+        assertEquals(Collections.singletonList("regex-1"), result.get(0).sourceTopicRegex());
         assertEquals("subtopology-1", result.get(0).subtopologyId());
         assertEquals(Collections.singletonList("source-topic-1"), result.get(0).sourceTopics());
         assertEquals(Collections.singletonList("sink-topic-1"), result.get(0).repartitionSinkTopics());
         assertEquals("repartition-topic-1", result.get(0).repartitionSourceTopics().get(0).name());
+        assertEquals((short) 3, result.get(0).repartitionSourceTopics().get(0).replicationFactor());
+        assertEquals(2, result.get(0).repartitionSourceTopics().get(0).partitions());
         assertEquals("changelog-topic-1", result.get(0).stateChangelogTopics().get(0).name());
-        assertEquals("regex-2", result.get(1).sourceTopicRegex());
+        assertEquals((short) 2, result.get(0).stateChangelogTopics().get(0).replicationFactor());
+        assertEquals(1, result.get(0).stateChangelogTopics().get(0).partitions());
+        assertEquals(Collections.singletonList("regex-2"), result.get(1).sourceTopicRegex());
         assertEquals("subtopology-2", result.get(1).subtopologyId());
         assertEquals(Collections.singletonList("source-topic-2"), result.get(1).sourceTopics());
         assertEquals(Collections.singletonList("sink-topic-2"), result.get(1).repartitionSinkTopics());
         assertEquals("repartition-topic-2", result.get(1).repartitionSourceTopics().get(0).name());
+        assertEquals((short) 3, result.get(1).repartitionSourceTopics().get(0).replicationFactor());
+        assertEquals(2, result.get(1).repartitionSourceTopics().get(0).partitions());
         assertEquals("changelog-topic-2", result.get(1).stateChangelogTopics().get(0).name());
+        assertEquals((short) 2, result.get(1).stateChangelogTopics().get(0).replicationFactor());
+        assertEquals(1, result.get(1).stateChangelogTopics().get(0).partitions());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -72,6 +72,7 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -548,9 +549,38 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                                       final TopologyMetadata topologyMetadata) {
         final InternalTopologyBuilder internalTopologyBuilder = topologyMetadata.lookupBuilderForNamedTopology(null);
 
+        final Map<String, Subtopology> subtopologyMap = initBrokerTopology(config, internalTopologyBuilder);
+
+        return new StreamsAssignmentInterface(
+            processId,
+            endpoint,
+            subtopologyMap,
+            config.getClientTags()
+        );
+    }
+
+    private static Map<String, Subtopology> initBrokerTopology(final StreamsConfig config, final InternalTopologyBuilder internalTopologyBuilder) {
+        final Map<String, String> defaultTopicConfigs = new HashMap<>();
+        for (final Map.Entry<String, Object> entry : config.originalsWithPrefix(StreamsConfig.TOPIC_PREFIX).entrySet()) {
+            if (entry.getValue() != null) {
+                defaultTopicConfigs.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        final long windowChangeLogAdditionalRetention = config.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG);
+
         final Map<String, Subtopology> subtopologyMap = new HashMap<>();
+        final Collection<Set<String>> copartitionGroups = internalTopologyBuilder.copartitionGroups();
+
         for (final Map.Entry<TopologyMetadata.Subtopology, TopicsInfo> topicsInfoEntry : internalTopologyBuilder.subtopologyToTopicsInfo()
             .entrySet()) {
+
+            final HashSet<String> allSourceTopics = new HashSet<>(
+                topicsInfoEntry.getValue().sourceTopics);
+            topicsInfoEntry.getValue().repartitionSourceTopics.forEach(
+                (repartitionSourceTopic, repartitionTopicInfo) -> {
+                    allSourceTopics.add(repartitionSourceTopic);
+                });
+
             subtopologyMap.put(
                 String.valueOf(topicsInfoEntry.getKey().nodeGroupId),
                 new Subtopology(
@@ -559,44 +589,28 @@ public class StreamThread extends Thread implements ProcessingThread {
                     topicsInfoEntry.getValue().repartitionSourceTopics.entrySet()
                         .stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, e ->
-                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(), e.getValue().topicConfigs))),
+                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(),
+                                Optional.of(config.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG).shortValue()),
+                                e.getValue().properties(defaultTopicConfigs, windowChangeLogAdditionalRetention)))),
                     topicsInfoEntry.getValue().stateChangelogTopics.entrySet()
                         .stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, e ->
-                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(), e.getValue().topicConfigs)))
-
+                            new StreamsAssignmentInterface.TopicInfo(e.getValue().numberOfPartitions(),
+                                Optional.of(config.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG).shortValue()),
+                                e.getValue().properties(defaultTopicConfigs, windowChangeLogAdditionalRetention)))),
+                    copartitionGroups.stream().filter(allSourceTopics::containsAll).collect(
+                        Collectors.toList())
                 )
             );
         }
 
-        // TODO: Which of these are actually needed?
-        // TODO: Maybe we want to split this into assignment properties and internal topic configuration properties
-        final HashMap<String, Object> assignmentProperties = new HashMap<>();
-        assignmentProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, config.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG));
-        assignmentProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, config.getString(StreamsConfig.APPLICATION_SERVER_CONFIG));
-        assignmentProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG));
-        assignmentProperties.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG,
-            config.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG));
-        assignmentProperties.put(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, config.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG));
-        assignmentProperties.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG,
-            config.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG,
-            config.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG,
-            config.getString(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
-            config.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG));
-        assignmentProperties.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG,
-            config.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG));
+        if (subtopologyMap.values().stream().mapToInt(x -> x.copartitionGroups.size()).sum()
+            != copartitionGroups.size()) {
+            throw new IllegalStateException(
+                "Not all copartition groups were converted to broker topology");
+        }
 
-        return new StreamsAssignmentInterface(
-            processId,
-            endpoint,
-            null,
-            subtopologyMap,
-            assignmentProperties,
-            config.getClientTags()
-        );
+        return subtopologyMap;
     }
 
     private static DefaultTaskManager maybeCreateSchedulingTaskManager(final boolean processingThreadsEnabled,


### PR DESCRIPTION
This change updates the current RPCs and schemas to add the following
metadata:

 - copartition groups are added to topology record and initialize RPC
 - multiple regexs are added to topology record and initialize RPC
 - replication factors are added for reach internal topic

We also add code to fill this information correctly from the
`InternalTopologyBuilder` object.

The fields `assignmentConfiguration` and `assignor` in the
`StreamsAssignmentInterface` are removed, because they are not
needed anymore.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
