### PR TITLE
KAFKA-17753: Update protobuf and commons-io dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -211,7 +211,7 @@ commons-beanutils-1.9.4
 commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
-commons-io-2.11.0
+commons-io-2.14.0
 commons-lang3-3.12.0
 commons-logging-1.2
 commons-validator-1.7
@@ -335,7 +335,7 @@ BSD 3-Clause
 jline-3.25.1, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
-protobuf-java-3.23.4, see: licenses/protobuf-java-BSD-3-clause
+protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 
 ---------------------------------------
 Do What The F*ck You Want To Public License

--- a/build.gradle
+++ b/build.gradle
@@ -952,6 +952,7 @@ project(':core') {
     implementation libs.scalaReflect
     implementation libs.scalaLogging
     implementation libs.slf4jApi
+    implementation libs.commonsIo // ZooKeeper dependency. Do not use, this is going away.
     implementation(libs.zookeeper) {
       // Dropwizard Metrics are required by ZooKeeper as of v3.6.0,
       // but the library should *not* be used in Kafka code
@@ -1535,6 +1536,7 @@ project(':clients') {
     implementation libs.snappy
     implementation libs.slf4jApi
     implementation libs.opentelemetryProto
+    implementation libs.protobuf
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
     shadowed libs.zstd

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -90,6 +90,7 @@ versions += [
   // gradle/resources/dependencycheck-suppressions.xml
   checkstyle: "8.36.2",
   commonsCli: "1.4",
+  commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.8",
@@ -142,6 +143,7 @@ versions += [
   metrics: "2.2.0",
   netty: "4.1.111.Final",
   opentelemetryProto: "1.0.0-alpha",
+  protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.1",
   reflections: "0.10.2",
   reload4j: "1.2.25",
@@ -179,6 +181,7 @@ libs += [
   bcpkix: "org.bouncycastle:bcpkix-jdk18on:$versions.bcpkix",
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
+  commonsIo: "commons-io:commons-io:$versions.commonsIo",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
@@ -242,6 +245,7 @@ libs += [
   nettyTransportNativeEpoll: "io.netty:netty-transport-native-epoll:$versions.netty",
   pcollections: "org.pcollections:pcollections:$versions.pcollections",
   opentelemetryProto: "io.opentelemetry.proto:opentelemetry-proto:$versions.opentelemetryProto",
+  protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
   reflections: "org.reflections:reflections:$versions.reflections",
   reload4j: "ch.qos.reload4j:reload4j:$versions.reload4j",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",


### PR DESCRIPTION
Update protobuf to 3.25.5 because earlier versions are vulnerable to CVE-2024-7254.
It is a dependency of OpenTelemetry.

Update Apache commons-io because earlier versions are vulnerable to CVE-2024-47554.
It is a dependency of Apache ZooKeeper.