### PR TITLE
KAFKA-17739: Clean up build.gradle to adopt the minimum Java version as 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,17 @@ subprojects {
     addParametersForTests(name, options)
   }
 
+  java {
+    // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
+    // `-target` incorrectly if this is unset
+    sourceCompatibility = minJavaVersion
+    targetCompatibility = minJavaVersion
+  }
+
+  compileJava {
+    options.release = minJavaVersion
+  }
+
   if (shouldPublish) {
 
     publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -315,10 +315,6 @@ subprojects {
     targetCompatibility = minJavaVersion
   }
 
-  compileJava {
-    options.release = minJavaVersion
-  }
-
   if (shouldPublish) {
 
     publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -308,13 +308,6 @@ subprojects {
     addParametersForTests(name, options)
   }
 
-  java {
-    // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
-    // `-target` incorrectly if this is unset
-    sourceCompatibility = minJavaVersion
-    targetCompatibility = minJavaVersion
-  }
-
   if (shouldPublish) {
 
     publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ plugins {
 
 ext {
   gradleVersion = versions.gradle
-  minJavaVersion = 8
+  minJavaVersion = 11
   buildVersionFileName = "kafka-version.properties"
 
   defaultMaxHeapSize = "2g"
@@ -184,12 +184,7 @@ allprojects {
     options.addStringOption('Xdoclint:none', '-quiet')
     // Javadoc warnings should fail the build in JDK 15+ https://bugs.openjdk.org/browse/JDK-8200363
     options.addBooleanOption('Werror', JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15))
-
-    // The URL structure was changed to include the locale after Java 8
-    if (JavaVersion.current().isJava11Compatible())
-      options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
-    else
-      options.links "https://docs.oracle.com/javase/8/docs/api/"
+    options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
   }
 
   clean {
@@ -309,23 +304,8 @@ subprojects {
     options.compilerArgs << "-Xlint:-serial"
     options.compilerArgs << "-Xlint:-try"
     options.compilerArgs << "-Werror"
-
-    // --release is the recommended way to select the target release, but it's only supported in Java 9 so we also
-    // set --source and --target via `sourceCompatibility` and `targetCompatibility` a couple of lines below
-    if (JavaVersion.current().isJava9Compatible())
-      options.release = minJavaVersion
-    // --source/--target 8 is deprecated in Java 20, suppress warning until Java 8 support is dropped in Kafka 4.0
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_20))
-      options.compilerArgs << "-Xlint:-options"
-
+    options.release = minJavaVersion
     addParametersForTests(name, options)
-  }
-
-  java {
-    // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
-    // `-target` incorrectly if this is unset
-    sourceCompatibility = minJavaVersion
-    targetCompatibility = minJavaVersion
   }
 
   if (shouldPublish) {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientProvider.java
@@ -27,7 +27,7 @@ public class OAuthBearerSaslClientProvider extends Provider {
 
     @SuppressWarnings("this-escape")
     protected OAuthBearerSaslClientProvider() {
-        super("SASL/OAUTHBEARER Client Provider", 1.0, "SASL/OAUTHBEARER Client Provider for Kafka");
+        super("SASL/OAUTHBEARER Client Provider", "1.0", "SASL/OAUTHBEARER Client Provider for Kafka");
         put("SaslClientFactory." + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
                 OAuthBearerSaslClientFactory.class.getName());
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerProvider.java
@@ -27,7 +27,7 @@ public class OAuthBearerSaslServerProvider extends Provider {
 
     @SuppressWarnings("this-escape")
     protected OAuthBearerSaslServerProvider() {
-        super("SASL/OAUTHBEARER Server Provider", 1.0, "SASL/OAUTHBEARER Server Provider for Kafka");
+        super("SASL/OAUTHBEARER Server Provider", "1.0", "SASL/OAUTHBEARER Server Provider for Kafka");
         put("SaslServerFactory." + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
                 OAuthBearerSaslServerFactory.class.getName());
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerProvider.java
@@ -27,7 +27,7 @@ public class PlainSaslServerProvider extends Provider {
 
     @SuppressWarnings("this-escape")
     protected PlainSaslServerProvider() {
-        super("Simple SASL/PLAIN Server Provider", 1.0, "Simple SASL/PLAIN Server Provider for Kafka");
+        super("Simple SASL/PLAIN Server Provider", "1.0", "Simple SASL/PLAIN Server Provider for Kafka");
         put("SaslServerFactory." + PlainSaslServer.PLAIN_MECHANISM, PlainSaslServerFactory.class.getName());
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClientProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClientProvider.java
@@ -27,7 +27,7 @@ public class ScramSaslClientProvider extends Provider {
 
     @SuppressWarnings("this-escape")
     protected ScramSaslClientProvider() {
-        super("SASL/SCRAM Client Provider", 1.0, "SASL/SCRAM Client Provider for Kafka");
+        super("SASL/SCRAM Client Provider", "1.0", "SASL/SCRAM Client Provider for Kafka");
         for (ScramMechanism mechanism : ScramMechanism.values())
             put("SaslClientFactory." + mechanism.mechanismName(), ScramSaslClientFactory.class.getName());
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerProvider.java
@@ -27,7 +27,7 @@ public class ScramSaslServerProvider extends Provider {
 
     @SuppressWarnings("this-escape")
     protected ScramSaslServerProvider() {
-        super("SASL/SCRAM Server Provider", 1.0, "SASL/SCRAM Server Provider for Kafka");
+        super("SASL/SCRAM Server Provider", "1.0", "SASL/SCRAM Server Provider for Kafka");
         for (ScramMechanism mechanism : ScramMechanism.values())
             put("SaslServerFactory." + mechanism.mechanismName(), ScramSaslServerFactory.class.getName());
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestPlainSaslServerProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestPlainSaslServerProvider.java
@@ -21,10 +21,10 @@ import java.security.Provider;
 public class TestPlainSaslServerProvider extends Provider {
 
     public TestPlainSaslServerProvider() {
-        this("TestPlainSaslServerProvider", 0.1, "test plain sasl server provider");
+        this("TestPlainSaslServerProvider", "0.1", "test plain sasl server provider");
     }
 
-    protected TestPlainSaslServerProvider(String name, double version, String info) {
+    protected TestPlainSaslServerProvider(String name, String version, String info) {
         super(name, version, info);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestProvider.java
@@ -24,11 +24,11 @@ public class TestProvider extends Provider {
     private static final String TRUST_MANAGER_FACTORY = String.format("TrustManagerFactory.%s", TestTrustManagerFactory.ALGORITHM);
 
     public TestProvider() {
-        this("TestProvider", 0.1, "provider for test cases");
+        this("TestProvider", "0.1", "provider for test cases");
     }
 
     @SuppressWarnings("this-escape")
-    protected TestProvider(String name, double version, String info) {
+    protected TestProvider(String name, String version, String info) {
         super(name, version, info);
         super.put(KEY_MANAGER_FACTORY, TestKeyManagerFactory.class.getName());
         super.put(TRUST_MANAGER_FACTORY, TestTrustManagerFactory.class.getName());

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestScramSaslServerProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestScramSaslServerProvider.java
@@ -21,10 +21,10 @@ import java.security.Provider;
 public class TestScramSaslServerProvider extends Provider {
 
     public TestScramSaslServerProvider() {
-        this("TestScramSaslServerProvider", 0.1, "test scram sasl server provider");
+        this("TestScramSaslServerProvider", "0.1", "test scram sasl server provider");
     }
 
-    protected TestScramSaslServerProvider(String name, double version, String info) {
+    protected TestScramSaslServerProvider(String name, String version, String info) {
         super(name, version, info);
     }
 

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -547,5 +547,10 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         </Or>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
+    <Match>
+        <!-- Suppress warning about using static DateFormat in a multithreaded context -->
+        <Class name="org.apache.kafka.tools.ReplicaVerificationTool$ReplicaBuffer"/>
+        <Bug pattern="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE"/>
+    </Match>
 
 </FindBugsFilter>

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -254,9 +255,10 @@ public final class LocalTieredStorage implements RemoteStorageManager {
 
         if (transfererClass != null) {
             try {
-                transferer = (Transferer) getClass().getClassLoader().loadClass(transfererClass).newInstance();
-
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException e) {
+                transferer = (Transferer) getClass().getClassLoader().loadClass(transfererClass)
+                        .getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException |
+                     InvocationTargetException | NoSuchMethodException e) {
                 throw new RuntimeException(format("Cannot create transferer from class '%s'", transfererClass), e);
             }
         }

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.trogdor.workload.TopicsSpec;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +75,10 @@ public class JsonSerializationTest {
         Class<T> clazz = (Class<T>) val1.getClass();
         T val2 = JsonUtil.JSON_SERDE.readValue(bytes, clazz);
         for (Field field : clazz.getDeclaredFields()) {
-            boolean wasAccessible = field.isAccessible();
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            boolean wasAccessible = field.canAccess(val2);
             field.setAccessible(true);
             assertNotNull(field.get(val2), "Field " + field + " was null.");
             field.setAccessible(wasAccessible);


### PR DESCRIPTION
JIRA: [KAFKA-17739](https://issues.apache.org/jira/browse/KAFKA-17739)
> We are planning to drop JDK 8. This is part of the upgrade from JDK 8 to JDK 11. You can see the full plan here: [KAFKA-12894](https://issues.apache.org/jira/browse/KAFKA-12894)
> 1. minJavaVersion=11
> 2. remove sourceCompatibility and targetCompatibility
> 3. cleanup all compatibility checks

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
