### PR TITLE
Internal topic auto creation

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -19,13 +19,14 @@ package kafka.coordinator.group
 import kafka.common.OffsetAndMetadata
 import kafka.server.{KafkaConfig, ReplicaManager}
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, StreamsGroupDescribeResponseData, StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData, StreamsGroupInitializeRequestData, StreamsGroupInitializeResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, StreamsGroupDescribeResponseData, StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData, StreamsGroupInitializeRequestData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{OffsetCommitRequest, RequestContext, TransactionResult}
 import org.apache.kafka.common.utils.{BufferSupplier, Time}
 import org.apache.kafka.coordinator.group
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.util.FutureUtils
@@ -80,7 +81,7 @@ private[group] class GroupCoordinatorAdapter(
   override def streamsGroupInitialize(
                                    context: RequestContext,
                                    request: StreamsGroupInitializeRequestData
-                                 ): CompletableFuture[StreamsGroupInitializeResponseData] = {
+                                 ): CompletableFuture[StreamsGroupInitializeResult] = {
     FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
       s"The old group coordinator does not support ${ApiKeys.STREAMS_GROUP_INITIALIZE.name} API."
     ))

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -120,7 +120,6 @@ class DefaultAutoTopicCreationManager(
     requestContext: RequestContext
   ): Unit = {
 
-    // Set default values for numPartitions and replicationFactor if they are not provided
     for ((_, creatableTopic) <- topics) {
       if (creatableTopic.numPartitions() == -1) {
         creatableTopic
@@ -192,8 +191,8 @@ class DefaultAutoTopicCreationManager(
   }
 
   private def sendCreateTopicRequest(
-                                      creatableTopics: Map[String, CreatableTopic],
-                                      requestContext: Option[RequestContext]
+    creatableTopics: Map[String, CreatableTopic],
+    requestContext: Option[RequestContext]
   ): Seq[MetadataResponseTopic] = {
     val topicsToCreate = new CreateTopicsRequestData.CreatableTopicCollection(creatableTopics.size)
     topicsToCreate.addAll(creatableTopics.values.asJavaCollection)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3880,9 +3880,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleStreamsGroupInitialize(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // TODO: The unit tests for this method are insufficient. Once we merge initialize with group heartbeat, we have to extend the tests to cover ACLs and internal topic creation
     val streamsGroupInitializeRequest = request.body[StreamsGroupInitializeRequest]
-
-    // TODO: Check ACLs on CREATE TOPIC & DESCRIBE_CONFIGS
 
     if (!isStreamsGroupProtocolEnabled()) {
       // The API is not supported by the "old" group coordinator (the default). If the
@@ -3893,6 +3892,53 @@ class KafkaApis(val requestChannel: RequestChannel,
       requestHelper.sendMaybeThrottle(request, streamsGroupInitializeRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
       CompletableFuture.completedFuture[Unit](())
     } else {
+      val requestContext = request.context
+
+      val internalTopics: Map[String, StreamsGroupInitializeRequestData.TopicInfo] = {
+        streamsGroupInitializeRequest.data().topology().asScala.flatMap(subtopology =>
+          subtopology.repartitionSourceTopics().iterator().asScala ++ subtopology.stateChangelogTopics().iterator().asScala
+        ).map(x => x.name() -> x).toMap
+      }
+
+      val prohibitedInternalTopics = internalTopics.keys.filter(Topic.isInternal)
+      if (prohibitedInternalTopics.nonEmpty) {
+        val errorResponse = new StreamsGroupInitializeResponseData()
+        errorResponse.setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code)
+        errorResponse.setErrorMessage(f"Use of Kafka internal topics ${prohibitedInternalTopics.mkString(",")} as Kafka Streams internal topics is prohibited.")
+        requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(errorResponse))
+        return CompletableFuture.completedFuture[Unit](())
+      }
+
+      val invalidTopics = internalTopics.keys.filterNot(Topic.isValid)
+      if (invalidTopics.nonEmpty) {
+        val errorResponse = new StreamsGroupInitializeResponseData()
+        errorResponse.setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code)
+        errorResponse.setErrorMessage(f"Internal topic names ${invalidTopics.mkString(",")} are not valid topic names.")
+        requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(errorResponse))
+        return CompletableFuture.completedFuture[Unit](())
+      }
+
+      // TODO: Once we move initialization to the heartbeat, we should only require these permissions if there are missing internal topics.
+      if(!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
+        val (_, createTopicUnauthorized) = authHelper.partitionSeqByAuthorized(request.context, CREATE, TOPIC, internalTopics.keys.toSeq)(identity[String])
+        if (createTopicUnauthorized.nonEmpty) {
+          val errorResponse = new StreamsGroupInitializeResponseData()
+          errorResponse.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+          errorResponse.setErrorMessage(f"Unauthorized to CREATE TOPIC ${createTopicUnauthorized.mkString(",")}.")
+          requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(errorResponse))
+          return CompletableFuture.completedFuture[Unit](())
+        }
+      }
+
+      val (_, describeConfigsAuthorized) = authHelper.partitionSeqByAuthorized(request.context, DESCRIBE_CONFIGS, TOPIC, internalTopics.keys.toSeq)(identity[String])
+      if (describeConfigsAuthorized.nonEmpty) {
+        val errorResponse = new StreamsGroupInitializeResponseData()
+        errorResponse.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+        errorResponse.setErrorMessage(f"Unauthorized to DESCRIBE_CONFIGS on topics ${describeConfigsAuthorized.mkString(",")} are unauthorized.")
+        requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(errorResponse))
+        return CompletableFuture.completedFuture[Unit](())
+      }
+
       groupCoordinator.streamsGroupInitialize(
         request.context,
         streamsGroupInitializeRequest.data,
@@ -3900,7 +3946,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         if (exception != null) {
           requestHelper.sendMaybeThrottle(request, streamsGroupInitializeRequest.getErrorResponse(exception))
         } else {
-          requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(response))
+          if (!response.creatableTopics().isEmpty) {
+            // TODO: Once we move this code to the heartbeat, we should indicate which topics are being created. We should also find a way to propagate failures to the client
+            autoTopicCreationManager.createStreamsInternalTopics(response.creatableTopics().asScala, requestContext);
+          }
+          requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(response.data()))
         }
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3950,7 +3950,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             // TODO: Once we move this code to the heartbeat, we should indicate which topics are being created. We should also find a way to propagate failures to the client
             autoTopicCreationManager.createStreamsInternalTopics(response.creatableTopics().asScala, requestContext);
           }
-          requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(response.data()))
+          requestHelper.sendMaybeThrottle(request, new StreamsGroupInitializeResponse(response.responseData()))
         }
       }
     }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -77,6 +77,7 @@ import org.apache.kafka.common.utils.{ImplicitLinkedHashCollection, ProducerIdAn
 import org.apache.kafka.coordinator.group.GroupConfig.{CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, CONSUMER_SESSION_TIMEOUT_MS_CONFIG, SHARE_HEARTBEAT_INTERVAL_MS_CONFIG, SHARE_SESSION_TIMEOUT_MS_CONFIG, SHARE_RECORD_LOCK_DURATION_MS_CONFIG}
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
 import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig}
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfigTest}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.metadata.LeaderAndIsr
@@ -11195,7 +11196,7 @@ class KafkaApisTest extends Logging {
 
     val requestChannelRequest = buildRequest(new StreamsGroupInitializeRequest.Builder(streamsGroupInitializeRequest, true).build())
 
-    val future = new CompletableFuture[StreamsGroupInitializeResponseData]()
+    val future = new CompletableFuture[StreamsGroupInitializeResult]()
     when(groupCoordinator.streamsGroupInitialize(
       requestChannelRequest.context,
       streamsGroupInitializeRequest
@@ -11206,7 +11207,7 @@ class KafkaApisTest extends Logging {
     )
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
-    val streamsGroupInitializeResponse = new StreamsGroupInitializeResponseData()
+    val streamsGroupInitializeResponse = new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData())
 
     future.complete(streamsGroupInitializeResponse)
     val response = verifyNoThrottling[StreamsGroupInitializeResponse](requestChannelRequest)
@@ -11221,7 +11222,7 @@ class KafkaApisTest extends Logging {
 
     val requestChannelRequest = buildRequest(new StreamsGroupInitializeRequest.Builder(streamsGroupInitializeRequest, true).build())
 
-    val future = new CompletableFuture[StreamsGroupInitializeResponseData]()
+    val future = new CompletableFuture[StreamsGroupInitializeResult]()
     when(groupCoordinator.streamsGroupInitialize(
       requestChannelRequest.context,
       streamsGroupInitializeRequest

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -51,6 +50,7 @@ import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 
@@ -93,10 +93,10 @@ public interface GroupCoordinator {
      * @param context           The request context.
      * @param request           The StreamsGroupInitializeRequest data.
      *
-     * @return  A future yielding the response.
+     * @return  A future yielding the result, which contains the response and all topics to be created.
      *          The error code(s) of the response are set to indicate the error(s) occurred during the execution.
      */
-    CompletableFuture<StreamsGroupInitializeResponseData> streamsGroupInitialize(
+    CompletableFuture<StreamsGroupInitializeResult> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -78,6 +78,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorShardBuilderSuppli
 import org.apache.kafka.coordinator.common.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.record.BrokerCompressionType;
@@ -352,14 +353,14 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * See {@link GroupCoordinator#streamsGroupInitialize(RequestContext, org.apache.kafka.common.message.StreamsGroupInitializeRequestData)}.
      */
     @Override
-    public CompletableFuture<StreamsGroupInitializeResponseData> streamsGroupInitialize(
+    public CompletableFuture<StreamsGroupInitializeResult> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     ) {
         if (!isActive.get()) {
-            return CompletableFuture.completedFuture(new StreamsGroupInitializeResponseData()
+            return CompletableFuture.completedFuture(new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData()
                 .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
-            );
+            ));
         }
 
         return runtime.scheduleWriteOperation(
@@ -371,9 +372,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "streams-group-initialize",
             request,
             exception,
-            (error, message) -> new StreamsGroupInitializeResponseData()
+            (error, message) -> new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData()
                 .setErrorCode(error.code())
-                .setErrorMessage(message),
+                .setErrorMessage(message)),
             log
         ));
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -104,6 +103,7 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.taskassignor.StickyTaskAssignor;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -382,7 +382,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
      * @return A Result containing the StreamsGroupInitialize response and
      *         a list of records to update the state machine.
      */
-    public CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(
+    public CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(
         RequestContext context,
         StreamsGroupInitializeRequestData request
     ) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+public class StreamsGroupInitializeResult {
+
+    private final StreamsGroupInitializeResponseData data;
+    private final Map<String, CreatableTopic> creatableTopics;
+
+    public StreamsGroupInitializeResult(StreamsGroupInitializeResponseData data, Map<String, CreatableTopic> creatableTopics) {
+        this.data = data;
+        this.creatableTopics = creatableTopics;
+    }
+
+    public StreamsGroupInitializeResult(StreamsGroupInitializeResponseData data) {
+        this.data = data;
+        this.creatableTopics = Collections.emptyMap();
+    }
+
+    public StreamsGroupInitializeResponseData data() {
+        return data;
+    }
+
+    public Map<String, CreatableTopic> creatableTopics() {
+        return creatableTopics;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final StreamsGroupInitializeResult that = (StreamsGroupInitializeResult) o;
+        return Objects.equals(data, that.data) && Objects.equals(creatableTopics,
+            that.creatableTopics);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, creatableTopics);
+    }
+
+    @Override
+    public String toString() {
+        return "StreamsGroupInitializeResult{" +
+            "data=" + data +
+            ", creatableTopics=" + creatableTopics +
+            '}';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupInitializeResult.java
@@ -38,7 +38,7 @@ public class StreamsGroupInitializeResult {
         this.creatableTopics = Collections.emptyMap();
     }
 
-    public StreamsGroupInitializeResponseData data() {
+    public StreamsGroupInitializeResponseData responseData() {
         return data;
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -78,6 +78,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.server.record.BrokerCompressionType;
 import org.apache.kafka.server.util.FutureUtils;
 
@@ -280,14 +281,15 @@ public class GroupCoordinatorServiceTest {
         StreamsGroupInitializeRequestData request = new StreamsGroupInitializeRequestData()
             .setGroupId("foo");
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
 
         assertEquals(
-            new StreamsGroupInitializeResponseData()
-                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()),
+            new StreamsGroupInitializeResult(
+                new StreamsGroupInitializeResponseData()
+                    .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())),
             future.get()
         );
     }
@@ -317,7 +319,7 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupInitializeResponseData()
         ));
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
@@ -368,7 +370,7 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
-        CompletableFuture<StreamsGroupInitializeResponseData> future = service.streamsGroupInitialize(
+        CompletableFuture<StreamsGroupInitializeResult> future = service.streamsGroupInitialize(
             requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE),
             request
         );
@@ -377,7 +379,7 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupInitializeResponseData()
                 .setErrorCode(expectedErrorCode)
                 .setErrorMessage(expectedErrorMessage),
-            future.get(5, TimeUnit.SECONDS)
+            future.get(5, TimeUnit.SECONDS).data()
         );
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -379,7 +379,7 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupInitializeResponseData()
                 .setErrorCode(expectedErrorCode)
                 .setErrorMessage(expectedErrorMessage),
-            future.get(5, TimeUnit.SECONDS).data()
+            future.get(5, TimeUnit.SECONDS).responseData()
         );
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -63,6 +63,7 @@ import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataValue;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
@@ -152,9 +153,9 @@ public class GroupCoordinatorShardTest {
 
         RequestContext context = requestContext(ApiKeys.STREAMS_GROUP_INITIALIZE);
         StreamsGroupInitializeRequestData request = new StreamsGroupInitializeRequestData();
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = new CoordinatorResult<>(
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = new CoordinatorResult<>(
             Collections.emptyList(),
-            new StreamsGroupInitializeResponseData()
+            new StreamsGroupInitializeResult(new StreamsGroupInitializeResponseData())
         );
 
         when(groupMetadataManager.streamsGroupInitialize(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -532,7 +532,7 @@ public class GroupMetadataManagerTest {
         CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response().data();
+        StreamsGroupInitializeResponseData response = result.response().responseData();
         assertEquals(Errors.NONE.code(), response.errorCode());
         List<CoordinatorRecord> coordinatorRecords = result.records();
         assertEquals(5, coordinatorRecords.size());
@@ -650,7 +650,7 @@ public class GroupMetadataManagerTest {
         CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response().data();
+        StreamsGroupInitializeResponseData response = result.response().responseData();
         assertEquals(Errors.NONE.code(), response.errorCode());
         assertTrue(result.records().isEmpty());
     }
@@ -694,7 +694,7 @@ public class GroupMetadataManagerTest {
         CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = context.streamsGroupInitialize(initialize);
 
         assertNotNull(result.response());
-        StreamsGroupInitializeResponseData response = result.response().data();
+        StreamsGroupInitializeResponseData response = result.response().responseData();
         assertEquals(Errors.NONE.code(), response.errorCode());
         assertTrue(result.records().isEmpty());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupInitializeRequestData;
-import org.apache.kafka.common.message.StreamsGroupInitializeResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.network.ClientInformation;
@@ -108,6 +107,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupInitializeResult;
 import org.apache.kafka.coordinator.group.taskassignor.TaskAssignor;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -720,7 +720,7 @@ public class GroupMetadataManagerTestContext {
     }
 
 
-    public CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> streamsGroupInitialize(
+    public CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> streamsGroupInitialize(
         StreamsGroupInitializeRequestData request
     ) {
         RequestContext context = new RequestContext(
@@ -739,7 +739,7 @@ public class GroupMetadataManagerTestContext {
             false
         );
 
-        CoordinatorResult<StreamsGroupInitializeResponseData, CoordinatorRecord> result = groupMetadataManager.streamsGroupInitialize(
+        CoordinatorResult<StreamsGroupInitializeResult, CoordinatorRecord> result = groupMetadataManager.streamsGroupInitialize(
             context,
             request
         );

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -127,19 +127,6 @@ public class SmokeTestDriverIntegrationTest extends IntegrationTestHarness {
         }
 
         for (final String topic: new String[]{
-            "SmokeTest-KSTREAM-REDUCE-STATE-STORE-0000000020-changelog",
-            "SmokeTest-minStoreName-changelog",
-            "SmokeTest-cntByCnt-repartition",
-            "SmokeTest-KTABLE-SUPPRESS-STATE-STORE-0000000011-changelog",
-            "SmokeTest-sum-STATE-STORE-0000000050-changelog",
-            "SmokeTest-uwin-cnt-changelog",
-            "SmokeTest-maxStoreName-changelog",
-            "SmokeTest-cntStoreName-changelog",
-            "SmokeTest-KTABLE-SUPPRESS-STATE-STORE-0000000027-changelog",
-            "SmokeTest-win-sum-changelog",
-            "SmokeTest-uwin-max-changelog",
-            "SmokeTest-uwin-min-changelog",
-            "SmokeTest-cntByCnt-changelog",
             "data",
             "echo",
             "max",

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -29,6 +29,8 @@ log4j.logger.org.apache.kafka.clients.consumer=INFO
 log4j.logger.org.apache.kafka.clients.producer=INFO
 log4j.logger.org.apache.kafka.streams=INFO
 log4j.logger.org.apache.kafka.coordinator.group=INFO
+log4j.logger.org.apache.kafka.clients.consumer.internals.StreamsGroupInitializeRequestManager=INFO
+log4j.logger.org.apache.kafka.clients.consumer.internals.StreamsGroupHeartbeatRequestManager=INFO
 
 # printing out the configs takes up a huge amount of the allotted characters,
 # and provides little value as we can always figure out the test configs without the logs


### PR DESCRIPTION
Auto-topic creation of internal topics for KIP-1071.

When initializing the topology, the client sends information about the internal topics required for the application. The key concept is that the topology description being sent to the broker is parametric in the number of partitions -- that is, the broker checks the number of partitions for the input partition, and derives the number of partitions for the internal topic. This logic is ported from the existing streams partition assignor.

The basic flow is that, upon receiving the initialize RPC, the group coordinator checks for the right ACL permissions, validates if the request is valid, then updates the topology record in the consumer offset topic, determines the right number of partitions for all internal topics and finally triggers a corresponding CreateTopic request.

Code for generating and validating internal topic configuration lives inside the group coordinator, but the actual creation of the topics is performed from within KafkaApis.

There is a dependency between updating the topology record in the consumer offset topic and creating the internal topics. In case of failures, one could be executed without the other. In this implementation, we update the topology record first, and then create internal topics. The topology record will be the single source of truth. If internal topic creation fails, we need to detect this inside the client. Right now, the heartbeat will respond with error if internal topics are missing. Once we merge the heartbeat and the initialization RPC, we should get the behavior that any attempt to join the group (with a topology description) will also be an attempt to create any missing internal topics.

Like existing RPCs (TopicMetadata and FindCoordinator), we auto-create topics asynchronously — so a create topic request is started, but the result is not immediately checked. I created a separate ticket to expose any errors occurring during the topic creation to the user - right now, they will only show up in the broker logs.

We need some extra logic for revalidating internal topics. With this change, the set of tasks is defined by the TopicsImage in the group coordinator and the partition-parametric topology description. The group epoch needs to be bumped when either changes, we need to make sure to cache the result of validating and instantiating a topology against a current set of input topics, so that we don’t have to redo it on every heartbeat. After fail-over, we need to reconstruct this cache from the topology and subscription records in the offset topic. I created a separate ticket for internal topic revalidation.