### PR TITLE
KAFKA-17099: Print the origin processor node in logs for processing exceptions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/FailedProcessingException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/FailedProcessingException.java
@@ -24,13 +24,20 @@ import org.apache.kafka.streams.errors.StreamsException;
  */
 public class FailedProcessingException extends StreamsException {
     private static final long serialVersionUID = 1L;
+    private final String failedProcessorNodeName;
 
-    public FailedProcessingException(final String errorMessage, final Exception exception) {
+    public FailedProcessingException(final String errorMessage, final String failedProcessorNodeName, final Exception exception) {
         super(errorMessage, exception);
+        this.failedProcessorNodeName = failedProcessorNodeName;
     }
 
-    public FailedProcessingException(final Exception exception) {
+    public FailedProcessingException(final String failedProcessorNodeName, final Exception exception) {
         // we need to explicitly set `message` to `null` here
         super(null, exception);
+        this.failedProcessorNodeName = failedProcessorNodeName;
+    }
+
+    public String failedProcessorNodeName() {
+        return failedProcessorNodeName;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -226,7 +226,11 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                     errorHandlerContext,
                     processingException
                 );
-                throw new FailedProcessingException("Fatal user code error in processing error callback", fatalUserException);
+                throw new FailedProcessingException(
+                    "Fatal user code error in processing error callback",
+                    internalProcessorContext.currentNode().name(),
+                    fatalUserException
+                );
             }
 
             if (response == ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL) {
@@ -234,7 +238,7 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                      " a processing error. If you would rather have the streaming pipeline" +
                      " continue after a processing error, please set the " +
                      PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG + " appropriately.");
-                throw new FailedProcessingException(processingException);
+                throw new FailedProcessingException(internalProcessorContext.currentNode().name(), processingException);
             } else {
                 droppedRecordsSensor.record();
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -337,7 +337,11 @@ public class RecordCollectorImpl implements RecordCollector {
                 ),
                 serializationException
             );
-            throw new FailedProcessingException("Fatal user code error in production error callback", fatalUserException);
+            throw new FailedProcessingException(
+                "Fatal user code error in production error callback",
+                processorNodeId,
+                fatalUserException
+            );
         }
 
         if (maybeFailResponse(response) == ProductionExceptionHandlerResponse.FAIL) {
@@ -444,7 +448,12 @@ public class RecordCollectorImpl implements RecordCollector {
                     serializedRecord,
                     productionException
                 );
-                sendException.set(new FailedProcessingException("Fatal user code error in production error callback", fatalUserException));
+                sendException.set(new FailedProcessingException(
+                    "Fatal user code error in production error callback",
+                    processorNodeId,
+                    fatalUserException
+                    )
+                );
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -808,12 +808,16 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             }
         } catch (final FailedProcessingException failedProcessingException) {
             // Do not keep the failed processing exception in the stack trace
-            handleException(failedProcessingException.getMessage(), failedProcessingException.getCause());
+            handleException(
+                failedProcessingException.getMessage(),
+                failedProcessingException.failedProcessorNodeName(),
+                failedProcessingException.getCause()
+            );
         } catch (final StreamsException exception) {
             record = null;
             throw exception;
         } catch (final RuntimeException e) {
-            handleException(e);
+            handleException(processorContext.currentNode().name(), e);
         } finally {
             processorContext.setCurrentNode(null);
         }
@@ -821,22 +825,23 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         return true;
     }
 
-    private void handleException(final Throwable originalException) {
+    private void handleException(final String failedProcessorNodeName, final Throwable originalException) {
         handleException(
             String.format(
                 "Exception caught in process. taskId=%s, processor=%s, topic=%s, partition=%d, offset=%d",
                 id(),
-                processorContext.currentNode().name(),
+                failedProcessorNodeName,
                 record.topic(),
                 record.partition(),
                 record.offset()
             ),
+            failedProcessorNodeName,
             originalException);
     }
 
-    private void handleException(final String errorMessage, final Throwable originalException) {
+    private void handleException(final String errorMessage, final String failedProcessorNodeName, final Throwable originalException) {
         if (errorMessage == null) {
-            handleException(originalException);
+            handleException(failedProcessorNodeName, originalException);
         }
 
         final StreamsException error = new StreamsException(errorMessage, originalException);
@@ -962,7 +967,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     errorHandlerContext,
                     processingException
                 );
-                throw new FailedProcessingException("Fatal user code error in processing error callback", fatalUserException);
+                throw new FailedProcessingException("Fatal user code error in processing error callback", node.name(), fatalUserException);
             }
 
             if (response == ProcessingExceptionHandler.ProcessingHandlerResponse.FAIL) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -95,7 +95,7 @@ public class ProcessingExceptionHandlerIntegrationTest {
                 () -> inputTopic.pipeKeyValueList(events, TIMESTAMP, Duration.ZERO));
 
             assertTrue(exception.getMessage().contains("Exception caught in process. "
-                + "taskId=0_0, processor=KSTREAM-SOURCE-0000000000, topic=TOPIC_NAME, "
+                + "taskId=0_0, processor=KSTREAM-PROCESSOR-0000000003, topic=TOPIC_NAME, "
                 + "partition=0, offset=1"));
             assertEquals(1, processor.theCapturedProcessor().processed().size());
             assertIterableEquals(expectedProcessedRecords, processor.theCapturedProcessor().processed());
@@ -183,7 +183,7 @@ public class ProcessingExceptionHandlerIntegrationTest {
             isExecuted.set(false);
             final StreamsException e = assertThrows(StreamsException.class, () -> inputTopic.pipeInput(eventError.key, eventError.value, TIMESTAMP));
             assertTrue(e.getMessage().contains("Exception caught in process. "
-                + "taskId=0_0, processor=KSTREAM-SOURCE-0000000000, topic=TOPIC_NAME, "
+                + "taskId=0_0, processor=KSTREAM-PROCESSOR-0000000003, topic=TOPIC_NAME, "
                 + "partition=0, offset=1"));
             assertFalse(isExecuted.get());
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -109,6 +109,7 @@ public class ProcessorNodeTest {
         assertTrue(failedProcessingException.getCause() instanceof RuntimeException);
         assertEquals("Processing exception should be caught and handled by the processing exception handler.",
             failedProcessingException.getCause().getMessage());
+        assertEquals(NAME, failedProcessingException.failedProcessorNodeName());
     }
 
     @Test
@@ -160,6 +161,7 @@ public class ProcessorNodeTest {
 
         assertInstanceOf(RuntimeException.class, failedProcessingException.getCause());
         assertEquals("KABOOM!", failedProcessingException.getCause().getMessage());
+        assertEquals(NAME, failedProcessingException.failedProcessorNodeName());
     }
 
     private static class ExceptionalProcessor implements Processor<Object, Object, Object, Object> {
@@ -189,7 +191,7 @@ public class ProcessorNodeTest {
         @Override
         public void process(final Record<Object, Object> record) {
             if (record.key().equals("FailedProcessingException")) {
-                throw new FailedProcessingException(new RuntimeException("Fail processing"));
+                throw new FailedProcessingException(NAME, new RuntimeException("Fail processing"));
             }
 
             if (record.key().equals("TaskCorruptedException")) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2646,7 +2646,7 @@ public class StreamTaskTest {
         final StreamsException streamsException = assertThrows(
             StreamsException.class,
             () -> task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, timestamp -> {
-                throw new FailedProcessingException(new RuntimeException("KABOOM!"));
+                throw new FailedProcessingException("name", new RuntimeException("KABOOM!"));
             })
         );
 


### PR DESCRIPTION
This PR leverages the updates brought by [KIP-1033](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1033%3A+Add+Kafka+Streams+exception+handler+for+exceptions+occurring+during+processing) to get the name of the processor node which raised a processing exception and display it in the stacktrace instead of the source node.
