### PR TITLE
MINOR Fixup KIP-932 label paths

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -19,6 +19,8 @@ build:
       - '.github/**'
       - 'gradle/**'
       - '*gradlew*'
+      - 'build.gradle'
+      - 'settings.gradle'
 
 clients:
 - changed-files:

--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -91,11 +91,12 @@ transactions:
       - any-glob-to-any-file:
           - 'transaction-coordinator/**'
 
-KIP-932:
+kip-932:
   - changed-files:
       - any-glob-to-any-file:
           - 'share/**'
           - 'share-coordinator/**'
+          - 'core/src/*/java/kafka/server/share/**'
 
 docker:
 - changed-files:
@@ -110,12 +111,12 @@ performance:
 consumer:
   - changed-files:
     - any-glob-to-any-file:
-      - 'clients/src/main/java/org/apache/kafka/clients/consumer/**'
+      - 'clients/src/*/java/org/apache/kafka/clients/consumer/**'
 
 producer:
   - changed-files:
     - any-glob-to-any-file:
-      - 'clients/src/main/java/org/apache/kafka/clients/producer/**'
+      - 'clients/src/*/java/org/apache/kafka/clients/producer/**'
 
 kraft:
   - changed-files:


### PR DESCRIPTION
Adds "share" paths in the "core" module to the `kip-932` label. Also fixes some other paths that were missing.