### PR TITLE
KAFKA-17677: Remove atomicGetOrUpdate

### DIFF
--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -241,24 +241,6 @@ object CoreUtils {
     properties
   }
 
-  /**
-   * Atomic `getOrElseUpdate` for concurrent maps. This is optimized for the case where
-   * keys often exist in the map, avoiding the need to create a new value. `createValue`
-   * may be invoked more than once if multiple threads attempt to insert a key at the same
-   * time, but the same inserted value will be returned to all threads.
-   *
-   * In Scala 2.12, `ConcurrentMap.getOrElse` has the same behaviour as this method, but JConcurrentMapWrapper that
-   * wraps Java maps does not.
-   */
-  def atomicGetOrUpdate[K, V](map: concurrent.Map[K, V], key: K, createValue: => V): V = {
-    map.get(key) match {
-      case Some(value) => value
-      case None =>
-        val value = createValue
-        map.putIfAbsent(key, value).getOrElse(value)
-    }
-  }
-
   def replicaToBrokerAssignmentAsScala(map: util.Map[Integer, util.List[Integer]]): Map[Int, Seq[Int]] = {
     map.asScala.map(e => (e._1.asInstanceOf[Int], e._2.asScala.map(_.asInstanceOf[Int])))
   }

--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -19,8 +19,6 @@ package kafka.utils
 
 import java.util
 import java.util.{Base64, UUID}
-import java.util.concurrent.{ConcurrentHashMap, Executors, TimeUnit}
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import java.nio.ByteBuffer
 import java.util.regex.Pattern
@@ -31,9 +29,6 @@ import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.utils.Utils
 import org.slf4j.event.Level
 
-import scala.jdk.CollectionConverters._
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 
 class CoreUtilsTest extends Logging {
 
@@ -123,29 +118,5 @@ class CoreUtilsTest extends Logging {
     val clusterId = CoreUtils.generateUuidAsBase64()
     assertEquals(clusterId.length, 22)
     assertTrue(clusterIdPattern.matcher(clusterId).matches())
-  }
-
-  @Test
-  def testAtomicGetOrUpdate(): Unit = {
-    val count = 1000
-    val nThreads = 5
-    val createdCount = new AtomicInteger
-    val map = new ConcurrentHashMap[Int, AtomicInteger]().asScala
-    implicit val executionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(nThreads))
-    try {
-      Await.result(Future.traverse(1 to count) { _ =>
-        Future {
-          map.getOrElseUpdate(0, {
-            createdCount.incrementAndGet
-            new AtomicInteger
-          }).incrementAndGet()
-        }
-      }, Duration(1, TimeUnit.MINUTES))
-      assertEquals(count, map(0).get)
-      val created = createdCount.get
-      assertTrue(created > 0 && created <= nThreads, s"Too many creations $created")
-    } finally {
-      executionContext.shutdownNow()
-    }
   }
 }

--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -135,7 +135,7 @@ class CoreUtilsTest extends Logging {
     try {
       Await.result(Future.traverse(1 to count) { _ =>
         Future {
-          CoreUtils.atomicGetOrUpdate(map, 0, {
+          map.getOrElseUpdate(0, {
             createdCount.incrementAndGet
             new AtomicInteger
           }).incrementAndGet()


### PR DESCRIPTION
JIRA: [KAFKA-17677](https://issues.apache.org/jira/browse/KAFKA-17677)

Since we are removing support for Scala 2.12, `CoreUtils#atomicGetOrUpdate` should also be removed, as it is a workaround for the different behavior between `ConcurrentMap.getOrElse` and `JConcurrentMapWrapper`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
