### PR TITLE
KAFKA-17723 Fix "this-escape" compiler warnings (MultiThreadedEventProcessor and DistributedHerder) introduced by JDK 23

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -255,6 +255,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * @param uponShutdown       any {@link AutoCloseable} objects that should be closed when this herder is {@link #stop() stopped},
      *                           after all services and resources owned by this herder are stopped
      */
+    @SuppressWarnings("this-escape")
     public DistributedHerder(DistributedConfig config,
                              Time time,
                              Worker worker,
@@ -272,6 +273,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     // visible for testing
+    @SuppressWarnings("this-escape")
     DistributedHerder(DistributedConfig config,
                       Worker worker,
                       String workerId,

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
@@ -33,7 +33,7 @@ import java.util.stream.IntStream;
  * A multithreaded {{@link CoordinatorEvent}} processor which uses a {{@link EventAccumulator}}
  * which guarantees that events sharing a partition key are not processed concurrently.
  */
-public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
+public final class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
 
     /**
      * The poll timeout to wait for an event by the EventProcessorThread.
@@ -90,7 +90,6 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      * @param time              The time.
      * @param eventAccumulator  The event accumulator.
      */
-    @SuppressWarnings("this-escape")
     public MultiThreadedEventProcessor(
         LogContext logContext,
         String threadPrefix,

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
@@ -90,6 +90,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      * @param time              The time.
      * @param eventAccumulator  The event accumulator.
      */
+    @SuppressWarnings("this-escape")
     public MultiThreadedEventProcessor(
         LogContext logContext,
         String threadPrefix,


### PR DESCRIPTION
KAFKA-17723: Fix "this-escape" compiler warnings introduced by JDK 21 

Ask is to add @SuppressWarnings("this-escape")  to MultiThreadedEventProcessor and DistributedHerder class constructors. 


More details on this compiler warning:
https://www.oracle.com/java/technologies/javase/21-relnote-issues.html#JDK-8015831