### PR TITLE
MINOR: Correctly catch console messages

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -93,8 +93,8 @@ object ConfigCommand extends Logging {
       opts.checkArgs()
 
       if (opts.options.has(opts.zkConnectOpt)) {
-        println(s"Warning: --zookeeper is deprecated and will be removed in a future version of Kafka.")
-        println(s"Use --bootstrap-server instead to specify a broker to connect to.")
+        System.out.println(s"Warning: --zookeeper is deprecated and will be removed in a future version of Kafka.")
+        System.out.println(s"Use --bootstrap-server instead to specify a broker to connect to.")
         processCommandWithZk(opts.options.valueOf(opts.zkConnectOpt), opts)
       } else {
         processCommand(opts)
@@ -172,7 +172,7 @@ object ConfigCommand extends Logging {
 
     adminZkClient.changeConfigs(entityType, entityName, configs, isUserClientId)
 
-    println(s"Completed updating config for entity: $entity.")
+    System.out.println(s"Completed updating config for entity: $entity.")
   }
 
   private def validateBrokersNotRunning(entityName: String,
@@ -278,7 +278,7 @@ object ConfigCommand extends Logging {
       val configs = adminZkClient.fetchEntityConfig(entity.root.entityType, entity.fullSanitizedName)
       // When describing all users, don't include empty user nodes with only <user, client> quota overrides.
       if (!configs.isEmpty || !describeAllUsers) {
-        println("Configs for %s are %s"
+        System.out.println("Configs for %s are %s"
           .format(entity, configs.asScala.map(kv => kv._1 + "=" + kv._2).mkString(",")))
       }
     }
@@ -304,7 +304,7 @@ object ConfigCommand extends Logging {
       configsToBeAdded.foreach(pair => props.setProperty(pair(0).trim, pair(1).replaceAll("\\[?\\]?", "").trim))
     }
     if (props.containsKey(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)) {
-      println(s"WARNING: The configuration ${TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG}=${props.getProperty(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)} is specified. " +
+      System.out.println(s"WARNING: The configuration ${TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG}=${props.getProperty(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)} is specified. " +
         "This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker or " +
         "if the inter.broker.protocol.version is 3.0 or newer. This configuration is deprecated and it will be removed in Apache Kafka 4.0.")
     }
@@ -552,14 +552,14 @@ object ConfigCommand extends Logging {
     entities.foreach { entity =>
       entity match {
         case BrokerDefaultEntityName =>
-          println(s"Default configs for $entityType in the cluster are:")
+          System.out.println(s"Default configs for $entityType in the cluster are:")
         case _ =>
           val configSourceStr = if (describeAll) "All" else "Dynamic"
-          println(s"$configSourceStr configs for ${entityType.dropRight(1)} $entity are:")
+          System.out.println(s"$configSourceStr configs for ${entityType.dropRight(1)} $entity are:")
       }
       getResourceConfig(adminClient, entityType, entity, includeSynonyms = true, describeAll).foreach { entry =>
         val synonyms = entry.synonyms.asScala.map(synonym => s"${synonym.source}:${synonym.name}=${synonym.value}").mkString(", ")
-        println(s"  ${entry.name}=${entry.value} sensitive=${entry.isSensitive} synonyms={$synonyms}")
+        System.out.println(s"  ${entry.name}=${entry.value} sensitive=${entry.isSensitive} synonyms={$synonyms}")
       }
     }
   }
@@ -646,7 +646,7 @@ object ConfigCommand extends Logging {
                        entitySubstr(ClientQuotaEntity.CLIENT_ID) ++
                        entitySubstr(ClientQuotaEntity.IP)).mkString(", ")
       val entriesStr = entries.asScala.map(e => s"${e._1}=${e._2}").mkString(", ")
-      println(s"Quota configs for $entityStr are $entriesStr")
+      System.out.println(s"Quota configs for $entityStr are $entriesStr")
     }
   }
 
@@ -660,9 +660,9 @@ object ConfigCommand extends Logging {
         try {
           val description = result.description(user).get(30, TimeUnit.SECONDS)
           val descriptionText = description.credentialInfos.asScala.map(info => s"${info.mechanism.mechanismName}=iterations=${info.iterations}").mkString(", ")
-          println(s"SCRAM credential configs for user-principal '$user' are $descriptionText")
+          System.out.println(s"SCRAM credential configs for user-principal '$user' are $descriptionText")
         } catch {
-          case e: Exception => println(s"Error retrieving SCRAM credential configs for user-principal '$user': ${e.getClass.getSimpleName}: ${e.getMessage}")
+          case e: Exception => System.out.println(s"Error retrieving SCRAM credential configs for user-principal '$user': ${e.getClass.getSimpleName}: ${e.getMessage}")
         }
       })
     }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -455,9 +455,9 @@ object ConfigCommand extends Logging {
     }
 
     if (entityNameHead.nonEmpty)
-      println(s"Completed updating config for ${entityTypeHead.dropRight(1)} $entityNameHead.")
+      System.out.println(s"Completed updating config for ${entityTypeHead.dropRight(1)} $entityNameHead.")
     else
-      println(s"Completed updating default config for $entityTypeHead in the cluster.")
+      System.out.println(s"Completed updating default config for $entityTypeHead in the cluster.")
   }
 
   private def alterUserScramCredentialConfigs(adminClient: Admin, user: String, scramConfigsToAddMap: Map[String, ConfigEntry], scramConfigsToDelete: Seq[String]) = {

--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.commons.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -95,9 +94,8 @@ public class ConfigCommandIntegrationTest {
             "--entity-type", "users",
             "--entity-name", "admin",
             "--alter", "--add-config", "consumer_byte_rate=20000"));
-        String message = captureStandardMsg(run(command));
-
-        assertTrue(StringUtils.isBlank(message), message);
+        String message = captureStandardMsg(false, run(command));
+        assertEquals("Completed updating config for user admin.", message);
     }
 
     @ClusterTest
@@ -106,15 +104,15 @@ public class ConfigCommandIntegrationTest {
             "--entity-type", "groups",
             "--entity-name", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
-        String message = captureStandardMsg(run(command));
-        assertTrue(StringUtils.isBlank(message), message);
+        String message = captureStandardMsg(false, run(command));
+        assertEquals("Completed updating config for group group.", message);
 
         // Test for the --group alias
         command = Stream.concat(quorumArgs(), Stream.of(
             "--group", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
-        message = captureStandardMsg(run(command));
-        assertTrue(StringUtils.isBlank(message), message);
+        message = captureStandardMsg(false, run(command));
+        assertEquals("Completed updating config for group group.", message);
     }
 
     @ClusterTest
@@ -123,15 +121,15 @@ public class ConfigCommandIntegrationTest {
                 "--entity-type", "client-metrics",
                 "--entity-name", "cm",
                 "--alter", "--add-config", "metrics=org.apache"));
-        String message = captureStandardMsg(run(command));
-        assertTrue(StringUtils.isBlank(message), message);
+        String message = captureStandardMsg(false, run(command));
+        assertEquals("Completed updating config for client-metric cm.", message);
 
         // Test for the --client-metrics alias
         command = Stream.concat(quorumArgs(), Stream.of(
                 "--client-metrics", "cm",
                 "--alter", "--add-config", "metrics=org.apache"));
-        message = captureStandardMsg(run(command));
-        assertTrue(StringUtils.isBlank(message), message);
+        message = captureStandardMsg(false, run(command));
+        assertEquals("Completed updating config for client-metric cm.", message);
     }
 
     @ClusterTest
@@ -307,7 +305,7 @@ public class ConfigCommandIntegrationTest {
             throw new RuntimeException();
         });
 
-        String errOut = captureStandardMsg(run(args));
+        String errOut = captureStandardMsg(true, run(args));
 
         checkErrOut.accept(errOut);
         assertNotNull(exitStatus.get());
@@ -318,8 +316,8 @@ public class ConfigCommandIntegrationTest {
         return Stream.of("--bootstrap-server", cluster.bootstrapServers());
     }
 
-    private List<String> entityOp(Optional<String> brokerId) {
-        return brokerId.map(id -> asList("--entity-name", id))
+    private List<String> entityOp(Optional<String> entityId) {
+        return entityId.map(id -> asList("--entity-name", id))
                 .orElse(singletonList("--entity-default"));
     }
 
@@ -457,8 +455,8 @@ public class ConfigCommandIntegrationTest {
         return Stream.of(lists).flatMap(List::stream).toArray(String[]::new);
     }
 
-    private String captureStandardMsg(Runnable runnable) {
-        return captureStandardStream(runnable);
+    private String captureStandardMsg(boolean isErr, Runnable runnable) {
+        return captureStandardStream(isErr, runnable);
     }
 
     private String transferConfigMapToString(Map<String, String> configs) {
@@ -468,17 +466,25 @@ public class ConfigCommandIntegrationTest {
                 .collect(Collectors.joining(","));
     }
 
-    private String captureStandardStream(Runnable runnable) {
+    // Copied from ToolsTestUtils.java, can be removed after we move ConfigCommand to tools module
+    private static String captureStandardStream(boolean isErr, Runnable runnable) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        PrintStream currentStream = System.err;
-        try (PrintStream tempStream = new PrintStream(outputStream)) {
+        PrintStream currentStream = isErr ? System.err : System.out;
+        PrintStream tempStream = new PrintStream(outputStream);
+        if (isErr)
             System.setErr(tempStream);
-            try {
-                runnable.run();
-                return outputStream.toString().trim();
-            } finally {
+        else
+            System.setOut(tempStream);
+        try {
+            runnable.run();
+            return outputStream.toString().trim();
+        } finally {
+            if (isErr)
                 System.setErr(currentStream);
-            }
+            else
+                System.setOut(currentStream);
+
+            tempStream.close();
         }
     }
 }

--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -94,7 +94,7 @@ public class ConfigCommandIntegrationTest {
             "--entity-type", "users",
             "--entity-name", "admin",
             "--alter", "--add-config", "consumer_byte_rate=20000"));
-        String message = captureStandardMsg(false, run(command));
+        String message = captureStandardStream(false, run(command));
         assertEquals("Completed updating config for user admin.", message);
     }
 
@@ -104,14 +104,14 @@ public class ConfigCommandIntegrationTest {
             "--entity-type", "groups",
             "--entity-name", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
-        String message = captureStandardMsg(false, run(command));
+        String message = captureStandardStream(false, run(command));
         assertEquals("Completed updating config for group group.", message);
 
         // Test for the --group alias
         command = Stream.concat(quorumArgs(), Stream.of(
             "--group", "group",
             "--alter", "--add-config", "consumer.session.timeout.ms=50000"));
-        message = captureStandardMsg(false, run(command));
+        message = captureStandardStream(false, run(command));
         assertEquals("Completed updating config for group group.", message);
     }
 
@@ -121,14 +121,14 @@ public class ConfigCommandIntegrationTest {
                 "--entity-type", "client-metrics",
                 "--entity-name", "cm",
                 "--alter", "--add-config", "metrics=org.apache"));
-        String message = captureStandardMsg(false, run(command));
+        String message = captureStandardStream(false, run(command));
         assertEquals("Completed updating config for client-metric cm.", message);
 
         // Test for the --client-metrics alias
         command = Stream.concat(quorumArgs(), Stream.of(
                 "--client-metrics", "cm",
                 "--alter", "--add-config", "metrics=org.apache"));
-        message = captureStandardMsg(false, run(command));
+        message = captureStandardStream(false, run(command));
         assertEquals("Completed updating config for client-metric cm.", message);
     }
 
@@ -305,7 +305,7 @@ public class ConfigCommandIntegrationTest {
             throw new RuntimeException();
         });
 
-        String errOut = captureStandardMsg(true, run(args));
+        String errOut = captureStandardStream(true, run(args));
 
         checkErrOut.accept(errOut);
         assertNotNull(exitStatus.get());
@@ -455,10 +455,6 @@ public class ConfigCommandIntegrationTest {
         return Stream.of(lists).flatMap(List::stream).toArray(String[]::new);
     }
 
-    private String captureStandardMsg(boolean isErr, Runnable runnable) {
-        return captureStandardStream(isErr, runnable);
-    }
-
     private String transferConfigMapToString(Map<String, String> configs) {
         return configs.entrySet()
                 .stream()
@@ -467,7 +463,7 @@ public class ConfigCommandIntegrationTest {
     }
 
     // Copied from ToolsTestUtils.java, can be removed after we move ConfigCommand to tools module
-    private static String captureStandardStream(boolean isErr, Runnable runnable) {
+    static String captureStandardStream(boolean isErr, Runnable runnable) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream currentStream = isErr ? System.err : System.out;
         PrintStream tempStream = new PrintStream(outputStream);


### PR DESCRIPTION
*More detailed description of your change*
Some tests didn't catch output messages correctly, for example, the output of a test should be "Completed updating config for user admin." but we didn't got it.  Copied a method from `ToolsTestUtils.java` which can be removed after we move `ConfigCommand` to tools module.

TODO: Change the output stream from `scala.Console.println` to `System.out.println`, if we continue using `scala.Console.println` we can only catch the first output msg, I hadn't find the reason but changing to `System.out.println` to fix it.

*Summary of testing strategy (including rationale)*
No

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
