### PR TITLE
KAFKA-17749: Fix Throttler metrics name

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/utils/Throttler.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/utils/Throttler.java
@@ -62,7 +62,8 @@ public class Throttler {
                      Time time) {
         this.desiredRatePerSec = desiredRatePerSec;
         this.checkIntervalNs = TimeUnit.MILLISECONDS.toNanos(checkIntervalMs);
-        this.meter = new KafkaMetricsGroup(Throttler.class).newMeter(metricName, units, TimeUnit.SECONDS);
+        // For compatibility - this metrics group was previously defined within a Scala class named `kafka.utils.Throttler`
+        this.meter = new KafkaMetricsGroup("kafka.utils", "Throttler").newMeter(metricName, units, TimeUnit.SECONDS);
         this.time = time;
         this.periodStartNs = time.nanoseconds();
     }


### PR DESCRIPTION
Since we (well I) inadvertently changed the Throttler metric names in https://github.com/apache/kafka/commit/e4e1116156d44d5e7a52ad8fb51a57d5e5755710 (included in both 3.8.0 and will be in 3.9.0), I suggest treating this as a bug and fixing it without doing a KIP.

We should be able to backport to 3.8.1 and 3.9.1.

cc @chia7712 since you reviewed https://github.com/apache/kafka/pull/16023

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
