### PR TITLE
MINOR Ensure CI runs on weekends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - 'trunk'
 
   schedule:
-    - cron: '0 0 * * *'    # Run daily at midnight UTC
+    - cron: '0 0 * * 6,7'    # Run on Saturday and Sunday at midnight UTC
 
   pull_request:
     types: [ opened, synchronize, ready_for_review, reopened ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - 'trunk'
 
+  schedule:
+    - cron: '0 11 * * *'    # Run at 11:00 UTC daily
+
   pull_request:
     types: [ opened, synchronize, ready_for_review, reopened ]
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - 'trunk'
 
   schedule:
-    - cron: '0 11 * * *'    # Run at 11:00 UTC daily
+    - cron: '0 0 * * *'    # Run daily at midnight UTC
 
   pull_request:
     types: [ opened, synchronize, ready_for_review, reopened ]


### PR DESCRIPTION
Add a "cron" schedule for the CI workflow to run daily at midnight UTC. This is more or less an arbitrary time. Since Kafka development is globally distributed, there is not an ideal "down" time for this automated run.