### PR TITLE
KAFKA-17520: backport Align ducktape version in tests/docker/Dockerfile and tests/setup.py to 3.9 branch

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -63,7 +63,8 @@ LABEL ducker.creator=$ducker_creator
 # we have to install git since it is included in openjdk:8 but not openjdk:11
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 iputils-ping && apt-get -y clean
 RUN python3 -m pip install -U pip==21.1.1;
-RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 debugpy && pip3 install --upgrade "ducktape>0.8"
+# NOTE: ducktape 0.11.4 requires python3.9
+RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 debugpy && pip3 install --upgrade "ducktape==0.11.4"
 
 COPY --from=build-native-image /build/kafka-binary/ /opt/kafka-binary/
 # Set up ssh

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
+      install_requires=["ducktape==0.11.4", "requests==2.31.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17520

I run e2e on 3.9 branch, is has error about ModuleNotFoundError: No module named `psutil`

That ducktape 0.12 is released (https://github.com/confluentinc/ducktape/releases/tag/v0.12.0), and it requires psutil now (https://github.com/confluentinc/ducktape/commit/33447b6e3a867deec6c5835631d1b1d22d3fea21)

So we should backport [KAFKA-17520](https://issues.apache.org/jira/browse/KAFKA-17520) to 3.9

After fix it I can run e2e test in my local on branch 3.9
![image](https://github.com/user-attachments/assets/b7f7d597-df03-421b-9120-d49b6bbc8fe6)
![image](https://github.com/user-attachments/assets/60fa2e1d-9dcb-4049-bc8f-29215896242a)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
