### PR TITLE
KAFKA-17768: Update protobuf and commons-io dependencies in 3.7.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -211,7 +211,7 @@ commons-beanutils-1.9.4
 commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
-commons-io-2.11.0
+commons-io-2.14.0
 commons-lang3-3.8.1
 commons-logging-1.2
 commons-validator-1.7
@@ -335,7 +335,7 @@ BSD 3-Clause
 jline-3.25.1, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
-protobuf-java-3.23.4, see: licenses/protobuf-java-BSD-3-clause
+protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 
 ---------------------------------------
 Do What The F*ck You Want To Public License

--- a/build.gradle
+++ b/build.gradle
@@ -972,6 +972,7 @@ project(':core') {
     implementation libs.scalaReflect
     implementation libs.scalaLogging
     implementation libs.slf4jApi
+    implementation libs.commonsIo // ZooKeeper dependency. Do not use, this is going away.
     implementation(libs.zookeeper) {
       // Dropwizard Metrics are required by ZooKeeper as of v3.6.0,
       // but the library should *not* be used in Kafka code
@@ -1430,6 +1431,7 @@ project(':clients') {
     implementation libs.snappy
     implementation libs.slf4jApi
     implementation libs.opentelemetryProto
+    implementation libs.protobuf
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
     shadowed libs.zstd

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -372,6 +373,7 @@ Found problem:
   }
 
   @Test
+  @nowarn("cat=deprecation")
   def testDirUuidGeneration(): Unit = {
     val tempDir = TestUtils.tempDir()
     try {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -98,6 +98,7 @@ versions += [
   // gradle/resources/dependencycheck-suppressions.xml
   checkstyle: "8.36.2",
   commonsCli: "1.4",
+  commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.6",
@@ -147,6 +148,7 @@ versions += [
   metrics: "2.2.0",
   netty: "4.1.110.Final",
   opentelemetryProto: "1.0.0-alpha",
+  protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.1",
   powermock: "2.0.9",
   reflections: "0.10.2",
@@ -182,6 +184,7 @@ libs += [
   bcpkix: "org.bouncycastle:bcpkix-jdk18on:$versions.bcpkix",
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
+  commonsIo: "commons-io:commons-io:$versions.commonsIo",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   easymock: "org.easymock:easymock:$easymockVersion",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
@@ -243,6 +246,7 @@ libs += [
   nettyTransportNativeEpoll: "io.netty:netty-transport-native-epoll:$versions.netty",
   pcollections: "org.pcollections:pcollections:$versions.pcollections",
   opentelemetryProto: "io.opentelemetry.proto:opentelemetry-proto:$versions.opentelemetryProto",
+  protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
   powermockJunit4: "org.powermock:powermock-module-junit4:$versions.powermock",
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",


### PR DESCRIPTION
JIRA: [KAFKA-17768](https://issues.apache.org/jira/browse/KAFKA-17768)
Update protobuf and Apache commons-io because earlier versions are vulnerable.
protobuf: [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8)
commons-io: [CVE-2024-47554](https://github.com/advisories/GHSA-78wr-2p64-hpwj)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
