### PR TITLE
KAFKA-17383; Update upgrade notes about removal of `offsets.commit.required.acks`

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -39,6 +39,10 @@
                         <li>The <code>delegation.token.master.key</code> configuration was removed.
                             Please use <code>delegation.token.secret.key</code> instead.
                         </li>
+                        <li>
+                            The <code>offsets.commit.required.acks</code> configuration was removed.
+                            See <a href="https://cwiki.apache.org/confluence/x/9YobEg">KIP-1041</a> for details.
+                        </li>
                     </ul>
                 </li>
                 <li><b>MirrorMaker</b>


### PR DESCRIPTION
This patch updates the upgrades note about the removal of `offsets.commit.required.acks` configuration in 4.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
