### PR TITLE
KAFKA-16896 upgrade spotless version after we drop JDK8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2824,15 +2824,12 @@ project(':streams:streams-scala') {
     dependsOn 'copyDependantLibs'
   }
 
-  // spotless 6.25 requires Java 11 at runtime
-  if (JavaVersion.current().isJava11Compatible()) {
-    apply plugin: 'com.diffplug.spotless'
-    spotless {
-      scala {
-        target '**/*.scala'
-        scalafmt("$versions.scalafmt").configFile('../../checkstyle/.scalafmt.conf').scalaMajorVersion(versions.baseScala)
-        licenseHeaderFile '../../checkstyle/java.header', 'package'
-      }
+  apply plugin: 'com.diffplug.spotless'
+  spotless {
+    scala {
+      target '**/*.scala'
+      scalafmt("$versions.scalafmt").configFile('../../checkstyle/.scalafmt.conf').scalaMajorVersion(versions.baseScala)
+      licenseHeaderFile '../../checkstyle/java.header', 'package'
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,7 @@ plugins {
   id "com.github.spotbugs" version '5.1.3' apply false
   id 'org.scoverage' version '8.0.3' apply false
   id 'io.github.goooler.shadow' version '8.1.3' apply false
-  //  Spotless 6.13.0 has issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), and Spotless 6.14.0+ requires JRE 11
-  //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
-  //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
-  id 'com.diffplug.spotless' version "6.14.0" apply false
+  id 'com.diffplug.spotless' version "6.25.0"
 }
 
 ext {
@@ -854,17 +851,12 @@ subprojects {
     skipProjects = [ ":jmh-benchmarks", ":trogdor" ]
     skipConfigurations = [ "zinc" ]
   }
-  //  the task `removeUnusedImports` is implemented by google-java-format,
-  //  and unfortunately the google-java-format version used by spotless 6.14.0 can't work with JDK 21.
-  //  Hence, we apply spotless tasks only if the env is either JDK11 or JDK17
-  if ((JavaVersion.current().isJava11() || (JavaVersion.current() == JavaVersion.VERSION_17))) {
-    apply plugin: 'com.diffplug.spotless'
-    spotless {
-      java {
-        targetExclude('**/generated/**/*.java','**/generated-test/**/*.java')
-        importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
-        removeUnusedImports()
-      }
+  apply plugin: 'com.diffplug.spotless'
+  spotless {
+    java {
+      targetExclude('**/generated/**/*.java','**/generated-test/**/*.java')
+      importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
+      removeUnusedImports()
     }
   }
 }
@@ -2832,7 +2824,7 @@ project(':streams:streams-scala') {
     dependsOn 'copyDependantLibs'
   }
 
-  // spotless 6.14 requires Java 11 at runtime
+  // spotless 6.25 requires Java 11 at runtime
   if (JavaVersion.current().isJava11Compatible()) {
     apply plugin: 'com.diffplug.spotless'
     spotless {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-16896
update spotless version to 6.25.0 because we drop jdk8 in CI

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
