### PR TITLE
KAFKA-17738: upgrade base image from jdk8 to jdk11

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-openjdk-8" bash tests/docker/run_tests.sh
+image_name="ducker-ak-openjdk-11" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -60,7 +60,6 @@ ARG ducker_creator=default
 LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
-# we have to install git since it is not included in openjdk:11
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 iputils-ping && apt-get -y clean
 RUN python3 -m pip install -U pip==21.1.1;
 # NOTE: ducktape 0.11.4 requires python3.9

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG jdk_version=openjdk:8
+ARG jdk_version=openjdk:11
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build
@@ -60,7 +60,7 @@ ARG ducker_creator=default
 LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
-# we have to install git since it is included in openjdk:8 but not openjdk:11
+# we have to install git since it is not included in openjdk:11
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 iputils-ping && apt-get -y clean
 RUN python3 -m pip install -U pip==21.1.1;
 # NOTE: ducktape 0.11.4 requires python3.9

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,7 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:8"
+default_jdk="openjdk:11"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"


### PR DESCRIPTION
We are planning to drop JDK 8. This is part of the upgrade from JDK 8 to JDK 11. You can see the full plan here: [KAFKA-12894](https://issues.apache.org/jira/browse/KAFKA-12894)

<br>
I randomly picked some E2E tests that do not depend on versions prior to Kafka v1.0.0. See the log below:

`TC_PATHS="tests/kafkatest/tests/tools" bash tests/docker/run_tests.sh`
```
WARNING: Ignoring custom format, because both --format and --quiet are set.
Mode provided for system tests run: jvm
docker build --memory=3200m --build-arg ducker_creator= --build-arg jdk_version=openjdk:11 --build-arg UID=1000 --build-arg KAFKA_MODE=jvm -t ducker-ak-openjdk-11 -f /home/yungh/kafka/kafka_fork/kafka_openjdk11/kafka/tests/docker/Dockerfile -- .
[+] Building 1.8s (70/70) FINISHED                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                         0.1s
 => => transferring dockerfile: 11.81kB                                                                                                                                      0.0s
 => WARN: MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 47)                                                                       0.1s
 => [internal] load metadata for docker.io/library/openjdk:11
 ------------------------------------snip ------------------------------------
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2024-10-09--002
run time:         6 minutes 13.349 seconds
tests run:        15
passed:           15
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.tools.replica_verification_test.ReplicaVerificationToolTest.test_replica_lags.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   24.371 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.replica_verification_test.ReplicaVerificationToolTest.test_replica_lags.metadata_quorum=ZK
status:     PASS
run time:   35.922 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SASL_PLAINTEXT.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   24.232 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SASL_PLAINTEXT.metadata_quorum=ZK
status:     PASS
run time:   22.637 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   29.524 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SASL_SSL.metadata_quorum=ZK
status:     PASS
run time:   27.057 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.kibosh_test.KiboshTest.test_kibosh_service
status:     PASS
run time:   4.563 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=PLAINTEXT.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   18.096 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=PLAINTEXT.metadata_quorum=ZK
status:     PASS
run time:   16.563 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SSL.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   23.625 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log4j_appender_test.Log4jAppenderTest.test_log4j_appender.security_protocol=SSL.metadata_quorum=ZK
status:     PASS
run time:   21.399 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log_compaction_test.LogCompactionTest.test_log_compaction.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   55.190 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.log_compaction_test.LogCompactionTest.test_log_compaction.metadata_quorum=ZK
status:     PASS
run time:   53.975 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.trogdor_test.TrogdorTest.test_network_partition_fault
status:     PASS
run time:   7.968 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.tools.trogdor_test.TrogdorTest.test_trogdor_service
status:     PASS
run time:   7.878 seconds
--------------------------------------------------------------------------------
```


`TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py" bash tests/docker/run_tests.sh`
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2024-10-09--004
run time:         27.560 seconds
tests run:        2
passed:           2
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   14.338 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ZK
status:     PASS
run time:   13.179 seconds
--------------------------------------------------------------------------------
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
