### PR TITLE
KAFKA-17693: Remove testEarliestLocalTimestampVersion and testCheckLatestTieredTimestampVersion

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
@@ -30,7 +29,6 @@ import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicR
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -39,10 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.requests.ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP;
-import static org.apache.kafka.common.requests.ListOffsetsRequest.LATEST_TIERED_TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListOffsetsRequestTest {

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -43,8 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListOffsetsRequestTest {
 
-    private final NodeApiVersions versionInfo = new NodeApiVersions(new ApiVersionsResponseData.ApiVersionCollection(), Collections.emptyList(), false);
-
     @Test
     public void testDuplicatePartitions() {
         List<ListOffsetsTopic> topics = Collections.singletonList(

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicR
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -16,10 +16,8 @@
  */
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsTopic;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -155,22 +155,6 @@ public class ListOffsetsRequestTest {
         assertTrue(topic.partitions().contains(lop1));
     }
 
-    @Test
-    public void testCheckEarliestLocalTimestampVersion() {
-        int maxVersion = ApiKeys.LIST_OFFSETS.latestVersion();
-        for (int i = 0; i <= maxVersion; i++) {
-            testUnsupportedVersion(i, EARLIEST_LOCAL_TIMESTAMP);
-        }
-    }
-
-    @Test
-    public void testCheckLatestTieredTimestampVersion() {
-        int maxVersion = ApiKeys.LIST_OFFSETS.latestVersion();
-        for (int i = 0; i <= maxVersion; i++) {
-            testUnsupportedVersion(i, LATEST_TIERED_TIMESTAMP);
-        }
-    }
-
     private void testUnsupportedVersion(int version, long timestamp) {
         if (timestamp == EARLIEST_LOCAL_TIMESTAMP && version < 8) {
             assertUnsupportedVersion(version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -155,21 +155,6 @@ public class ListOffsetsRequestTest {
         assertTrue(topic.partitions().contains(lop1));
     }
 
-    private void testUnsupportedVersion(int version, long timestamp) {
-        if (timestamp == EARLIEST_LOCAL_TIMESTAMP && version < 8) {
-            assertUnsupportedVersion(version);
-        } else if (timestamp == LATEST_TIERED_TIMESTAMP && version < 9) {
-            assertUnsupportedVersion(version);
-        }
-    }
-
-    private void assertUnsupportedVersion(int version) {
-        ApiKeys apiKey = ApiKeys.LIST_OFFSETS;
-        UnsupportedVersionException exception = assertThrows(UnsupportedVersionException.class,
-                () -> versionInfo.latestUsableVersion(apiKey, (short) version, apiKey.latestVersion()));
-        assertEquals("The node does not support " + apiKey, exception.getMessage());
-    }
-
     @Test
     public void testListOffsetsRequestOldestVersion() {
         ListOffsetsRequest.Builder consumerRequestBuilder = ListOffsetsRequest.Builder


### PR DESCRIPTION
Remove `testEarliestLocalTimestampVersion` and `testCheckLatestTieredTimestampVersion`

The ticket description mentioned that `testListOffsetsRequestOldestVersion` should be moved to the Java `ListOffsetRequestTest`, which was already completed in [#17100](https://github.com/apache/kafka/pull/17100) , so no additional changes are needed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
