### PR TITLE
KAFKA-17248: Override admin client to push metrics true, test for case where streams metrics [4/N]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -188,7 +188,7 @@ public class AdminClientConfig extends AbstractConfig {
                                         RETRY_BACKOFF_MAX_MS_DOC)
                                 .define(ENABLE_METRICS_PUSH_CONFIG,
                                         Type.BOOLEAN,
-                                        true,
+                                        false,
                                         Importance.LOW,
                                         ENABLE_METRICS_PUSH_DOC)
                                 .define(REQUEST_TIMEOUT_MS_CONFIG,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -8073,7 +8073,7 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testClientInstanceId() {
-        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+        try (AdminClientUnitTestEnv env = mockClientEnv(AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG, "true")) {
             Uuid expected = Uuid.randomUuid();
 
             GetTelemetrySubscriptionsResponseData responseData =

--- a/core/src/test/java/kafka/admin/ClientTelemetryTest.java
+++ b/core/src/test/java/kafka/admin/ClientTelemetryTest.java
@@ -80,6 +80,7 @@ public class ClientTelemetryTest {
     public void testClientInstanceId(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException {
         Map<String, Object> configs = new HashMap<>();
         configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        configs.put(AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG, true);
         try (Admin admin = Admin.create(configs)) {
             String testTopicName = "test_topic";
             admin.createTopics(Collections.singletonList(new NewTopic(testTopicName, 1, (short) 1)));

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -51,6 +51,7 @@ import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssignor;
 import org.apache.kafka.streams.state.BuiltInDslStoreSuppliers;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1473,58 +1474,43 @@ public class StreamsConfig extends AbstractConfig {
         final Boolean adminMetricsConfig = maybeMetricsPushEnabled(ADMIN_CLIENT_PREFIX);
 
         if (streamTelemetryEnabled) {
-            checkConsumerMetricsConfig(adminMetricsConfig, consumerMetricsConfig, mainConsumerMetricsConfig);
-            checkMainConsumerAndAdminMetricsConfig(adminMetricsConfig, consumerMetricsConfig, mainConsumerMetricsConfig);
-            checkMainConsumerMetricsConfig(mainConsumerMetricsConfig);
-            checkAdminMetricsConfig(adminMetricsConfig);
+            checkConsumerAndMainConsumerAndAdminMetricsConfig(adminMetricsConfig, consumerMetricsConfig, mainConsumerMetricsConfig);
+            checkMainConsumerAndAdminMetricsConfig(adminMetricsConfig, mainConsumerMetricsConfig, "enabled");
         }
     }
 
-    private void checkConsumerMetricsConfig(final Boolean adminMetricsConfig,
-                                            final Boolean consumerMetricsConfig,
-                                            final Boolean mainConsumerMetricsConfig) {
-        if (consumerMetricsConfig != null && !consumerMetricsConfig
-                && mainConsumerMetricsConfig == null
-                && adminMetricsConfig == null) {
-            throw new ConfigException("Kafka Streams metrics push enabled but consumer.enable.metrics is false, the setting needs to be consistent between the two");
+
+    private void checkConsumerAndMainConsumerAndAdminMetricsConfig(final Boolean adminMetricsConfig,
+                                                                   final Boolean consumerMetricsConfig,
+                                                                   final Boolean mainConsumerMetricsConfig) {
+        if (consumerMetricsConfig != null) {
+            if (!consumerMetricsConfig
+                    && mainConsumerMetricsConfig == null
+                    && adminMetricsConfig == null) {
+                throw new ConfigException("Kafka Streams metrics push enabled but consumer.enable.metrics is false, the setting needs to be consistent between the two");
+            } else if (consumerMetricsConfig) {
+                checkMainConsumerAndAdminMetricsConfig(adminMetricsConfig, mainConsumerMetricsConfig, "and consumer.enable.metrics are enabled,");
+            }
         }
     }
 
-    private void checkMainConsumerAndAdminMetricsConfig(final Boolean adminMetricsConfig,
-                                                        final Boolean consumerMetricsConfig,
-                                                        final Boolean mainConsumerMetricsConfig) {
-        if (consumerMetricsConfig != null && consumerMetricsConfig
-                && mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig
+    private void checkMainConsumerAndAdminMetricsConfig(final Boolean adminMetricsConfig, final Boolean mainConsumerMetricsConfig, final String message) {
+        if (mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig
                 && adminMetricsConfig != null && !adminMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push and consumer.enable.metrics are true, but main.consumer and admin.client metrics push are disabled, the setting needs to be consistent between the two");
-        } else if (consumerMetricsConfig != null && consumerMetricsConfig
-                && mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push and consumer.enable.metrics are true, but main.consumer metrics disabled, the setting needs to be consistent between the two");
-        } else if (consumerMetricsConfig != null && consumerMetricsConfig
-                && adminMetricsConfig != null && !adminMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push and consumer.enable.metrics are true, but admin.client metrics push are disabled, the setting needs to be consistent between the two");
-        } else if (mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig
-                && adminMetricsConfig != null && !adminMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push enabled, but main.consumer and admin.client metrics push is false, these settings need to updated");
+            throw new ConfigException("Kafka Streams metrics push " + message + " but main.consumer and admin.client metrics push are disabled, the setting needs to be consistent between the two");
+        } else if (mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig) {
+            throw new ConfigException("Kafka Streams metrics push " + message + " but main.consumer metrics push is disabled, the setting needs to be consistent between the two");
+        } else if (adminMetricsConfig != null && !adminMetricsConfig) {
+            throw new ConfigException("Kafka Streams metrics push " + message + " but admin.client metrics push is disabled, the setting needs to be consistent between the two");
         }
     }
-
-    private void checkMainConsumerMetricsConfig(final Boolean mainConsumerMetricsConfig) {
-        if (mainConsumerMetricsConfig != null && !mainConsumerMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push enabled, but main.consumer metrics push is false, the setting needs to be consistent between the two");
-        }
-    }
-
-    private void checkAdminMetricsConfig(final Boolean adminMetricsConfig) {
-        if (adminMetricsConfig != null && !adminMetricsConfig) {
-            throw new ConfigException("Kafka Streams metrics push enabled, but admin.client metrics push is false, the setting needs to be consistent between the two");
-        }
-    }
-
 
     private Boolean maybeMetricsPushEnabled(final String prefix) {
-        return originalsWithPrefix(prefix).containsKey(ENABLE_METRICS_PUSH_CONFIG) ?
-                (boolean) originalsWithPrefix(prefix).get(ENABLE_METRICS_PUSH_CONFIG) : null;
+        Boolean configSetValue = null;
+        if (originalsWithPrefix(prefix).containsKey(ENABLE_METRICS_PUSH_CONFIG)) {
+            configSetValue =  (Boolean) originalsWithPrefix(prefix).get(ENABLE_METRICS_PUSH_CONFIG);
+        }
+        return configSetValue;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -1313,7 +1313,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push enabled, but main.consumer metrics push is false, the setting needs to be consistent between the two")
+                containsString("main.consumer metrics push is disabled")
         );
     }
 
@@ -1339,7 +1339,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push and consumer.enable.metrics are true, but main.consumer and admin.client metrics push are disabled, the setting needs to be consistent between the two")
+                containsString("Kafka Streams metrics push and consumer.enable.metrics are enabled, but main.consumer and admin.client metrics push are disabled")
         );
     }
 
@@ -1352,7 +1352,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push and consumer.enable.metrics are true, but main.consumer metrics disabled, the setting needs to be consistent between the two")
+                containsString("main.consumer metrics push is disabled")
         );
     }
 
@@ -1365,7 +1365,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push and consumer.enable.metrics are true, but admin.client metrics push are disabled, the setting needs to be consistent between the two")
+                containsString("admin.client metrics push is disabled")
         );
     }
 
@@ -1401,7 +1401,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push enabled, but admin.client metrics push is false, the setting needs to be consistent between the two")
+                containsString("admin.client metrics push is disabled")
         );
     }
 
@@ -1414,7 +1414,7 @@ public class StreamsConfigTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Kafka Streams metrics push enabled, but main.consumer and admin.client metrics push is false, these settings need to updated")
+                containsString("main.consumer and admin.client metrics push are disabled")
         );
     }
 


### PR DESCRIPTION
This PR disables metrics push for the `AdminClient` as the default.  KafkaStreams enables metrics push for its internal `AdminClient`.  

Tests are included that assert an error if a user disables either the main consumer or admin client metrics push but Kafka Streams metrics push config is enabled.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
