### PR TITLE
KAFKA-17751: fix pollTimeout calculation in pollFollowerAsVoter

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
@@ -61,6 +62,7 @@ import static org.apache.kafka.raft.KafkaRaftClientTest.replicaKey;
 import static org.apache.kafka.snapshot.Snapshots.BOOTSTRAP_SNAPSHOT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaRaftClientReconfigTest {
@@ -2163,6 +2165,8 @@ public class KafkaRaftClientReconfigTest {
         context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
+        context.time.sleep(context.fetchTimeoutMs - 1);
+        assertNotEquals(OptionalLong.of(0L), context.messageQueue.lastPollTimeoutMs());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2165,7 +2165,10 @@ public class KafkaRaftClientReconfigTest {
         context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
-        context.time.sleep(context.fetchTimeoutMs - 1);
+
+        // after more than 3 fetch timeouts the update voter period timer should have expired.
+        // check that the update voter period timer doesn't remain at zero (0) and cause the message queue to get
+        // called with a zero (0) timeout and result in a busy-loop.
         assertNotEquals(OptionalLong.of(0L), context.messageQueue.lastPollTimeoutMs());
     }
 


### PR DESCRIPTION
KAFKA-16534 introduced a change to send UpdateVoterRequest every `3 * fetchTimeoutMs`. It also introduced a regression where if the voter nodes do not need an update then `updateVoterTimer` wasn't reset. This resulted in a busy-loop in the KraftClient's `poll()` method resulting in high CPU usage.

This PR modifies the conditions in `pollFollowerAsVoter` to reset `updateVoterTimer` appropriately.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
