### PR TITLE
KAFKA-17727: swallow exceptions on segment flush

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Modifier;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
@@ -1005,6 +1006,25 @@ public final class Utils {
             fileChannel.force(true);
         } catch (NoSuchFileException e) {
             log.warn("Failed to flush file {}", path, e);
+        }
+    }
+
+    @FunctionalInterface
+    public interface FlushSegmentAction {
+        void run() throws IOException;
+    }
+
+    /**
+     * Executes the callback to flush segments and swallows {@link NoSuchFileException} and
+     * {@link ClosedChannelException}.
+     *
+     * @throws IOException on any other IO Error
+     */
+    public static void flushSegmentsIfExists(FlushSegmentAction flushSegmentAction) throws IOException {
+        try {
+            flushSegmentAction.run();
+        } catch (NoSuchFileException | ClosedChannelException e) {
+            log.warn("Failed to flush file", e);
         }
     }
 

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -673,6 +673,17 @@ class LocalLogTest {
   }
 
   @Test
+  def testFlushingClosedSegment(): Unit = {
+    appendRecords(List(KeyValue("k1", "v1").toRecord()))
+    val newSegment = log.roll()
+
+    // simulate the log segment being closed concurrently
+    log.close()
+
+    assertDoesNotThrow((() => log.flush(newSegment.baseOffset)): Executable)
+  }
+
+  @Test
   def testFlushingNonExistentDir(): Unit = {
     val spyLog = spy(log)
 


### PR DESCRIPTION
`UnifiedLog::roll` schedules a flush which introduced a race as the underlying log may have been closed due to a directory reassignment or deletion. This may lead to `ClosedChannelException` or `NoSuchFileException`, which if uncaught may mark the log directory as offline inadvertently.

This change therefore swallows the aforementioned exceptions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
