### PR TITLE
KAFKA-17731: Removed timed waiting signal for client telemetry close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1225,7 +1225,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         wakeupTrigger.disableWakeups();
 
         final Timer closeTimer = time.timer(timeout);
-        clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(timeout.toMillis()));
+        clientTelemetryReporter.ifPresent(ClientTelemetryReporter::initiateClose);
         closeTimer.update();
         // Prepare shutting down the network thread
         swallow(log, Level.ERROR, "Failed to release assignment before closing consumer",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
@@ -1118,7 +1118,7 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         AtomicReference<Throwable> firstException = new AtomicReference<>();
 
         final Timer closeTimer = createTimerForRequest(timeout);
-        clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(timeout.toMillis()));
+        clientTelemetryReporter.ifPresent(ClientTelemetryReporter::initiateClose);
         closeTimer.update();
         // Close objects with a timeout. The timeout is required because the coordinator & the fetcher send requests to
         // the server in the process of closing which may not respect the overall timeout defined for closing the

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -840,7 +840,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         wakeupTrigger.disableWakeups();
 
         final Timer closeTimer = time.timer(timeout);
-        clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(timeout.toMillis()));
+        clientTelemetryReporter.ifPresent(ClientTelemetryReporter::initiateClose);
         closeTimer.update();
 
         // Prepare shutting down the network thread

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1393,6 +1393,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             } else {
                 // Try to close gracefully.
                 final Timer closeTimer = time.timer(timeout);
+                clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(closeTimer.remainingMs()));
+                closeTimer.update();
+
                 if (this.sender != null) {
                     this.sender.initiateClose();
                     closeTimer.update();
@@ -1407,7 +1410,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         closeTimer.update();
                     }
                 }
-                clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(closeTimer.remainingMs()));
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1393,7 +1393,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             } else {
                 // Try to close gracefully.
                 final Timer closeTimer = time.timer(timeout);
-                clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(closeTimer.remainingMs()));
+                clientTelemetryReporter.ifPresent(ClientTelemetryReporter::initiateClose);
                 closeTimer.update();
 
                 if (this.sender != null) {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -218,10 +218,10 @@ public class ClientTelemetryReporter implements MetricsReporter {
         telemetryProvider.updateLabels(labels);
     }
 
-    public void initiateClose(long timeoutMs) {
+    public void initiateClose() {
         log.debug("Initiate close of ClientTelemetryReporter");
         try {
-            clientTelemetrySender.initiateClose(timeoutMs);
+            clientTelemetrySender.initiateClose();
         } catch (Exception exception) {
             log.error("Failed to initiate close of client telemetry reporter", exception);
         }
@@ -601,8 +601,8 @@ public class ClientTelemetryReporter implements MetricsReporter {
         }
 
         @Override
-        public void initiateClose(long timeoutMs) {
-            log.debug("initiate close for client telemetry, check if terminal push required. Timeout {} ms.", timeoutMs);
+        public void initiateClose() {
+            log.debug("initiate close for client telemetry, check if terminal push required.");
 
             lock.writeLock().lock();
             try {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -821,7 +821,7 @@ public class ClientTelemetryReporter implements MetricsReporter {
                 log.debug("Setting telemetry state from {} to {}", oldState, newState);
                 return true;
             } catch (IllegalStateException e) {
-                log.warn("Error updating client telemetry state, disabled telemetry", e);
+                log.warn("Error updating client telemetry state, disabled telemetry");
                 enabled = false;
                 return false;
             } finally {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetrySender.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetrySender.java
@@ -107,8 +107,6 @@ public interface ClientTelemetrySender extends AutoCloseable {
     /**
      * Initiates shutdown of this client. This method is called when the enclosing client instance
      * is being closed. This method should not throw an exception if the client is already closed.
-     *
-     * @param timeoutMs The maximum time to wait for the client to close.
      */
-    void initiateClose(long timeoutMs);
+    void initiateClose();
 }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporterTest.java
@@ -736,14 +736,14 @@ public class ClientTelemetryReporterTest {
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.SUBSCRIPTION_IN_PROGRESS));
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.PUSH_NEEDED));
 
-        clientTelemetryReporter.initiateClose(60000);
+        clientTelemetryReporter.initiateClose();
         assertEquals(ClientTelemetryState.TERMINATING_PUSH_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
             .telemetrySender()).state());
     }
 
     @Test
     public void testTelemetryReporterInitiateCloseNoSubscription() {
-        clientTelemetryReporter.initiateClose(60000);
+        clientTelemetryReporter.initiateClose();
         assertEquals(ClientTelemetryState.SUBSCRIPTION_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
             .telemetrySender()).state());
     }
@@ -756,17 +756,17 @@ public class ClientTelemetryReporterTest {
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.PUSH_NEEDED));
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATING_PUSH_NEEDED));
 
-        clientTelemetryReporter.initiateClose(60000);
+        clientTelemetryReporter.initiateClose();
         assertEquals(ClientTelemetryState.TERMINATING_PUSH_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
             .telemetrySender()).state());
 
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATING_PUSH_IN_PROGRESS));
-        clientTelemetryReporter.initiateClose(60000);
+        clientTelemetryReporter.initiateClose();
         assertEquals(ClientTelemetryState.TERMINATING_PUSH_IN_PROGRESS, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
             .telemetrySender()).state());
 
         assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATED));
-        clientTelemetryReporter.initiateClose(60000);
+        clientTelemetryReporter.initiateClose();
         assertEquals(ClientTelemetryState.TERMINATED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
             .telemetrySender()).state());
     }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporterTest.java
@@ -729,6 +729,48 @@ public class ClientTelemetryReporterTest {
         assertTrue(timeMs >= 500 && timeMs <= 1500);
     }
 
+    @Test
+    public void testTelemetryReporterInitiateClose() {
+        ClientTelemetryReporter.DefaultClientTelemetrySender telemetrySender = (ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter.telemetrySender();
+        telemetrySender.updateSubscriptionResult(subscription, time.milliseconds());
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.SUBSCRIPTION_IN_PROGRESS));
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.PUSH_NEEDED));
+
+        clientTelemetryReporter.initiateClose(60000);
+        assertEquals(ClientTelemetryState.TERMINATING_PUSH_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
+            .telemetrySender()).state());
+    }
+
+    @Test
+    public void testTelemetryReporterInitiateCloseNoSubscription() {
+        clientTelemetryReporter.initiateClose(60000);
+        assertEquals(ClientTelemetryState.SUBSCRIPTION_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
+            .telemetrySender()).state());
+    }
+
+    @Test
+    public void testTelemetryReporterInitiateCloseAlreadyInTerminatedStates() {
+        ClientTelemetryReporter.DefaultClientTelemetrySender telemetrySender = (ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter.telemetrySender();
+        telemetrySender.updateSubscriptionResult(subscription, time.milliseconds());
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.SUBSCRIPTION_IN_PROGRESS));
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.PUSH_NEEDED));
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATING_PUSH_NEEDED));
+
+        clientTelemetryReporter.initiateClose(60000);
+        assertEquals(ClientTelemetryState.TERMINATING_PUSH_NEEDED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
+            .telemetrySender()).state());
+
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATING_PUSH_IN_PROGRESS));
+        clientTelemetryReporter.initiateClose(60000);
+        assertEquals(ClientTelemetryState.TERMINATING_PUSH_IN_PROGRESS, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
+            .telemetrySender()).state());
+
+        assertTrue(telemetrySender.maybeSetState(ClientTelemetryState.TERMINATED));
+        clientTelemetryReporter.initiateClose(60000);
+        assertEquals(ClientTelemetryState.TERMINATED, ((ClientTelemetryReporter.DefaultClientTelemetrySender) clientTelemetryReporter
+            .telemetrySender()).state());
+    }
+
     @AfterEach
     public void tearDown() {
         clientTelemetryReporter.close();


### PR DESCRIPTION
When Kafka Consumer is being closed then sometimes the wait goes for 30 secs as last telemetry push request doesn't get complete.

The issue can only be reproduced when consumer is closed just after creating i.e. instantiated Kafka Consumer and closed it. When consumer is instantly closed then, then worker thread goes for timed_waiting state and expects last telemetry push request, which gets completed by background thread poll. But as the consumer is instantly closed, the heartbeat thread can't send the telemetry request, which makes the consumer close to wait for timeout.

The PR addresses the concern by removing the timed waiting signal altogether and just update the state to `TERMINATING_PUSH_NEEDED`. If client triggers the next `poll` then the request will be sent else skipped. The last telemetry push request is good to have.

The PR also moved the code for telemetry `initialize close` in Kafka Producer prior to `other` close. Otherwise reporters were closed prior call to `initialize close` of client telemetry reporter.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
