### PR TITLE
KAFKA-17740 Update Readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/
 
 We build and test Apache Kafka with 11, 17 and 21. We set the `release` parameter in javac and scalac
 to `11` to ensure the generated binaries are compatible with Java 11 or higher (independently of the Java version
-used for compilation). Java 8 support project-wide has been deprecated since Apache Kafka 3.0, Java 11 support for
-the broker and tools has been deprecated since Apache Kafka 3.7 and removal of both is planned for Apache Kafka 4.0 (
-see [KIP-750](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223) and
-[KIP-1013](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=284789510) for more details).
+used for compilation). Java 11 support for the broker and tools has been deprecated since Apache Kafka 3.7 and removal 
+of both is planned for Apache Kafka 4.0.([KIP-1013](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=284789510) for more details).
 
 Scala 2.13 is the only supported version in Apache Kafka.
 

--- a/README.md
+++ b/README.md
@@ -191,14 +191,10 @@ You can run checkstyle using:
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
-**Please note that `./gradlew spotlessCheck` currently has an issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
-
 #### Spotless ####
 The import order is a part of static check. please call `spotlessApply` (require JDK 11+) to optimize the imports of Java codes before filing pull request.
 
     ./gradlew spotlessApply
-
-**Please note that `./gradlew spotlessApply` currently has an issue with Java 21 (see https://github.com/diffplug/spotless/pull/1920), so make sure to run this with JDK 11 or 17**
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` 
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
 #### Spotless ####
-The import order is a part of static check. please call `spotlessApply` (require JDK 11+) to optimize the imports of Java codes before filing pull request.
+The import order is a part of static check. please call `spotlessApply` to optimize the imports of Java codes before filing pull request.
 
     ./gradlew spotlessApply
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ See our [web site](https://kafka.apache.org) for details on the project.
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with Java 8, 11, 17 and 21. We set the `release` parameter in javac and scalac
-to `8` to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
+We build and test Apache Kafka with 11, 17 and 21. We set the `release` parameter in javac and scalac
+to `11` to ensure the generated binaries are compatible with Java 11 or higher (independently of the Java version
 used for compilation). Java 8 support project-wide has been deprecated since Apache Kafka 3.0, Java 11 support for
 the broker and tools has been deprecated since Apache Kafka 3.7 and removal of both is planned for Apache Kafka 4.0 (
 see [KIP-750](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223) and

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, Java 17, and Java 21 are supported.
+  Java 11, Java 17, and Java 21 are supported.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1251,8 +1251,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   Java 11, Java 17, and Java 21 are supported.
   <p>
-  Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
-  has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.
+  Note that Java 11 support for the broker and tools has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.
   <p>
   Java 11 and later versions perform significantly better if TLS is enabled, so they are highly recommended (they also include a number of other
   performance improvements: G1GC, CRC32C, Compact Strings, Thread-Local Handshakes and more).

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -42,7 +42,7 @@ $ cd kafka_{{scalaVersion}}-{{fullDotVersion}}</code></pre>
             <a href="#quickstart_startserver">Step 2: Start the Kafka environment</a>
         </h4>
 
-        <p class="note">NOTE: Your local environment must have Java 8+ installed.</p>
+        <p class="note">NOTE: Your local environment must have Java 11+ installed.</p>
 
         <p>Apache Kafka can be started using KRaft or ZooKeeper. To get started with either configuration follow one of the sections below but not both.</p>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -131,6 +131,10 @@
                     Scala 2.12 support has been removed in Apache Kafka 4.0
                     See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308218">KIP-751</a> for more details
                 </li>
+                <li>
+                    Java 8 support has been removed in Apache Kafka 4.0
+                    See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223">KIP-750</a> for more details
+                </li>
                 <li>The <code>--delete-config</code> option in the <code>kafka-topics</code> command line tool has been deprecated.
                 </li>
             </ul>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -1699,7 +1699,7 @@
 <h5><a id="upgrade_200_notable" href="#upgrade_200_notable">Notable changes in 2.0.0</a></h5>
 <ul>
     <li><a href="https://cwiki.apache.org/confluence/x/oYtjB">KIP-186</a> increases the default offset retention time from 1 day to 7 days. This makes it less likely to "lose" offsets in an application that commits infrequently. It also increases the active set of offsets and therefore can increase memory usage on the broker. Note that the console consumer currently enables offset commit by default and can be the source of a large number of offsets which this change will now preserve for 7 days instead of 1. You can preserve the existing behavior by setting the broker config <code>offsets.retention.minutes</code> to 1440.</li>
-    <li>Support for Java 7 and Java 8 has been dropped, Java 11 is now the minimum version required.</li>
+    <li>Support for Java 7 has been dropped, Java 8 is now the minimum version required.</li>
     <li> The default value for <code>ssl.endpoint.identification.algorithm</code> was changed to <code>https</code>, which performs hostname verification (man-in-the-middle attacks are possible otherwise). Set <code>ssl.endpoint.identification.algorithm</code> to an empty string to restore the previous behaviour. </li>
     <li><a href="https://issues.apache.org/jira/browse/KAFKA-5674">KAFKA-5674</a> extends the lower interval of <code>max.connections.per.ip</code> minimum to zero and therefore allows IP-based filtering of inbound connections.</li>
     <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-272%3A+Add+API+version+tag+to+broker%27s+RequestsPerSec+metric">KIP-272</a>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -1699,7 +1699,7 @@
 <h5><a id="upgrade_200_notable" href="#upgrade_200_notable">Notable changes in 2.0.0</a></h5>
 <ul>
     <li><a href="https://cwiki.apache.org/confluence/x/oYtjB">KIP-186</a> increases the default offset retention time from 1 day to 7 days. This makes it less likely to "lose" offsets in an application that commits infrequently. It also increases the active set of offsets and therefore can increase memory usage on the broker. Note that the console consumer currently enables offset commit by default and can be the source of a large number of offsets which this change will now preserve for 7 days instead of 1. You can preserve the existing behavior by setting the broker config <code>offsets.retention.minutes</code> to 1440.</li>
-    <li>Support for Java 7 has been dropped, Java 8 is now the minimum version required.</li>
+    <li>Support for Java 7 and Java 8 has been dropped, Java 11 is now the minimum version required.</li>
     <li> The default value for <code>ssl.endpoint.identification.algorithm</code> was changed to <code>https</code>, which performs hostname verification (man-in-the-middle attacks are possible otherwise). Set <code>ssl.endpoint.identification.algorithm</code> to an empty string to restore the previous behaviour. </li>
     <li><a href="https://issues.apache.org/jira/browse/KAFKA-5674">KAFKA-5674</a> extends the lower interval of <code>max.connections.per.ip</code> minimum to zero and therefore allows IP-based filtering of inbound connections.</li>
     <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-272%3A+Add+API+version+tag+to+broker%27s+RequestsPerSec+metric">KIP-272</a>


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17740
We are planning to drop JDK 8 and this is the last step,  update the document for JDK 8, More details is in [KAFKA-12894](https://issues.apache.org/jira/browse/KAFKA-12894).


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
