### PR TITLE
KAFKA-17757: Migrate Utils.mkEntry to Map.entry

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetch.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class Fetch<K, V> {
@@ -48,8 +47,8 @@ public class Fetch<K, V> {
     ) {
         Map<TopicPartition, List<ConsumerRecord<K, V>>> recordsMap = records.isEmpty()
                 ? new HashMap<>()
-                : mkMap(mkEntry(partition, records));
-        Map<TopicPartition, OffsetAndMetadata> nextOffsetAndMetadataMap = mkMap(mkEntry(partition, nextOffsetAndMetadata));
+                : mkMap(Map.entry(partition, records));
+        Map<TopicPartition, OffsetAndMetadata> nextOffsetAndMetadataMap = mkMap(Map.entry(partition, nextOffsetAndMetadata));
         return new Fetch<>(recordsMap, positionAdvanced, records.size(), nextOffsetAndMetadataMap);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/feature/BaseVersionRange.java
+++ b/clients/src/main/java/org/apache/kafka/common/feature/BaseVersionRange.java
@@ -95,7 +95,7 @@ class BaseVersionRange {
     }
 
     public Map<String, Short> toMap() {
-        return Utils.mkMap(Utils.mkEntry(minKeyLabel, min()), Utils.mkEntry(maxKeyLabel, max()));
+        return Utils.mkMap(Map.entry(minKeyLabel, min()), Map.entry(maxKeyLabel, max()));
     }
 
     private static String mapToString(final Map<String, Short> map) {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.serialization.Serdes.ListSerde.SerializationStrategy;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class ListDeserializer<Inner> implements Deserializer<List<Inner>> {
@@ -44,12 +43,12 @@ public class ListDeserializer<Inner> implements Deserializer<List<Inner>> {
     final Logger log = LoggerFactory.getLogger(ListDeserializer.class);
 
     private static final Map<Class<? extends Deserializer<?>>, Integer> FIXED_LENGTH_DESERIALIZERS = mkMap(
-        mkEntry(ShortDeserializer.class, Short.BYTES),
-        mkEntry(IntegerDeserializer.class, Integer.BYTES),
-        mkEntry(FloatDeserializer.class, Float.BYTES),
-        mkEntry(LongDeserializer.class, Long.BYTES),
-        mkEntry(DoubleDeserializer.class, Double.BYTES),
-        mkEntry(UUIDDeserializer.class, 36)
+        Map.entry(ShortDeserializer.class, Short.BYTES),
+        Map.entry(IntegerDeserializer.class, Integer.BYTES),
+        Map.entry(FloatDeserializer.class, Float.BYTES),
+        Map.entry(LongDeserializer.class, Long.BYTES),
+        Map.entry(DoubleDeserializer.class, Double.BYTES),
+        Map.entry(UUIDDeserializer.class, 36)
     );
 
     private Deserializer<Inner> inner;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -751,9 +751,9 @@ public class KafkaAdminClientTest {
 
     private static FeatureMetadata defaultFeatureMetadata() {
         return new FeatureMetadata(
-            Utils.mkMap(Utils.mkEntry("test_feature_1", new FinalizedVersionRange((short) 2, (short) 2))),
+            Utils.mkMap(Map.entry("test_feature_1", new FinalizedVersionRange((short) 2, (short) 2))),
             Optional.of(1L),
-            Utils.mkMap(Utils.mkEntry("test_feature_1", new SupportedVersionRange((short) 1, (short) 5))));
+            Utils.mkMap(Map.entry("test_feature_1", new SupportedVersionRange((short) 1, (short) 5))));
     }
 
     private static Features<org.apache.kafka.common.feature.SupportedVersionRange> convertSupportedFeaturesMap(Map<String, SupportedVersionRange> features) {
@@ -4472,7 +4472,7 @@ public class KafkaAdminClientTest {
 
         ListConsumerGroupOffsetsSpec groupASpec = new ListConsumerGroupOffsetsSpec().topicPartitions(groupAPartitions);
         ListConsumerGroupOffsetsSpec groupBSpec = new ListConsumerGroupOffsetsSpec().topicPartitions(groupBPartitions);
-        return Utils.mkMap(Utils.mkEntry("groupA", groupASpec), Utils.mkEntry("groupB", groupBSpec));
+        return Utils.mkMap(Map.entry("groupA", groupASpec), Map.entry("groupB", groupBSpec));
     }
 
     private void waitForRequest(MockClient mockClient, ApiKeys apiKeys) throws Exception {
@@ -6798,8 +6798,8 @@ public class KafkaAdminClientTest {
 
     private Map<String, FeatureUpdate> makeTestFeatureUpdates() {
         return Utils.mkMap(
-            Utils.mkEntry("test_feature_1", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
-            Utils.mkEntry("test_feature_2", new FeatureUpdate((short) 3,  FeatureUpdate.UpgradeType.SAFE_DOWNGRADE)));
+            Map.entry("test_feature_1", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
+            Map.entry("test_feature_2", new FeatureUpdate((short) 3,  FeatureUpdate.UpgradeType.SAFE_DOWNGRADE)));
     }
 
     private void testUpdateFeatures(Map<String, FeatureUpdate> featureUpdates,
@@ -6868,8 +6868,8 @@ public class KafkaAdminClientTest {
                 env.cluster().nodeById(controllerId));
             final KafkaFuture<Void> future = env.adminClient().updateFeatures(
                 Utils.mkMap(
-                    Utils.mkEntry("test_feature_1", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
-                    Utils.mkEntry("test_feature_2", new FeatureUpdate((short) 3,  FeatureUpdate.UpgradeType.SAFE_DOWNGRADE))),
+                    Map.entry("test_feature_1", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
+                    Map.entry("test_feature_2", new FeatureUpdate((short) 3,  FeatureUpdate.UpgradeType.SAFE_DOWNGRADE))),
                 new UpdateFeaturesOptions().timeoutMs(10000)
             ).all();
             future.get();
@@ -6892,8 +6892,8 @@ public class KafkaAdminClientTest {
             assertThrows(
                 IllegalArgumentException.class,
                 () -> env.adminClient().updateFeatures(
-                    Utils.mkMap(Utils.mkEntry("feature", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
-                                Utils.mkEntry("", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE))),
+                    Utils.mkMap(Map.entry("feature", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE)),
+                                Map.entry("", new FeatureUpdate((short) 2,  FeatureUpdate.UpgradeType.UPGRADE))),
                     new UpdateFeaturesOptions()));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1228,7 +1228,7 @@ public class KafkaConsumerTest {
         Node coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
 
         // fetch offset for one topic
-        client.prepareResponseFrom(offsetResponse(Utils.mkMap(Utils.mkEntry(tp0, offset1), Utils.mkEntry(tp1, -1L)), Errors.NONE), coordinator);
+        client.prepareResponseFrom(offsetResponse(Utils.mkMap(Map.entry(tp0, offset1), Map.entry(tp1, -1L)), Errors.NONE), coordinator);
         final Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Set.of(tp0, tp1));
         assertEquals(2, committed.size());
         assertEquals(offset1, committed.get(tp0).offset());
@@ -2403,7 +2403,7 @@ public class KafkaConsumerTest {
         ConsumerPartitionAssignor assignor = new CooperativeStickyAssignor();
         KafkaConsumer<String, String> consumer = newConsumer(groupProtocol, time, client, subscription, metadata, assignor, true, groupInstanceId);
 
-        initMetadata(client, Utils.mkMap(Utils.mkEntry(topic, 1), Utils.mkEntry(topic2, 1), Utils.mkEntry(topic3, 1)));
+        initMetadata(client, Utils.mkMap(Map.entry(topic, 1), Map.entry(topic2, 1), Map.entry(topic3, 1)));
 
         consumer.subscribe(Arrays.asList(topic, topic2), getConsumerRebalanceListener(consumer));
 
@@ -3276,7 +3276,7 @@ public void testClosingConsumerUnregistersConsumerMetrics(GroupProtocol groupPro
         MockClient client = new MockClient(time, metadata);
         KafkaConsumer<String, String> consumer = newConsumer(groupProtocol, time, client, subscription, metadata, assignor, true, groupInstanceId);
         MockRebalanceListener countingRebalanceListener = new MockRebalanceListener();
-        initMetadata(client, Utils.mkMap(Utils.mkEntry(topic, 1), Utils.mkEntry(topic2, 1), Utils.mkEntry(topic3, 1)));
+        initMetadata(client, Utils.mkMap(Map.entry(topic, 1), Map.entry(topic2, 1), Map.entry(topic3, 1)));
 
         consumer.subscribe(Arrays.asList(topic, topic2), countingRebalanceListener);
         Node node = metadata.fetch().nodes().get(0);
@@ -3306,7 +3306,7 @@ public void testClosingConsumerUnregistersConsumerMetrics(GroupProtocol groupPro
 
         ConsumerMetadata metadata = createMetadata(subscription);
         MockClient client = new MockClient(time, metadata);
-        initMetadata(client, Utils.mkMap(Utils.mkEntry(topic, 1)));
+        initMetadata(client, Utils.mkMap(Map.entry(topic, 1)));
         Node node = metadata.fetch().nodes().get(0);
 
         consumer = newConsumer(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -46,7 +46,6 @@ import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssig
 import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.nullRacks;
 import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.racks;
 import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAssignment;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -388,7 +387,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithUniformSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 7), Map.entry("t3", 2));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, allTopics);
 
@@ -409,7 +408,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithNonEqualSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 7), Map.entry("t3", 2));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, asList("t1", "t3"));
 
@@ -430,7 +429,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithUniformPartitions() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 5), mkEntry("t2", 5), mkEntry("t3", 5));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 5), Map.entry("t2", 5), Map.entry("t3", 5));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, allTopics);
         List<String> nonRackAwareAssignment = asList(
@@ -450,7 +449,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithUniformPartitionsNonEqualSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 5), mkEntry("t2", 5), mkEntry("t3", 5));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 5), Map.entry("t2", 5), Map.entry("t3", 5));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, asList("t1", "t3"));
 
@@ -471,7 +470,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithCoPartitioning() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 6), mkEntry("t3", 2), mkEntry("t4", 2));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 6), Map.entry("t3", 2), Map.entry("t4", 2));
         List<List<String>> consumerTopics = asList(asList("t1", "t2"), asList("t1", "t2"), asList("t3", "t4"), asList("t3", "t4"));
         List<String> consumerRacks = asList(ALL_RACKS[0], ALL_RACKS[1], ALL_RACKS[1], ALL_RACKS[0]);
         List<String> nonRackAwareAssignment = asList(
@@ -506,9 +505,9 @@ public class RangeAssignorTest {
 
     @Test
     public void testCoPartitionedAssignmentWithSameSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 6),
-                mkEntry("t3", 2), mkEntry("t4", 2),
-                mkEntry("t5", 4), mkEntry("t6", 4));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 6),
+                Map.entry("t3", 2), Map.entry("t4", 2),
+                Map.entry("t5", 4), Map.entry("t6", 4));
         List<String> topicList = asList("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9");
         List<List<String>> consumerTopics = asList(topicList, topicList, topicList);
         List<String> consumerRacks = asList(ALL_RACKS[0], ALL_RACKS[1], ALL_RACKS[2]);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -53,7 +53,6 @@ import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssig
 import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.racks;
 import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAssignment;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -184,7 +183,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         partitionsPerTopic.put(topic, partitionInfos(topic, 2));
         subscriptions = mkMap(
-                mkEntry(consumerId, buildSubscriptionV2Above(
+                Map.entry(consumerId, buildSubscriptionV2Above(
                         topics(topic),
                         Arrays.asList(tp(topic, 0), tp(topic, 1), tp(otherTopic, 0), tp(otherTopic, 1)),
                         generationId, 0)
@@ -1270,7 +1269,7 @@ public abstract class AbstractStickyAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithUniformSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 7), Map.entry("t3", 2));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, allTopics);
         List<String> nonRackAwareAssignment = asList(
@@ -1337,7 +1336,7 @@ public abstract class AbstractStickyAssignorTest {
 
     @Test
     public void testRackAwareAssignmentWithNonEqualSubscription() {
-        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        Map<String, Integer> topics = mkMap(Map.entry("t1", 6), Map.entry("t2", 7), Map.entry("t3", 2));
         List<String> allTopics = asList("t1", "t2", "t3");
         List<List<String>> consumerTopics = asList(allTopics, allTopics, asList("t1", "t3"));
         List<String> nonRackAwareAssignment = asList(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -123,7 +123,6 @@ import static org.apache.kafka.clients.consumer.internals.ConsumerRebalanceListe
 import static org.apache.kafka.clients.consumer.internals.ConsumerRebalanceListenerMethodName.ON_PARTITIONS_LOST;
 import static org.apache.kafka.clients.consumer.internals.ConsumerRebalanceListenerMethodName.ON_PARTITIONS_REVOKED;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.TestUtils.requiredConsumerConfig;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -479,7 +478,7 @@ public class AsyncKafkaConsumerTest {
         ConsumerRebalanceListener listener = new ConsumerRebalanceListener() {
             @Override
             public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
-                assertDoesNotThrow(() -> consumer.commitSync(mkMap(mkEntry(tp, new OffsetAndMetadata(0)))));
+                assertDoesNotThrow(() -> consumer.commitSync(mkMap(Map.entry(tp, new OffsetAndMetadata(0)))));
                 callbackExecuted.set(true);
             }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -123,7 +123,6 @@ import static org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Rebala
 import static org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.RebalanceProtocol.EAGER;
 import static org.apache.kafka.clients.consumer.CooperativeStickyAssignor.COOPERATIVE_STICKY_ASSIGNOR_NAME;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -188,9 +187,9 @@ public abstract class ConsumerCoordinatorTest {
             new IllegalStateException("Illegal state for assignment!"),
             "throw-fatal-error-on-assignment-assignor");
         this.assignors = Arrays.asList(partitionAssignor, throwOnAssignmentAssignor, throwFatalErrorOnAssignmentAssignor);
-        this.assignorMap = mkMap(mkEntry(partitionAssignor.name(), partitionAssignor),
-            mkEntry(throwOnAssignmentAssignor.name(), throwOnAssignmentAssignor),
-            mkEntry(throwFatalErrorOnAssignmentAssignor.name(), throwFatalErrorOnAssignmentAssignor));
+        this.assignorMap = mkMap(Map.entry(partitionAssignor.name(), partitionAssignor),
+            Map.entry(throwOnAssignmentAssignor.name(), throwOnAssignmentAssignor),
+            Map.entry(throwFatalErrorOnAssignmentAssignor.name(), throwFatalErrorOnAssignmentAssignor));
     }
 
     @BeforeEach
@@ -1483,7 +1482,7 @@ public abstract class ConsumerCoordinatorTest {
     @Test
     public void testRebalanceWithMetadataChange() {
         MetadataResponse metadataResponse1 = RequestTestUtils.metadataUpdateWith(1,
-                Utils.mkMap(Utils.mkEntry(topic1, 1), Utils.mkEntry(topic2, 1)));
+                mkMap(Map.entry(topic1, 1), Map.entry(topic2, 1)));
         MetadataResponse metadataResponse2 = RequestTestUtils.metadataUpdateWith(1, singletonMap(topic1, 1));
         verifyRebalanceWithMetadataChange(Optional.empty(), partitionAssignor, metadataResponse1, metadataResponse2, true);
     }
@@ -2011,8 +2010,8 @@ public abstract class ConsumerCoordinatorTest {
         // note that `MockPartitionAssignor.prepare` is not called therefore calling `MockPartitionAssignor.assign`
         // will throw a IllegalStateException. this indirectly verifies that `assign` is correctly skipped.
         Map<String, List<String>> memberSubscriptions = mkMap(
-            mkEntry(consumerId, singletonList(topic1)),
-            mkEntry(consumerId2, singletonList(topic2))
+            Map.entry(consumerId, singletonList(topic1)),
+            Map.entry(consumerId2, singletonList(topic2))
         );
         client.prepareResponse(joinGroupLeaderResponse(1, consumerId, memberSubscriptions, true, Errors.NONE, Optional.empty()));
         client.prepareResponse(syncGroupResponse(singletonList(t1p), Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
@@ -68,7 +68,6 @@ import java.util.stream.Stream;
 import static org.apache.kafka.clients.consumer.internals.AbstractMembershipManager.TOPIC_PARTITION_COMPARATOR;
 import static org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer.invokeRebalanceCallbacks;
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -775,8 +774,8 @@ public class ConsumerMembershipManagerTest {
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
         when(metadata.topicNames()).thenReturn(
             mkMap(
-                mkEntry(topicId1, topic1),
-                mkEntry(topicId2, topic2)
+                Map.entry(topicId1, topic1),
+                Map.entry(topicId2, topic2)
             )
         );
 
@@ -788,8 +787,8 @@ public class ConsumerMembershipManagerTest {
         // No reconciliation triggered, because another reconciliation is in progress.
         Map<Uuid, SortedSet<Integer>> newAssignment =
             mkMap(
-                mkEntry(topicId1, mkSortedSet(0)),
-                mkEntry(topicId2, mkSortedSet(0))
+                Map.entry(topicId1, mkSortedSet(0)),
+                Map.entry(topicId2, mkSortedSet(0))
             );
 
         receiveAssignment(newAssignment, membershipManager);
@@ -849,8 +848,8 @@ public class ConsumerMembershipManagerTest {
 
         Map<Uuid, SortedSet<Integer>> newAssignment =
             mkMap(
-                mkEntry(topicId1, mkSortedSet(0)),
-                mkEntry(topicId2, mkSortedSet(0))
+                Map.entry(topicId1, mkSortedSet(0)),
+                Map.entry(topicId2, mkSortedSet(0))
             );
 
         receiveAssignment(newAssignment, membershipManager);
@@ -872,8 +871,8 @@ public class ConsumerMembershipManagerTest {
         // with membership manager entering ACKNOWLEDGING state.
 
         Map<Uuid, String> fullTopicMetadata = mkMap(
-            mkEntry(topicId1, topic1),
-            mkEntry(topicId2, topic2)
+            Map.entry(topicId1, topic1),
+            Map.entry(topicId2, topic2)
         );
         when(metadata.topicNames()).thenReturn(fullTopicMetadata);
 
@@ -2597,7 +2596,7 @@ public class ConsumerMembershipManagerTest {
     private void mockOwnedPartition(ConsumerMembershipManager membershipManager, Uuid topicId, String topic) {
         int partition = 0;
         TopicPartition previouslyOwned = new TopicPartition(topic, partition);
-        membershipManager.updateAssignment(mkMap(mkEntry(topicId, new TreeSet<>(Collections.singletonList(partition)))));
+        membershipManager.updateAssignment(mkMap(Map.entry(topicId, new TreeSet<>(Collections.singletonList(partition)))));
         when(subscriptionState.assignedPartitions()).thenReturn(Collections.singleton(previouslyOwned));
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
@@ -828,12 +828,12 @@ public class OffsetFetcherTest {
 
             Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestampMap =
                 offsetFetcher.offsetsForTimes(
-                    Utils.mkMap(Utils.mkEntry(tp0, fetchTimestamp),
-                    Utils.mkEntry(tp1, fetchTimestamp)), time.timer(Integer.MAX_VALUE));
+                    Utils.mkMap(Map.entry(tp0, fetchTimestamp),
+                    Map.entry(tp1, fetchTimestamp)), time.timer(Integer.MAX_VALUE));
 
             assertEquals(Utils.mkMap(
-                Utils.mkEntry(tp0, new OffsetAndTimestamp(4L, fetchTimestamp)),
-                Utils.mkEntry(tp1, new OffsetAndTimestamp(5L, fetchTimestamp))), offsetAndTimestampMap);
+                Map.entry(tp0, new OffsetAndTimestamp(4L, fetchTimestamp)),
+                Map.entry(tp1, new OffsetAndTimestamp(5L, fetchTimestamp))), offsetAndTimestampMap);
 
             // The NOT_LEADER exception future should not be cleared as we already refreshed the metadata before
             // first retry, thus never hitting.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -59,7 +59,6 @@ import java.util.stream.Stream;
 import static org.apache.kafka.clients.consumer.internals.AbstractMembershipManager.TOPIC_PARTITION_COMPARATOR;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_SHARE_METRIC_GROUP_PREFIX;
 import static org.apache.kafka.common.requests.ShareGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -465,8 +464,8 @@ public class ShareMembershipManagerTest {
 
         Map<Uuid, SortedSet<Integer>> newAssignment =
                 mkMap(
-                        mkEntry(topicId1, mkSortedSet(0)),
-                        mkEntry(topicId2, mkSortedSet(0))
+                        Map.entry(topicId1, mkSortedSet(0)),
+                        Map.entry(topicId2, mkSortedSet(0))
                 );
 
         receiveAssignment(newAssignment, membershipManager);
@@ -488,8 +487,8 @@ public class ShareMembershipManagerTest {
         // with membership manager entering ACKNOWLEDGING state.
 
         Map<Uuid, String> fullTopicMetadata = mkMap(
-                mkEntry(topicId1, topic1),
-                mkEntry(topicId2, topic2)
+                Map.entry(topicId1, topic1),
+                Map.entry(topicId2, topic2)
         );
         when(metadata.topicNames()).thenReturn(fullTopicMetadata);
 
@@ -1461,7 +1460,7 @@ public class ShareMembershipManagerTest {
     private void mockOwnedPartition(ShareMembershipManager membershipManager, Uuid topicId, String topic) {
         int partition = 0;
         TopicPartition previouslyOwned = new TopicPartition(topic, partition);
-        membershipManager.updateAssignment(mkMap(mkEntry(topicId, new TreeSet<>(Collections.singletonList(partition)))));
+        membershipManager.updateAssignment(mkMap(Map.entry(topicId, new TreeSet<>(Collections.singletonList(partition)))));
         when(subscriptionState.assignedPartitions()).thenReturn(Collections.singleton(previouslyOwned));
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
     }

--- a/clients/src/test/java/org/apache/kafka/common/feature/FeaturesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/FeaturesTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -54,7 +53,7 @@ public class FeaturesTest {
         SupportedVersionRange v1 = new SupportedVersionRange((short) 1, (short) 2);
         SupportedVersionRange v2 = new SupportedVersionRange((short) 3, (short) 4);
         Map<String, SupportedVersionRange> allFeatures =
-            mkMap(mkEntry("feature_1", v1), mkEntry("feature_2", v2));
+            mkMap(Map.entry("feature_1", v1), Map.entry("feature_2", v2));
         Features<SupportedVersionRange> features = Features.supportedFeatures(allFeatures);
         assertEquals(allFeatures, features.features());
     }
@@ -63,7 +62,7 @@ public class FeaturesTest {
     public void testGetAPI() {
         SupportedVersionRange v1 = new SupportedVersionRange((short) 1, (short) 2);
         SupportedVersionRange v2 = new SupportedVersionRange((short) 3, (short) 4);
-        Map<String, SupportedVersionRange> allFeatures = mkMap(mkEntry("feature_1", v1), mkEntry("feature_2", v2));
+        Map<String, SupportedVersionRange> allFeatures = mkMap(Map.entry("feature_1", v1), Map.entry("feature_2", v2));
         Features<SupportedVersionRange> features = Features.supportedFeatures(allFeatures);
         assertEquals(v1, features.get("feature_1"));
         assertEquals(v2, features.get("feature_2"));
@@ -74,13 +73,13 @@ public class FeaturesTest {
     public void testFromFeaturesMapToFeaturesMap() {
         SupportedVersionRange v1 = new SupportedVersionRange((short) 1, (short) 2);
         SupportedVersionRange v2 = new SupportedVersionRange((short) 3, (short) 4);
-        Map<String, SupportedVersionRange> allFeatures = mkMap(mkEntry("feature_1", v1), mkEntry("feature_2", v2));
+        Map<String, SupportedVersionRange> allFeatures = mkMap(Map.entry("feature_1", v1), Map.entry("feature_2", v2));
 
         Features<SupportedVersionRange> features = Features.supportedFeatures(allFeatures);
 
         Map<String, Map<String, Short>> expected = mkMap(
-            mkEntry("feature_1", mkMap(mkEntry("min_version", (short) 1), mkEntry("max_version", (short) 2))),
-            mkEntry("feature_2", mkMap(mkEntry("min_version", (short) 3), mkEntry("max_version", (short) 4))));
+            Map.entry("feature_1", mkMap(Map.entry("min_version", (short) 1), Map.entry("max_version", (short) 2))),
+            Map.entry("feature_2", mkMap(Map.entry("min_version", (short) 3), Map.entry("max_version", (short) 4))));
         assertEquals(expected, features.toMap());
         assertEquals(features, Features.fromSupportedFeaturesMap(expected));
     }
@@ -90,7 +89,7 @@ public class FeaturesTest {
         SupportedVersionRange v1 = new SupportedVersionRange((short) 1, (short) 2);
         SupportedVersionRange v2 = new SupportedVersionRange((short) 3, (short) 4);
         Map<String, SupportedVersionRange> allFeatures
-            = mkMap(mkEntry("feature_1", v1), mkEntry("feature_2", v2));
+            = mkMap(Map.entry("feature_1", v1), Map.entry("feature_2", v2));
 
         Features<SupportedVersionRange> features = Features.supportedFeatures(allFeatures);
 
@@ -103,7 +102,7 @@ public class FeaturesTest {
     public void testSupportedFeaturesFromMapFailureWithInvalidMissingMaxVersion() {
         // This is invalid because 'max_version' key is missing.
         Map<String, Map<String, Short>> invalidFeatures = mkMap(
-            mkEntry("feature_1", mkMap(mkEntry("min_version", (short) 1))));
+            Map.entry("feature_1", mkMap(Map.entry("min_version", (short) 1))));
         assertThrows(
             IllegalArgumentException.class,
             () -> Features.fromSupportedFeaturesMap(invalidFeatures));
@@ -112,13 +111,13 @@ public class FeaturesTest {
     @Test
     public void testEquals() {
         SupportedVersionRange v1 = new SupportedVersionRange((short) 1, (short) 2);
-        Map<String, SupportedVersionRange> allFeatures = mkMap(mkEntry("feature_1", v1));
+        Map<String, SupportedVersionRange> allFeatures = mkMap(Map.entry("feature_1", v1));
         Features<SupportedVersionRange> features = Features.supportedFeatures(allFeatures);
         Features<SupportedVersionRange> featuresClone = Features.supportedFeatures(allFeatures);
         assertEquals(features, featuresClone);
 
         SupportedVersionRange v2 = new SupportedVersionRange((short) 1, (short) 3);
-        Map<String, SupportedVersionRange> allFeaturesDifferent = mkMap(mkEntry("feature_1", v2));
+        Map<String, SupportedVersionRange> allFeaturesDifferent = mkMap(Map.entry("feature_1", v2));
         Features<SupportedVersionRange> featuresDifferent = Features.supportedFeatures(allFeaturesDifferent);
         assertNotEquals(features, featuresDifferent);
 

--- a/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionRangeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionRangeTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,7 +61,7 @@ public class SupportedVersionRangeTest {
 
         Map<String, Short> versionRangeMap = versionRange.toMap();
         assertEquals(
-            mkMap(mkEntry("min_version", versionRange.min()), mkEntry("max_version", versionRange.max())),
+            mkMap(Map.entry("min_version", versionRange.min()), Map.entry("max_version", versionRange.max())),
             versionRangeMap);
 
         SupportedVersionRange newVersionRange = SupportedVersionRange.fromMap(versionRangeMap);
@@ -75,42 +74,42 @@ public class SupportedVersionRangeTest {
     public void testFromMapFailure() {
         // min_version can't be < 0.
         Map<String, Short> invalidWithBadMinVersion =
-            mkMap(mkEntry("min_version", (short) -1), mkEntry("max_version", (short) 0));
+            mkMap(Map.entry("min_version", (short) -1), Map.entry("max_version", (short) 0));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithBadMinVersion));
 
         // max_version can't be < 0.
         Map<String, Short> invalidWithBadMaxVersion =
-            mkMap(mkEntry("min_version", (short) 0), mkEntry("max_version", (short) -1));
+            mkMap(Map.entry("min_version", (short) 0), Map.entry("max_version", (short) -1));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithBadMaxVersion));
 
         // min_version and max_version can't be < 0.
         Map<String, Short> invalidWithBadMinMaxVersion =
-            mkMap(mkEntry("min_version", (short) -1), mkEntry("max_version", (short) -1));
+            mkMap(Map.entry("min_version", (short) -1), Map.entry("max_version", (short) -1));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithBadMinMaxVersion));
 
         // min_version can't be > max_version.
         Map<String, Short> invalidWithLowerMaxVersion =
-            mkMap(mkEntry("min_version", (short) 2), mkEntry("max_version", (short) 1));
+            mkMap(Map.entry("min_version", (short) 2), Map.entry("max_version", (short) 1));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithLowerMaxVersion));
 
         // min_version key missing.
         Map<String, Short> invalidWithMinKeyMissing =
-            mkMap(mkEntry("max_version", (short) 1));
+            mkMap(Map.entry("max_version", (short) 1));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithMinKeyMissing));
 
         // max_version key missing.
         Map<String, Short> invalidWithMaxKeyMissing =
-            mkMap(mkEntry("min_version", (short) 1));
+            mkMap(Map.entry("min_version", (short) 1));
         assertThrows(
             IllegalArgumentException.class,
             () -> SupportedVersionRange.fromMap(invalidWithMaxKeyMissing));

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -91,11 +91,11 @@ public class ApiVersionsResponseTest {
         final short minVersion = 0;
         final short maxVersion = 1;
         Map<ApiKeys, ApiVersion> activeControllerApiVersions = Utils.mkMap(
-            Utils.mkEntry(forwardableAPIKey, new ApiVersion()
+            Map.entry(forwardableAPIKey, new ApiVersion()
                 .setApiKey(forwardableAPIKey.id)
                 .setMinVersion(minVersion)
                 .setMaxVersion(maxVersion)),
-            Utils.mkEntry(nonForwardableAPIKey, new ApiVersion()
+            Map.entry(nonForwardableAPIKey, new ApiVersion()
                 .setApiKey(nonForwardableAPIKey.id)
                 .setMinVersion(minVersion)
                 .setMaxVersion(maxVersion))
@@ -145,8 +145,8 @@ public class ApiVersionsResponseTest {
                 true,
                 true)).
             setSupportedFeatures(Features.supportedFeatures(
-                Utils.mkMap(Utils.mkEntry("feature", new SupportedVersionRange((short) 1, (short) 4))))).
-            setFinalizedFeatures(Utils.mkMap(Utils.mkEntry("feature", (short) 3))).
+                Utils.mkMap(Map.entry("feature", new SupportedVersionRange((short) 1, (short) 4))))).
+            setFinalizedFeatures(Utils.mkMap(Map.entry("feature", (short) 3))).
             setFinalizedFeaturesEpoch(10L).
             build();
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -88,9 +88,9 @@ public class OffsetFetchResponseTest {
                 OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NOT_COORDINATOR, partitionDataMap);
                 assertEquals(Errors.NOT_COORDINATOR, response.error());
                 assertEquals(3, response.errorCounts().size());
-                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
-                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
-                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                assertEquals(Utils.mkMap(Map.entry(Errors.NOT_COORDINATOR, 1),
+                    Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Map.entry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
                     response.errorCounts());
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
@@ -105,9 +105,9 @@ public class OffsetFetchResponseTest {
                     Collections.singletonMap(groupOne, partitionDataMap));
                 assertEquals(Errors.NOT_COORDINATOR, response.groupLevelError(groupOne));
                 assertEquals(3, response.errorCounts().size());
-                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
-                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
-                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                assertEquals(Utils.mkMap(Map.entry(Errors.NOT_COORDINATOR, 1),
+                    Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Map.entry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
                     response.errorCounts());
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
@@ -159,11 +159,11 @@ public class OffsetFetchResponseTest {
                 assertTrue(response.groupHasError(groupTwo));
                 assertFalse(response.groupHasError(groupThree));
                 assertEquals(5, response.errorCounts().size());
-                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
-                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
-                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1),
-                    Utils.mkEntry(Errors.COORDINATOR_LOAD_IN_PROGRESS, 1),
-                    Utils.mkEntry(Errors.NONE, 2)),
+                assertEquals(Utils.mkMap(Map.entry(Errors.NOT_COORDINATOR, 1),
+                    Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Map.entry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1),
+                    Map.entry(Errors.COORDINATOR_LOAD_IN_PROGRESS, 1),
+                    Map.entry(Errors.NONE, 2)),
                     response.errorCounts());
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
@@ -206,17 +206,17 @@ public class OffsetFetchResponseTest {
 
                     // Partition level error populated in older versions.
                     assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
-                    assertEquals(Utils.mkMap(Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                    assertEquals(Utils.mkMap(Map.entry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
+                        Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
                         oldResponse.errorCounts());
                 } else {
                     assertEquals(Errors.NONE.code(), data.errorCode());
 
                     assertEquals(Errors.NONE, oldResponse.error());
                     assertEquals(Utils.mkMap(
-                        Utils.mkEntry(Errors.NONE, 1),
-                        Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                        Map.entry(Errors.NONE, 1),
+                        Map.entry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
+                        Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
                         oldResponse.errorCounts());
                 }
 
@@ -258,9 +258,9 @@ public class OffsetFetchResponseTest {
 
                 assertEquals(Errors.NONE, oldResponse.groupLevelError(groupOne));
                 assertEquals(Utils.mkMap(
-                    Utils.mkEntry(Errors.NONE, 1),
-                    Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
-                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                    Map.entry(Errors.NONE, 1),
+                    Map.entry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
+                    Map.entry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
                     oldResponse.errorCounts());
                 assertEquals(throttleTimeMs, oldResponse.throttleTimeMs());
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,9 +35,9 @@ public class FixedOrderMapTest {
         map.put("c", 2);
         map.put("b", 3);
         final Iterator<Map.Entry<String, Integer>> iterator = map.entrySet().iterator();
-        assertEquals(mkEntry("a", 0), iterator.next());
-        assertEquals(mkEntry("b", 3), iterator.next());
-        assertEquals(mkEntry("c", 2), iterator.next());
+        assertEquals(Map.entry("a", 0), iterator.next());
+        assertEquals(Map.entry("b", 3), iterator.next());
+        assertEquals(Map.entry("c", 2), iterator.next());
         assertFalse(iterator.hasNext());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -78,7 +78,6 @@ import static org.apache.kafka.common.utils.Utils.formatBytes;
 import static org.apache.kafka.common.utils.Utils.getHost;
 import static org.apache.kafka.common.utils.Utils.getPort;
 import static org.apache.kafka.common.utils.Utils.intersection;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.murmur2;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.common.utils.Utils.validHostPattern;
@@ -1079,10 +1078,10 @@ public class UtilsTest {
             recordingCallable(recorded, null, new TestException("exception-3"))
         ));
         Map<String, Object> expected = Utils.mkMap(
-            mkEntry("valid-0", "valid-0"),
-            mkEntry("exception-1", new TestException("exception-1")),
-            mkEntry("valid-2", "valid-2"),
-            mkEntry("exception-3", new TestException("exception-3"))
+            Map.entry("valid-0", "valid-0"),
+            Map.entry("exception-1", new TestException("exception-1")),
+            Map.entry("valid-2", "valid-2"),
+            Map.entry("exception-3", new TestException("exception-3"))
         );
         assertEquals(expected, recorded);
 
@@ -1092,8 +1091,8 @@ public class UtilsTest {
             recordingCallable(recorded, "valid-1", null)
         ));
         expected = Utils.mkMap(
-            mkEntry("valid-0", "valid-0"),
-            mkEntry("valid-1", "valid-1")
+            Map.entry("valid-0", "valid-0"),
+            Map.entry("valid-1", "valid-1")
         );
         assertEquals(expected, recorded);
 
@@ -1103,8 +1102,8 @@ public class UtilsTest {
             recordingCallable(recorded, null, new TestException("exception-1")))
         );
         expected = Utils.mkMap(
-            mkEntry("exception-0", new TestException("exception-0")),
-            mkEntry("exception-1", new TestException("exception-1"))
+            Map.entry("exception-0", new TestException("exception-0")),
+            Map.entry("exception-1", new TestException("exception-1"))
         );
         assertEquals(expected, recorded);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStoreTest.java
@@ -95,7 +95,7 @@ public class ConnectorOffsetBackingStoreTest {
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
             mkEntry(OFFSET_KEY_SERIALIZED, null),
-            mkEntry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED))
+            Map.entry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED))
         ), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
@@ -128,7 +128,7 @@ public class ConnectorOffsetBackingStoreTest {
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
             mkEntry(OFFSET_KEY_SERIALIZED, null),
-            mkEntry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
+            Map.entry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
         )), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
@@ -162,7 +162,7 @@ public class ConnectorOffsetBackingStoreTest {
         AtomicReference<Throwable> callbackError = new AtomicReference<>();
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
-            mkEntry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED),
+            Map.entry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED),
             mkEntry(OFFSET_KEY_SERIALIZED_1, null))
         ), (error, result) -> {
             callbackInvoked.set(true);
@@ -198,8 +198,8 @@ public class ConnectorOffsetBackingStoreTest {
         AtomicReference<Throwable> callbackError = new AtomicReference<>();
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
-            mkEntry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED),
-            mkEntry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
+            Map.entry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED),
+            Map.entry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
         )), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
@@ -232,7 +232,7 @@ public class ConnectorOffsetBackingStoreTest {
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
             mkEntry(OFFSET_KEY_SERIALIZED, null),
-            mkEntry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
+            Map.entry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
         )), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
@@ -260,7 +260,7 @@ public class ConnectorOffsetBackingStoreTest {
         AtomicReference<Object> callbackResult = new AtomicReference<>();
         AtomicReference<Throwable> callbackError = new AtomicReference<>();
 
-        Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(mkEntry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED))), (error, result) -> {
+        Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(Map.entry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED))), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
             callbackError.set(error);
@@ -286,7 +286,7 @@ public class ConnectorOffsetBackingStoreTest {
         AtomicReference<Object> callbackResult = new AtomicReference<>();
         AtomicReference<Throwable> callbackError = new AtomicReference<>();
 
-        Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(mkEntry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED))), (error, result) -> {
+        Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(Map.entry(OFFSET_KEY_SERIALIZED, OFFSET_VALUE_SERIALIZED))), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
             callbackError.set(error);
@@ -376,7 +376,7 @@ public class ConnectorOffsetBackingStoreTest {
 
         Future<Void> setFuture = offsetBackingStore.set(getSerialisedOffsets(mkMap(
             mkEntry(OFFSET_KEY_SERIALIZED, null),
-            mkEntry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
+            Map.entry(OFFSET_KEY_SERIALIZED_1, OFFSET_VALUE_SERIALIZED)
         )), (error, result) -> {
             callbackInvoked.set(true);
             callbackResult.set(result);
@@ -441,7 +441,7 @@ public class ConnectorOffsetBackingStoreTest {
         Node noNode = Node.noNode();
         Node[] nodes = new Node[]{noNode};
         consumer.updatePartitions(topic, Collections.singletonList(new PartitionInfo(topic, 0, noNode, nodes, nodes)));
-        consumer.updateBeginningOffsets(mkMap(mkEntry(new TopicPartition(topic, 0), 100L)));
+        consumer.updateBeginningOffsets(mkMap(Map.entry(new TopicPartition(topic, 0), 100L)));
         return consumer;
     }
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogram.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogram.java
@@ -56,10 +56,10 @@ public final class KafkaMetricHistogram implements CompoundStat {
      */
     private static final Map<Double, String> PERCENTILE_NAMES =
         Utils.mkMap(
-            Utils.mkEntry(50.0, "p50"),
-            Utils.mkEntry(95.0, "p95"),
-            Utils.mkEntry(99.0, "p99"),
-            Utils.mkEntry(99.9, "p999")
+            Map.entry(50.0, "p50"),
+            Map.entry(95.0, "p95"),
+            Map.entry(99.0, "p99"),
+            Map.entry(99.9, "p999")
         );
 
     /**

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -19,6 +19,7 @@ package kafka.controller
 import com.yammer.metrics.core.{Meter, Timer}
 
 import java.util.concurrent.TimeUnit
+import java.util.Map.entry
 import kafka.common._
 import kafka.cluster.Broker
 import kafka.controller.KafkaController.{ActiveBrokerCountMetricName, ActiveControllerCountMetricName, AlterReassignmentsCallback, ControllerStateMetricName, ElectLeadersCallback, FencedBrokerCountMetricName, GlobalPartitionCountMetricName, GlobalTopicCountMetricName, ListReassignmentsCallback, OfflinePartitionsCountMetricName, PreferredReplicaImbalanceCountMetricName, ReplicasIneligibleToDeleteCountMetricName, ReplicasToDeleteCountMetricName, TopicsIneligibleToDeleteCountMetricName, TopicsToDeleteCountMetricName, UpdateFeaturesCallback, ZkMigrationStateMetricName}
@@ -1984,7 +1985,7 @@ class KafkaController(val config: KafkaConfig,
           s" versionLevel:${update.versionLevel} is lower than the" +
           s" supported minVersion:${supportedVersionRange.min}."))
       } else {
-        val newFinalizedFeature = Utils.mkMap(Utils.mkEntry(update.feature, newVersion: java.lang.Short))
+        val newFinalizedFeature = Utils.mkMap(entry(update.feature, newVersion: java.lang.Short))
         val numIncompatibleBrokers = controllerContext.liveOrShuttingDownBrokers.count(broker => {
           BrokerFeatures.hasIncompatibleFeatures(broker.features, newFinalizedFeature)
         })

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -249,12 +249,12 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
                 SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString())));
 
         globalSensors = Collections.unmodifiableMap(Utils.mkMap(
-            Utils.mkEntry(OFFSET_COMMITS_SENSOR_NAME, offsetCommitsSensor),
-            Utils.mkEntry(OFFSET_EXPIRED_SENSOR_NAME, offsetExpiredSensor),
-            Utils.mkEntry(OFFSET_DELETIONS_SENSOR_NAME, offsetDeletionsSensor),
-            Utils.mkEntry(CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME, classicGroupCompletedRebalancesSensor),
-            Utils.mkEntry(CONSUMER_GROUP_REBALANCES_SENSOR_NAME, consumerGroupRebalanceSensor),
-            Utils.mkEntry(SHARE_GROUP_REBALANCES_SENSOR_NAME, shareGroupRebalanceSensor)
+            Map.entry(OFFSET_COMMITS_SENSOR_NAME, offsetCommitsSensor),
+            Map.entry(OFFSET_EXPIRED_SENSOR_NAME, offsetExpiredSensor),
+            Map.entry(OFFSET_DELETIONS_SENSOR_NAME, offsetDeletionsSensor),
+            Map.entry(CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME, classicGroupCompletedRebalancesSensor),
+            Map.entry(CONSUMER_GROUP_REBALANCES_SENSOR_NAME, consumerGroupRebalanceSensor),
+            Map.entry(SHARE_GROUP_REBALANCES_SENSOR_NAME, shareGroupRebalanceSensor)
         ));
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -110,24 +110,24 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         this.classicGroupGauges = Collections.emptyMap();
 
         this.consumerGroupGauges = Utils.mkMap(
-            Utils.mkEntry(ConsumerGroupState.EMPTY,
+            Map.entry(ConsumerGroupState.EMPTY,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ConsumerGroupState.ASSIGNING,
+            Map.entry(ConsumerGroupState.ASSIGNING,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ConsumerGroupState.RECONCILING,
+            Map.entry(ConsumerGroupState.RECONCILING,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ConsumerGroupState.STABLE,
+            Map.entry(ConsumerGroupState.STABLE,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ConsumerGroupState.DEAD,
+            Map.entry(ConsumerGroupState.DEAD,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
         );
 
         this.shareGroupGauges = Utils.mkMap(
-            Utils.mkEntry(ShareGroup.ShareGroupState.EMPTY,
+            Map.entry(ShareGroup.ShareGroupState.EMPTY,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ShareGroup.ShareGroupState.STABLE,
+            Map.entry(ShareGroup.ShareGroupState.STABLE,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ShareGroup.ShareGroupState.DEAD,
+            Map.entry(ShareGroup.ShareGroupState.DEAD,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
         );
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -3583,7 +3583,7 @@ public class GroupMetadataManagerTest {
 
         context.groupMetadataManager.updateClassicGroupSizeCounter();
         verify(context.metrics, times(1)).setClassicGroupGauges(eq(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.EMPTY, 4L)
+            Map.entry(ClassicGroupState.EMPTY, 4L)
         )));
 
         group1.transitionTo(PREPARING_REBALANCE);
@@ -3596,10 +3596,10 @@ public class GroupMetadataManagerTest {
 
         context.groupMetadataManager.updateClassicGroupSizeCounter();
         verify(context.metrics, times(1)).setClassicGroupGauges(eq(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.STABLE, 1L),
-            Utils.mkEntry(ClassicGroupState.DEAD, 1L)
+            Map.entry(ClassicGroupState.PREPARING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.STABLE, 1L),
+            Map.entry(ClassicGroupState.DEAD, 1L)
         )));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME;
@@ -168,17 +169,17 @@ public class GroupCoordinatorMetricsTest {
         coordinatorMetrics.activateMetricsShard(shard1);
 
         shard0.setClassicGroupGauges(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.STABLE, 1L),
-            Utils.mkEntry(ClassicGroupState.EMPTY, 1L)
+            Map.entry(ClassicGroupState.PREPARING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.STABLE, 1L),
+            Map.entry(ClassicGroupState.EMPTY, 1L)
         ));
         shard1.setClassicGroupGauges(Utils.mkMap(
-            Utils.mkEntry(ClassicGroupState.PREPARING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
-            Utils.mkEntry(ClassicGroupState.STABLE, 1L),
-            Utils.mkEntry(ClassicGroupState.EMPTY, 1L),
-            Utils.mkEntry(ClassicGroupState.DEAD, 1L)
+            Map.entry(ClassicGroupState.PREPARING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.COMPLETING_REBALANCE, 1L),
+            Map.entry(ClassicGroupState.STABLE, 1L),
+            Map.entry(ClassicGroupState.EMPTY, 1L),
+            Map.entry(ClassicGroupState.DEAD, 1L)
         ));
 
         IntStream.range(0, 5).forEach(__ -> shard0.incrementNumConsumerGroups(ConsumerGroupState.ASSIGNING));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -64,7 +64,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.Assertions.assertRecordEquals;
 import static org.apache.kafka.coordinator.group.Assertions.assertRecordsEquals;
@@ -668,7 +667,7 @@ public class ConsumerGroupTest {
         // Compute while taking into account member 1.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, member1),
@@ -683,7 +682,7 @@ public class ConsumerGroupTest {
         // It should return foo now.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, null),
@@ -705,8 +704,8 @@ public class ConsumerGroupTest {
         // Compute while taking into account member 2.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, member2),
@@ -721,8 +720,8 @@ public class ConsumerGroupTest {
         // It should return foo and bar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, null),
@@ -734,7 +733,7 @@ public class ConsumerGroupTest {
         // Compute while taking into account removal of member 2.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(member2, null),
@@ -746,7 +745,7 @@ public class ConsumerGroupTest {
         // Removing member1 results in returning bar.
         assertEquals(
             mkMap(
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(member1, null),
@@ -758,9 +757,9 @@ public class ConsumerGroupTest {
         // Compute while taking into account member 3.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, member3),
@@ -775,9 +774,9 @@ public class ConsumerGroupTest {
         // It should return foo, bar and zar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, null),
@@ -799,7 +798,7 @@ public class ConsumerGroupTest {
         // Compute while taking into account removal of member 2 and member 3.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(new HashSet<>(Arrays.asList(member2, member3))),
@@ -811,8 +810,8 @@ public class ConsumerGroupTest {
         // Compute while taking into account removal of member 1.
         assertEquals(
             mkMap(
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(Collections.singleton(member1)),
@@ -824,9 +823,9 @@ public class ConsumerGroupTest {
         // It should return foo, bar and zar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(Collections.emptySet()),
@@ -922,7 +921,7 @@ public class ConsumerGroupTest {
         // Verify that partition 0 is assigned to member1.
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(0, memberId1)))
+                Map.entry(topicId, mkMap(Map.entry(0, memberId1)))
             ),
             consumerGroup.invertedTargetAssignment()
         );
@@ -937,7 +936,7 @@ public class ConsumerGroupTest {
         // Verify that partition 0 is no longer assigned and partition 1 is assigned to member1
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId1)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId1)))
             ),
             consumerGroup.invertedTargetAssignment()
         );
@@ -952,7 +951,7 @@ public class ConsumerGroupTest {
         // Verify that partition 1 is assigned to member2
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId2)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId2)))
             ),
             consumerGroup.invertedTargetAssignment()
         );
@@ -967,9 +966,9 @@ public class ConsumerGroupTest {
         // Verify that partition 1 is still assigned to member2 and partition 0 is assigned to member1
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(
-                    mkEntry(0, memberId1),
-                    mkEntry(1, memberId2)
+                Map.entry(topicId, mkMap(
+                    Map.entry(0, memberId1),
+                    Map.entry(1, memberId2)
                 ))
             ),
             consumerGroup.invertedTargetAssignment()
@@ -981,7 +980,7 @@ public class ConsumerGroupTest {
         // Verify that partition 0 is no longer assigned and partition 1 is still assigned to member2
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId2)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId2)))
             ),
             consumerGroup.invertedTargetAssignment()
         );
@@ -1233,8 +1232,8 @@ public class ConsumerGroupTest {
 
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             consumerGroup.computeSubscriptionMetadata(
                 consumerGroup.computeSubscribedTopicNames(null, null),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupTest.java
@@ -40,8 +40,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
@@ -180,7 +180,7 @@ public class ShareGroupTest {
         // Compute while taking into account member 1.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, member1),
@@ -195,7 +195,7 @@ public class ShareGroupTest {
         // It should return foo now.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, null),
@@ -217,8 +217,8 @@ public class ShareGroupTest {
         // Compute while taking into account member 2.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, member2),
@@ -233,8 +233,8 @@ public class ShareGroupTest {
         // It should return foo and bar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, null),
@@ -246,7 +246,7 @@ public class ShareGroupTest {
         // Compute while taking into account removal of member 2.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(member2, null),
@@ -258,7 +258,7 @@ public class ShareGroupTest {
         // Removing member1 results in returning bar.
         assertEquals(
             mkMap(
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(member1, null),
@@ -270,9 +270,9 @@ public class ShareGroupTest {
         // Compute while taking into account member 3.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, member3),
@@ -287,9 +287,9 @@ public class ShareGroupTest {
         // It should return foo, bar and zar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, null),
@@ -311,7 +311,7 @@ public class ShareGroupTest {
         // Compute while taking into account removal of member 2 and member 3.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(new HashSet<>(Arrays.asList(member2, member3))),
@@ -323,8 +323,8 @@ public class ShareGroupTest {
         // Compute while taking into account removal of member 1.
         assertEquals(
             mkMap(
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(Collections.singleton(member1)),
@@ -336,9 +336,9 @@ public class ShareGroupTest {
         // It should return foo, bar and zar.
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2)),
-                mkEntry("zar", new TopicMetadata(zarTopicId, "zar", 3))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2)),
+                Map.entry("zar", new TopicMetadata(zarTopicId, "zar", 3))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(Collections.emptySet()),
@@ -433,7 +433,7 @@ public class ShareGroupTest {
         // Verify that partition 0 is assigned to member1.
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(0, memberId1)))
+                Map.entry(topicId, mkMap(Map.entry(0, memberId1)))
             ),
             shareGroup.invertedTargetAssignment()
         );
@@ -448,7 +448,7 @@ public class ShareGroupTest {
         // Verify that partition 0 is no longer assigned and partition 1 is assigned to member1
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId1)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId1)))
             ),
             shareGroup.invertedTargetAssignment()
         );
@@ -463,7 +463,7 @@ public class ShareGroupTest {
         // Verify that partition 1 is assigned to member2
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId2)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId2)))
             ),
             shareGroup.invertedTargetAssignment()
         );
@@ -478,9 +478,9 @@ public class ShareGroupTest {
         // Verify that partition 1 is still assigned to member2 and partition 0 is assigned to member1
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(
-                    mkEntry(0, memberId1),
-                    mkEntry(1, memberId2)
+                Map.entry(topicId, mkMap(
+                    Map.entry(0, memberId1),
+                    Map.entry(1, memberId2)
                 ))
             ),
             shareGroup.invertedTargetAssignment()
@@ -492,7 +492,7 @@ public class ShareGroupTest {
         // Verify that partition 0 is no longer assigned and partition 1 is still assigned to member2
         assertEquals(
             mkMap(
-                mkEntry(topicId, mkMap(mkEntry(1, memberId2)))
+                Map.entry(topicId, mkMap(Map.entry(1, memberId2)))
             ),
             shareGroup.invertedTargetAssignment()
         );
@@ -643,8 +643,8 @@ public class ShareGroupTest {
 
         assertEquals(
             mkMap(
-                mkEntry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
-                mkEntry("bar", new TopicMetadata(barTopicId, "bar", 2))
+                Map.entry("foo", new TopicMetadata(fooTopicId, "foo", 1)),
+                Map.entry("bar", new TopicMetadata(barTopicId, "bar", 2))
             ),
             shareGroup.computeSubscriptionMetadata(
                 shareGroup.computeSubscribedTopicNames(null, null),

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -2334,15 +2334,15 @@ public class ReplicationControlManagerTest {
         assertEquals(Collections.emptyList(), result1.records());
 
         ElectLeadersResponseData expectedResponse1 = buildElectLeadersResponse(NONE, electAllPartitions, Utils.mkMap(
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 0),
                 new ApiError(ELIGIBLE_LEADERS_NOT_AVAILABLE)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 1),
                 new ApiError(ELECTION_NOT_NEEDED)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 2),
                 new ApiError(ELECTION_NOT_NEEDED)
             )
@@ -2373,15 +2373,15 @@ public class ReplicationControlManagerTest {
         assertLeaderAndIsr(replication, partition2, 0, new int[]{0});
 
         ElectLeadersResponseData expectedResponse = buildElectLeadersResponse(NONE, electAllPartitions, Utils.mkMap(
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 0),
                 ApiError.NONE
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 1),
                 new ApiError(ELECTION_NOT_NEEDED)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 2),
                 new ApiError(ELECTION_NOT_NEEDED)
             )
@@ -2491,23 +2491,23 @@ public class ReplicationControlManagerTest {
         ControllerResult<ElectLeadersResponseData> election1Result =
             replication.electLeaders(request1);
         ElectLeadersResponseData expectedResponse1 = buildElectLeadersResponse(NONE, false, Utils.mkMap(
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 0),
                 new ApiError(PREFERRED_LEADER_NOT_AVAILABLE)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 1),
                 new ApiError(ELECTION_NOT_NEEDED)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 2),
                 new ApiError(PREFERRED_LEADER_NOT_AVAILABLE)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("bar", 0),
                 new ApiError(UNKNOWN_TOPIC_OR_PARTITION, "No such topic as bar")
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("bar", 1),
                 new ApiError(UNKNOWN_TOPIC_OR_PARTITION, "No such topic as bar")
             )
@@ -2549,23 +2549,23 @@ public class ReplicationControlManagerTest {
             alterPartitionResult.response());
 
         ElectLeadersResponseData expectedResponse2 = buildElectLeadersResponse(NONE, false, Utils.mkMap(
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 0),
                 ApiError.NONE
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 1),
                 new ApiError(ELECTION_NOT_NEEDED)
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("foo", 2),
                 ApiError.NONE
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("bar", 0),
                 new ApiError(UNKNOWN_TOPIC_OR_PARTITION, "No such topic as bar")
             ),
-            Utils.mkEntry(
+            Map.entry(
                 new TopicPartition("bar", 1),
                 new ApiError(UNKNOWN_TOPIC_OR_PARTITION, "No such topic as bar")
             )

--- a/raft/src/test/java/org/apache/kafka/raft/EndpointsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/EndpointsTest.java
@@ -47,7 +47,7 @@ final class EndpointsTest {
     @Test
     void testAddressWithValidEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         Optional<InetSocketAddress> address = endpoints.address(testListener);
@@ -67,7 +67,7 @@ final class EndpointsTest {
     @Test
     void testVotersRecordEndpointsWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         VotersRecord.Endpoint endpoint = endpoints.votersRecordEndpoints().next();
@@ -85,7 +85,7 @@ final class EndpointsTest {
     @Test
     void testSize() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
 
         assertEquals(1, Endpoints.fromInetSocketAddresses(endpointMap).size());
         assertEquals(0, Endpoints.empty().size());
@@ -94,7 +94,7 @@ final class EndpointsTest {
     @Test
     void testIsEmptyWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
 
         assertFalse(Endpoints.fromInetSocketAddresses(endpointMap).isEmpty());
     }
@@ -102,7 +102,7 @@ final class EndpointsTest {
     @Test
     void testEqualsAndHashCodeWithSameEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
 
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
         Endpoints sameEndpoints = Endpoints.fromInetSocketAddresses(endpointMap);
@@ -114,11 +114,11 @@ final class EndpointsTest {
     @Test
     void testEqualsAndHashCodeWithDifferentEndpoints() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         Map<ListenerName, InetSocketAddress> anotherEndpointMap = Utils.mkMap(
-                Utils.mkEntry(
+                Map.entry(
                         ListenerName.normalised("another"),
                         InetSocketAddress.createUnresolved("localhost", 9093)));
         Endpoints differentEndpoints = Endpoints.fromInetSocketAddresses(anotherEndpointMap);
@@ -130,7 +130,7 @@ final class EndpointsTest {
     @Test
     void testToBeginQuorumEpochRequestWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         BeginQuorumEpochRequestData.LeaderEndpointCollection leaderEndpoints = endpoints.toBeginQuorumEpochRequest();
@@ -151,7 +151,7 @@ final class EndpointsTest {
     @Test
     void testFromInetSocketAddressesWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
 
         assertEquals(1, Endpoints.fromInetSocketAddresses(endpointMap).size());
     }
@@ -159,7 +159,7 @@ final class EndpointsTest {
     @Test
     void testFromVotersRecordEndpointsWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         List<VotersRecord.Endpoint> votersEndpoints = new ArrayList<>();
@@ -184,7 +184,7 @@ final class EndpointsTest {
     @Test
     void testFromBeginQuorumEpochRequestWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         BeginQuorumEpochRequestData.LeaderEndpointCollection leaderEndpoints = new BeginQuorumEpochRequestData.LeaderEndpointCollection();
@@ -211,7 +211,7 @@ final class EndpointsTest {
     @Test
     void testFromBeginQuorumEpochResponseWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         BeginQuorumEpochResponseData.NodeEndpointCollection nodeEndpointCollection = new BeginQuorumEpochResponseData.NodeEndpointCollection();
@@ -239,7 +239,7 @@ final class EndpointsTest {
     @Test
     void testFromEndQuorumEpochRequestWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         EndQuorumEpochRequestData.LeaderEndpointCollection leaderEndpoints = new EndQuorumEpochRequestData.LeaderEndpointCollection();
@@ -262,7 +262,7 @@ final class EndpointsTest {
     @Test
     void testFromEndQuorumEpochResponseWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         EndQuorumEpochResponseData.NodeEndpointCollection nodeEndpointCollection = new EndQuorumEpochResponseData.NodeEndpointCollection();
@@ -288,7 +288,7 @@ final class EndpointsTest {
     @Test
     void testFromVoteResponseWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         VoteResponseData.NodeEndpointCollection nodeEndpointCollection = new VoteResponseData.NodeEndpointCollection();
@@ -314,7 +314,7 @@ final class EndpointsTest {
     @Test
     void testFromFetchResponseWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         FetchResponseData.NodeEndpointCollection nodeEndpointCollection = new FetchResponseData.NodeEndpointCollection();
@@ -338,7 +338,7 @@ final class EndpointsTest {
     @Test
     void testFromFetchSnapshotResponseWithEndpoint() {
         Map<ListenerName, InetSocketAddress> endpointMap = Utils.mkMap(
-                Utils.mkEntry(testListener, testSocketAddress));
+                Map.entry(testListener, testSocketAddress));
         Endpoints endpoints = Endpoints.fromInetSocketAddresses(endpointMap);
 
         FetchSnapshotResponseData.NodeEndpointCollection nodeEndpointCollection = new FetchSnapshotResponseData.NodeEndpointCollection();

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
@@ -116,33 +116,33 @@ public final class ServerTopicConfigSynonyms {
     }
 
     private static Entry<String, List<ConfigSynonym>> sameName(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(configName)));
+        return Map.entry(configName, asList(new ConfigSynonym(configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> sameNameWithLogPrefix(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(LOG_PREFIX + configName)));
+        return Map.entry(configName, asList(new ConfigSynonym(LOG_PREFIX + configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> sameNameWithLogCleanerPrefix(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + configName)));
+        return Map.entry(configName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> singleWithLogPrefix(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(LOG_PREFIX + brokerConfigName)));
+        return Map.entry(topicConfigName, asList(new ConfigSynonym(LOG_PREFIX + brokerConfigName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> singleWithLogCleanerPrefix(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + brokerConfigName)));
+        return Map.entry(topicConfigName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + brokerConfigName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> listWithLogPrefix(String topicConfigName, ConfigSynonym... synonyms) {
         List<ConfigSynonym> synonymsWithPrefix = Arrays.stream(synonyms)
             .map(s -> new ConfigSynonym(LOG_PREFIX + s.name(), s.converter()))
             .collect(Collectors.toList());
-        return Utils.mkEntry(topicConfigName, synonymsWithPrefix);
+        return Map.entry(topicConfigName, synonymsWithPrefix);
     }
 
     private static Entry<String, List<ConfigSynonym>> single(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(brokerConfigName)));
+        return Map.entry(topicConfigName, asList(new ConfigSynonym(brokerConfigName)));
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -81,8 +81,8 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             new Max());
 
         this.globalSensors = Collections.unmodifiableMap(Utils.mkMap(
-            Utils.mkEntry(SHARE_COORDINATOR_WRITE_SENSOR_NAME, shareCoordinatorWriteSensor),
-            Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME, shareCoordinatorWriteLatencySensor)
+            Map.entry(SHARE_COORDINATOR_WRITE_SENSOR_NAME, shareCoordinatorWriteSensor),
+            Map.entry(SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME, shareCoordinatorWriteLatencySensor)
         ));
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/AlterLogDirTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/AlterLogDirTest.java
@@ -22,8 +22,8 @@ import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class AlterLogDirTest extends TieredStorageTestHarness {
@@ -47,7 +47,7 @@ public final class AlterLogDirTest extends TieredStorageTestHarness {
         builder
                 // create topicB with 1 partition and 1 RF
                 .createTopic(topicB, partitionCount, replicationFactor, maxBatchCountPerSegment,
-                        mkMap(mkEntry(p0, Arrays.asList(broker1, broker0))), enableRemoteLogStorage)
+                        mkMap(Map.entry(p0, Arrays.asList(broker1, broker0))), enableRemoteLogStorage)
                 // send records to partition 0
                 .expectSegmentToBeOffloaded(broker1, topicB, p0, 0, new KeyValueSpec("k0", "v0"))
                 .expectSegmentToBeOffloaded(broker1, topicB, p0, 1, new KeyValueSpec("k1", "v1"))

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseReassignReplicaTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseReassignReplicaTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public abstract class BaseReassignReplicaTest extends TieredStorageTestHarness {
@@ -75,7 +74,7 @@ public abstract class BaseReassignReplicaTest extends TieredStorageTestHarness {
                 .expectUserTopicMappedToMetadataPartitions(topicA, metadataPartitions)
                 // create topicB with 1 partition and 1 RF
                 .createTopic(topicB, partitionCount, replicationFactor, maxBatchCountPerSegment,
-                        mkMap(mkEntry(p0, Collections.singletonList(broker0))), enableRemoteLogStorage)
+                        mkMap(Map.entry(p0, Collections.singletonList(broker0))), enableRemoteLogStorage)
                 // send records to partition 0
                 .expectSegmentToBeOffloaded(broker0, topicB, p0, 0, new KeyValueSpec("k0", "v0"))
                 .expectSegmentToBeOffloaded(broker0, topicB, p0, 1, new KeyValueSpec("k1", "v1"))

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.DELETE_SEGMENT;
 
@@ -44,7 +43,7 @@ public final class DeleteSegmentsDueToLogStartOffsetBreachTest extends TieredSto
         final Integer partitionCount = 1;
         final Integer replicationFactor = 2;
         final Integer maxBatchCountPerSegment = 2;
-        final Map<Integer, List<Integer>> replicaAssignment = mkMap(mkEntry(p0, Arrays.asList(broker0, broker1)));
+        final Map<Integer, List<Integer>> replicaAssignment = mkMap(Map.entry(p0, Arrays.asList(broker0, broker1)));
         final boolean enableRemoteLogStorage = true;
         final int beginEpoch = 0;
         final long startOffset = 3;

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteTopicTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.DELETE_SEGMENT;
 
@@ -48,8 +47,8 @@ public final class DeleteTopicTest extends TieredStorageTestHarness {
         final Integer maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> assignment = mkMap(
-                mkEntry(p0, Arrays.asList(broker0, broker1)),
-                mkEntry(p1, Arrays.asList(broker1, broker0))
+                Map.entry(p0, Arrays.asList(broker0, broker1)),
+                Map.entry(p1, Arrays.asList(broker1, broker0))
         );
 
         builder

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DisableRemoteLogOnTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DisableRemoteLogOnTopicTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.DELETE_SEGMENT;
 
@@ -59,7 +58,7 @@ public final class DisableRemoteLogOnTopicTest extends TieredStorageTestHarness 
         final Integer maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> assignment = mkMap(
-                mkEntry(p0, Arrays.asList(broker0, broker1))
+                Map.entry(p0, Arrays.asList(broker0, broker1))
         );
         // local.retention.ms/bytes need to set to the same value as retention.ms/bytes when disabling remote log copy
         final Map<String, String> disableRemoteCopy = new HashMap<>();

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/EnableRemoteLogOnTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/EnableRemoteLogOnTopicTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class EnableRemoteLogOnTopicTest extends TieredStorageTestHarness {
@@ -48,8 +47,8 @@ public final class EnableRemoteLogOnTopicTest extends TieredStorageTestHarness {
         final Integer maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = false;
         final Map<Integer, List<Integer>> assignment = mkMap(
-                mkEntry(p0, Arrays.asList(broker0, broker1)),
-                mkEntry(p1, Arrays.asList(broker1, broker0))
+                Map.entry(p0, Arrays.asList(broker0, broker1)),
+                Map.entry(p1, Arrays.asList(broker1, broker0))
         );
 
         builder

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTestHarness {
@@ -48,7 +47,7 @@ public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTes
         final Integer replicationFactor = 2;
         final Integer maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
-        final Map<Integer, List<Integer>> assignment = mkMap(mkEntry(p0, Arrays.asList(broker0, broker1)));
+        final Map<Integer, List<Integer>> assignment = mkMap(Map.entry(p0, Arrays.asList(broker0, broker1)));
         final List<String> checkpointFiles = Arrays.asList(
                 ReplicaManager.HighWatermarkFilename(),
                 LogManager.RecoveryPointCheckpointFile(),

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ListOffsetsTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ListOffsetsTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.DELETE_SEGMENT;
 
@@ -63,7 +62,7 @@ public class ListOffsetsTest extends TieredStorageTestHarness {
         final int p0 = 0;
         final Time time = new MockTime();
         final long timestamp = time.milliseconds();
-        final Map<Integer, List<Integer>> assignment = mkMap(mkEntry(p0, Arrays.asList(broker0, broker1)));
+        final Map<Integer, List<Integer>> assignment = mkMap(Map.entry(p0, Arrays.asList(broker0, broker1)));
 
         builder
                 .createTopic(topicA, 1, 2, 2, assignment, true)

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/PartitionsExpandTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/PartitionsExpandTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class PartitionsExpandTest extends TieredStorageTestHarness {
@@ -60,7 +60,7 @@ public final class PartitionsExpandTest extends TieredStorageTestHarness {
                 .produce(topicA, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
                         new KeyValueSpec("k2", "v2"))
                 // expand the topicA partition-count to 3
-                .createPartitions(topicA, 3, mkMap(mkEntry(p1, p1Assignment), mkEntry(p2, p2Assignment)))
+                .createPartitions(topicA, 3, mkMap(Map.entry(p1, p1Assignment), Map.entry(p2, p2Assignment)))
                 // consume from the beginning of the topic to read data from local and remote storage for partition 0
                 .expectFetchFromTieredStorage(broker0, topicA, p0, 2)
                 .consume(topicA, p0, 0L, 3, 2)

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ReassignReplicaShrinkTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ReassignReplicaShrinkTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class ReassignReplicaShrinkTest extends TieredStorageTestHarness {
@@ -60,8 +59,8 @@ public final class ReassignReplicaShrinkTest extends TieredStorageTestHarness {
         final Integer maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> replicaAssignment = mkMap(
-                mkEntry(p0, Arrays.asList(broker0, broker1)),
-                mkEntry(p1, Arrays.asList(broker1, broker0))
+                Map.entry(p0, Arrays.asList(broker0, broker1)),
+                Map.entry(p1, Arrays.asList(broker1, broker0))
         );
 
         builder

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -58,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
@@ -108,13 +108,13 @@ public class AdjustStreamThreadCountTest {
 
         properties = mkObjectProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
-                mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000)
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
+                Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                Map.entry(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000)
             )
         );
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EOSUncleanShutdownIntegrationTest.java
@@ -41,13 +41,13 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cleanStateBeforeTest;
@@ -115,10 +115,10 @@ public class EOSUncleanShutdownIntegrationTest {
         });
 
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
         final KafkaStreams driver =  new KafkaStreams(builder.build(), STREAMS_CONFIG);
         driver.cleanUp();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -86,15 +86,15 @@ public class EmitOnChangeIntegrationTest {
     public void shouldEmitSameRecordAfterFailover() throws Exception {
         final Properties properties  = mkObjectProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1),
-                mkEntry(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0),
-                mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 300000L),
-                mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class),
-                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000)
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1),
+                Map.entry(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0),
+                Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 300000L),
+                Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class),
+                Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                Map.entry(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000)
             )
         );
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -95,7 +95,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.DEFAULT_TIMEOUT;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
@@ -183,12 +182,12 @@ public class EosIntegrationTest {
     public void shouldCommitCorrectOffsetIfInputTopicIsTransactional() throws Exception {
         runSimpleCopyTest(1, SINGLE_PARTITION_INPUT_TOPIC, null, SINGLE_PARTITION_OUTPUT_TOPIC, true);
 
-        try (final Admin adminClient = Admin.create(mkMap(mkEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())));
+        try (final Admin adminClient = Admin.create(mkMap(Map.entry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())));
              final Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(mkMap(
-                 mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                 mkEntry(ConsumerConfig.GROUP_ID_CONFIG, applicationId),
-                 mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class),
-                 mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class)))) {
+                 Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                 Map.entry(ConsumerConfig.GROUP_ID_CONFIG, applicationId),
+                 Map.entry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class),
+                 Map.entry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class)))) {
 
             waitForEmptyConsumerGroup(adminClient, applicationId, 5 * MAX_POLL_INTERVAL_MS);
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -67,7 +67,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
@@ -80,9 +79,9 @@ import static org.hamcrest.Matchers.is;
 public class HighAvailabilityTaskAssignorIntegrationTest {
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3,
         new Properties(), mkMap(
-            mkEntry(0, mkMap(mkEntry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_0))),
-            mkEntry(1, mkMap(mkEntry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_1))),
-            mkEntry(2, mkMap(mkEntry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_2)))
+            Map.entry(0, mkMap(Map.entry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_0))),
+            Map.entry(1, mkMap(Map.entry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_1))),
+            Map.entry(2, mkMap(Map.entry(ServerConfigs.BROKER_RACK_CONFIG, AssignmentTestUtils.RACK_2)))
     ));
 
     @BeforeAll
@@ -260,10 +259,10 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
 
         final Properties producerProperties = mkProperties(
             mkMap(
-                mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(ProducerConfig.ACKS_CONFIG, "all"),
-                mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()),
-                mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(ProducerConfig.ACKS_CONFIG, "all"),
+                Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()),
+                Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
             )
         );
 
@@ -277,9 +276,9 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
     private static Properties getConsumerProperties() {
         return mkProperties(
                 mkMap(
-                    mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                    mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()),
-                    mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+                    Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                    Map.entry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()),
+                    Map.entry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
                 )
             );
     }
@@ -308,22 +307,22 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
                                                 final String rack) {
         return mkObjectProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "0"),
-                mkEntry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "0"), // make the warmup catch up completely
-                mkEntry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "2"),
-                mkEntry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "60000"),
-                mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
-                mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L),
-                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "0"),
+                Map.entry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "0"), // make the warmup catch up completely
+                Map.entry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "2"),
+                Map.entry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "60000"),
+                Map.entry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
+                Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L),
+                Map.entry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
                 // Increasing the number of threads to ensure that a rebalance happens each time a consumer sends a rejoin (KAFKA-10455)
-                mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40),
-                mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName()),
-                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName()),
-                mkEntry(CommonClientConfigs.CLIENT_RACK_CONFIG, rack),
-                mkEntry(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG, rackAwareStrategy)
+                Map.entry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40),
+                Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName()),
+                Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName()),
+                Map.entry(CommonClientConfigs.CLIENT_RACK_CONFIG, rack),
+                Map.entry(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG, rackAwareStrategy)
             )
         );
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -104,7 +104,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -138,7 +137,7 @@ public class IQv2StoreIntegrationTest {
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
     private static final Position POSITION_0 =
-        Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 5L)))));
+        Position.fromMap(mkMap(Map.entry(INPUT_TOPIC_NAME, mkMap(Map.entry(0, 5L)))));
 
     public static class UnknownQuery implements Query<Void> { }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
@@ -51,12 +51,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
@@ -116,12 +116,12 @@ public class JoinGracePeriodDurabilityIntegrationTest {
         joinedStream.to(output);
 
         final Properties streamsConfig = mkObjectProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-            mkEntry(StreamsConfig.POLL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-            mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            Map.entry(StreamsConfig.POLL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+            Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class)
         ));
 
         streamsConfig.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
@@ -199,10 +199,10 @@ public class JoinGracePeriodDurabilityIntegrationTest {
     private void verifyOutput(final String topic, final List<KeyValueTimestamp<String, String>> keyValueTimestamps) {
         final Properties properties = mkProperties(
             mkMap(
-                mkEntry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
-                mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
-                mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName())
+                Map.entry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
+                Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
+                Map.entry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName())
             )
         );
         IntegrationTestUtils.verifyKeyValueTimestamps(properties, topic, keyValueTimestamps);
@@ -218,10 +218,10 @@ public class JoinGracePeriodDurabilityIntegrationTest {
 
     private static void produceSynchronouslyToPartitionZero(final String topic, final List<KeyValueTimestamp<String, String>> toProduce) {
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
         IntegrationTestUtils.produceSynchronously(producerConfig, false, topic, Optional.of(0), toProduce);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
@@ -85,8 +85,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
 
     private static Properties getStreamsProperties(final String optimization) {
         return mkProperties(mkMap(
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, optimization)
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, optimization)
         ));
     }
 
@@ -203,8 +203,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
 
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                    mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)")
+                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                    Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)")
                 );
                 assertThat(
                     outputTopic.readKeyValuesToMap(),
@@ -214,8 +214,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                         rejoinOutputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                            mkEntry("lhs1", "rejoin((lhsValue1|rhs1,rhsValue1),lhsValue1|rhs1)"),
-                            mkEntry("lhs2", "rejoin((lhsValue2|rhs2,rhsValue2),lhsValue2|rhs2)")
+                            Map.entry("lhs1", "rejoin((lhsValue1|rhs1,rhsValue1),lhsValue1|rhs1)"),
+                            Map.entry("lhs2", "rejoin((lhsValue2|rhs2,rhsValue2),lhsValue2|rhs2)")
                         ))
                     );
                 }
@@ -233,14 +233,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                     outputTopic.readKeyValuesToMap(),
                     is(mkMap(
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
                     ))
                 );
                 if (rejoin) {
                     assertThat(
                         rejoinOutputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                            mkEntry("lhs3", "rejoin((lhsValue3|rhs1,rhsValue1),lhsValue3|rhs1)")
+                            Map.entry("lhs3", "rejoin((lhsValue3|rhs1,rhsValue1),lhsValue3|rhs1)")
                         ))
                     );
                 }
@@ -248,9 +248,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                         asMap(store),
                         is(mkMap(
-                            mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                            mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                            mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
+                            Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                            Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                            Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
                         ))
                     );
                 }
@@ -276,8 +276,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                     asMap(store),
                     is(mkMap(
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
+                        Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
                     ))
                 );
             }
@@ -308,9 +308,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             assertThat(
                 outputTopic.readKeyValuesToMap(),
                 is(leftJoin
-                    ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                    mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                    mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
+                    ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)"),
+                    Map.entry("lhs2", "(lhsValue2|rhs2,null)"),
+                    Map.entry("lhs3", "(lhsValue3|rhs1,null)"))
                     : emptyMap()
                 )
             );
@@ -318,9 +318,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                     asMap(store),
                     is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
+                        ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs2,null)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,null)"))
                         : emptyMap()
                     )
                 );
@@ -330,20 +330,20 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
 
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                    mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
+                is(mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                    Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
                 )
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
                     is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
+                        ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs2,null)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
 
-                        : mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
+                        : mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
                     )
                 );
             }
@@ -352,14 +352,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
 
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)")))
+                is(mkMap(Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)")))
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
+                    is(mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
                     )
                 );
             }
@@ -373,9 +373,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
+                    is(mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
                     )
                 );
             }
@@ -393,11 +393,11 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                     asMap(store),
                     is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
+                        ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                        Map.entry("lhs3", "(lhsValue3|rhs1,null)"))
 
-                        : mkMap(mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"))
+                        : mkMap(Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)"))
                     )
                 );
             }
@@ -423,7 +423,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
 
             {
                 final Map<String, String> expected =
-                    leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap();
+                    leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap();
                 assertThat(
                     outputTopic.readKeyValuesToMap(),
                     is(expected)
@@ -523,12 +523,12 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             // the left join of course emits the half-joined output
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
+                is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
+                    is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
                 );
             }
             // "moving" our subscription to another non-existent FK results in an unnecessary tombstone for inner join,
@@ -538,24 +538,24 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 1);
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)))
+                is(mkMap(Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)))
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
+                    is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
                 );
             }
             // of course, moving it again to yet another non-existent FK has the same effect
             left.pipeInput("lhs1", "lhsValue1|rhs3", baseTimestamp + 2);
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)))
+                is(mkMap(Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)))
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
+                    is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
                 );
             }
 
@@ -570,7 +570,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
+                    is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
                 );
             }
 
@@ -579,14 +579,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             assertThat(
                 outputTopic.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                 ))
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
                     is(mkMap(
-                        mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                        Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                     ))
                 );
             }
@@ -597,13 +597,13 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             assertThat(
                 outputTopic.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)
+                    Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)
                 ))
             );
             if (materialized) {
                 assertThat(
                     asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
+                    is(leftJoin ? mkMap(Map.entry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
                 );
             }
         }
@@ -644,7 +644,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 2);
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                 );
                 assertThat(
                     outputTopic.readKeyValuesToMap(),
@@ -662,7 +662,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 3);
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
+                    Map.entry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
                 );
                 assertThat(
                     outputTopic.readKeyValuesToMap(),
@@ -687,7 +687,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                         asMap(store),
                         is(mkMap(
-                            mkEntry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
+                            Map.entry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
                         ))
                     );
                 }
@@ -712,7 +712,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp);
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,null)")
+                    Map.entry("lhs1", "(lhsValue1|rhs1,null)")
                 );
                 assertThat(outputTopic.readKeyValuesToMap(), is(expected));
                 if (materialized) {
@@ -753,7 +753,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp);
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,null)")
+                    Map.entry("lhs1", "(lhsValue1|rhs1,null)")
                 );
                 assertThat(outputTopic.readKeyValuesToMap(), is(expected));
                 if (materialized) {
@@ -764,7 +764,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|returnNull", baseTimestamp);
             {
                 final Map<String, String> expected = mkMap(
-                    mkEntry("lhs1", "(lhsValue1|returnNull,null)")
+                    Map.entry("lhs1", "(lhsValue1|returnNull,null)")
                 );
                 assertThat(outputTopic.readKeyValuesToMap(), is(expected));
                 if (materialized) {
@@ -942,8 +942,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs2", "lhsValue2|rhs1", baseTimestamp + 5);
             {
                 final Map<String, String> expected = mkMap(
-                        mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs1,rhsValue1)")
+                        Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2|rhs1,rhsValue1)")
                 );
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
@@ -963,14 +963,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                mkEntry("lhs2", null)
+                                Map.entry("lhs2", null)
                         ))
                 );
                 if (materialized) {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                             ))
                     );
                 }
@@ -988,14 +988,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                             ))
                     );
                 }
             } else {
                 final Map<String, String> expected = mkMap(
-                        mkEntry("lhs1", "(lhsValue1_ooo|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
+                        Map.entry("lhs1", "(lhsValue1_ooo|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
                 );
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
@@ -1020,7 +1020,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
+                                    Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                             ))
                     );
                 }
@@ -1028,14 +1028,14 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                mkEntry("lhs1", null)
+                                Map.entry("lhs1", null)
                         ))
                 );
                 if (materialized) {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
+                                    Map.entry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
                             ))
                     );
                 }
@@ -1046,8 +1046,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs2", "lhsValue2_new|rhs1", baseTimestamp + 8);
             {
                 final Map<String, String> expected = mkMap(
-                        mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
+                        Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
+                        Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
                 );
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
@@ -1072,8 +1072,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
+                                    Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
+                                    Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
                             ))
                     );
                 }
@@ -1081,16 +1081,16 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
-                                mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
+                                Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
+                                Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
                         ))
                 );
                 if (materialized) {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
+                                    Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
+                                    Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
                             ))
                     );
                 }
@@ -1107,8 +1107,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
+                                    Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
+                                    Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
                             ))
                     );
                 }
@@ -1117,16 +1117,16 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             outputTopic.readKeyValuesToMap(),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,null)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,null)")
+                                    Map.entry("lhs1", "(lhsValue1_new|rhs1,null)"),
+                                    Map.entry("lhs2", "(lhsValue2_new|rhs1,null)")
                             ))
                     );
                     if (materialized) {
                         assertThat(
                                 asMap(store),
                                 is(mkMap(
-                                        mkEntry("lhs1", "(lhsValue1_new|rhs1,null)"),
-                                        mkEntry("lhs2", "(lhsValue2_new|rhs1,null)")
+                                        Map.entry("lhs1", "(lhsValue1_new|rhs1,null)"),
+                                        Map.entry("lhs2", "(lhsValue2_new|rhs1,null)")
                                 ))
                         );
                     }
@@ -1134,8 +1134,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             outputTopic.readKeyValuesToMap(),
                             is(mkMap(
-                                    mkEntry("lhs1", null),
-                                    mkEntry("lhs2", null)
+                                    Map.entry("lhs1", null),
+                                    Map.entry("lhs2", null)
                             ))
                     );
                     if (materialized) {
@@ -1153,16 +1153,16 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
-                                mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
+                                Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
+                                Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
                         ))
                 );
                 if (materialized) {
                     assertThat(
                             asMap(store),
                             is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
+                                    Map.entry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
+                                    Map.entry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
                             ))
                     );
                 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
@@ -538,7 +538,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 1);
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)))
+                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)))
             );
             if (materialized) {
                 assertThat(
@@ -550,7 +550,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs3", baseTimestamp + 2);
             assertThat(
                 outputTopic.readKeyValuesToMap(),
-                is(mkMap(Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)))
+                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)))
             );
             if (materialized) {
                 assertThat(
@@ -597,7 +597,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             assertThat(
                 outputTopic.readKeyValuesToMap(),
                 is(mkMap(
-                    Map.entry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)
+                    mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)
                 ))
             );
             if (materialized) {
@@ -963,7 +963,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                Map.entry("lhs2", null)
+                                mkEntry("lhs2", null)
                         ))
                 );
                 if (materialized) {
@@ -1028,7 +1028,7 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 assertThat(
                         outputTopic.readKeyValuesToMap(),
                         is(mkMap(
-                                Map.entry("lhs1", null)
+                                mkEntry("lhs1", null)
                         ))
                 );
                 if (materialized) {
@@ -1134,8 +1134,8 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     assertThat(
                             outputTopic.readKeyValuesToMap(),
                             is(mkMap(
-                                    Map.entry("lhs1", null),
-                                    Map.entry("lhs2", null)
+                                    mkEntry("lhs1", null),
+                                    mkEntry("lhs2", null)
                             ))
                     );
                     if (materialized) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinMaterializationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinMaterializationIntegrationTest.java
@@ -64,7 +64,7 @@ public class KTableKTableForeignKeyJoinMaterializationIntegrationTest {
     @BeforeEach
     public void before() {
         streamsConfig = mkProperties(mkMap(
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -437,8 +436,8 @@ public class ProcessingExceptionHandlerIntegrationTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
     }
@@ -454,8 +453,8 @@ public class ProcessingExceptionHandlerIntegrationTest {
             "stream-task-metrics",
             "The average number of dropped records per second",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -99,7 +99,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static java.time.Instant.ofEpochMilli;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
@@ -457,8 +456,8 @@ public class QueryableStateIntegrationTest {
         );
 
         final Properties properties = mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
 
         CLUSTER.createTopic(input);
@@ -497,8 +496,8 @@ public class QueryableStateIntegrationTest {
         CLUSTER.createTopic(input);
 
         final Properties properties = mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
 
         try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
@@ -46,10 +46,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cleanStateBeforeTest;
@@ -165,10 +165,10 @@ public class ResetPartitionTimeIntegrationTest {
     private void verifyOutput(final String topic, final List<KeyValueTimestamp<String, String>> keyValueTimestamps) {
         final Properties properties = mkProperties(
             mkMap(
-                mkEntry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
-                mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
-                mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName())
+                Map.entry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
+                Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
+                Map.entry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName())
             )
         );
         IntegrationTestUtils.verifyKeyValueTimestamps(properties, topic, keyValueTimestamps);
@@ -176,10 +176,10 @@ public class ResetPartitionTimeIntegrationTest {
 
     private static void produceSynchronouslyToPartitionZero(final String topic, final List<KeyValueTimestamp<String, String>> toProduce) {
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
         IntegrationTestUtils.produceSynchronously(producerConfig, false, topic, Optional.of(0), toProduce);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -95,7 +95,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.Topology.AutoOffsetReset.EARLIEST;
@@ -147,7 +146,7 @@ public class RestoreIntegrationTest {
     }
 
     private Properties props(final boolean stateUpdaterEnabled) {
-        return props(mkObjectProperties(mkMap(mkEntry(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled))));
+        return props(mkObjectProperties(mkMap(Map.entry(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled))));
     }
 
     private Properties props(final Properties extraProperties) {
@@ -553,13 +552,13 @@ public class RestoreIntegrationTest {
         CLUSTER.createTopic(outputTopic, 5, 1);
 
         final Map<String, Object> kafkaStreams1Configuration = mkMap(
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1"),
-            mkEntry(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1"),
-            mkEntry(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), 1)
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1"),
+            Map.entry(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1"),
+            Map.entry(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), 1)
         );
         final Map<String, Object> kafkaStreams2Configuration = mkMap(
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks2"),
-            mkEntry(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2")
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks2"),
+            Map.entry(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2")
         );
 
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
@@ -61,12 +61,12 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -81,7 +81,7 @@ public class SlidingWindowedKStreamIntegrationTest {
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS,
         mkProperties(
-            mkMap(mkEntry("log.retention.hours", "-1"), mkEntry("log.retention.bytes", "-1")) // Don't expire records since we manipulate timestamp
+            mkMap(Map.entry("log.retention.hours", "-1"), Map.entry("log.retention.bytes", "-1")) // Don't expire records since we manipulate timestamp
         )
     );
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StateDirectoryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StateDirectoryIntegrationTest.java
@@ -43,11 +43,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -78,10 +78,10 @@ public class StateDirectoryIntegrationTest {
         CLUSTER.createTopic(input);
 
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-            mkEntry(ProducerConfig.ACKS_CONFIG, "all"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName())
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            Map.entry(ProducerConfig.ACKS_CONFIG, "all"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName())
         ));
 
         try (final KafkaProducer<String, String> producer =
@@ -110,9 +110,9 @@ public class StateDirectoryIntegrationTest {
             // Create KafkaStreams instance
             final String applicationId = uniqueTestName + "-app";
             final Properties streamsConfig = mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir),
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, stateDir),
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
             ));
 
             final KafkaStreams streams = new KafkaStreams(topology, streamsConfig);
@@ -184,10 +184,10 @@ public class StateDirectoryIntegrationTest {
         CLUSTER.createTopic(input);
 
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-            mkEntry(ProducerConfig.ACKS_CONFIG, "all"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName())
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            Map.entry(ProducerConfig.ACKS_CONFIG, "all"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName())
         ));
 
         try (final KafkaProducer<String, String> producer =
@@ -216,9 +216,9 @@ public class StateDirectoryIntegrationTest {
             // Create KafkaStreams instance
             final String applicationId = uniqueTestName + "-app";
             final Properties streamsConfig = mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir),
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, stateDir),
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
             ));
 
             final KafkaStreams streams = new KafkaStreams(topology, streamsConfig);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -58,12 +58,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
@@ -110,13 +110,13 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
     private Properties basicProps() {
         return mkObjectProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
-                mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(StreamsConfig.consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), 10000)
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
+                Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                Map.entry(StreamsConfig.consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), 10000)
             )
         );
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
@@ -63,17 +63,17 @@ public class StreamsUpgradeTestIntegrationTest {
     public void testVersionProbingUpgrade() throws InterruptedException {
         final KafkaStreams kafkaStreams1 = StreamsUpgradeTest.buildStreams(mkProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
             )
         ));
         final KafkaStreams kafkaStreams2 = StreamsUpgradeTest.buildStreams(mkProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
             )
         ));
         final KafkaStreams kafkaStreams3 = StreamsUpgradeTest.buildStreams(mkProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
             )
         ));
         startSync(kafkaStreams1, kafkaStreams2, kafkaStreams3);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -64,7 +65,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.lang.Long.MAX_VALUE;
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cleanStateBeforeTest;
@@ -142,10 +142,10 @@ public class SuppressionDurabilityIntegrationTest {
             .to(outputRaw, Produced.with(STRING_SERDE, Serdes.Long()));
 
         final Properties streamsConfig = mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-            mkEntry(StreamsConfig.POLL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            Map.entry(StreamsConfig.POLL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
 
         streamsConfig.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
@@ -286,10 +286,10 @@ public class SuppressionDurabilityIntegrationTest {
     private void verifyOutput(final String topic, final List<KeyValueTimestamp<String, Long>> keyValueTimestamps) {
         final Properties properties = mkProperties(
             mkMap(
-                mkEntry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
-                mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
-                mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<Long>) LONG_DESERIALIZER).getClass().getName())
+                Map.entry(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
+                Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ((Deserializer<String>) STRING_DESERIALIZER).getClass().getName()),
+                Map.entry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ((Deserializer<Long>) LONG_DESERIALIZER).getClass().getName())
             )
         );
         IntegrationTestUtils.verifyKeyValueTimestamps(properties, topic, keyValueTimestamps);
@@ -305,10 +305,10 @@ public class SuppressionDurabilityIntegrationTest {
 
     private static void produceSynchronouslyToPartitionZero(final String topic, final List<KeyValueTimestamp<String, String>> toProduce) {
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
         IntegrationTestUtils.produceSynchronously(producerConfig, false, topic, Optional.of(0), toProduce);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -65,7 +65,6 @@ import java.util.stream.Collectors;
 import static java.lang.Long.MAX_VALUE;
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
@@ -508,12 +507,12 @@ public class SuppressionIntegrationTest {
 
     private static Properties getStreamsConfig(final String appId) {
         return mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-            mkEntry(StreamsConfig.POLL_MS_CONFIG, Integer.toString(COMMIT_INTERVAL)),
-            mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, AT_LEAST_ONCE),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            Map.entry(StreamsConfig.POLL_MS_CONFIG, Integer.toString(COMMIT_INTERVAL)),
+            Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(COMMIT_INTERVAL)),
+            Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, AT_LEAST_ONCE),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
     }
 
@@ -527,10 +526,10 @@ public class SuppressionIntegrationTest {
 
     private static void produceSynchronously(final String topic, final List<KeyValueTimestamp<String, String>> toProduce) {
         final Properties producerConfig = mkProperties(mkMap(
-            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
-            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
-            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            Map.entry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            Map.entry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+            Map.entry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
         ));
         IntegrationTestUtils.produceSynchronously(producerConfig, false, topic, Optional.empty(), toProduce);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -43,11 +43,11 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -104,15 +104,15 @@ public class TaskAssignorIntegrationTest {
 
         final Properties properties = mkObjectProperties(
             mkMap(
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                mkEntry(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "5"),
-                mkEntry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "6"),
-                mkEntry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "7"),
-                mkEntry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "480000"),
-                mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
-                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, MyLegacyTaskAssignor.class.getName())
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                Map.entry(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "5"),
+                Map.entry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "6"),
+                Map.entry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "7"),
+                Map.entry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "480000"),
+                Map.entry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
+                Map.entry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, MyLegacyTaskAssignor.class.getName())
             )
         );
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -44,12 +44,12 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
@@ -100,13 +100,13 @@ public class TaskMetadataIntegrationTest {
 
         properties  = mkObjectProperties(
                 mkMap(
-                        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
-                        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                        mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-                        mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
-                        mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                        mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                        mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1L)
+                        Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                        Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                        Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                        Map.entry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
+                        Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                        Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                        Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1L)
                 )
         );
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
@@ -64,13 +64,13 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static java.time.Duration.ofMillis;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -87,7 +87,7 @@ public class TimeWindowedKStreamIntegrationTest {
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS,
         mkProperties(
-            mkMap(mkEntry("log.retention.hours", "-1"), mkEntry("log.retention.bytes", "-1")) // Don't expire records since we manipulate timestamp
+            mkMap(Map.entry("log.retention.hours", "-1"), Map.entry("log.retention.bytes", "-1")) // Don't expire records since we manipulate timestamp
         )
     );
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -22,7 +22,6 @@ import org.apache.kafka.streams.processor.assignment.ProcessId;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 class StandbyTaskAssignorFactory {
@@ -36,7 +35,7 @@ class StandbyTaskAssignorFactory {
             // racksForProcess should be populated if rackAwareTaskAssignor isn't null
             final Map<ProcessId, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
             return new ClientTagAwareStandbyTaskAssignor(
-                (processId, clientState) -> mkMap(mkEntry("rack", racksForProcess.get(processId))),
+                (processId, clientState) -> mkMap(Map.entry("rack", racksForProcess.get(processId))),
                 assignmentConfigs -> Collections.singletonList("rack")
             );
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -45,7 +45,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.state.internals.ExceptionUtils.executeAll;
@@ -80,7 +79,7 @@ public class CachingKeyValueStore
     @SuppressWarnings("rawtypes")
     private final Map<Class, CacheQueryHandler> queryHandlers =
         mkMap(
-            mkEntry(
+            Map.entry(
                 KeyQuery.class,
                 (query, mergedPosition, positionBound, config, store) ->
                     runKeyQuery(query, mergedPosition, positionBound, config)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -58,7 +58,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
@@ -102,11 +101,11 @@ public class MeteredKeyValueStore<K, V>
     @SuppressWarnings("rawtypes")
     private final Map<Class, QueryHandler> queryHandlers =
         mkMap(
-            mkEntry(
+            Map.entry(
                 RangeQuery.class,
                 (query, positionBound, config, store) -> runRangeQuery(query, positionBound, config)
             ),
-            mkEntry(
+            Map.entry(
                 KeyQuery.class,
                 (query, positionBound, config, store) -> runKeyQuery(query, positionBound, config)
             )

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -51,7 +51,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.LongAdder;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
@@ -80,7 +79,7 @@ public class MeteredSessionStore<K, V>
     @SuppressWarnings("rawtypes")
     private final Map<Class, QueryHandler> queryHandlers =
             mkMap(
-                    mkEntry(
+                    Map.entry(
                             WindowRangeQuery.class,
                             (query, positionBound, config, store) -> runRangeQuery(query, positionBound, config)
                     )

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -41,7 +41,6 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
@@ -68,19 +67,19 @@ public class MeteredTimestampedKeyValueStore<K, V>
     @SuppressWarnings("rawtypes")
     private final Map<Class, StoreQueryUtils.QueryHandler> queryHandlers =
             mkMap(
-                    mkEntry(
+                    Map.entry(
                             RangeQuery.class,
                             (query, positionBound, config, store) -> runRangeQuery(query, positionBound, config)
                     ),
-                    mkEntry(
+                    Map.entry(
                             TimestampedRangeQuery.class,
                             (query, positionBound, config, store) -> runTimestampedRangeQuery(query, positionBound, config)
                     ),
-                    mkEntry(
+                    Map.entry(
                             KeyQuery.class,
                             (query, positionBound, config, store) -> runKeyQuery(query, positionBound, config)
                     ),
-                    mkEntry(
+                    Map.entry(
                             TimestampedKeyQuery.class,
                             (query, positionBound, config, store) -> runTimestampedKeyQuery(query, positionBound, config)
                     )

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -50,7 +50,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
@@ -103,19 +102,19 @@ public class MeteredVersionedKeyValueStore<K, V>
 
         private final Map<Class, QueryHandler> queryHandlers =
             mkMap(
-                mkEntry(
+                Map.entry(
                     RangeQuery.class,
                     (query, positionBound, config, store) -> runRangeQuery(query, positionBound, config)
                 ),
-                mkEntry(
+                Map.entry(
                     KeyQuery.class,
                     (query, positionBound, config, store) -> runKeyQuery(query, positionBound, config)
                 ),
-                mkEntry(
+                Map.entry(
                     VersionedKeyQuery.class,
                     (query, positionBound, config, store) -> runVersionedKeyQuery(query, positionBound, config)
                 ),
-                mkEntry(
+                Map.entry(
                     MultiVersionedKeyQuery.class,
                     (query, positionBound, config, store) -> runMultiVersionedKeyQuery(query, positionBound, config)
                 )

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -54,7 +54,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.LongAdder;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
@@ -83,7 +82,7 @@ public class MeteredWindowStore<K, V>
     @SuppressWarnings("rawtypes")
     private final Map<Class, QueryHandler> queryHandlers =
         mkMap(
-            mkEntry(
+            Map.entry(
                 WindowRangeQuery.class,
                 (query, positionBound, config, store) -> runRangeQuery(
                     query,
@@ -91,7 +90,7 @@ public class MeteredWindowStore<K, V>
                     config
                 )
             ),
-            mkEntry(
+            Map.entry(
                 WindowKeyQuery.class,
                 (query, positionBound, config, store) -> runKeyQuery(
                     query,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -58,7 +58,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class StoreQueryUtils {
@@ -81,27 +80,27 @@ public final class StoreQueryUtils {
     @SuppressWarnings("rawtypes")
     private static final Map<Class, QueryHandler> QUERY_HANDLER_MAP =
         mkMap(
-            mkEntry(
+            Map.entry(
                 RangeQuery.class,
                 StoreQueryUtils::runRangeQuery
             ),
-            mkEntry(
+            Map.entry(
                 KeyQuery.class,
                 StoreQueryUtils::runKeyQuery
             ),
-            mkEntry(
+            Map.entry(
                 WindowKeyQuery.class,
                 StoreQueryUtils::runWindowKeyQuery
             ),
-            mkEntry(
+            Map.entry(
                 WindowRangeQuery.class,
                 StoreQueryUtils::runWindowRangeQuery
             ),
-            mkEntry(
+            Map.entry(
                 VersionedKeyQuery.class,
                 StoreQueryUtils::runVersionedKeyQuery
             ),
-            mkEntry(
+            Map.entry(
                 MultiVersionedKeyQuery.class,
                 StoreQueryUtils::runMultiVersionedKeyQuery
             )

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -2398,7 +2398,7 @@ public class KStreamImplTest {
             inputTopic.pipeInput("A", "01");
             inputTopic.pipeInput("B", "02");
             inputTopic.pipeInput("A", "03");
-            final Map<String, String> expectedStore = mkMap(mkEntry("A", "03"), mkEntry("B", "02"));
+            final Map<String, String> expectedStore = mkMap(Map.entry("A", "03"), Map.entry("B", "02"));
 
             assertThat(asMap(store), is(expectedStore));
         }
@@ -2561,8 +2561,8 @@ public class KStreamImplTest {
             left.pipeInput("lhs2", "lhsValue2|rhs2");
 
             final Map<String, String> expected = mkMap(
-                mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)")
+                Map.entry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
+                Map.entry("lhs2", "(lhsValue2|rhs2,rhsValue2)")
             );
             assertThat(outputTopic.readKeyValuesToMap(), is(expected));
 
@@ -2572,7 +2572,7 @@ public class KStreamImplTest {
             assertThat(
                 outputTopic.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
+                    Map.entry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
                 ))
             );
 
@@ -2647,7 +2647,7 @@ public class KStreamImplTest {
             left.pipeInput("lhs2", "lhsValue2");
 
             final Map<String, String> expected = mkMap(
-                mkEntry("lhs1", "lhsValue1+rhsValue1")
+                Map.entry("lhs1", "lhsValue1+rhsValue1")
             );
 
             assertThat(
@@ -2660,7 +2660,7 @@ public class KStreamImplTest {
             assertThat(
                 output.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs3", "lhsValue3+rhsValue3")
+                    Map.entry("lhs3", "lhsValue3+rhsValue3")
                 ))
             );
 
@@ -2668,7 +2668,7 @@ public class KStreamImplTest {
             assertThat(
                 output.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs1", "lhsValue4+rhsValue1")
+                    Map.entry("lhs1", "lhsValue4+rhsValue1")
                 ))
             );
         }
@@ -2723,7 +2723,7 @@ public class KStreamImplTest {
             left.pipeInput("lhs2", "lhsValue2");
 
             final Map<String, String> expected = mkMap(
-                mkEntry("lhs1", "lhsValue1+rhsValue1")
+                Map.entry("lhs1", "lhsValue1+rhsValue1")
             );
 
             assertThat(
@@ -2736,7 +2736,7 @@ public class KStreamImplTest {
             assertThat(
                 output.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs3", "lhsValue3+rhsValue3")
+                    Map.entry("lhs3", "lhsValue3+rhsValue3")
                 ))
             );
 
@@ -2744,7 +2744,7 @@ public class KStreamImplTest {
             assertThat(
                 output.readKeyValuesToMap(),
                 is(mkMap(
-                    mkEntry("lhs1", "lhsValue4+rhsValue1")
+                    Map.entry("lhs1", "lhsValue4+rhsValue1")
                 ))
             );
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamRepartitionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamRepartitionTest.java
@@ -149,8 +149,8 @@ public class KStreamRepartitionTest {
                 .to(outputTopic);
 
         final Map<String, Integer> repartitionTopicsWithNumOfPartitions = Utils.mkMap(
-                Utils.mkEntry(toRepartitionTopicName(topicBRepartitionedName), topicBNumberOfPartitions),
-                Utils.mkEntry(toRepartitionTopicName(inputTopicRepartitionedName), inputTopicNumberOfPartitions)
+                Map.entry(toRepartitionTopicName(topicBRepartitionedName), topicBNumberOfPartitions),
+                Map.entry(toRepartitionTopicName(inputTopicRepartitionedName), inputTopicNumberOfPartitions)
         );
 
         final TopologyException expected = assertThrows(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -58,11 +58,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static java.time.Duration.ofMillis;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -525,8 +525,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         dropRate = new MetricName(
@@ -534,8 +534,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-task-metrics",
             "The average number of dropped records per second",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         assertThat(metrics.metrics().get(dropTotal).metricValue(), is(1.0));
@@ -600,8 +600,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         dropRate = new MetricName(
@@ -609,8 +609,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-task-metrics",
             "The average number of dropped records per second",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -77,7 +77,6 @@ import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -1726,8 +1725,8 @@ public class KStreamSlidingWindowAggregateTest {
                 "stream-task-metrics",
                 "The total number of dropped records",
                 mkMap(
-                        mkEntry("thread-id", threadId),
-                        mkEntry("task-id", "0_0")
+                        Map.entry("thread-id", threadId),
+                        Map.entry("task-id", "0_0")
                 )
         );
         dropRateMetric = new MetricName(
@@ -1735,8 +1734,8 @@ public class KStreamSlidingWindowAggregateTest {
                 "stream-task-metrics",
                 "The average number of dropped records per second",
                 mkMap(
-                        mkEntry("thread-id", threadId),
-                        mkEntry("task-id", "0_0")
+                        Map.entry("thread-id", threadId),
+                        Map.entry("task-id", "0_0")
                 )
         );
         latenessMaxMetric = new MetricName(
@@ -1745,8 +1744,8 @@ public class KStreamSlidingWindowAggregateTest {
                 "The observed maximum lateness of records in milliseconds, measured by comparing the record "
                         + "timestamp with the current stream time",
                 mkMap(
-                        mkEntry("thread-id", threadId),
-                        mkEntry("task-id", "0_0")
+                        Map.entry("thread-id", threadId),
+                        Map.entry("task-id", "0_0")
                 )
         );
         latenessAvgMetric = new MetricName(
@@ -1755,8 +1754,8 @@ public class KStreamSlidingWindowAggregateTest {
                 "The observed average lateness of records in milliseconds, measured by comparing the record "
                         + "timestamp with the current stream time",
                 mkMap(
-                        mkEntry("thread-id", threadId),
-                        mkEntry("task-id", "0_0")
+                        Map.entry("thread-id", threadId),
+                        Map.entry("task-id", "0_0")
                 )
         );
         assertThat(driver.metrics().get(dropTotalMetric).metricValue(), dropTotal);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -69,12 +69,12 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -1056,8 +1056,8 @@ public class KStreamWindowAggregateTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         dropRateMetric = new MetricName(
@@ -1065,8 +1065,8 @@ public class KStreamWindowAggregateTest {
             "stream-task-metrics",
             "The average number of dropped records per second",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         latenessMaxMetric = new MetricName(
@@ -1075,8 +1075,8 @@ public class KStreamWindowAggregateTest {
             "The observed maximum lateness of records in milliseconds, measured by comparing the record "
                 + "timestamp with the current stream time",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
         latenessAvgMetric = new MetricName(
@@ -1085,8 +1085,8 @@ public class KStreamWindowAggregateTest {
             "The observed average lateness of records in milliseconds, measured by comparing the record "
                 + "timestamp with the current stream time",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         );
 
@@ -1106,9 +1106,9 @@ public class KStreamWindowAggregateTest {
             "stream-processor-node-metrics",
             "The total number of emit final records",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0"),
-                mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0"),
+                Map.entry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
         );
         emittedRateMetric = new MetricName(
@@ -1116,9 +1116,9 @@ public class KStreamWindowAggregateTest {
             "stream-processor-node-metrics",
             "The average number of emit final records per second",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0"),
-                mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0"),
+                Map.entry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -53,10 +53,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,7 +69,7 @@ public class KTableAggregateTest {
     private final Grouped<String, String> stringSerialized = Grouped.with(stringSerde, stringSerde);
     private final MockApiProcessorSupplier<String, Object, Void, Void> supplier = new MockApiProcessorSupplier<>();
     private static final Properties CONFIG = mkProperties(mkMap(
-        mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory("kafka-test").getAbsolutePath())));
+        Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory("kafka-test").getAbsolutePath())));
 
     @Test
     public void testAggBasic() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableForeignKeyJoinScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableForeignKeyJoinScenarioTest.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -177,8 +176,8 @@ public class KTableKTableForeignKeyJoinScenarioTest {
     public void shouldUseExpectedTopicsWithSerde() {
         final String applicationId = "ktable-ktable-joinOnForeignKey";
         final Properties streamsConfig = mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
 
         final UniqueTopicSerdeScope serdeScope = new UniqueTopicSerdeScope();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
@@ -56,6 +56,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static java.time.Duration.ZERO;
@@ -78,7 +79,7 @@ public class SuppressScenarioTest {
     private static final Serde<String> STRING_SERDE = Serdes.String();
     private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
     private final Properties config = Utils.mkProperties(Utils.mkMap(
-        Utils.mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+        Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
     ));
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ResponseJoinProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ResponseJoinProcessorSupplierTest.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -250,8 +249,8 @@ public class ResponseJoinProcessorSupplierTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", Thread.currentThread().getName()),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", Thread.currentThread().getName()),
+                Map.entry("task-id", "0_0")
             )
         );
 
@@ -264,8 +263,8 @@ public class ResponseJoinProcessorSupplierTest {
             "stream-task-metrics",
             "The average number of dropped records per second",
             mkMap(
-                mkEntry("thread-id", Thread.currentThread().getName()),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", Thread.currentThread().getName()),
+                Map.entry("task-id", "0_0")
             )
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -46,7 +46,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -67,9 +66,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-processor-node-metrics",
         "The total number of emitted records from the suppression buffer",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("processor-node-id", "testNode")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("processor-node-id", "testNode")
         )
     );
 
@@ -78,9 +77,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-processor-node-metrics",
         "The average number of emitted records from the suppression buffer per second",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("processor-node-id", "testNode")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("processor-node-id", "testNode")
         )
     );
 
@@ -89,9 +88,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-state-metrics",
         "The average size of buffered records",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("in-memory-suppression-state-id", "test-store")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("in-memory-suppression-state-id", "test-store")
         )
     );
 
@@ -100,9 +99,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-state-metrics",
         "The maximum size of buffered records",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("in-memory-suppression-state-id", "test-store")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("in-memory-suppression-state-id", "test-store")
         )
     );
 
@@ -111,9 +110,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-state-metrics",
         "The average count of buffered records",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("in-memory-suppression-state-id", "test-store")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("in-memory-suppression-state-id", "test-store")
         )
     );
 
@@ -122,9 +121,9 @@ public class KTableSuppressProcessorMetricsTest {
         "stream-state-metrics",
         "The maximum count of buffered records",
         mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("in-memory-suppression-state-id", "test-store")
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry("in-memory-suppression-state-id", "test-store")
         )
     );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -50,7 +50,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -74,8 +73,8 @@ public class ActiveTaskCreatorTest {
     private final MockClientSupplier mockClientSupplier = new MockClientSupplier();
     private final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), "clientId", "processId", new MockTime());
     private final Map<String, Object> properties = mkMap(
-        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")
+        Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+        Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")
     );
     final UUID uuid = UUID.randomUUID();
 
@@ -270,8 +269,8 @@ public class ActiveTaskCreatorTest {
             activeTaskCreator.createTasks(
                 mockClientSupplier.consumer,
                 mkMap(
-                    mkEntry(task00, Collections.singleton(new TopicPartition("topic", 0))),
-                    mkEntry(task01, Collections.singleton(new TopicPartition("topic", 1)))
+                    Map.entry(task00, Collections.singleton(new TopicPartition("topic", 0))),
+                    Map.entry(task01, Collections.singleton(new TopicPartition("topic", 1)))
                 )
             ).stream().map(Task::id).collect(Collectors.toSet()),
             equalTo(Set.of(task00, task01))

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -56,26 +56,26 @@ public class ChangelogTopicsTest {
     private static final TopicsInfo TOPICS_INFO1 = new TopicsInfo(
         Set.of(SINK_TOPIC_NAME),
         Set.of(SOURCE_TOPIC_NAME),
-        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+        mkMap(Map.entry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(Map.entry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
     );
     private static final TopicsInfo TOPICS_INFO2 = new TopicsInfo(
         Set.of(SINK_TOPIC_NAME),
         Set.of(SOURCE_TOPIC_NAME),
-        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(Map.entry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
         mkMap()
     );
     private static final TopicsInfo TOPICS_INFO3 = new TopicsInfo(
         Set.of(SINK_TOPIC_NAME),
         Set.of(SOURCE_TOPIC_NAME),
-        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG))
+        mkMap(Map.entry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(Map.entry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG))
     );
     private static final TopicsInfo TOPICS_INFO4 = new TopicsInfo(
         Set.of(SINK_TOPIC_NAME),
         Set.of(SOURCE_TOPIC_NAME),
-        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(SOURCE_TOPIC_NAME, null), mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+        mkMap(Map.entry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(mkEntry(SOURCE_TOPIC_NAME, null), Map.entry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
     );
     private static final TaskId TASK_0_0 = new TaskId(0, 0);
     private static final TaskId TASK_0_1 = new TaskId(0, 1);
@@ -86,8 +86,8 @@ public class ChangelogTopicsTest {
     @Test
     public void shouldNotContainChangelogsForStatelessTasks() {
         when(internalTopicManager.makeReady(Collections.emptyMap())).thenReturn(Collections.emptySet());
-        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO2));
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, Set.of(TASK_0_0, TASK_0_1, TASK_0_2)));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO2));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(Map.entry(SUBTOPOLOGY_0, Set.of(TASK_0_0, TASK_0_1, TASK_0_2)));
 
         final ChangelogTopics changelogTopics =
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
@@ -102,11 +102,11 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldNotContainAnyPreExistingChangelogsIfChangelogIsNewlyCreated() {
-        when(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+        when(internalTopicManager.makeReady(mkMap(Map.entry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .thenReturn(Set.of(CHANGELOG_TOPIC_NAME1));
-        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO1));
         final Set<TaskId> tasks = Set.of(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(Map.entry(SUBTOPOLOGY_0, tasks));
 
         final ChangelogTopics changelogTopics =
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
@@ -122,11 +122,11 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldOnlyContainPreExistingNonSourceBasedChangelogs() {
-        when(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+        when(internalTopicManager.makeReady(mkMap(Map.entry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .thenReturn(Collections.emptySet());
-        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO1));
         final Set<TaskId> tasks = Set.of(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(Map.entry(SUBTOPOLOGY_0, tasks));
 
         final ChangelogTopics changelogTopics =
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
@@ -149,9 +149,9 @@ public class ChangelogTopicsTest {
     @Test
     public void shouldOnlyContainPreExistingSourceBasedChangelogs() {
         when(internalTopicManager.makeReady(Collections.emptyMap())).thenReturn(Collections.emptySet());
-        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO3));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO3));
         final Set<TaskId> tasks = Set.of(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(Map.entry(SUBTOPOLOGY_0, tasks));
 
         final ChangelogTopics changelogTopics =
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
@@ -172,11 +172,11 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldContainBothTypesOfPreExistingChangelogs() {
-        when(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+        when(internalTopicManager.makeReady(mkMap(Map.entry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .thenReturn(Collections.emptySet());
-        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO4));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO4));
         final Set<TaskId> tasks = Set.of(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(Map.entry(SUBTOPOLOGY_0, tasks));
 
         final ChangelogTopics changelogTopics =
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
@@ -118,14 +118,14 @@ public class CopartitionedTopicsEnforcerTest {
         final TopologyException ex = assertThrows(
             TopologyException.class,
             () -> validator.enforce(Set.of(topic1.name(), topic2.name()),
-                                    Utils.mkMap(Utils.mkEntry(topic1.name(), topic1),
-                                                Utils.mkEntry(topic2.name(), topic2)),
+                                    Utils.mkMap(Map.entry(topic1.name(), topic1),
+                                                Map.entry(topic2.name(), topic2)),
                                     cluster.withPartitions(partitions))
         );
 
         final TreeMap<String, Integer> sorted = new TreeMap<>(
-            Utils.mkMap(Utils.mkEntry(topic1.name(), topic1.numberOfPartitions().get()),
-                        Utils.mkEntry(topic2.name(), topic2.numberOfPartitions().get()))
+            Utils.mkMap(Map.entry(topic1.name(), topic1.numberOfPartitions().get()),
+                        Map.entry(topic2.name(), topic2.numberOfPartitions().get()))
         );
 
         assertEquals(String.format("Invalid topology: thread " +
@@ -139,8 +139,8 @@ public class CopartitionedTopicsEnforcerTest {
         final InternalTopicConfig topic2 = createRepartitionTopicConfigWithEnforcedNumberOfPartitions("repartitioned-2", 10);
 
         validator.enforce(Set.of(topic1.name(), topic2.name()),
-                          Utils.mkMap(Utils.mkEntry(topic1.name(), topic1),
-                                      Utils.mkEntry(topic2.name(), topic2)),
+                          Utils.mkMap(Map.entry(topic1.name(), topic1),
+                                      Map.entry(topic2.name(), topic2)),
                           cluster.withPartitions(partitions));
 
         assertThat(topic1.numberOfPartitions(), equalTo(Optional.of(10)));
@@ -154,7 +154,7 @@ public class CopartitionedTopicsEnforcerTest {
         final TopologyException ex = assertThrows(
             TopologyException.class,
             () -> validator.enforce(Set.of(topic1.name(), "second"),
-                                    Utils.mkMap(Utils.mkEntry(topic1.name(), topic1)),
+                                    Utils.mkMap(Map.entry(topic1.name(), topic1)),
                                     cluster.withPartitions(partitions))
         );
 
@@ -169,7 +169,7 @@ public class CopartitionedTopicsEnforcerTest {
         final InternalTopicConfig topic1 = createRepartitionTopicConfigWithEnforcedNumberOfPartitions("repartitioned-1", 2);
 
         validator.enforce(Set.of(topic1.name(), "second"),
-                          Utils.mkMap(Utils.mkEntry(topic1.name(), topic1)),
+                          Utils.mkMap(Map.entry(topic1.name(), topic1)),
                           cluster.withPartitions(partitions));
 
         assertThat(topic1.numberOfPartitions(), equalTo(Optional.of(2)));
@@ -182,9 +182,9 @@ public class CopartitionedTopicsEnforcerTest {
         final InternalTopicConfig topic3 = createRepartitionTopicConfigWithEnforcedNumberOfPartitions("repartitioned-3", 2);
 
         validator.enforce(Set.of(topic1.name(), topic2.name()),
-                          Utils.mkMap(Utils.mkEntry(topic1.name(), topic1),
-                                      Utils.mkEntry(topic2.name(), topic2),
-                                      Utils.mkEntry(topic3.name(), topic3)),
+                          Utils.mkMap(Map.entry(topic1.name(), topic1),
+                                      Map.entry(topic2.name(), topic2),
+                                      Map.entry(topic3.name(), topic3)),
                           cluster.withPartitions(partitions));
 
         assertEquals(topic1.numberOfPartitions(), topic2.numberOfPartitions());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
@@ -119,11 +118,11 @@ class DefaultStateUpdaterTest {
 
     private Properties configProps(final int commitInterval) {
         return mkObjectProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2),
-            mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, commitInterval),
-            mkEntry(producerPrefix(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), commitInterval)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
+            Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2),
+            Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, commitInterval),
+            Map.entry(producerPrefix(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), commitInterval)
         ));
     }
 
@@ -136,8 +135,8 @@ class DefaultStateUpdaterTest {
         when(changelogReader.completedChangelogs()).thenReturn(Set.of(TOPIC_PARTITION_B_0));
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(TASK_1_1));
         doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(
-            mkEntry(TASK_1_1, failedStatefulTask),
-            mkEntry(TASK_0_2, standbyTask)
+            Map.entry(TASK_1_1, failedStatefulTask),
+            Map.entry(TASK_0_2, standbyTask)
         ));
         stateUpdater.add(statelessTask);
         stateUpdater.add(restoredStatefulTask);
@@ -214,7 +213,7 @@ class DefaultStateUpdaterTest {
     public void shouldThrowIfRestartedWithNonEmptyFailedTasks() throws Exception {
         final StreamTask failedTask = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(TASK_0_0));
-        doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(mkEntry(TASK_0_0, failedTask)));
+        doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(Map.entry(TASK_0_0, failedTask)));
         stateUpdater.start();
         stateUpdater.add(failedTask);
         verifyExceptionsAndFailedTasks(new ExceptionAndTask(taskCorruptedException, failedTask));
@@ -459,7 +458,7 @@ class DefaultStateUpdaterTest {
         when(changelogReader.allChangelogsCompleted())
             .thenReturn(false);
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(task.id()));
-        doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(mkEntry(TASK_0_0, task)));
+        doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(Map.entry(TASK_0_0, task)));
         stateUpdater.start();
         stateUpdater.add(task);
         verifyRestoredActiveTasks();
@@ -654,9 +653,9 @@ class DefaultStateUpdaterTest {
         final TaskCorruptedException taskCorruptedException =
             new TaskCorruptedException(Set.of(activeTask1.id(), activeTask2.id()));
         final Map<TaskId, Task> updatingTasks1 = mkMap(
-            mkEntry(activeTask1.id(), activeTask1),
-            mkEntry(activeTask2.id(), activeTask2),
-            mkEntry(standbyTask.id(), standbyTask)
+            Map.entry(activeTask1.id(), activeTask1),
+            Map.entry(activeTask2.id(), activeTask2),
+            Map.entry(standbyTask.id(), standbyTask)
         );
         doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks1);
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
@@ -679,8 +678,8 @@ class DefaultStateUpdaterTest {
         final StandbyTask task1 = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         final StandbyTask task2 = standbyTask(TASK_1_0, Set.of(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task1.id(), task1),
-            mkEntry(task2.id(), task2)
+            Map.entry(task1.id(), task1),
+            Map.entry(task2.id(), task2)
         );
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(task1.id()));
         final ExceptionAndTask expectedExceptionAndTasks = new ExceptionAndTask(taskCorruptedException, task1);
@@ -926,7 +925,7 @@ class DefaultStateUpdaterTest {
         final StreamsException streamsException = new StreamsException("Something happened", task.id());
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
-        final Map<TaskId, Task> updatingTasks = mkMap(mkEntry(task.id(), task));
+        final Map<TaskId, Task> updatingTasks = mkMap(Map.entry(task.id(), task));
         doThrow(streamsException)
             .doReturn(0L)
             .when(changelogReader).restore(updatingTasks);
@@ -952,8 +951,8 @@ class DefaultStateUpdaterTest {
         final StreamTask failedTask = statefulTask(TASK_0_2, Set.of(TOPIC_PARTITION_C_0)).inState(State.RESTORING).build();
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(TASK_0_2));
         doThrow(taskCorruptedException).when(changelogReader).restore(mkMap(
-            mkEntry(TASK_0_0, updatingTask),
-            mkEntry(TASK_0_2, failedTask)
+            Map.entry(TASK_0_0, updatingTask),
+            Map.entry(TASK_0_2, failedTask)
         ));
         when(changelogReader.completedChangelogs()).thenReturn(Set.of(TOPIC_PARTITION_B_0));
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
@@ -1101,8 +1100,8 @@ class DefaultStateUpdaterTest {
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task.id(), task),
-            mkEntry(controlTask.id(), controlTask)
+            Map.entry(task.id(), task),
+            Map.entry(controlTask.id(), controlTask)
         );
         doThrow(streamsException)
             .doReturn(0L)
@@ -1218,8 +1217,8 @@ class DefaultStateUpdaterTest {
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task.id(), task),
-            mkEntry(controlTask.id(), controlTask)
+            Map.entry(task.id(), task),
+            Map.entry(controlTask.id(), controlTask)
         );
         doThrow(streamsException)
             .doReturn(0L)
@@ -1243,8 +1242,8 @@ class DefaultStateUpdaterTest {
         final String exceptionMessage = "The Streams were crossed!";
         final StreamsException streamsException = new StreamsException(exceptionMessage);
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task1.id(), task1),
-            mkEntry(task2.id(), task2)
+            Map.entry(task1.id(), task1),
+            Map.entry(task2.id(), task2)
         );
         doReturn(0L).doThrow(streamsException).when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
@@ -1270,13 +1269,13 @@ class DefaultStateUpdaterTest {
         final StreamsException streamsException1 = new StreamsException(exceptionMessage, task1.id());
         final StreamsException streamsException2 = new StreamsException(exceptionMessage, task3.id());
         final Map<TaskId, Task> updatingTasksBeforeFirstThrow = mkMap(
-            mkEntry(task1.id(), task1),
-            mkEntry(task2.id(), task2),
-            mkEntry(task3.id(), task3)
+            Map.entry(task1.id(), task1),
+            Map.entry(task2.id(), task2),
+            Map.entry(task3.id(), task3)
         );
         final Map<TaskId, Task> updatingTasksBeforeSecondThrow = mkMap(
-            mkEntry(task2.id(), task2),
-            mkEntry(task3.id(), task3)
+            Map.entry(task2.id(), task2),
+            Map.entry(task3.id(), task3)
         );
         doReturn(0L)
             .doThrow(streamsException1)
@@ -1307,9 +1306,9 @@ class DefaultStateUpdaterTest {
         final Set<TaskId> expectedTaskIds = Set.of(task1.id(), task2.id());
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(expectedTaskIds);
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task1.id(), task1),
-            mkEntry(task2.id(), task2),
-            mkEntry(task3.id(), task3)
+            Map.entry(task1.id(), task1),
+            Map.entry(task2.id(), task2),
+            Map.entry(task3.id(), task3)
         );
         doReturn(0L).doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
@@ -1335,8 +1334,8 @@ class DefaultStateUpdaterTest {
         final StandbyTask task2 = standbyTask(TASK_0_2, Set.of(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
         final IllegalStateException illegalStateException = new IllegalStateException("Nobody expects the Spanish inquisition!");
         final Map<TaskId, Task> updatingTasks = mkMap(
-            mkEntry(task1.id(), task1),
-            mkEntry(task2.id(), task2)
+            Map.entry(task1.id(), task1),
+            Map.entry(task2.id(), task2)
         );
         doThrow(illegalStateException).when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
@@ -1365,7 +1364,7 @@ class DefaultStateUpdaterTest {
         final String exceptionMessage = "The Streams were crossed!";
         final StreamsException streamsException1 = new StreamsException(exceptionMessage, task1.id());
         final Map<TaskId, Task> updatingTasks1 = mkMap(
-            mkEntry(task1.id(), task1)
+            Map.entry(task1.id(), task1)
         );
         doThrow(streamsException1)
             .when(changelogReader).restore(updatingTasks1);
@@ -1373,18 +1372,18 @@ class DefaultStateUpdaterTest {
         final StreamsException streamsException3 = new StreamsException(exceptionMessage, task3.id());
         final StreamsException streamsException4 = new StreamsException(exceptionMessage, task4.id());
         final Map<TaskId, Task> updatingTasks2 = mkMap(
-            mkEntry(task2.id(), task2),
-            mkEntry(task3.id(), task3),
-            mkEntry(task4.id(), task4)
+            Map.entry(task2.id(), task2),
+            Map.entry(task3.id(), task3),
+            Map.entry(task4.id(), task4)
         );
         doThrow(streamsException2).when(changelogReader).restore(updatingTasks2);
         final Map<TaskId, Task> updatingTasks3 = mkMap(
-            mkEntry(task3.id(), task3),
-            mkEntry(task4.id(), task4)
+            Map.entry(task3.id(), task3),
+            Map.entry(task4.id(), task4)
         );
         doThrow(streamsException3).when(changelogReader).restore(updatingTasks3);
         final Map<TaskId, Task> updatingTasks4 = mkMap(
-            mkEntry(task4.id(), task4)
+            Map.entry(task4.id(), task4)
         );
         doThrow(streamsException4).when(changelogReader).restore(updatingTasks4);
         stateUpdater.start();
@@ -1530,13 +1529,13 @@ class DefaultStateUpdaterTest {
             new TaskCorruptedException(Set.of(standbyTask1.id(), standbyTask2.id()));
         final StreamsException streamsException = new StreamsException("The Streams were crossed!", activeTask1.id());
         final Map<TaskId, Task> updatingTasks1 = mkMap(
-            mkEntry(activeTask1.id(), activeTask1),
-            mkEntry(standbyTask1.id(), standbyTask1),
-            mkEntry(standbyTask2.id(), standbyTask2)
+            Map.entry(activeTask1.id(), activeTask1),
+            Map.entry(standbyTask1.id(), standbyTask1),
+            Map.entry(standbyTask2.id(), standbyTask2)
         );
         doReturn(0L).doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks1);
         final Map<TaskId, Task> updatingTasks2 = mkMap(
-            mkEntry(activeTask1.id(), activeTask1)
+            Map.entry(activeTask1.id(), activeTask1)
         );
         doReturn(0L).doThrow(streamsException).doReturn(0L).when(changelogReader).restore(updatingTasks2);
         stateUpdater.start();
@@ -1578,14 +1577,14 @@ class DefaultStateUpdaterTest {
         final StandbyTask standbyTask3 = standbyTask(TASK_A_0_1, Set.of(TOPIC_PARTITION_A_1)).inState(State.RUNNING).build();
         final StandbyTask standbyTask4 = standbyTask(TASK_B_0_1, Set.of(TOPIC_PARTITION_B_1)).inState(State.RUNNING).build();
         final Map<TaskId, Task> tasks1234 = mkMap(
-            mkEntry(activeTask1.id(), activeTask1),
-            mkEntry(activeTask2.id(), activeTask2),
-            mkEntry(standbyTask3.id(), standbyTask3),
-            mkEntry(standbyTask4.id(), standbyTask4)
+            Map.entry(activeTask1.id(), activeTask1),
+            Map.entry(activeTask2.id(), activeTask2),
+            Map.entry(standbyTask3.id(), standbyTask3),
+            Map.entry(standbyTask4.id(), standbyTask4)
         );
         final Map<TaskId, Task> tasks13 = mkMap(
-            mkEntry(activeTask1.id(), activeTask1),
-            mkEntry(standbyTask3.id(), standbyTask3)
+            Map.entry(activeTask1.id(), activeTask1),
+            Map.entry(standbyTask3.id(), standbyTask3)
         );
 
         when(topologyMetadata.isPaused(activeTask2.id().topologyName())).thenReturn(true);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -66,7 +66,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
@@ -146,11 +145,11 @@ public class GlobalStateManagerImplTest {
         when(optionalMockReprocessFactory.isPresent()).thenReturn(false);
         topology = withGlobalStores(asList(store1, store2, store3, store4, store5), storeToTopic,
             mkMap(
-                mkEntry(storeName1, Optional.empty()),
-                mkEntry(storeName2, Optional.empty()),
-                mkEntry(storeName3, Optional.empty()),
-                mkEntry(storeName4, Optional.empty()),
-                mkEntry(storeName5, optionalMockReprocessFactory)
+                Map.entry(storeName1, Optional.empty()),
+                Map.entry(storeName2, Optional.empty()),
+                Map.entry(storeName3, Optional.empty()),
+                Map.entry(storeName4, Optional.empty()),
+                Map.entry(storeName5, optionalMockReprocessFactory)
             )
         );
         streamsConfig = new StreamsConfig(new Properties() {
@@ -589,10 +588,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -632,10 +631,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -673,10 +672,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -721,10 +720,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4, t5);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -755,10 +754,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -798,10 +797,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -839,10 +838,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -887,10 +886,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4, t5);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -921,10 +920,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 0L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -964,10 +963,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -1005,10 +1004,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 1000L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -1048,10 +1047,10 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4, t5);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
-            mkEntry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+            Map.entry(StreamsConfig.TASK_TIMEOUT_MS_CONFIG, 10L)
         ));
 
         stateManager = new GlobalStateManagerImpl(
@@ -1089,9 +1088,9 @@ public class GlobalStateManagerImplTest {
         consumer.updateEndOffsets(endOffsets);
 
         streamsConfig = new StreamsConfig(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
 
         stateManager = new GlobalStateManagerImpl(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -149,8 +149,8 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
 
         internalTopicManager.setup(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2)
         ));
 
         final Set<String> newlyCreatedTopics = mockAdminClient.listTopics().names().get();
@@ -185,17 +185,17 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
         when(admin.createTopics(Set.of(newTopic1, newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicSuccessfulFuture),
-                mkEntry(topic2, createTopicFailFuture)
+                Map.entry(topic1, createTopicSuccessfulFuture),
+                Map.entry(topic2, createTopicFailFuture)
             )));
         when(admin.createTopics(Set.of(newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic2, createTopicSuccessfulFuture)
+                Map.entry(topic2, createTopicSuccessfulFuture)
             )));
 
         topicManager.setup(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2)
         ));
     }
 
@@ -223,14 +223,14 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
         when(admin.createTopics(Set.of(newTopic)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicSuccessfulFuture)
+                Map.entry(topic1, createTopicSuccessfulFuture)
             )))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                    mkEntry(topic2, createTopicSuccessfulFuture)
+                    Map.entry(topic2, createTopicSuccessfulFuture)
             )));
 
         topicManager.setup(mkMap(
-            mkEntry(topic1, internalTopicConfig)
+            Map.entry(topic1, internalTopicConfig)
         ));
     }
 
@@ -394,11 +394,11 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
         when(admin.createTopics(Set.of(newTopic)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicFailFuture)
+                Map.entry(topic1, createTopicFailFuture)
             )));
 
         assertThrows(StreamsException.class, () -> topicManager.setup(mkMap(
-            mkEntry(topic1, internalTopicConfig)
+            Map.entry(topic1, internalTopicConfig)
         )));
     }
 
@@ -431,7 +431,7 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
         final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
         when(admin.createTopics(Set.of(newTopic)))
-            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(mkEntry(topic1, createTopicFailFuture))));
+            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(Map.entry(topic1, createTopicFailFuture))));
 
         assertThrows(
             TimeoutException.class,
@@ -451,7 +451,7 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
         final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
         when(admin.createTopics(Set.of(newTopic)))
-            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(mkEntry(topic1, createTopicFutureThatNeverCompletes))));
+            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(Map.entry(topic1, createTopicFutureThatNeverCompletes))));
 
         assertThrows(
             TimeoutException.class,
@@ -473,13 +473,13 @@ public class InternalTopicManagerTest {
         final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
         deleteTopicSuccessfulFuture.complete(null);
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicSuccessfulFuture))));
 
         assertThrows(
             StreamsException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -501,23 +501,23 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
         when(admin.createTopics(Set.of(newTopic1, newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicSuccessfulFuture),
-                mkEntry(topic2, createTopicFailFuture1)
+                Map.entry(topic1, createTopicSuccessfulFuture),
+                Map.entry(topic2, createTopicFailFuture1)
             )));
         when(admin.createTopics(Set.of(newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic3, createTopicSuccessfulFuture)
+                Map.entry(topic3, createTopicSuccessfulFuture)
             )));
         final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
         deleteTopicSuccessfulFuture.complete(null);
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicSuccessfulFuture))));
 
         assertThrows(
             IllegalStateException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -542,22 +542,22 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
         when(admin.createTopics(Set.of(newTopic1, newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicSuccessfulFuture),
-                mkEntry(topic2, createTopicFailFuture1)
+                Map.entry(topic1, createTopicSuccessfulFuture),
+                Map.entry(topic2, createTopicFailFuture1)
             )));
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
         when(admin.createTopics(Set.of(newTopic2)))
-            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(mkEntry(topic2, createTopicFutureThatNeverCompletes))));
+            .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(Map.entry(topic2, createTopicFutureThatNeverCompletes))));
         final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
         deleteTopicSuccessfulFuture.complete(null);
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicSuccessfulFuture))));
 
         assertThrows(
             TimeoutException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -589,14 +589,14 @@ public class InternalTopicManagerTest {
         final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
         deleteTopicSuccessfulFuture.complete(null);
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFailFuture))))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicFailFuture))))
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicSuccessfulFuture))));
 
         assertThrows(
             StreamsException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -614,13 +614,13 @@ public class InternalTopicManagerTest {
         setupCleanUpScenario(admin, streamsConfig, internalTopicConfig1, internalTopicConfig2);
         final KafkaFutureImpl<Void> deleteTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFutureThatNeverCompletes))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicFutureThatNeverCompletes))));
 
         assertThrows(
             TimeoutException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -636,13 +636,13 @@ public class InternalTopicManagerTest {
         final KafkaFutureImpl<Void> deleteTopicFailFuture = new KafkaFutureImpl<>();
         deleteTopicFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
         when(admin.deleteTopics(Set.of(topic1)))
-            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFailFuture))));
+            .thenAnswer(answer -> new MockDeleteTopicsResult(mkMap(Map.entry(topic1, deleteTopicFailFuture))));
 
         assertThrows(
             StreamsException.class,
             () -> topicManager.setup(mkMap(
-                mkEntry(topic1, internalTopicConfig1),
-                mkEntry(topic2, internalTopicConfig2)
+                Map.entry(topic1, internalTopicConfig1),
+                Map.entry(topic2, internalTopicConfig2)
             ))
         );
     }
@@ -660,12 +660,12 @@ public class InternalTopicManagerTest {
         final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
         when(admin.createTopics(Set.of(newTopic1, newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic1, createTopicSuccessfulFuture),
-                mkEntry(topic2, createTopicFailFuture1)
+                Map.entry(topic1, createTopicSuccessfulFuture),
+                Map.entry(topic2, createTopicFailFuture1)
             )));
         when(admin.createTopics(Set.of(newTopic2)))
             .thenAnswer(answer -> new MockCreateTopicsResult(mkMap(
-                mkEntry(topic2, createTopicFailFuture2)
+                Map.entry(topic2, createTopicFailFuture2)
             )));
     }
 
@@ -779,12 +779,12 @@ public class InternalTopicManagerTest {
         // it should retry with just topic2 and then let it succeed
         when(admin.describeTopics(Set.of(topic1, topic2)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
-                mkEntry(topic1, topicDescriptionSuccessFuture),
-                mkEntry(topic2, topicDescriptionFailFuture)
+                Map.entry(topic1, topicDescriptionSuccessFuture),
+                Map.entry(topic2, topicDescriptionFailFuture)
             )));
         when(admin.createTopics(Collections.singleton(new NewTopic(topic2, Optional.of(1), Optional.of((short) 1))
-            .configs(mkMap(mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
-                                 mkEntry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"))))))
+            .configs(mkMap(Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+                                 Map.entry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"))))))
             .thenAnswer(answer -> new MockCreateTopicsResult(Collections.singletonMap(topic2, topicCreationFuture)));
         when(admin.describeTopics(Collections.singleton(topic2)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(Collections.singletonMap(topic2, topicDescriptionSuccessFuture)));
@@ -794,8 +794,8 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig topic2Config = new UnwindowedUnversionedChangelogTopicConfig(topic2, Collections.emptyMap());
         topic2Config.setNumberOfPartitions(1);
         topicManager.makeReady(mkMap(
-            mkEntry(topic1, topicConfig),
-            mkEntry(topic2, topic2Config)
+            Map.entry(topic1, topicConfig),
+            Map.entry(topic2, topic2Config)
         ));
     }
 
@@ -921,10 +921,10 @@ public class InternalTopicManagerTest {
                 Collections.singletonMap(topic1, topicDescriptionUnknownTopicFuture)));
         when(admin.createTopics(Collections.singleton(
                 new NewTopic(topic1, Optional.of(1), Optional.of((short) 1))
-            .configs(mkMap(mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
-                mkEntry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"),
-                mkEntry(TopicConfig.SEGMENT_BYTES_CONFIG, "52428800"),
-                mkEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"))))))
+            .configs(mkMap(Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
+                Map.entry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"),
+                Map.entry(TopicConfig.SEGMENT_BYTES_CONFIG, "52428800"),
+                Map.entry(TopicConfig.RETENTION_MS_CONFIG, "-1"))))))
             .thenAnswer(answer -> new MockCreateTopicsResult(Collections.singletonMap(topic1, topicCreationFuture)));
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
@@ -1034,8 +1034,8 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2)
         ));
 
         assertThat(validationResult.missingTopics(), empty());
@@ -1062,9 +1062,9 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig3 = setupRepartitionTopicConfig(missingTopic2, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(missingTopic1, internalTopicConfig2),
-            mkEntry(missingTopic2, internalTopicConfig3)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(missingTopic1, internalTopicConfig2),
+            Map.entry(missingTopic2, internalTopicConfig3)
         ));
 
         final Set<String> missingTopics = validationResult.missingTopics();
@@ -1084,9 +1084,9 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig3 = setupRepartitionTopicConfig(topic3, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2),
-            mkEntry(topic3, internalTopicConfig3)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2),
+            Map.entry(topic3, internalTopicConfig3)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1127,9 +1127,9 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig3 = setupUnwindowedUnversionedChangelogTopicConfig(topic3, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2),
-            mkEntry(topic3, internalTopicConfig3)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2),
+            Map.entry(topic3, internalTopicConfig3)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1174,11 +1174,11 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig5 = setupWindowedChangelogTopicConfig(topic5, 1, retentionMs);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2),
-            mkEntry(topic3, internalTopicConfig3),
-            mkEntry(topic4, internalTopicConfig4),
-            mkEntry(topic5, internalTopicConfig5)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2),
+            Map.entry(topic3, internalTopicConfig3),
+            Map.entry(topic4, internalTopicConfig4),
+            Map.entry(topic5, internalTopicConfig5)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1227,10 +1227,10 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig4 = setupVersionedChangelogTopicConfig(topic4, 1, compactionLagMs);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2),
-            mkEntry(topic3, internalTopicConfig3),
-            mkEntry(topic4, internalTopicConfig4)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2),
+            Map.entry(topic3, internalTopicConfig3),
+            Map.entry(topic4, internalTopicConfig4)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1286,11 +1286,11 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig5 = setupRepartitionTopicConfig(topic5, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2),
-            mkEntry(topic3, internalTopicConfig3),
-            mkEntry(topic4, internalTopicConfig4),
-            mkEntry(topic5, internalTopicConfig5)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2),
+            Map.entry(topic3, internalTopicConfig3),
+            Map.entry(topic4, internalTopicConfig4),
+            Map.entry(topic5, internalTopicConfig5)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1336,7 +1336,7 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig1 = setupWindowedChangelogTopicConfig(topic1, 1, retentionMs);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1)
+            Map.entry(topic1, internalTopicConfig1)
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
@@ -1414,8 +1414,8 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
         ));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionFailFuture))))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionFailFuture))))
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionSuccessfulFuture))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(
             new Config(repartitionTopicConfig().entrySet().stream()
@@ -1423,7 +1423,7 @@ public class InternalTopicManagerTest {
         );
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         final ValidationResult validationResult = topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig));
@@ -1447,7 +1447,7 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
         ));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionSuccessfulFuture))));
         final KafkaFutureImpl<Config> topicConfigsFailFuture = new KafkaFutureImpl<>();
         topicConfigsFailFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
@@ -1457,8 +1457,8 @@ public class InternalTopicManagerTest {
         );
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigsFailFuture))))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigsFailFuture))))
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         final ValidationResult validationResult = topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig));
@@ -1491,12 +1491,12 @@ public class InternalTopicManagerTest {
         ));
         when(admin.describeTopics(Set.of(topic1, topic2)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
-                mkEntry(topic1, topicDescriptionSuccessfulFuture1),
-                mkEntry(topic2, topicDescriptionFailFuture)
+                Map.entry(topic1, topicDescriptionSuccessfulFuture1),
+                Map.entry(topic2, topicDescriptionFailFuture)
             )));
         when(admin.describeTopics(Set.of(topic2)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
-                mkEntry(topic2, topicDescriptionSuccessfulFuture2)
+                Map.entry(topic2, topicDescriptionSuccessfulFuture2)
             )));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(
@@ -1507,15 +1507,15 @@ public class InternalTopicManagerTest {
         final ConfigResource topicResource2 = new ConfigResource(Type.TOPIC, topic2);
         when(admin.describeConfigs(Set.of(topicResource1, topicResource2)))
             .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(
-                mkEntry(topicResource1, topicConfigSuccessfulFuture),
-                mkEntry(topicResource2, topicConfigSuccessfulFuture)
+                Map.entry(topicResource1, topicConfigSuccessfulFuture),
+                Map.entry(topicResource2, topicConfigSuccessfulFuture)
             )));
         final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
 
         final ValidationResult validationResult = topicManager.validate(mkMap(
-            mkEntry(topic1, internalTopicConfig1),
-            mkEntry(topic2, internalTopicConfig2)
+            Map.entry(topic1, internalTopicConfig1),
+            Map.entry(topic2, internalTopicConfig2)
         ));
 
         assertThat(validationResult.missingTopics(), empty());
@@ -1533,7 +1533,7 @@ public class InternalTopicManagerTest {
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionFailFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionFailFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(Throwable.class, () -> topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig)));
@@ -1553,7 +1553,7 @@ public class InternalTopicManagerTest {
         configDescriptionFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, configDescriptionFailFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, configDescriptionFailFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(Throwable.class, () -> topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig)));
@@ -1574,12 +1574,12 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
         ));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic2, topicDescriptionSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic2, topicDescriptionSuccessfulFuture))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(new Config(Collections.emptySet()));
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
@@ -1603,13 +1603,13 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
         ));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionSuccessfulFuture))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(new Config(Collections.emptySet()));
         final ConfigResource topicResource1 = new ConfigResource(Type.TOPIC, topic1);
         final ConfigResource topicResource2 = new ConfigResource(Type.TOPIC, topic2);
         when(admin.describeConfigs(Collections.singleton(topicResource1)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource2, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource2, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
@@ -1699,12 +1699,12 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
         ));
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionSuccessfulFuture))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(brokerSideTopicConfig);
         final ConfigResource topicResource1 = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource1)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource1, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource1, topicConfigSuccessfulFuture))));
 
         assertThrows(
             IllegalStateException.class,
@@ -1726,7 +1726,7 @@ public class InternalTopicManagerTest {
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new TimeoutException());
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionFailFuture))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionFailFuture))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(
             new Config(repartitionTopicConfig().entrySet().stream()
@@ -1734,7 +1734,7 @@ public class InternalTopicManagerTest {
         );
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
@@ -1756,7 +1756,7 @@ public class InternalTopicManagerTest {
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFutureThatNeverCompletes = new KafkaFutureImpl<>();
         when(admin.describeTopics(Collections.singleton(topic1)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(mkEntry(topic1, topicDescriptionFutureThatNeverCompletes))));
+            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(Map.entry(topic1, topicDescriptionFutureThatNeverCompletes))));
         final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
         topicConfigSuccessfulFuture.complete(
             new Config(repartitionTopicConfig().entrySet().stream()
@@ -1764,7 +1764,7 @@ public class InternalTopicManagerTest {
         );
         final ConfigResource topicResource = new ConfigResource(Type.TOPIC, topic1);
         when(admin.describeConfigs(Collections.singleton(topicResource)))
-            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(mkEntry(topicResource, topicConfigSuccessfulFuture))));
+            .thenAnswer(answer -> new MockDescribeConfigsResult(mkMap(Map.entry(topicResource, topicConfigSuccessfulFuture))));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
@@ -1788,30 +1788,30 @@ public class InternalTopicManagerTest {
 
     private Map<String, String> repartitionTopicConfig() {
         return mkMap(
-            mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
-            mkEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
+            Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
+            Map.entry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
             mkEntry(TopicConfig.RETENTION_BYTES_CONFIG, null)
         );
     }
 
     private Map<String, String> unwindowedUnversionedChangelogConfig() {
         return mkMap(
-            mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+            Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
         );
     }
 
     private Map<String, String> windowedChangelogConfig(final long retentionMs) {
         return mkMap(
-            mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE),
-            mkEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs)),
+            Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE),
+            Map.entry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs)),
             mkEntry(TopicConfig.RETENTION_BYTES_CONFIG, null)
         );
     }
 
     private Map<String, String> versionedChangelogConfig(final long compactionLagMs) {
         return mkMap(
-            mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
-            mkEntry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))
+            Map.entry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+            Map.entry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))
         );
     }
 
@@ -1837,7 +1837,7 @@ public class InternalTopicManagerTest {
                                                                   final long retentionMs) {
         final InternalTopicConfig internalTopicConfig = new WindowedChangelogTopicConfig(
             topicName,
-            mkMap(mkEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs))),
+            mkMap(Map.entry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs))),
             10
         );
         internalTopicConfig.setNumberOfPartitions(partitionCount);
@@ -1849,7 +1849,7 @@ public class InternalTopicManagerTest {
                                                                    final long compactionLagMs) {
         final InternalTopicConfig internalTopicConfig = new VersionedChangelogTopicConfig(
             topicName,
-            mkMap(mkEntry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))),
+            mkMap(Map.entry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))),
             12
         );
         internalTopicConfig.setNumberOfPartitions(partitionCount);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -68,7 +68,6 @@ import java.util.regex.Pattern;
 
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG;
@@ -1366,8 +1365,8 @@ public class InternalTopologyBuilderTest {
         builder.initializeSubscription();
 
         builder.rewriteTopology(new StreamsConfig(mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "asdf"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "asdf")
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "asdf"),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "asdf")
         ))));
 
         assertThat(builder.buildGlobalStateTopology().storeToChangelogTopic().get(globalStoreName), is(globalTopic));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -47,12 +47,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -150,7 +150,7 @@ public class PartitionGroupTest {
 
     private void testFirstBatch(final PartitionGroup group) {
         StampedRecord record;
-        final PartitionGroup.RecordInfo info = new RecordInfo();
+        final RecordInfo info = new RecordInfo();
         assertThat(group.numBuffered(), is(0));
         assertNull(group.headRecordLeaderEpoch(partition1));
         assertNull(group.headRecordLeaderEpoch(partition2));
@@ -218,7 +218,7 @@ public class PartitionGroupTest {
 
     private void testSecondBatch(final PartitionGroup group) {
         StampedRecord record;
-        final PartitionGroup.RecordInfo info = new RecordInfo();
+        final RecordInfo info = new RecordInfo();
 
         // add 2 more records with timestamp 2, 4 to partition-1
         final List<ConsumerRecord<byte[], byte[]>> list3 = Arrays.asList(
@@ -355,7 +355,7 @@ public class PartitionGroupTest {
         assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         StampedRecord record;
-        final PartitionGroup.RecordInfo info = new RecordInfo();
+        final RecordInfo info = new RecordInfo();
 
         // get first two records from partition 1
         record = group.nextRecord(info, time.milliseconds());
@@ -481,7 +481,7 @@ public class PartitionGroupTest {
             new PartitionGroup(
                 logContext,
                 mkMap(
-                    mkEntry(partition1, queue1)
+                    Map.entry(partition1, queue1)
                 ),
                 tp -> OptionalLong.of(0L),
                 getValueSensor(metrics, lastLatenessValue),
@@ -545,7 +545,7 @@ public class PartitionGroupTest {
     public void shouldUpdatePartitionQueuesExpand() {
         final PartitionGroup group = new PartitionGroup(
             logContext,
-            mkMap(mkEntry(partition1, queue1)),
+            mkMap(Map.entry(partition1, queue1)),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
             enforcedProcessingSensor,
@@ -578,7 +578,7 @@ public class PartitionGroupTest {
     public void shouldUpdatePartitionQueuesShrinkAndExpand() {
         final PartitionGroup group = new PartitionGroup(
             logContext,
-            mkMap(mkEntry(partition1, queue1)),
+            mkMap(Map.entry(partition1, queue1)),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
             enforcedProcessingSensor,
@@ -610,7 +610,7 @@ public class PartitionGroupTest {
     public void shouldUpdateBufferSizeCorrectlyForSkippedRecords() {
         final PartitionGroup group = new PartitionGroup(
             logContext,
-            mkMap(mkEntry(partition1, queue1)),
+            mkMap(Map.entry(partition1, queue1)),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
             enforcedProcessingSensor,
@@ -693,8 +693,8 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
@@ -731,8 +731,8 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
@@ -770,8 +770,8 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> lags.getOrDefault(tp, OptionalLong.empty()),
             getValueSensor(metrics, lastLatenessValue),
@@ -807,8 +807,8 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> lags.getOrDefault(tp, OptionalLong.empty()),
             getValueSensor(metrics, lastLatenessValue),
@@ -844,8 +844,8 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),
@@ -949,7 +949,7 @@ public class PartitionGroupTest {
         final PartitionGroup group = new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1)
+                Map.entry(partition1, queue1)
             ),
             tp -> lags.getOrDefault(tp, OptionalLong.empty()),
             getValueSensor(metrics, lastLatenessValue),
@@ -985,8 +985,8 @@ public class PartitionGroupTest {
         return new PartitionGroup(
             logContext,
             mkMap(
-                mkEntry(partition1, queue1),
-                mkEntry(partition2, queue2)
+                Map.entry(partition1, queue1),
+                Map.entry(partition2, queue2)
             ),
             tp -> OptionalLong.of(0L),
             getValueSensor(metrics, lastLatenessValue),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTEARRAY_VALUE_SERIALIZER;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTES_KEY_SERIALIZER;
@@ -901,8 +900,8 @@ public class ProcessorContextImplTest {
 
         final ProcessorMetadata metadata = new ProcessorMetadata(
             mkMap(
-                mkEntry("key1", 10L),
-                mkEntry("key2", 100L)
+                Map.entry("key1", 10L),
+                Map.entry("key2", 100L)
             )
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -72,7 +72,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -205,9 +204,9 @@ public class ProcessorStateManagerTest {
             stateDirectory,
             changelogReader,
             mkMap(
-                mkEntry(persistentStoreName, persistentStoreTopicName),
-                mkEntry(persistentStoreTwoName, persistentStoreTwoTopicName),
-                mkEntry(nonPersistentStoreName, nonPersistentStoreTopicName)
+                Map.entry(persistentStoreName, persistentStoreTopicName),
+                Map.entry(persistentStoreTwoName, persistentStoreTwoTopicName),
+                Map.entry(nonPersistentStoreName, nonPersistentStoreTopicName)
             ),
             Set.of(persistentStorePartition, nonPersistentStorePartition),
             false);
@@ -226,8 +225,8 @@ public class ProcessorStateManagerTest {
             logContext,
             stateDirectory,
             changelogReader, mkMap(
-                mkEntry(persistentStoreName, persistentStoreTopicName),
-                mkEntry(persistentStoreTwoName, persistentStoreTopicName)
+                Map.entry(persistentStoreName, persistentStoreTopicName),
+                Map.entry(persistentStoreTwoName, persistentStoreTopicName)
             ),
             Collections.emptySet(),
             false);
@@ -419,9 +418,9 @@ public class ProcessorStateManagerTest {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(
-            mkEntry(persistentStorePartition, checkpointOffset),
-            mkEntry(nonPersistentStorePartition, checkpointOffset),
-            mkEntry(irrelevantPartition, 999L)
+            Map.entry(persistentStorePartition, checkpointOffset),
+            Map.entry(nonPersistentStorePartition, checkpointOffset),
+            Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
 
@@ -440,9 +439,9 @@ public class ProcessorStateManagerTest {
                 nonPersistentStorePartition),
                 stateMgr.changelogPartitions());
             assertEquals(mkMap(
-                mkEntry(persistentStorePartition, checkpointOffset + 1L),
-                mkEntry(persistentStoreTwoPartition, 0L),
-                mkEntry(nonPersistentStorePartition, 0L)),
+                Map.entry(persistentStorePartition, checkpointOffset + 1L),
+                Map.entry(persistentStoreTwoPartition, 0L),
+                Map.entry(nonPersistentStorePartition, 0L)),
                 stateMgr.changelogOffsets()
             );
 
@@ -460,9 +459,9 @@ public class ProcessorStateManagerTest {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(
-                mkEntry(persistentStorePartition, checkpointOffset),
-                mkEntry(nonPersistentStorePartition, checkpointOffset),
-                mkEntry(irrelevantPartition, 999L)
+                Map.entry(persistentStorePartition, checkpointOffset),
+                Map.entry(nonPersistentStorePartition, checkpointOffset),
+                Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
 
@@ -481,9 +480,9 @@ public class ProcessorStateManagerTest {
                     nonPersistentStorePartition),
                     stateMgr.changelogPartitions());
             assertEquals(mkMap(
-                    mkEntry(persistentStorePartition, checkpointOffset + 1L),
-                    mkEntry(persistentStoreTwoPartition, 0L),
-                    mkEntry(nonPersistentStorePartition, 0L)),
+                    Map.entry(persistentStorePartition, checkpointOffset + 1L),
+                    Map.entry(persistentStoreTwoPartition, 0L),
+                    Map.entry(nonPersistentStorePartition, 0L)),
                     stateMgr.changelogOffsets()
             );
 
@@ -611,8 +610,8 @@ public class ProcessorStateManagerTest {
 
             // should ignore irrelevant topic partitions
             stateMgr.updateChangelogOffsets(mkMap(
-                mkEntry(persistentStorePartition, 220L),
-                mkEntry(irrelevantPartition, 9000L)
+                Map.entry(persistentStorePartition, 220L),
+                Map.entry(irrelevantPartition, 9000L)
             ));
             stateMgr.checkpoint();
 
@@ -970,9 +969,9 @@ public class ProcessorStateManagerTest {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(
-            mkEntry(persistentStorePartition, checkpointOffset),
-            mkEntry(nonPersistentStorePartition, checkpointOffset),
-            mkEntry(irrelevantPartition, 999L)
+            Map.entry(persistentStorePartition, checkpointOffset),
+            Map.entry(nonPersistentStorePartition, checkpointOffset),
+            Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
 
@@ -1000,8 +999,8 @@ public class ProcessorStateManagerTest {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(
-            mkEntry(persistentStorePartition, checkpointOffset),
-            mkEntry(irrelevantPartition, 999L)
+            Map.entry(persistentStorePartition, checkpointOffset),
+            Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
 
@@ -1030,8 +1029,8 @@ public class ProcessorStateManagerTest {
             assertThat(stateMgr.storeMetadata(persistentStorePartition), notNullValue());
 
             stateMgr.updateChangelogOffsets(mkMap(
-                mkEntry(nonPersistentStorePartition, 876L),
-                mkEntry(persistentStorePartition, 666L))
+                Map.entry(nonPersistentStorePartition, 876L),
+                Map.entry(persistentStorePartition, 666L))
             );
             stateMgr.checkpoint();
 
@@ -1078,9 +1077,9 @@ public class ProcessorStateManagerTest {
     public void shouldDeleteCheckPointFileIfEosEnabled() throws IOException {
         final long checkpointOffset = 10L;
         final Map<TopicPartition, Long> offsets = mkMap(
-                mkEntry(persistentStorePartition, checkpointOffset),
-                mkEntry(nonPersistentStorePartition, checkpointOffset),
-                mkEntry(irrelevantPartition, 999L)
+                Map.entry(persistentStorePartition, checkpointOffset),
+                Map.entry(nonPersistentStorePartition, checkpointOffset),
+                Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, true);
@@ -1093,9 +1092,9 @@ public class ProcessorStateManagerTest {
     public void shouldNotDeleteCheckPointFileIfEosNotEnabled() throws IOException {
         final long checkpointOffset = 10L;
         final Map<TopicPartition, Long> offsets = mkMap(
-                mkEntry(persistentStorePartition, checkpointOffset),
-                mkEntry(nonPersistentStorePartition, checkpointOffset),
-                mkEntry(irrelevantPartition, 999L)
+                Map.entry(persistentStorePartition, checkpointOffset),
+                Map.entry(nonPersistentStorePartition, checkpointOffset),
+                Map.entry(irrelevantPartition, 999L)
         );
         checkpoint.write(offsets);
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, false);
@@ -1233,9 +1232,9 @@ public class ProcessorStateManagerTest {
             stateDirectory,
             changelogReader,
             mkMap(
-                mkEntry(persistentStoreName, persistentStoreTopicName),
-                mkEntry(persistentStoreTwoName, persistentStoreTwoTopicName),
-                mkEntry(nonPersistentStoreName, nonPersistentStoreTopicName)
+                Map.entry(persistentStoreName, persistentStoreTopicName),
+                Map.entry(persistentStoreTwoName, persistentStoreTwoTopicName),
+                Map.entry(nonPersistentStoreName, nonPersistentStoreTopicName)
             ),
             emptySet(),
             false);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -60,13 +60,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -225,8 +225,8 @@ public class ProcessorTopologyTest {
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
 
         processorTopology.updateSourceTopics(mkMap(
-            mkEntry(sourceNodeWithinSubtopology, Collections.singletonList(topicWithinSubtopology)),
-            mkEntry(sourceNodeOutsideSubtopology, Collections.singletonList(topicOutsideSubtopology))
+            Map.entry(sourceNodeWithinSubtopology, Collections.singletonList(topicWithinSubtopology)),
+            Map.entry(sourceNodeOutsideSubtopology, Collections.singletonList(topicOutsideSubtopology))
             )
         );
 
@@ -265,8 +265,8 @@ public class ProcessorTopologyTest {
         final Throwable exception = assertThrows(
             IllegalStateException.class,
             () -> processorTopology.updateSourceTopics(mkMap(
-                mkEntry(sourceNode, Collections.singletonList(doublySubscribedTopic)),
-                mkEntry(updatedSourceNode, Arrays.asList(topic, doublySubscribedTopic))
+                Map.entry(sourceNode, Collections.singletonList(doublySubscribedTopic)),
+                Map.entry(updatedSourceNode, Arrays.asList(topic, doublySubscribedTopic))
             ))
         );
         assertThat(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
@@ -281,32 +280,32 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 2));
 
         final Map<String, String> clientTags1 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-1"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-1"));
         final Map<String, String> clientTags2 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-2"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-2"));
         final Map<String, String> clientTags3 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-3"));
         final Map<String, String> clientTags4 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-1"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-1"));
         final Map<String, String> clientTags5 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-2"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-2"));
         final Map<String, String> clientTags6 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-3"));
         final Map<String, String> clientTags7 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-3"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-1"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-3"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-1"));
         final Map<String, String> clientTags8 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-3"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-2"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-3"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-2"));
         final Map<String, String> clientTags9 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-3"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-3"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-3"));
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
         subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));
@@ -347,23 +346,23 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 2));
 
         final Map<String, String> clientTags1 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-1"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-1"));
         final Map<String, String> clientTags2 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-2"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-2"));
         final Map<String, String> clientTags3 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-1"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-1"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-3"));
         final Map<String, String> clientTags4 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-1"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-1"));
         final Map<String, String> clientTags5 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-2"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-2"));
         final Map<String, String> clientTags6 = mkMap(
-            mkEntry(ALL_TAG_KEYS.get(0), "value-0-2"),
-            mkEntry(ALL_TAG_KEYS.get(1), "value-1-3"));
+            Map.entry(ALL_TAG_KEYS.get(0), "value-0-2"),
+            Map.entry(ALL_TAG_KEYS.get(1), "value-1-3"));
 
         final Map<String, Map<String, String>> hostTags = new HashMap<>();
         subscriptions.put(consumer1, getSubscription(PID_1, EMPTY_TASKS, clientTags1));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -85,7 +85,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
@@ -464,8 +463,8 @@ public class RecordCollectorTest {
                 "stream-task-metrics",
                 "The total number of dropped records",
                 mkMap(
-                        mkEntry("thread-id", Thread.currentThread().getName()),
-                        mkEntry("task-id", taskId.toString())
+                        Map.entry("thread-id", Thread.currentThread().getName()),
+                        Map.entry("task-id", taskId.toString())
                 )
         ));
 
@@ -1303,8 +1302,8 @@ public class RecordCollectorTest {
             "stream-task-metrics",
             "The total number of dropped records",
             mkMap(
-                mkEntry("thread-id", Thread.currentThread().getName()),
-                mkEntry("task-id", taskId.toString())
+                Map.entry("thread-id", Thread.currentThread().getName()),
+                Map.entry("task-id", taskId.toString())
             )
         ));
         assertEquals(1.0, metric.metricValue());
@@ -1548,8 +1547,8 @@ public class RecordCollectorTest {
                     "stream-task-metrics",
                     "The total number of dropped records",
                     mkMap(
-                        mkEntry("thread-id", Thread.currentThread().getName()),
-                        mkEntry("task-id", taskId.toString())
+                        Map.entry("thread-id", Thread.currentThread().getName()),
+                        Map.entry("task-id", taskId.toString())
                     ))).metricValue(),
                 equalTo(1.0)
             );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNAMED_TOPOLOGY;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
@@ -85,15 +84,15 @@ public class RepartitionTopicsTest {
         Set.of(REPARTITION_TOPIC_NAME1),
         Set.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2),
         mkMap(
-            mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-            mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2)
+            Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+            Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2)
         ),
         Collections.emptyMap()
     );
     private static final TopicsInfo TOPICS_INFO2 = new TopicsInfo(
         Set.of(SINK_TOPIC_NAME1),
         Set.of(REPARTITION_TOPIC_NAME1),
-        mkMap(mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1)),
+        mkMap(Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1)),
         Collections.emptyMap()
     );
     final  StreamsConfig config = new DummyStreamsConfig();
@@ -116,15 +115,15 @@ public class RepartitionTopicsTest {
     @Test
     public void shouldSetupRepartitionTopics() {
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
-            .thenReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
+            .thenReturn(mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO1), Map.entry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         final Set<String> coPartitionGroup1 = Set.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2);
         final Set<String> coPartitionGroup2 = Set.of(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_NAME2);
         final List<Set<String>> coPartitionGroups = Arrays.asList(coPartitionGroup1, coPartitionGroup2);
         when(internalTopologyBuilder.copartitionGroups()).thenReturn(coPartitionGroups);
         when(internalTopicManager.makeReady(
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2)
             ))
         ).thenReturn(Collections.emptySet());
         setupCluster(false);
@@ -158,7 +157,7 @@ public class RepartitionTopicsTest {
     public void shouldReturnMissingSourceTopics() {
         final Set<String> missingSourceTopics = Set.of(SOURCE_TOPIC_NAME1);
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
-            .thenReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
+            .thenReturn(mkMap(Map.entry(SUBTOPOLOGY_0, TOPICS_INFO1), Map.entry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         setupClusterWithMissingTopics(missingSourceTopics, false);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -185,8 +184,8 @@ public class RepartitionTopicsTest {
             new RepartitionTopicConfig(REPARTITION_WITHOUT_PARTITION_COUNT, TOPIC_CONFIG5);
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
             .thenReturn(mkMap(
-                mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1),
-                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                Map.entry(SUBTOPOLOGY_0, TOPICS_INFO1),
+                Map.entry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         setupCluster(false);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
@@ -211,14 +210,14 @@ public class RepartitionTopicsTest {
             Set.of(REPARTITION_WITHOUT_PARTITION_COUNT),
             Set.of(SOURCE_TOPIC_NAME1),
             mkMap(
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ),
             Collections.emptyMap()
         );
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
             .thenReturn(mkMap(
-                mkEntry(SUBTOPOLOGY_0, topicsInfo),
-                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                Map.entry(SUBTOPOLOGY_0, topicsInfo),
+                Map.entry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         setupClusterWithMissingPartitionCounts(Set.of(SOURCE_TOPIC_NAME1), true);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
@@ -246,23 +245,23 @@ public class RepartitionTopicsTest {
             Set.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT),
             Set.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME2),
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ),
             Collections.emptyMap()
         );
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
             .thenReturn(mkMap(
-                mkEntry(SUBTOPOLOGY_0, topicsInfo),
-                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                Map.entry(SUBTOPOLOGY_0, topicsInfo),
+                Map.entry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         when(internalTopologyBuilder.copartitionGroups()).thenReturn(Collections.emptyList());
         when(internalTopicManager.makeReady(
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ))
         ).thenReturn(Collections.emptySet());
         setupCluster(true);
@@ -300,23 +299,23 @@ public class RepartitionTopicsTest {
             Set.of(REPARTITION_TOPIC_NAME2, REPARTITION_WITHOUT_PARTITION_COUNT),
             Set.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME1),
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ),
             Collections.emptyMap()
         );
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
             .thenReturn(mkMap(
-                mkEntry(SUBTOPOLOGY_0, topicsInfo),
-                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                Map.entry(SUBTOPOLOGY_0, topicsInfo),
+                Map.entry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         when(internalTopologyBuilder.copartitionGroups()).thenReturn(Collections.emptyList());
         when(internalTopicManager.makeReady(
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_CONFIG2),
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ))
         ).thenReturn(Collections.emptySet());
         setupCluster(true);
@@ -356,7 +355,7 @@ public class RepartitionTopicsTest {
             Collections.emptyMap()
         );
         when(internalTopologyBuilder.subtopologyToTopicsInfo())
-            .thenReturn(mkMap(mkEntry(SUBTOPOLOGY_0, topicsInfo)));
+            .thenReturn(mkMap(Map.entry(SUBTOPOLOGY_0, topicsInfo)));
         setupCluster(false);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -431,8 +430,8 @@ public class RepartitionTopicsTest {
             Set.of(SINK_TOPIC_NAME2),
             Set.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT),
             mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
+                Map.entry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1),
+                Map.entry(REPARTITION_WITHOUT_PARTITION_COUNT, repartitionTopicConfigWithoutPartitionCount)
             ),
             Collections.emptyMap()
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -41,7 +41,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -106,9 +105,9 @@ public class SourceNodeTest {
         final String threadId = Thread.currentThread().getName();
         final String groupName = "stream-processor-node-metrics";
         final Map<String, String> metricTags = mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", context.taskId().toString()),
-            mkEntry("processor-node-id", node.name())
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", context.taskId().toString()),
+            Map.entry("processor-node-id", node.name())
         );
 
         assertTrue(StreamsTestUtils.containsMetric(metrics, "process-rate", groupName, metricTags));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -59,11 +59,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.Task.State.CREATED;
@@ -108,7 +108,7 @@ public class StandbyTaskTest {
 
     private final ProcessorTopology topology = ProcessorTopologyFactories.withLocalStores(
         asList(store1, store2),
-        mkMap(mkEntry(storeName1, storeChangelogTopicName1), mkEntry(storeName2, storeChangelogTopicName2))
+        mkMap(Map.entry(storeName1, storeChangelogTopicName1), Map.entry(storeName2, storeChangelogTopicName2))
     );
 
     private final MockTime time = new MockTime();
@@ -122,12 +122,12 @@ public class StandbyTaskTest {
 
     private StreamsConfig createConfig(final File baseDir) throws IOException {
         return new StreamsConfig(mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
-            mkEntry(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, DEBUG.name),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath()),
-            mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+            Map.entry(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, DEBUG.name),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
+            Map.entry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath()),
+            Map.entry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName())
         )));
     }
 
@@ -449,9 +449,9 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         config = new StreamsConfig(mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2)
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
+            Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2)
         )));
 
         task = createStandbyTask();
@@ -556,8 +556,8 @@ public class StandbyTaskTest {
             "stream-task-metrics",
             descriptionIsNotVerified,
             mkMap(
-                mkEntry("task-id", taskId),
-                mkEntry(THREAD_ID_TAG, Thread.currentThread().getName())
+                Map.entry("task-id", taskId),
+                Map.entry(THREAD_ID_TAG, Thread.currentThread().getName())
             )
         ));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -72,7 +73,6 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.StateDirectory.PROCESS_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
@@ -633,8 +633,8 @@ public class StateDirectoryTest {
             new StateDirectory(
                 new StreamsConfig(
                     mkMap(
-                        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, ""),
-                        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "")
+                        Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, ""),
+                        Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "")
                     )
                 ),
                 new MockTime(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -64,7 +64,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.StoreChangelogReader.ChangelogReaderState.ACTIVE_RESTORING;
 import static org.apache.kafka.streams.processor.internals.StoreChangelogReader.ChangelogReaderState.STANDBY_UPDATING;
@@ -1181,9 +1180,9 @@ public class StoreChangelogReaderTest {
         when(activeStateManager.storeMetadata(tp1)).thenReturn(storeMetadataOne);
         when(activeStateManager.storeMetadata(tp2)).thenReturn(storeMetadataTwo);
         when(activeStateManager.changelogOffsets()).thenReturn(mkMap(
-            mkEntry(tp, 5L),
-            mkEntry(tp1, 5L),
-            mkEntry(tp2, 5L)
+            Map.entry(tp, 5L),
+            Map.entry(tp1, 5L),
+            Map.entry(tp2, 5L)
         ));
 
         setupConsumer(10, tp);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -110,7 +110,6 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
@@ -306,24 +305,24 @@ public class StreamTaskTest {
             throw new RuntimeException(e);
         }
         return new StreamsConfig(mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, canonicalPath),
-            mkEntry(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, DEBUG.name),
-            mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eosConfig),
-            mkEntry(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, enforcedProcessingValue),
-            mkEntry(StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, deserializationExceptionHandler.getName()),
-            mkEntry(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG, processingExceptionHandler.getName()),
-            mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, timestampExtractor.getName())
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
+            Map.entry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, canonicalPath),
+            Map.entry(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, DEBUG.name),
+            Map.entry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
+            Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eosConfig),
+            Map.entry(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, enforcedProcessingValue),
+            Map.entry(StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, deserializationExceptionHandler.getName()),
+            Map.entry(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG, processingExceptionHandler.getName()),
+            Map.entry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, timestampExtractor.getName())
         )));
     }
 
     @BeforeEach
     public void setup() {
         consumer.assign(asList(partition1, partition2));
-        consumer.updateBeginningOffsets(mkMap(mkEntry(partition1, 0L), mkEntry(partition2, 0L)));
+        consumer.updateBeginningOffsets(mkMap(Map.entry(partition1, 0L), Map.entry(partition2, 0L)));
         stateDirectory = new StateDirectory(createConfig("100"), new MockTime(), true, false);
         // Unless we initialise a lock on the state directory we cannot unlock it successfully during teardown
         stateDirectory.initializeProcessId();
@@ -452,7 +451,7 @@ public class StreamTaskTest {
             }) {
 
             consumer.assign(asList(partition1, partition2));
-            consumer.updateBeginningOffsets(mkMap(mkEntry(partition1, 0L), mkEntry(partition2, 0L)));
+            consumer.updateBeginningOffsets(mkMap(Map.entry(partition1, 0L), Map.entry(partition2, 0L)));
 
             consumer.seek(partition1, 5L);
             consumer.seek(partition2, 15L);
@@ -483,8 +482,8 @@ public class StreamTaskTest {
         stateDirectory = mock(StateDirectory.class);
 
         final ProcessorMetadata processorMetadata = new ProcessorMetadata(mkMap(
-            mkEntry("key1", 1L),
-            mkEntry("key2", 2L)
+            Map.entry("key1", 1L),
+            Map.entry("key2", 2L)
         ));
 
         consumer.commitSync(partitions.stream()
@@ -511,22 +510,22 @@ public class StreamTaskTest {
         stateDirectory = mock(StateDirectory.class);
 
         final ProcessorMetadata processorMetadata1 = new ProcessorMetadata(mkMap(
-            mkEntry("key1", 1L),
-            mkEntry("key2", 2L)
+            Map.entry("key1", 1L),
+            Map.entry("key2", 2L)
         ));
 
         final Map<TopicPartition, OffsetAndMetadata> meta1 = mkMap(
-            mkEntry(partition1, new OffsetAndMetadata(0L, new TopicPartitionMetadata(10L, processorMetadata1).encode())
+            Map.entry(partition1, new OffsetAndMetadata(0L, new TopicPartitionMetadata(10L, processorMetadata1).encode())
             )
         );
 
         final ProcessorMetadata processorMetadata2 = new ProcessorMetadata(mkMap(
-            mkEntry("key1", 10L),
-            mkEntry("key3", 30L)
+            Map.entry("key1", 10L),
+            Map.entry("key3", 30L)
         ));
 
         final Map<TopicPartition, OffsetAndMetadata> meta2 = mkMap(
-            mkEntry(partition2, new OffsetAndMetadata(0L, new TopicPartitionMetadata(20L, processorMetadata2).encode())
+            Map.entry(partition2, new OffsetAndMetadata(0L, new TopicPartitionMetadata(20L, processorMetadata2).encode())
             )
         );
 
@@ -989,8 +988,8 @@ public class StreamTaskTest {
             "stream-task-metrics",
             descriptionIsNotVerified,
             mkMap(
-                mkEntry("task-id", taskId),
-                mkEntry(THREAD_ID_TAG, Thread.currentThread().getName())
+                Map.entry("task-id", taskId),
+                Map.entry(THREAD_ID_TAG, Thread.currentThread().getName())
             )
         ));
     }
@@ -1005,9 +1004,9 @@ public class StreamTaskTest {
             String.format(nameFormat, operation),
             "stream-processor-node-metrics",
             mkMap(
-                mkEntry("task-id", taskId),
-                mkEntry("processor-node-id", processorNodeId),
-                mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()
+                Map.entry("task-id", taskId),
+                Map.entry("processor-node-id", processorNodeId),
+                Map.entry(THREAD_ID_TAG, Thread.currentThread().getName()
                 )
             )
         );
@@ -1321,7 +1320,7 @@ public class StreamTaskTest {
         assertFalse(task.commitNeeded());
 
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> record = mkMap(
-                mkEntry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)))
+                Map.entry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)))
         );
         task.addRecords(partition1, record.get(partition1));
         task.updateNextOffsets(partition1, new OffsetAndMetadata(1, Optional.empty(), ""));
@@ -1378,13 +1377,13 @@ public class StreamTaskTest {
         final TopicPartitionMetadata expected = new TopicPartitionMetadata(3L,
             new ProcessorMetadata(
                 mkMap(
-                    mkEntry("key1", 100L),
-                    mkEntry("key2", 200L)
+                    Map.entry("key1", 100L),
+                    Map.entry("key2", 200L)
                 )
             )
         );
 
-        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, Optional.of(2), expected.encode())))));
+        assertThat(offsetsAndMetadata, equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(5L, Optional.of(2), expected.encode())))));
     }
 
     @Test
@@ -1415,7 +1414,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(task.prepareCommit(), equalTo(
                 mkMap(
-                        mkEntry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode()))
+                        Map.entry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode()))
                 )
         ));
 
@@ -1432,8 +1431,8 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(task.prepareCommit(), equalTo(
             mkMap(
-                mkEntry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode())),
-                mkEntry(partition2, new OffsetAndMetadata(1L, Optional.of(0), metadata.encode()))
+                Map.entry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode())),
+                Map.entry(partition2, new OffsetAndMetadata(1L, Optional.of(0), metadata.encode()))
             )
         ));
         task.postCommit(false);
@@ -1471,7 +1470,7 @@ public class StreamTaskTest {
         final TopicPartitionMetadata expectedMetadata1 = new TopicPartitionMetadata(0L,
             new ProcessorMetadata(
                 mkMap(
-                    mkEntry("key1", 100L)
+                    Map.entry("key1", 100L)
                 )
             )
         );
@@ -1479,7 +1478,7 @@ public class StreamTaskTest {
         final TopicPartitionMetadata expectedMetadata2 = new TopicPartitionMetadata(RecordQueue.UNKNOWN,
             new ProcessorMetadata(
                 mkMap(
-                    mkEntry("key1", 100L)
+                    Map.entry("key1", 100L)
                 )
             )
         );
@@ -1488,8 +1487,8 @@ public class StreamTaskTest {
 
         assertThat(task.prepareCommit(), equalTo(
             mkMap(
-                mkEntry(partition1, new OffsetAndMetadata(1L,  Optional.of(1), expectedMetadata1.encode())),
-                mkEntry(partition2, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata2.encode()))
+                Map.entry(partition1, new OffsetAndMetadata(1L,  Optional.of(1), expectedMetadata1.encode())),
+                Map.entry(partition2, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata2.encode()))
             )));
         task.postCommit(false);
 
@@ -1502,7 +1501,7 @@ public class StreamTaskTest {
         final TopicPartitionMetadata expectedMetadata3 = new TopicPartitionMetadata(1L,
             new ProcessorMetadata(
                 mkMap(
-                    mkEntry("key1", 100L)
+                    Map.entry("key1", 100L)
                 )
             )
         );
@@ -1510,7 +1509,7 @@ public class StreamTaskTest {
 
         // Processor metadata not updated, we just need to commit to partition1 again with new offset
         assertThat(task.prepareCommit(), equalTo(
-                mkMap(mkEntry(partition1, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata3.encode())))
+                mkMap(Map.entry(partition1, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata3.encode())))
         ));
         task.postCommit(false);
 
@@ -1958,11 +1957,11 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = withRepartitionTopics(
             asList(source1, source2),
-            mkMap(mkEntry(topic1, source1), mkEntry(repartition.topic(), source2)),
+            mkMap(Map.entry(topic1, source1), Map.entry(repartition.topic(), source2)),
             singleton(repartition.topic())
         );
         consumer.assign(asList(partition1, repartition));
-        consumer.updateBeginningOffsets(mkMap(mkEntry(repartition, 0L)));
+        consumer.updateBeginningOffsets(mkMap(Map.entry(repartition, 0L)));
 
         final StreamsConfig config = createConfig();
         final InternalProcessorContext<?, ?> context = new ProcessorContextImpl(
@@ -1995,8 +1994,8 @@ public class StreamTaskTest {
 
 
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = mkMap(
-                mkEntry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L))),
-                mkEntry(repartition, singletonList(getConsumerRecordWithOffsetAsTimestamp(repartition, 10L)))
+                Map.entry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L))),
+                Map.entry(repartition, singletonList(getConsumerRecordWithOffsetAsTimestamp(repartition, 10L)))
         );
 
         task.addRecords(partition1, records.get(partition1));
@@ -2269,7 +2268,7 @@ public class StreamTaskTest {
         task.completeRestoration(noOpResetter -> { });
 
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> record = mkMap(
-                mkEntry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L)))
+                Map.entry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L)))
         );
         task.addRecords(partition1, record.get(partition1));
         task.updateNextOffsets(partition1, new OffsetAndMetadata(6, Optional.empty(), ""));
@@ -2300,7 +2299,7 @@ public class StreamTaskTest {
         task.completeRestoration(noOpResetter -> { }); // should checkpoint
 
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> record = mkMap(
-                mkEntry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset))));
+                Map.entry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset))));
         task.addRecords(partition1, record.get(partition1));
         task.updateNextOffsets(partition1, new OffsetAndMetadata(offset + 1, Optional.empty(), ""));
         task.process(100L);
@@ -2361,7 +2360,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
 
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> record = mkMap(
-                mkEntry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset))));
+                Map.entry(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset))));
         task.addRecords(partition1, record.get(partition1));
         task.updateNextOffsets(partition1, new OffsetAndMetadata(offset + 1, Optional.empty(), ""));
 
@@ -2486,8 +2485,8 @@ public class StreamTaskTest {
         newPartitions.add(new TopicPartition("newTopic", 0));
 
         task.updateInputPartitions(newPartitions, mkMap(
-            mkEntry(source1.name(), asList(topic1, "newTopic")),
-            mkEntry(source2.name(), singletonList(topic2)))
+            Map.entry(source1.name(), asList(topic1, "newTopic")),
+            Map.entry(source2.name(), singletonList(topic2)))
         );
 
         assertThat(task.inputPartitions(), equalTo(newPartitions));
@@ -2673,7 +2672,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
+            equalTo(mkMap(Map.entry(partition1,
                 new OffsetAndMetadata(offset + 1,
                     new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode()))))
         );
@@ -2705,7 +2704,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
         );
     }
 
@@ -2735,14 +2734,14 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
         );
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
         );
     }
 
@@ -2772,7 +2771,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
+            equalTo(mkMap(Map.entry(partition1,
                 new OffsetAndMetadata(offset + 1,
                     new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode()))))
         );
@@ -2804,7 +2803,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
         );
     }
 
@@ -2835,14 +2834,14 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
         );
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
         assertThat(
             task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+            equalTo(mkMap(Map.entry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
         );
     }
 
@@ -3054,7 +3053,7 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
             singletonList(source1),
-            mkMap(mkEntry(topic1, source1)),
+            mkMap(Map.entry(topic1, source1)),
             singletonList(stateStore),
             Collections.singletonMap(storeName, topic1));
 
@@ -3089,7 +3088,7 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
             asList(source1, source2),
-            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2)),
+            mkMap(Map.entry(topic1, source1), Map.entry(topic2, source2)),
             singletonList(stateStore),
             emptyMap());
 
@@ -3129,7 +3128,7 @@ public class StreamTaskTest {
     private StreamTask createFaultyStatefulTask(final StreamsConfig config) {
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
             asList(source1, source3),
-            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source3)),
+            mkMap(Map.entry(topic1, source1), Map.entry(topic2, source3)),
             singletonList(stateStore),
             emptyMap()
         );
@@ -3169,7 +3168,7 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
             asList(source1, source2),
-            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2)),
+            mkMap(Map.entry(topic1, source1), Map.entry(topic2, source2)),
             singletonList(stateStore),
             logged ? Collections.singletonMap(storeName, storeName + "-changelog") : Collections.emptyMap());
 
@@ -3202,7 +3201,7 @@ public class StreamTaskTest {
     private StreamTask createSingleSourceStateless(final StreamsConfig config) {
         final ProcessorTopology topology = withSources(
             asList(source1, processorStreamTime, processorSystemTime),
-            mkMap(mkEntry(topic1, source1))
+            mkMap(Map.entry(topic1, source1))
         );
 
         source1.addChild(processorStreamTime);
@@ -3237,7 +3236,7 @@ public class StreamTaskTest {
     private StreamTask createStatelessTask(final StreamsConfig config) {
         final ProcessorTopology topology = withSources(
             asList(source1, source2, processorStreamTime, processorSystemTime),
-            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2))
+            mkMap(Map.entry(topic1, source1), Map.entry(topic2, source2))
         );
 
         source1.addChild(processorStreamTime);
@@ -3310,7 +3309,7 @@ public class StreamTaskTest {
     private void createTimeoutTask(final String eosConfig) {
         final ProcessorTopology topology = withSources(
             singletonList(timeoutSource),
-            mkMap(mkEntry(topic1, timeoutSource))
+            mkMap(Map.entry(topic1, timeoutSource))
         );
 
         final StreamsConfig config = createConfig(eosConfig, "0");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -135,7 +135,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.adminClientId;
@@ -255,17 +254,17 @@ public class StreamThreadTest {
 
     private Properties configProps(final boolean enableEoS, final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         return mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
-            mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
-            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath()),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, enableEoS ? StreamsConfig.EXACTLY_ONCE_V2 : StreamsConfig.AT_LEAST_ONCE),
-            mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName()),
-            mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName()),
-            mkEntry(InternalConfig.STATE_UPDATER_ENABLED, Boolean.toString(stateUpdaterEnabled)),
-            mkEntry(InternalConfig.PROCESSING_THREADS_ENABLED, Boolean.toString(processingThreadsEnabled)),
-            mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "1")
+            Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
+            Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
+            Map.entry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
+            Map.entry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
+            Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath()),
+            Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, enableEoS ? StreamsConfig.EXACTLY_ONCE_V2 : StreamsConfig.AT_LEAST_ONCE),
+            Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName()),
+            Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName()),
+            Map.entry(InternalConfig.STATE_UPDATER_ENABLED, Boolean.toString(stateUpdaterEnabled)),
+            Map.entry(InternalConfig.PROCESSING_THREADS_ENABLED, Boolean.toString(processingThreadsEnabled)),
+            Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "1")
         ));
     }
 
@@ -368,7 +367,7 @@ public class StreamThreadTest {
 
         final StateListenerStub stateListener = new StateListenerStub();
         thread.setStateListener(stateListener);
-        assertEquals(thread.state(), StreamThread.State.CREATED);
+        assertEquals(thread.state(), State.CREATED);
 
         final ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener();
 
@@ -376,11 +375,11 @@ public class StreamThreadTest {
         final List<TopicPartition> assignedPartitions;
 
         // revoke nothing
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         revokedPartitions = Collections.emptyList();
         rebalanceListener.onPartitionsRevoked(revokedPartitions);
 
-        assertEquals(thread.state(), StreamThread.State.PARTITIONS_REVOKED);
+        assertEquals(thread.state(), State.PARTITIONS_REVOKED);
 
         // assign single partition
         assignedPartitions = Collections.singletonList(t1p1);
@@ -390,12 +389,12 @@ public class StreamThreadTest {
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         rebalanceListener.onPartitionsAssigned(assignedPartitions);
         runOnce(processingThreadsEnabled);
-        assertEquals(thread.state(), StreamThread.State.RUNNING);
+        assertEquals(thread.state(), State.RUNNING);
         assertEquals(4, stateListener.numChanges);
-        assertEquals(StreamThread.State.PARTITIONS_ASSIGNED, stateListener.oldState);
+        assertEquals(State.PARTITIONS_ASSIGNED, stateListener.oldState);
 
         thread.shutdown();
-        assertSame(StreamThread.State.PENDING_SHUTDOWN, thread.state());
+        assertSame(State.PENDING_SHUTDOWN, thread.state());
     }
 
     @ParameterizedTest
@@ -408,18 +407,18 @@ public class StreamThreadTest {
 
         thread.start();
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.STARTING,
+            () -> thread.state() == State.STARTING,
             10 * 1000,
             "Thread never started.");
 
         thread.shutdown();
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.DEAD,
+            () -> thread.state() == State.DEAD,
             10 * 1000,
             "Thread never shut down.");
 
         thread.shutdown();
-        assertEquals(thread.state(), StreamThread.State.DEAD);
+        assertEquals(thread.state(), State.DEAD);
     }
 
     @ParameterizedTest
@@ -497,7 +496,7 @@ public class StreamThreadTest {
 
         final String taskGroupName = "stream-task-metrics";
         final Map<String, String> taskTags =
-            mkMap(mkEntry("task-id", "all"), mkEntry("thread-id", thread.getName()));
+            mkMap(Map.entry("task-id", "all"), Map.entry("thread-id", thread.getName()));
         assertNull(metrics.metrics().get(metrics.metricName(
             "commit-latency-avg", taskGroupName, descriptionIsNotVerified, taskTags)));
         assertNull(metrics.metrics().get(metrics.metricName(
@@ -760,13 +759,13 @@ public class StreamThreadTest {
 
         thread.start();
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.STARTING,
+            () -> thread.state() == State.STARTING,
             10 * 1000,
             "Thread never started.");
 
         thread.shutdown();
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.DEAD,
+            () -> thread.state() == State.DEAD,
             10 * 1000,
             "Thread never shut down.");
 
@@ -824,7 +823,7 @@ public class StreamThreadTest {
 
         thread.start();
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.STARTING,
+            () -> thread.state() == State.STARTING,
             10 * 1000,
             "Thread never started.");
 
@@ -842,7 +841,7 @@ public class StreamThreadTest {
         thread.taskManager().handleRebalanceComplete();
 
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.DEAD,
+            () -> thread.state() == State.DEAD,
             10 * 1000,
             "Thread never shut down.");
 
@@ -864,7 +863,7 @@ public class StreamThreadTest {
 
         AtomicLong nextRebalanceMs() {
             return ((ReferenceContainer) consumerConfigs.get(
-                    StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR)
+                    InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR)
                 ).nextScheduledRebalanceMs;
         }
     }
@@ -903,8 +902,8 @@ public class StreamThreadTest {
                                                                                          properties));
         thread = createStreamThread(CLIENT_ID, config);
 
-        thread.setState(StreamThread.State.STARTING);
-        thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+        thread.setState(State.STARTING);
+        thread.setState(State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
@@ -1175,7 +1174,7 @@ public class StreamThreadTest {
 
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
         thread.updateThreadMetadata("adminClientId");
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
         activeTasks.put(task1, Collections.singleton(t1p1));
@@ -1238,7 +1237,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, stateUpdaterEnabled, processingThreadsEnabled));
         thread = createStreamThread(CLIENT_ID, config);
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1277,7 +1276,7 @@ public class StreamThreadTest {
         final Properties props = configProps(true, stateUpdaterEnabled, processingThreadsEnabled);
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(props));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1336,7 +1335,7 @@ public class StreamThreadTest {
 
         thread.start();
         TestUtils.waitForCondition(
-                () -> thread.state() == StreamThread.State.STARTING,
+                () -> thread.state() == State.STARTING,
                 10 * 1000,
                 "Thread never started.");
 
@@ -1349,12 +1348,12 @@ public class StreamThreadTest {
 
         Thread.sleep(1000);
         assertEquals(Set.of(task1, task2), thread.taskManager().activeTaskIds());
-        assertEquals(StreamThread.State.PENDING_SHUTDOWN, thread.state());
+        assertEquals(State.PENDING_SHUTDOWN, thread.state());
 
         thread.rebalanceListener().onPartitionsAssigned(assignedPartitions);
 
         TestUtils.waitForCondition(
-            () -> thread.state() == StreamThread.State.DEAD,
+            () -> thread.state() == State.DEAD,
             10 * 1000,
             "Thread never shut down.");
         assertEquals(Collections.emptySet(), thread.taskManager().activeTaskIds());
@@ -1377,7 +1376,7 @@ public class StreamThreadTest {
             .updateThreadMetadata(adminClientId(CLIENT_ID));
         thread.setStateListener(
             (t, newState, oldState) -> {
-                if (oldState == StreamThread.State.CREATED && newState == StreamThread.State.STARTING) {
+                if (oldState == State.CREATED && newState == State.STARTING) {
                     thread.shutdown();
                 }
             });
@@ -1511,7 +1510,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, stateUpdaterEnabled, processingThreadsEnabled));
         thread = createStreamThread(CLIENT_ID, config);
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -1537,7 +1536,7 @@ public class StreamThreadTest {
 
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1602,7 +1601,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1684,7 +1683,7 @@ public class StreamThreadTest {
         );
         internalTopologyBuilder.buildTopology();
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1699,12 +1698,12 @@ public class StreamThreadTest {
         final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer();
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(mkMap(
-                mkEntry(t1p1, 0L)
+                Map.entry(t1p1, 0L)
         ));
 
         final MockConsumer<byte[], byte[]> restoreConsumer = (MockConsumer<byte[], byte[]>) thread.restoreConsumer();
         restoreConsumer.updateBeginningOffsets(mkMap(
-                mkEntry(storeChangelogTopicPartition, 0L)
+                Map.entry(storeChangelogTopicPartition, 0L)
         ));
         final MockAdminClient admin = (MockAdminClient) thread.adminClient();
         admin.updateEndOffsets(singletonMap(storeChangelogTopicPartition, 0L));
@@ -1778,7 +1777,7 @@ public class StreamThreadTest {
 
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1842,7 +1841,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1923,7 +1922,7 @@ public class StreamThreadTest {
             HANDLER
         );
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1943,7 +1942,7 @@ public class StreamThreadTest {
         runOnce(processingThreadsEnabled);
 
         final ThreadMetadata metadata = thread.threadMetadata();
-        assertEquals(StreamThread.State.RUNNING.name(), metadata.threadState());
+        assertEquals(State.RUNNING.name(), metadata.threadState());
         assertTrue(metadata.activeTasks().contains(new TaskMetadataImpl(task1, Set.of(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
         assertTrue(metadata.standbyTasks().isEmpty());
 
@@ -1983,7 +1982,7 @@ public class StreamThreadTest {
         restoreConsumer.updateEndOffsets(offsets);
         restoreConsumer.updateBeginningOffsets(offsets);
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -1998,7 +1997,7 @@ public class StreamThreadTest {
         runOnce(processingThreadsEnabled);
 
         final ThreadMetadata threadMetadata = thread.threadMetadata();
-        assertEquals(StreamThread.State.RUNNING.name(), threadMetadata.threadState());
+        assertEquals(State.RUNNING.name(), threadMetadata.threadState());
         assertTrue(threadMetadata.standbyTasks().contains(new TaskMetadataImpl(task1, Set.of(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
         assertTrue(threadMetadata.activeTasks().isEmpty());
     }
@@ -2107,7 +2106,7 @@ public class StreamThreadTest {
             = new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(task3), CHECKPOINT_FILE_NAME));
         checkpoint.write(Collections.singletonMap(partition2, 5L));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -2246,7 +2245,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, stateUpdaterEnabled, processingThreadsEnabled));
         thread = createStreamThread(CLIENT_ID, config);
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2325,7 +2324,7 @@ public class StreamThreadTest {
         final long currTime = mockTime.milliseconds();
         thread = createStreamThread(CLIENT_ID, stateUpdaterEnabled, processingThreadsEnabled);
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2375,14 +2374,14 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, stateUpdaterEnabled, processingThreadsEnabled));
         thread = createStreamThread(CLIENT_ID, config);
         ThreadMetadata metadata = thread.threadMetadata();
-        assertEquals(StreamThread.State.CREATED.name(), metadata.threadState());
+        assertEquals(State.CREATED.name(), metadata.threadState());
 
-        thread.setState(StreamThread.State.STARTING);
-        thread.setState(StreamThread.State.PARTITIONS_REVOKED);
-        thread.setState(StreamThread.State.PARTITIONS_ASSIGNED);
-        thread.setState(StreamThread.State.RUNNING);
+        thread.setState(State.STARTING);
+        thread.setState(State.PARTITIONS_REVOKED);
+        thread.setState(State.PARTITIONS_ASSIGNED);
+        thread.setState(State.RUNNING);
         metadata = thread.threadMetadata();
-        assertEquals(StreamThread.State.RUNNING.name(), metadata.threadState());
+        assertEquals(State.RUNNING.name(), metadata.threadState());
     }
 
     @ParameterizedTest
@@ -2442,7 +2441,7 @@ public class StreamThreadTest {
         mockAdminClient.updateEndOffsets(Collections.singletonMap(changelogPartition, 2L));
 
         mockConsumer.schedulePollTask(() -> {
-            thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+            thread.setState(State.PARTITIONS_REVOKED);
             thread.rebalanceListener().onPartitionsAssigned(topicPartitionSet);
         });
 
@@ -2522,8 +2521,8 @@ public class StreamThreadTest {
         properties.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(properties));
 
-        thread.setState(StreamThread.State.STARTING);
-        thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+        thread.setState(State.STARTING);
+        thread.setState(State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
@@ -2596,11 +2595,11 @@ public class StreamThreadTest {
             .updateThreadMetadata(adminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
-            thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+            thread.setState(State.PARTITIONS_REVOKED);
             thread.rebalanceListener().onPartitionsLost(assignedPartitions);
         });
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         assertThrows(TaskMigratedException.class, () -> runOnce(processingThreadsEnabled));
     }
 
@@ -2626,11 +2625,11 @@ public class StreamThreadTest {
             .updateThreadMetadata(adminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
-            thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+            thread.setState(State.PARTITIONS_REVOKED);
             thread.rebalanceListener().onPartitionsRevoked(assignedPartitions);
         });
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         assertThrows(TaskMigratedException.class, () -> runOnce(processingThreadsEnabled));
     }
 
@@ -2812,7 +2811,7 @@ public class StreamThreadTest {
             }
         }.updateThreadMetadata(adminClientId(CLIENT_ID));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.runLoop();
 
         verify(consumer, times(2)).subscribe((Collection<String>) any(), any());
@@ -2875,7 +2874,7 @@ public class StreamThreadTest {
             }
         }.updateThreadMetadata(adminClientId(CLIENT_ID));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.runLoop();
 
         verify(consumer).subscribe((Collection<String>) any(), any());
@@ -2935,7 +2934,7 @@ public class StreamThreadTest {
             }
         }.updateThreadMetadata(adminClientId(CLIENT_ID));
 
-        thread.setState(StreamThread.State.STARTING);
+        thread.setState(State.STARTING);
         thread.runLoop();
 
         verify(consumer).subscribe((Collection<String>) any(), any());
@@ -2962,9 +2961,9 @@ public class StreamThreadTest {
         when(task3.state()).thenReturn(Task.State.CREATED);
 
         when(taskManager.allOwnedTasks()).thenReturn(mkMap(
-            mkEntry(taskId1, task1),
-            mkEntry(taskId2, task2),
-            mkEntry(taskId3, task3)
+            Map.entry(taskId1, task1),
+            Map.entry(taskId2, task2),
+            Map.entry(taskId3, task3)
         ));
 
         // expect not to try and commit task3, because it's not running.
@@ -2997,8 +2996,8 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(properties);
         thread = createStreamThread(CLIENT_ID, config);
 
-        thread.setState(StreamThread.State.STARTING);
-        thread.setState(StreamThread.State.PARTITIONS_REVOKED);
+        thread.setState(State.STARTING);
+        thread.setState(State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
@@ -3214,14 +3213,14 @@ public class StreamThreadTest {
         ) {
             @Override
             void runOnceWithProcessingThreads() {
-                setState(StreamThread.State.PENDING_SHUTDOWN);
+                setState(State.PENDING_SHUTDOWN);
                 if (shouldFail) {
                     throw new StreamsException(Thread.currentThread().getName());
                 }
             }
             @Override
             void runOnceWithoutProcessingThreads() {
-                setState(StreamThread.State.PENDING_SHUTDOWN);
+                setState(State.PENDING_SHUTDOWN);
                 if (shouldFail) {
                     throw new StreamsException(Thread.currentThread().getName());
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -114,7 +114,6 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assignTasksToThreads;
@@ -398,9 +397,9 @@ public class StreamsPartitionAssignorTest {
                 asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3);
 
         final Map<String, List<TaskId>> previousAssignment = mkMap(
-            mkEntry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
-            mkEntry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
-            mkEntry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
+            Map.entry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
+            Map.entry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
+            Map.entry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
         );
 
         final ClientState state = new ClientState();
@@ -431,9 +430,9 @@ public class StreamsPartitionAssignorTest {
             new ArrayList<>(asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3));
 
         final Map<String, List<TaskId>> previousAssignment = mkMap(
-            mkEntry(CONSUMER_1, new ArrayList<>(asList(TASK_0_0, TASK_1_1, TASK_1_3))),
-            mkEntry(CONSUMER_2, new ArrayList<>(asList(TASK_0_3, TASK_1_0))),
-            mkEntry(CONSUMER_3, new ArrayList<>(asList(TASK_0_1, TASK_0_2, TASK_1_2)))
+            Map.entry(CONSUMER_1, new ArrayList<>(asList(TASK_0_0, TASK_1_1, TASK_1_3))),
+            Map.entry(CONSUMER_2, new ArrayList<>(asList(TASK_0_3, TASK_1_0))),
+            Map.entry(CONSUMER_3, new ArrayList<>(asList(TASK_0_1, TASK_0_2, TASK_1_2)))
         );
 
         final ClientState state = new ClientState();
@@ -470,9 +469,9 @@ public class StreamsPartitionAssignorTest {
             asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3);
 
         final Map<String, List<TaskId>> previousAssignment = mkMap(
-            mkEntry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
-            mkEntry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
-            mkEntry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
+            Map.entry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
+            Map.entry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
+            Map.entry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
         );
 
         final ClientState state = new ClientState();
@@ -511,9 +510,9 @@ public class StreamsPartitionAssignorTest {
             asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3);
 
         final Map<String, List<TaskId>> previousAssignment = mkMap(
-            mkEntry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
-            mkEntry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
-            mkEntry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
+            Map.entry(CONSUMER_1, asList(TASK_0_0, TASK_1_1, TASK_1_3)),
+            Map.entry(CONSUMER_2, asList(TASK_0_3, TASK_1_0)),
+            Map.entry(CONSUMER_3, asList(TASK_0_1, TASK_0_2, TASK_1_2))
         );
 
         final ClientState state = new ClientState();
@@ -558,9 +557,9 @@ public class StreamsPartitionAssignorTest {
             asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1);
 
         final Map<String, List<TaskId>> assignment = mkMap(
-            mkEntry(CONSUMER_1, new ArrayList<>(asList(TASK_0_0, TASK_0_3, TASK_1_2))),
-            mkEntry(CONSUMER_2, new ArrayList<>(asList(TASK_0_1, TASK_1_0, TASK_2_0))),
-            mkEntry(CONSUMER_3, new ArrayList<>(asList(TASK_0_2, TASK_1_1, TASK_2_1)))
+            Map.entry(CONSUMER_1, new ArrayList<>(asList(TASK_0_0, TASK_0_3, TASK_1_2))),
+            Map.entry(CONSUMER_2, new ArrayList<>(asList(TASK_0_1, TASK_1_0, TASK_2_0))),
+            Map.entry(CONSUMER_3, new ArrayList<>(asList(TASK_0_2, TASK_1_1, TASK_2_1)))
         );
 
         final ClientState state = new ClientState();
@@ -666,7 +665,7 @@ public class StreamsPartitionAssignorTest {
             true
         );
 
-        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(Map.entry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(
@@ -1299,7 +1298,7 @@ public class StreamsPartitionAssignorTest {
             true
         );
         final Map<String, List<TopicPartitionInfo>> changelogTopicPartitionInfo = mkMap(
-            mkEntry(APPLICATION_ID + "-store1-changelog",
+            Map.entry(APPLICATION_ID + "-store1-changelog",
                 asList(
                     new TopicPartitionInfo(0, NODE_0, asList(REPLICA_0), asList(REPLICA_0)),
                     new TopicPartitionInfo(1, NODE_1, asList(REPLICA_1), asList(REPLICA_1)),
@@ -1902,13 +1901,13 @@ public class StreamsPartitionAssignorTest {
     public void shouldUpdateClusterMetadataAndHostInfoOnAssignment(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, false);
         final Map<HostInfo, Set<TopicPartition>> initialHostState = mkMap(
-            mkEntry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
-            mkEntry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
+            Map.entry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
+            Map.entry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
         );
 
         final Map<HostInfo, Set<TopicPartition>> newHostState = mkMap(
-            mkEntry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
-            mkEntry(new HostInfo("newotherhost", 9090), Set.of(t2p0, t2p1))
+            Map.entry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
+            Map.entry(new HostInfo("newotherhost", 9090), Set.of(t2p0, t2p1))
         );
 
         streamsMetadataState = mock(StreamsMetadataState.class);
@@ -1928,13 +1927,13 @@ public class StreamsPartitionAssignorTest {
     public void shouldTriggerImmediateRebalanceOnHostInfoChange(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, false);
         final Map<HostInfo, Set<TopicPartition>> oldHostState = mkMap(
-            mkEntry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
-            mkEntry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
+            Map.entry(new HostInfo("localhost", 9090), Set.of(t1p0, t1p1)),
+            Map.entry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
         );
 
         final Map<HostInfo, Set<TopicPartition>> newHostState = mkMap(
-            mkEntry(new HostInfo("newhost", 9090), Set.of(t1p0, t1p1)),
-            mkEntry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
+            Map.entry(new HostInfo("newhost", 9090), Set.of(t1p0, t1p1)),
+            Map.entry(new HostInfo("otherhost", 9090), Set.of(t2p0, t2p1))
         );
 
         createDefaultMockTaskManager();
@@ -2518,7 +2517,7 @@ public class StreamsPartitionAssignorTest {
                           ));
 
         configureDefault(parameterizedConfig);
-        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(Map.entry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(
@@ -2573,7 +2572,7 @@ public class StreamsPartitionAssignorTest {
             ));
 
         configureDefault(parameterizedConfig);
-        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(mkEntry(
+        final List<Map<String, List<TopicPartitionInfo>>> partitionInfo = singletonList(mkMap(Map.entry(
                 "stream-partition-assignor-test-store-changelog",
                 singletonList(
                     new TopicPartitionInfo(
@@ -2739,7 +2738,7 @@ public class StreamsPartitionAssignorTest {
     @MethodSource("parameter")
     public void testClientTags(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, false);
-        clientTags = mkMap(mkEntry("cluster", "cluster1"), mkEntry("zone", "az1"));
+        clientTags = mkMap(Map.entry("cluster", "cluster1"), Map.entry("zone", "az1"));
         createDefaultMockTaskManager();
         configureDefaultPartitionAssignor(parameterizedConfig);
         final Set<String> topics = Set.of("input");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -95,7 +95,6 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.intersection;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNAMED_TOPOLOGY;
@@ -250,9 +249,9 @@ public class TaskManagerTest {
     @Test
     public void shouldClassifyExistingTasksWithoutStateUpdater() {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, false);
-        final Map<TaskId, Set<TopicPartition>> runningActiveTasks = mkMap(mkEntry(taskId01, Set.of(t1p1)));
-        final Map<TaskId, Set<TopicPartition>> standbyTasks = mkMap(mkEntry(taskId02, Set.of(t2p2)));
-        final Map<TaskId, Set<TopicPartition>> restoringActiveTasks = mkMap(mkEntry(taskId03, Set.of(t1p3)));
+        final Map<TaskId, Set<TopicPartition>> runningActiveTasks = mkMap(Map.entry(taskId01, Set.of(t1p1)));
+        final Map<TaskId, Set<TopicPartition>> standbyTasks = mkMap(Map.entry(taskId02, Set.of(t2p2)));
+        final Map<TaskId, Set<TopicPartition>> restoringActiveTasks = mkMap(Map.entry(taskId03, Set.of(t1p3)));
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>(runningActiveTasks);
         activeTasks.putAll(restoringActiveTasks);
         handleAssignment(runningActiveTasks, standbyTasks, restoringActiveTasks);
@@ -288,7 +287,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(
             Collections.emptyMap(),
-            mkMap(mkEntry(standbyTask.id(), newInputPartition))
+            mkMap(Map.entry(standbyTask.id(), newInputPartition))
         );
 
         verify(standbyTask).resume();
@@ -341,8 +340,8 @@ public class TaskManagerTest {
         when(schedulingTaskManager.lockTasks(any())).thenReturn(mockFuture);
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(taskId00, taskId00Partitions)),
-                mkMap(mkEntry(taskId01, taskId01Partitions))
+            mkMap(Map.entry(taskId00, taskId00Partitions)),
+                mkMap(Map.entry(taskId01, taskId01Partitions))
         );
 
         verify(schedulingTaskManager).lockTasks(Set.of(taskId00, taskId01));
@@ -547,7 +546,7 @@ public class TaskManagerTest {
         future.complete(new StateUpdater.RemovedTaskResult(activeTaskToUpdateInputPartitions));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(activeTaskToUpdateInputPartitions.id(), newInputPartitions)),
+            mkMap(Map.entry(activeTaskToUpdateInputPartitions.id(), newInputPartitions)),
             Collections.emptyMap()
         );
 
@@ -578,7 +577,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(
             Collections.emptyMap(),
-            mkMap(mkEntry(activeTaskToRecycle.id(), activeTaskToRecycle.inputPartitions()))
+            mkMap(Map.entry(activeTaskToRecycle.id(), activeTaskToRecycle.inputPartitions()))
         );
 
         verify(tasks).addPendingTasksToInit(Collections.singleton(recycledStandbyTask));
@@ -604,7 +603,7 @@ public class TaskManagerTest {
             StreamsException.class,
             () -> taskManager.handleAssignment(
                 Collections.emptyMap(),
-                mkMap(mkEntry(activeTaskToRecycle.id(), activeTaskToRecycle.inputPartitions()))
+                mkMap(Map.entry(activeTaskToRecycle.id(), activeTaskToRecycle.inputPartitions()))
             )
         );
 
@@ -631,7 +630,7 @@ public class TaskManagerTest {
         future.complete(new StateUpdater.RemovedTaskResult(standbyTaskToRecycle));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
+            mkMap(Map.entry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -660,7 +659,7 @@ public class TaskManagerTest {
         assertThrows(
             StreamsException.class,
             () -> taskManager.handleAssignment(
-                mkMap(mkEntry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
+                mkMap(Map.entry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
                 Collections.emptyMap()
             )
         );
@@ -680,7 +679,7 @@ public class TaskManagerTest {
         when(stateUpdater.tasks()).thenReturn(Set.of(reassignedActiveTask));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(reassignedActiveTask.id(), reassignedActiveTask.inputPartitions())),
+            mkMap(Map.entry(reassignedActiveTask.id(), reassignedActiveTask.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -699,7 +698,7 @@ public class TaskManagerTest {
         when(tasks.allNonFailedTasks()).thenReturn(Set.of(reassignedActiveTask));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(reassignedActiveTask.id(), reassignedActiveTask.inputPartitions())),
+            mkMap(Map.entry(reassignedActiveTask.id(), reassignedActiveTask.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -727,7 +726,7 @@ public class TaskManagerTest {
             StreamsException.class,
             () -> taskManager.handleAssignment(
                 Collections.emptyMap(),
-                mkMap(mkEntry(failedActiveTaskToRecycle.id(), failedActiveTaskToRecycle.inputPartitions()))
+                mkMap(Map.entry(failedActiveTaskToRecycle.id(), failedActiveTaskToRecycle.inputPartitions()))
             )
         );
 
@@ -756,7 +755,7 @@ public class TaskManagerTest {
         final StreamsException exception = assertThrows(
             StreamsException.class,
             () -> taskManager.handleAssignment(
-                mkMap(mkEntry(failedStandbyTaskToRecycle.id(), failedStandbyTaskToRecycle.inputPartitions())),
+                mkMap(Map.entry(failedStandbyTaskToRecycle.id(), failedStandbyTaskToRecycle.inputPartitions())),
                 Collections.emptyMap()
             )
         );
@@ -786,7 +785,7 @@ public class TaskManagerTest {
         final StreamsException exception = assertThrows(
             StreamsException.class,
             () -> taskManager.handleAssignment(
-                mkMap(mkEntry(failedActiveTaskToReassign.id(), taskId00Partitions)),
+                mkMap(Map.entry(failedActiveTaskToReassign.id(), taskId00Partitions)),
                 Collections.emptyMap()
             )
         );
@@ -816,8 +815,8 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(
             mkMap(
-                mkEntry(reassignedActiveTask1.id(), reassignedActiveTask1.inputPartitions()),
-                mkEntry(reassignedActiveTask2.id(), taskId00Partitions)
+                Map.entry(reassignedActiveTask1.id(), reassignedActiveTask1.inputPartitions()),
+                Map.entry(reassignedActiveTask2.id(), taskId00Partitions)
             ),
             Collections.emptyMap()
         );
@@ -839,7 +838,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(
             Collections.emptyMap(),
-            mkMap(mkEntry(standbyTaskToUpdateInputPartitions.id(), taskId03Partitions))
+            mkMap(Map.entry(standbyTaskToUpdateInputPartitions.id(), taskId03Partitions))
         );
         verify(stateUpdater, never()).remove(standbyTaskToUpdateInputPartitions.id());
         verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
@@ -857,7 +856,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(
             Collections.emptyMap(),
-            mkMap(mkEntry(reassignedStandbyTask.id(), reassignedStandbyTask.inputPartitions()))
+            mkMap(Map.entry(reassignedStandbyTask.id(), reassignedStandbyTask.inputPartitions()))
         );
 
         verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
@@ -888,7 +887,7 @@ public class TaskManagerTest {
         futureForStandbyTaskToRecycle.complete(new StateUpdater.RemovedTaskResult(standbyTaskToRecycle));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
+            mkMap(Map.entry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -914,14 +913,14 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
 
         when(stateUpdater.tasks()).thenReturn(Set.of(standbyTaskInStateUpdater));
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, runningActiveTask)));
+        when(tasks.allTasksPerId()).thenReturn(mkMap(Map.entry(taskId03, runningActiveTask)));
         when(tasks.pendingTasksToInit()).thenReturn(Set.of(activeTaskToInit));
         assertEquals(
             taskManager.allTasks(),
             mkMap(
-                mkEntry(taskId03, runningActiveTask),
-                mkEntry(taskId02, standbyTaskInStateUpdater),
-                mkEntry(taskId01, activeTaskToInit)
+                Map.entry(taskId03, runningActiveTask),
+                Map.entry(taskId02, standbyTaskInStateUpdater),
+                Map.entry(taskId01, activeTaskToInit)
             )
         );
     }
@@ -937,8 +936,8 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
 
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, activeTask)));
-        assertEquals(taskManager.allOwnedTasks(), mkMap(mkEntry(taskId03, activeTask)));
+        when(tasks.allTasksPerId()).thenReturn(mkMap(Map.entry(taskId03, activeTask)));
+        assertEquals(taskManager.allOwnedTasks(), mkMap(Map.entry(taskId03, activeTask)));
     }
 
     @Test
@@ -950,7 +949,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
         final Set<Task> createdTasks = Set.of(activeTaskToBeCreated);
         final Map<TaskId, Set<TopicPartition>> tasksToBeCreated = mkMap(
-            mkEntry(activeTaskToBeCreated.id(), activeTaskToBeCreated.inputPartitions()));
+            Map.entry(activeTaskToBeCreated.id(), activeTaskToBeCreated.inputPartitions()));
         when(activeTaskCreator.createTasks(consumer, tasksToBeCreated)).thenReturn(createdTasks);
 
         taskManager.handleAssignment(tasksToBeCreated, Collections.emptyMap());
@@ -968,12 +967,12 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
         final Set<Task> createdTasks = Set.of(standbyTaskToBeCreated);
         when(standbyTaskCreator.createTasks(mkMap(
-            mkEntry(standbyTaskToBeCreated.id(), standbyTaskToBeCreated.inputPartitions())))
+            Map.entry(standbyTaskToBeCreated.id(), standbyTaskToBeCreated.inputPartitions())))
         ).thenReturn(createdTasks);
 
         taskManager.handleAssignment(
             Collections.emptyMap(),
-            mkMap(mkEntry(standbyTaskToBeCreated.id(), standbyTaskToBeCreated.inputPartitions()))
+            mkMap(Map.entry(standbyTaskToBeCreated.id(), standbyTaskToBeCreated.inputPartitions()))
         );
 
         verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
@@ -994,7 +993,7 @@ public class TaskManagerTest {
             .thenReturn(standbyTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
 
-        taskManager.handleAssignment(emptyMap(), mkMap(mkEntry(taskId01, taskId01Partitions)));
+        taskManager.handleAssignment(emptyMap(), mkMap(Map.entry(taskId01, taskId01Partitions)));
 
         verify(activeTaskToRecycle).prepareCommit();
         verify(tasks).addPendingTasksToInit(Set.of(standbyTask));
@@ -1017,7 +1016,7 @@ public class TaskManagerTest {
             .thenReturn(standbyTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, false);
 
-        taskManager.handleAssignment(emptyMap(), mkMap(mkEntry(taskId01, taskId01Partitions)));
+        taskManager.handleAssignment(emptyMap(), mkMap(Map.entry(taskId01, taskId01Partitions)));
 
         verify(activeTaskToRecycle).prepareCommit();
         verify(tasks).replaceActiveWithStandby(standbyTask);
@@ -1037,7 +1036,7 @@ public class TaskManagerTest {
         final IllegalStateException illegalStateException = assertThrows(
             IllegalStateException.class,
             () -> taskManager.handleAssignment(
-                mkMap(mkEntry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
+                mkMap(Map.entry(standbyTaskToRecycle.id(), standbyTaskToRecycle.inputPartitions())),
                 Collections.emptyMap()
             )
         );
@@ -1096,7 +1095,7 @@ public class TaskManagerTest {
         when(tasks.updateActiveTaskInputPartitions(activeTaskToUpdateInputPartitions, newInputPartitions)).thenReturn(true);
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(activeTaskToUpdateInputPartitions.id(), newInputPartitions)),
+            mkMap(Map.entry(activeTaskToUpdateInputPartitions.id(), newInputPartitions)),
             Collections.emptyMap()
         );
 
@@ -1115,7 +1114,7 @@ public class TaskManagerTest {
         when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToResume));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
+            mkMap(Map.entry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -1133,7 +1132,7 @@ public class TaskManagerTest {
         when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToResume));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
+            mkMap(Map.entry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
             Collections.emptyMap()
         );
 
@@ -1158,7 +1157,7 @@ public class TaskManagerTest {
             IllegalStateException.class,
             () -> taskManager.handleAssignment(
                 Collections.emptyMap(),
-                mkMap(mkEntry(standbyTaskToUpdateInputPartitions.id(), newInputPartitions))
+                mkMap(Map.entry(standbyTaskToUpdateInputPartitions.id(), newInputPartitions))
             )
         );
 
@@ -1180,13 +1179,13 @@ public class TaskManagerTest {
         when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToClose));
 
         taskManager.handleAssignment(
-            mkMap(mkEntry(activeTaskToCreate.id(), activeTaskToCreate.inputPartitions())),
+            mkMap(Map.entry(activeTaskToCreate.id(), activeTaskToCreate.inputPartitions())),
             Collections.emptyMap()
         );
 
         verify(activeTaskCreator).createTasks(
             consumer,
-            mkMap(mkEntry(activeTaskToCreate.id(), activeTaskToCreate.inputPartitions()))
+            mkMap(Map.entry(activeTaskToCreate.id(), activeTaskToCreate.inputPartitions()))
         );
         verify(activeTaskToClose).closeClean();
         verify(standbyTaskCreator).createTasks(Collections.emptyMap());
@@ -1711,12 +1710,12 @@ public class TaskManagerTest {
     @Test
     public void shouldAddSubscribedTopicsFromAssignmentToTopologyMetadata() {
         final Map<TaskId, Set<TopicPartition>> activeTasksAssignment = mkMap(
-            mkEntry(taskId01, Set.of(t1p1)),
-            mkEntry(taskId02, Set.of(t1p2, t2p2))
+            Map.entry(taskId01, Set.of(t1p1)),
+            Map.entry(taskId02, Set.of(t1p2, t2p2))
         );
         final Map<TaskId, Set<TopicPartition>> standbyTasksAssignment = mkMap(
-            mkEntry(taskId03, Set.of(t1p3)),
-            mkEntry(taskId04, Set.of(t1p4))
+            Map.entry(taskId03, Set.of(t1p3)),
+            Map.entry(taskId04, Set.of(t1p4))
         );
         when(standbyTaskCreator.createTasks(standbyTasksAssignment)).thenReturn(Collections.emptySet());
 
@@ -1830,7 +1829,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
+        when(tasks.allTasksPerId()).thenReturn(mkMap(Map.entry(taskId00, runningStatefulTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(standbyTask, restoringStatefulTask));
         when(tasks.allNonFailedTasks()).thenReturn(Set.of(runningStatefulTask));
         expectLockObtainedFor(taskId00, taskId01, taskId02, taskId03);
@@ -1856,10 +1855,10 @@ public class TaskManagerTest {
     @Test
     public void shouldReportLatestOffsetAsOffsetSumForRunningTask() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), Task.LATEST_OFFSET),
-            mkEntry(new TopicPartition("changelog", 1), Task.LATEST_OFFSET)
+            Map.entry(new TopicPartition("changelog", 0), Task.LATEST_OFFSET),
+            Map.entry(new TopicPartition("changelog", 1), Task.LATEST_OFFSET)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, Task.LATEST_OFFSET));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, Task.LATEST_OFFSET));
 
         computeOffsetSumAndVerify(changelogOffsets, expectedOffsetSums);
     }
@@ -1867,10 +1866,10 @@ public class TaskManagerTest {
     @Test
     public void shouldComputeOffsetSumForNonRunningActiveTask() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), 5L),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), 5L),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 15L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 15L));
 
         computeOffsetSumAndVerify(changelogOffsets, expectedOffsetSums);
     }
@@ -1880,17 +1879,17 @@ public class TaskManagerTest {
         final StreamTask restoringStatefulTask = statefulTask(taskId00, taskId00ChangelogPartitions)
             .inState(State.RESTORING).build();
         final long changelogOffset = 42L;
-        when(restoringStatefulTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p0changelog, changelogOffset)));
+        when(restoringStatefulTask.changelogOffsets()).thenReturn(mkMap(Map.entry(t1p0changelog, changelogOffset)));
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
-        final Map<TopicPartition, Long> changelogOffsetInCheckpoint = mkMap(mkEntry(t1p0changelog, 24L));
+        final Map<TopicPartition, Long> changelogOffsetInCheckpoint = mkMap(Map.entry(t1p0changelog, 24L));
         writeCheckpointFile(taskId00, changelogOffsetInCheckpoint);
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStatefulTask));
         taskManager.handleRebalanceStart(singleton("topic"));
 
-        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId00, changelogOffset))));
+        assertThat(taskManager.taskOffsetSums(), is(mkMap(Map.entry(taskId00, changelogOffset))));
     }
 
     @Test
@@ -1898,17 +1897,17 @@ public class TaskManagerTest {
         final StandbyTask restoringStandbyTask = standbyTask(taskId00, taskId00ChangelogPartitions)
             .inState(State.RUNNING).build();
         final long changelogOffset = 42L;
-        when(restoringStandbyTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p0changelog, changelogOffset)));
+        when(restoringStandbyTask.changelogOffsets()).thenReturn(mkMap(Map.entry(t1p0changelog, changelogOffset)));
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
-        final Map<TopicPartition, Long> changelogOffsetInCheckpoint = mkMap(mkEntry(t1p0changelog, 24L));
+        final Map<TopicPartition, Long> changelogOffsetInCheckpoint = mkMap(Map.entry(t1p0changelog, 24L));
         writeCheckpointFile(taskId00, changelogOffsetInCheckpoint);
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStandbyTask));
         taskManager.handleRebalanceStart(singleton("topic"));
 
-        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId00, changelogOffset))));
+        assertThat(taskManager.taskOffsetSums(), is(mkMap(Map.entry(taskId00, changelogOffset))));
     }
 
     @Test
@@ -1923,22 +1922,22 @@ public class TaskManagerTest {
         final long changelogOffsetOfRestoringStatefulTask = 24L;
         final long changelogOffsetOfRestoringStandbyTask = 84L;
         when(runningStatefulTask.changelogOffsets())
-            .thenReturn(mkMap(mkEntry(t1p0changelog, changelogOffsetOfRunningTask)));
+            .thenReturn(mkMap(Map.entry(t1p0changelog, changelogOffsetOfRunningTask)));
         when(restoringStatefulTask.changelogOffsets())
-            .thenReturn(mkMap(mkEntry(t1p1changelog, changelogOffsetOfRestoringStatefulTask)));
+            .thenReturn(mkMap(Map.entry(t1p1changelog, changelogOffsetOfRestoringStatefulTask)));
         when(restoringStandbyTask.changelogOffsets())
-            .thenReturn(mkMap(mkEntry(t1p2changelog, changelogOffsetOfRestoringStandbyTask)));
+            .thenReturn(mkMap(Map.entry(t1p2changelog, changelogOffsetOfRestoringStandbyTask)));
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
+        when(tasks.allTasksPerId()).thenReturn(mkMap(Map.entry(taskId00, runningStatefulTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStandbyTask, restoringStatefulTask));
 
         assertThat(
             taskManager.taskOffsetSums(),
             is(mkMap(
-                mkEntry(taskId00, changelogOffsetOfRunningTask),
-                mkEntry(taskId01, changelogOffsetOfRestoringStatefulTask),
-                mkEntry(taskId02, changelogOffsetOfRestoringStandbyTask)
+                Map.entry(taskId00, changelogOffsetOfRunningTask),
+                Map.entry(taskId01, changelogOffsetOfRestoringStatefulTask),
+                Map.entry(taskId02, changelogOffsetOfRestoringStandbyTask)
             ))
         );
     }
@@ -1946,10 +1945,10 @@ public class TaskManagerTest {
     @Test
     public void shouldSkipUnknownOffsetsWhenComputingOffsetSum() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), OffsetCheckpoint.OFFSET_UNKNOWN),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), OffsetCheckpoint.OFFSET_UNKNOWN),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 10L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 10L));
 
         computeOffsetSumAndVerify(changelogOffsets, expectedOffsetSums);
     }
@@ -1974,10 +1973,10 @@ public class TaskManagerTest {
     @Test
     public void shouldComputeOffsetSumForStandbyTask() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), 5L),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), 5L),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 15L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 15L));
 
         expectLockObtainedFor(taskId00);
         expectDirectoryNotEmpty(taskId00);
@@ -1997,10 +1996,10 @@ public class TaskManagerTest {
     @Test
     public void shouldComputeOffsetSumForUnassignedTaskWeCanLock() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), 5L),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), 5L),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 15L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 15L));
 
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
@@ -2014,10 +2013,10 @@ public class TaskManagerTest {
     @Test
     public void shouldComputeOffsetSumFromCheckpointFileForUninitializedTask() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), 5L),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), 5L),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 15L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 15L));
 
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
@@ -2037,10 +2036,10 @@ public class TaskManagerTest {
     @Test
     public void shouldComputeOffsetSumFromCheckpointFileForClosedTask() throws Exception {
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 0), 5L),
-            mkEntry(new TopicPartition("changelog", 1), 10L)
+            Map.entry(new TopicPartition("changelog", 0), 5L),
+            Map.entry(new TopicPartition("changelog", 1), 10L)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, 15L));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, 15L));
 
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
@@ -2086,11 +2085,11 @@ public class TaskManagerTest {
     public void shouldPinOffsetSumToLongMaxValueInCaseOfOverflow() throws Exception {
         final long largeOffset = Long.MAX_VALUE / 2;
         final Map<TopicPartition, Long> changelogOffsets = mkMap(
-            mkEntry(new TopicPartition("changelog", 1), largeOffset),
-            mkEntry(new TopicPartition("changelog", 2), largeOffset),
-            mkEntry(new TopicPartition("changelog", 3), largeOffset)
+            Map.entry(new TopicPartition("changelog", 1), largeOffset),
+            Map.entry(new TopicPartition("changelog", 2), largeOffset),
+            Map.entry(new TopicPartition("changelog", 3), largeOffset)
         );
-        final Map<TaskId, Long> expectedOffsetSums = mkMap(mkEntry(taskId00, Long.MAX_VALUE));
+        final Map<TaskId, Long> expectedOffsetSums = mkMap(Map.entry(taskId00, Long.MAX_VALUE));
 
         expectLockObtainedFor(taskId00);
         makeTaskFolders(taskId00.toString());
@@ -2381,7 +2380,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions)
             .inState(State.RUNNING).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId02, corruptedTask)));
+        when(tasks.allTasksPerId()).thenReturn(mkMap(Map.entry(taskId02, corruptedTask)));
         when(tasks.task(taskId02)).thenReturn(corruptedTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
         when(consumer.assignment()).thenReturn(intersection(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions));
@@ -2410,9 +2409,9 @@ public class TaskManagerTest {
             .inState(State.RUNNING).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         when(tasks.allTasksPerId()).thenReturn(mkMap(
-            mkEntry(taskId00, activeRestoringTask),
-            mkEntry(taskId01, standbyTask),
-            mkEntry(taskId02, corruptedTask)
+            Map.entry(taskId00, activeRestoringTask),
+            Map.entry(taskId01, standbyTask),
+            Map.entry(taskId02, corruptedTask)
         ));
         when(tasks.task(taskId02)).thenReturn(corruptedTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, false);
@@ -2672,9 +2671,9 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets01);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
         );
 
         when(consumer.assignment())
@@ -2730,9 +2729,9 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(unrevokedTaskOffsets);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
             );
 
         when(consumer.assignment())
@@ -2857,8 +2856,8 @@ public class TaskManagerTest {
     @Test
     public void shouldNotCompleteRestorationIfTasksCannotInitialize() {
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions)
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
@@ -2886,7 +2885,7 @@ public class TaskManagerTest {
         assertThat(task01.state(), is(Task.State.CREATED));
         assertThat(
             taskManager.activeTaskMap(),
-            Matchers.equalTo(mkMap(mkEntry(taskId00, task00), mkEntry(taskId01, task01)))
+            Matchers.equalTo(mkMap(Map.entry(taskId00, task00), Map.entry(taskId01, task01)))
         );
         assertThat(taskManager.standbyTaskMap(), Matchers.anEmptyMap());
         verify(changeLogReader).enforceRestoreActive();
@@ -2896,7 +2895,7 @@ public class TaskManagerTest {
     @Test
     public void shouldNotCompleteRestorationIfTaskCannotCompleteRestoration() {
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
-            mkEntry(taskId00, taskId00Partitions)
+            Map.entry(taskId00, taskId00Partitions)
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
@@ -2916,7 +2915,7 @@ public class TaskManagerTest {
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(
             taskManager.activeTaskMap(),
-            Matchers.equalTo(mkMap(mkEntry(taskId00, task00)))
+            Matchers.equalTo(mkMap(Map.entry(taskId00, task00)))
         );
         assertThat(taskManager.standbyTaskMap(), Matchers.anEmptyMap());
         verify(changeLogReader).enforceRestoreActive();
@@ -2966,13 +2965,13 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets01);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
         );
 
         final Map<TaskId, Set<TopicPartition>> assignmentStandby = mkMap(
-            mkEntry(taskId10, taskId10Partitions)
+            Map.entry(taskId10, taskId10Partitions)
         );
         when(consumer.assignment()).thenReturn(assignment);
 
@@ -3031,13 +3030,13 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets01);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
         );
 
         final Map<TaskId, Set<TopicPartition>> assignmentStandby = mkMap(
-            mkEntry(taskId10, taskId10Partitions)
+            Map.entry(taskId10, taskId10Partitions)
         );
         when(consumer.assignment()).thenReturn(assignment);
 
@@ -3172,10 +3171,10 @@ public class TaskManagerTest {
 
         final TopicPartition changelog = new TopicPartition("changelog", 0);
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions),
-            mkEntry(taskId03, taskId03Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions),
+            Map.entry(taskId03, taskId03Partitions)
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
@@ -3246,10 +3245,10 @@ public class TaskManagerTest {
             taskManager.activeTaskMap(),
             Matchers.equalTo(
                 mkMap(
-                    mkEntry(taskId00, task00),
-                    mkEntry(taskId01, task01),
-                    mkEntry(taskId02, task02),
-                    mkEntry(taskId03, task03)
+                    Map.entry(taskId00, task00),
+                    Map.entry(taskId01, task01),
+                    Map.entry(taskId02, task02),
+                    Map.entry(taskId03, task03)
                 )
             )
         );
@@ -3280,7 +3279,7 @@ public class TaskManagerTest {
     public void shouldCloseActiveTasksAndPropagateStreamsProducerExceptionsOnCleanShutdown() {
         final TopicPartition changelog = new TopicPartition("changelog", 0);
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
-            mkEntry(taskId00, taskId00Partitions)
+            Map.entry(taskId00, taskId00Partitions)
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
@@ -3303,7 +3302,7 @@ public class TaskManagerTest {
             taskManager.activeTaskMap(),
             Matchers.equalTo(
                 mkMap(
-                    mkEntry(taskId00, task00)
+                    Map.entry(taskId00, task00)
                 )
             )
         );
@@ -3386,9 +3385,9 @@ public class TaskManagerTest {
     public void shouldCloseActiveTasksAndIgnoreExceptionsOnUncleanShutdown() {
         final TopicPartition changelog = new TopicPartition("changelog", 0);
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
@@ -3429,9 +3428,9 @@ public class TaskManagerTest {
             taskManager.activeTaskMap(),
             Matchers.equalTo(
                 mkMap(
-                    mkEntry(taskId00, task00),
-                    mkEntry(taskId01, task01),
-                    mkEntry(taskId02, task02)
+                    Map.entry(taskId00, task00),
+                    Map.entry(taskId01, task01),
+                    Map.entry(taskId02, task02)
                 )
             )
         );
@@ -3667,14 +3666,14 @@ public class TaskManagerTest {
         final StateMachineTask task05 = new StateMachineTask(taskId05, taskId05Partitions, false, stateManager);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions)
         );
         final Map<TaskId, Set<TopicPartition>> assignmentStandby = mkMap(
-            mkEntry(taskId03, taskId03Partitions),
-            mkEntry(taskId04, taskId04Partitions),
-            mkEntry(taskId05, taskId05Partitions)
+            Map.entry(taskId03, taskId03Partitions),
+            Map.entry(taskId04, taskId04Partitions),
+            Map.entry(taskId05, taskId05Partitions)
         );
 
         when(consumer.assignment()).thenReturn(assignment);
@@ -3957,14 +3956,14 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets1);
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
-            mkEntry(taskId00, taskId00Partitions),
-            mkEntry(taskId01, taskId01Partitions),
-            mkEntry(taskId02, taskId02Partitions),
-            mkEntry(taskId03, taskId03Partitions)
+            Map.entry(taskId00, taskId00Partitions),
+            Map.entry(taskId01, taskId01Partitions),
+            Map.entry(taskId02, taskId02Partitions),
+            Map.entry(taskId03, taskId03Partitions)
         );
 
         final Map<TaskId, Set<TopicPartition>> assignmentStandby = mkMap(
-            mkEntry(taskId10, taskId10Partitions)
+            Map.entry(taskId10, taskId10Partitions)
         );
 
         when(consumer.assignment()).thenReturn(assignment);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,8 +40,8 @@ public class TaskMetadataImplTest {
     public static final TopicPartition TP_0 = new TopicPartition("t", 0);
     public static final TopicPartition TP_1 = new TopicPartition("t", 1);
     public static final Set<TopicPartition> TOPIC_PARTITIONS = Set.of(TP_0, TP_1);
-    public static final Map<TopicPartition, Long> COMMITTED_OFFSETS = mkMap(mkEntry(TP_1, 1L), mkEntry(TP_1, 2L));
-    public static final Map<TopicPartition, Long> END_OFFSETS = mkMap(mkEntry(TP_1, 1L), mkEntry(TP_1, 3L));
+    public static final Map<TopicPartition, Long> COMMITTED_OFFSETS = mkMap(Map.entry(TP_1, 1L), Map.entry(TP_1, 2L));
+    public static final Map<TopicPartition, Long> END_OFFSETS = mkMap(Map.entry(TP_1, 1L), Map.entry(TP_1, 3L));
     public static final Optional<Long> TIME_CURRENT_IDLING_STARTED = Optional.of(3L);
 
     private TaskMetadata taskMetadata;
@@ -81,7 +80,7 @@ public class TaskMetadataImplTest {
         final TaskMetadataImpl stillSameDifferCommittedOffsets = new TaskMetadataImpl(
             TASK_ID,
             TOPIC_PARTITIONS,
-            mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
+            mkMap(Map.entry(TP_1, 1000000L), Map.entry(TP_1, 2L)),
             END_OFFSETS,
             TIME_CURRENT_IDLING_STARTED);
         assertThat(taskMetadata, equalTo(stillSameDifferCommittedOffsets));
@@ -94,7 +93,7 @@ public class TaskMetadataImplTest {
             TASK_ID,
             TOPIC_PARTITIONS,
             COMMITTED_OFFSETS,
-            mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
+            mkMap(Map.entry(TP_1, 1000000L), Map.entry(TP_1, 2L)),
             TIME_CURRENT_IDLING_STARTED);
         assertThat(taskMetadata, equalTo(stillSameDifferEndOffsets));
         assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferEndOffsets.hashCode()));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
@@ -84,9 +84,9 @@ public class TasksTest {
         assertEquals(Set.of(statefulTask.id(), statelessTask.id(), standbyTask.id()), tasks.allTaskIds());
         assertEquals(
             mkMap(
-                mkEntry(statefulTask.id(), statefulTask),
-                mkEntry(statelessTask.id(), statelessTask),
-                mkEntry(standbyTask.id(), standbyTask)
+                Map.entry(statefulTask.id(), statefulTask),
+                Map.entry(statelessTask.id(), statelessTask),
+                Map.entry(standbyTask.id(), standbyTask)
             ),
             tasks.allTasksPerId());
         assertTrue(tasks.contains(statefulTask.id()));
@@ -97,27 +97,27 @@ public class TasksTest {
     @Test
     public void shouldDrainPendingTasksToCreate() {
         tasks.addPendingActiveTasksToCreate(mkMap(
-            mkEntry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
-            mkEntry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1)),
-            mkEntry(new TaskId(0, 0, "B"), Set.of(TOPIC_PARTITION_B_0)),
-            mkEntry(new TaskId(0, 1, "B"), Set.of(TOPIC_PARTITION_B_1))
+            Map.entry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
+            Map.entry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1)),
+            Map.entry(new TaskId(0, 0, "B"), Set.of(TOPIC_PARTITION_B_0)),
+            Map.entry(new TaskId(0, 1, "B"), Set.of(TOPIC_PARTITION_B_1))
         ));
 
         tasks.addPendingStandbyTasksToCreate(mkMap(
-            mkEntry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
-            mkEntry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1)),
-            mkEntry(new TaskId(0, 0, "B"), Set.of(TOPIC_PARTITION_B_0)),
-            mkEntry(new TaskId(0, 1, "B"), Set.of(TOPIC_PARTITION_B_1))
+            Map.entry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
+            Map.entry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1)),
+            Map.entry(new TaskId(0, 0, "B"), Set.of(TOPIC_PARTITION_B_0)),
+            Map.entry(new TaskId(0, 1, "B"), Set.of(TOPIC_PARTITION_B_1))
         ));
 
         assertEquals(mkMap(
-            mkEntry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
-            mkEntry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1))
+            Map.entry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
+            Map.entry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1))
         ), tasks.drainPendingActiveTasksForTopologies(Set.of("A")));
 
         assertEquals(mkMap(
-            mkEntry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
-            mkEntry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1))
+            Map.entry(new TaskId(0, 0, "A"), Set.of(TOPIC_PARTITION_A_0)),
+            Map.entry(new TaskId(0, 1, "A"), Set.of(TOPIC_PARTITION_A_1))
         ), tasks.drainPendingStandbyTasksForTopologies(Set.of("A")));
 
         tasks.clearPendingTasksToCreate();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,14 +52,14 @@ public class ThreadMetadataImplTest {
     public static final TaskMetadata TM_0 = new TaskMetadataImpl(
         TASK_ID_0,
         Set.of(TP_0_0, TP_1_0),
-        mkMap(mkEntry(TP_0_0, 1L), mkEntry(TP_1_0, 2L)),
-        mkMap(mkEntry(TP_0_0, 1L), mkEntry(TP_1_0, 2L)),
+        mkMap(Map.entry(TP_0_0, 1L), Map.entry(TP_1_0, 2L)),
+        mkMap(Map.entry(TP_0_0, 1L), Map.entry(TP_1_0, 2L)),
         Optional.of(3L));
     public static final TaskMetadata TM_1 = new TaskMetadataImpl(
         TASK_ID_1,
         Set.of(TP_0_1, TP_1_1),
-        mkMap(mkEntry(TP_0_1, 1L), mkEntry(TP_1_1, 2L)),
-        mkMap(mkEntry(TP_0_1, 1L), mkEntry(TP_1_1, 2L)),
+        mkMap(Map.entry(TP_0_1, 1L), Map.entry(TP_1_1, 2L)),
+        mkMap(Map.entry(TP_0_1, 1L), Map.entry(TP_1_1, 2L)),
         Optional.of(3L));
     public static final Set<TaskMetadata> STANDBY_TASKS = Set.of(TM_0, TM_1);
     public static final Set<TaskMetadata> ACTIVE_TASKS = Set.of(TM_1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_1;
@@ -57,8 +56,8 @@ public class AssignmentInfoTest {
     );
 
     private final Map<TaskId, Set<TopicPartition>> standbyTasks = mkMap(
-        mkEntry(TASK_1_0, Set.of(new TopicPartition("t1", 0), new TopicPartition("t2", 0))),
-        mkEntry(TASK_1_1, Set.of(new TopicPartition("t1", 1), new TopicPartition("t2", 1)))
+        Map.entry(TASK_1_0, Set.of(new TopicPartition("t1", 0), new TopicPartition("t2", 0))),
+        Map.entry(TASK_1_1, Set.of(new TopicPartition("t1", 1), new TopicPartition("t2", 1)))
     );
 
     private static final List<TaskId> NAMED_ACTIVE_TASKS = Arrays.asList(
@@ -72,27 +71,27 @@ public class AssignmentInfoTest {
     );
 
     private static final Map<TaskId, Set<TopicPartition>> NAMED_STANDBY_TASKS = mkMap(
-        mkEntry(NAMED_TASK_T0_0_0, Set.of(new TopicPartition("t0-1", 0), new TopicPartition("t0-2", 0))),
-        mkEntry(NAMED_TASK_T0_0_1, Set.of(new TopicPartition("t0-1", 1), new TopicPartition("t0-2", 1))),
-        mkEntry(NAMED_TASK_T1_0_0, Set.of(new TopicPartition("t1-1", 0), new TopicPartition("t1-2", 0)))
+        Map.entry(NAMED_TASK_T0_0_0, Set.of(new TopicPartition("t0-1", 0), new TopicPartition("t0-2", 0))),
+        Map.entry(NAMED_TASK_T0_0_1, Set.of(new TopicPartition("t0-1", 1), new TopicPartition("t0-2", 1))),
+        Map.entry(NAMED_TASK_T1_0_0, Set.of(new TopicPartition("t1-1", 0), new TopicPartition("t1-2", 0)))
     );
 
     private final Map<HostInfo, Set<TopicPartition>> activeAssignment = mkMap(
-        mkEntry(new HostInfo("localhost", 8088),
+        Map.entry(new HostInfo("localhost", 8088),
             Set.of(new TopicPartition("t0", 0),
                 new TopicPartition("t1", 0),
                 new TopicPartition("t2", 0))),
-        mkEntry(new HostInfo("localhost", 8089),
+        Map.entry(new HostInfo("localhost", 8089),
             Set.of(new TopicPartition("t0", 1),
                 new TopicPartition("t1", 1),
                 new TopicPartition("t2", 1)))
     );
 
     private final Map<HostInfo, Set<TopicPartition>> standbyAssignment = mkMap(
-        mkEntry(new HostInfo("localhost", 8088),
+        Map.entry(new HostInfo("localhost", 8088),
             Set.of(new TopicPartition("t1", 0),
                 new TopicPartition("t2", 0))),
-        mkEntry(new HostInfo("localhost", 8089),
+        Map.entry(new HostInfo("localhost", 8089),
             Set.of(new TopicPartition("t1", 1),
                 new TopicPartition("t2", 1)))
     );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -67,7 +67,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.apache.kafka.common.utils.Utils.entriesToMap;
 import static org.apache.kafka.common.utils.Utils.intersection;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -626,7 +625,7 @@ public final class AssignmentTestUtils {
         final Map<ProcessId, Map<String, Optional<String>>> processRacks = new HashMap<>();
         for (int i = 1; i <= clientSize; i++) {
             final String rack = racks.get(i % nodeSize);
-            processRacks.put(processIdForInt(i), mkMap(mkEntry("1", Optional.of(rack))));
+            processRacks.put(processIdForInt(i), mkMap(Map.entry("1", Optional.of(rack))));
         }
         return processRacks;
     }
@@ -803,56 +802,56 @@ public final class AssignmentTestUtils {
 
     static Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForAllTasks() {
         return mkMap(
-            mkEntry(TASK_0_0, Set.of(TP_0_0)),
-            mkEntry(TASK_0_1, Set.of(TP_0_1)),
-            mkEntry(TASK_0_2, Set.of(TP_0_2)),
-            mkEntry(TASK_0_3, Set.of(TP_0_3)),
-            mkEntry(TASK_0_4, Set.of(TP_0_4)),
-            mkEntry(TASK_0_5, Set.of(TP_0_5)),
-            mkEntry(TASK_0_6, Set.of(TP_0_6)),
-            mkEntry(TASK_1_0, Set.of(TP_1_0)),
-            mkEntry(TASK_1_1, Set.of(TP_1_1)),
-            mkEntry(TASK_1_2, Set.of(TP_1_2)),
-            mkEntry(TASK_1_3, Set.of(TP_1_3)),
-            mkEntry(TASK_2_0, Set.of(TP_2_0)),
-            mkEntry(TASK_2_1, Set.of(TP_2_1)),
-            mkEntry(TASK_2_2, Set.of(TP_2_2)),
-            mkEntry(TASK_2_3, Set.of(TP_2_3)),
-            mkEntry(TASK_3_0, Set.of(TP_3_0)),
-            mkEntry(TASK_3_1, Set.of(TP_3_1)),
-            mkEntry(TASK_3_2, Set.of(TP_3_2))
+            Map.entry(TASK_0_0, Set.of(TP_0_0)),
+            Map.entry(TASK_0_1, Set.of(TP_0_1)),
+            Map.entry(TASK_0_2, Set.of(TP_0_2)),
+            Map.entry(TASK_0_3, Set.of(TP_0_3)),
+            Map.entry(TASK_0_4, Set.of(TP_0_4)),
+            Map.entry(TASK_0_5, Set.of(TP_0_5)),
+            Map.entry(TASK_0_6, Set.of(TP_0_6)),
+            Map.entry(TASK_1_0, Set.of(TP_1_0)),
+            Map.entry(TASK_1_1, Set.of(TP_1_1)),
+            Map.entry(TASK_1_2, Set.of(TP_1_2)),
+            Map.entry(TASK_1_3, Set.of(TP_1_3)),
+            Map.entry(TASK_2_0, Set.of(TP_2_0)),
+            Map.entry(TASK_2_1, Set.of(TP_2_1)),
+            Map.entry(TASK_2_2, Set.of(TP_2_2)),
+            Map.entry(TASK_2_3, Set.of(TP_2_3)),
+            Map.entry(TASK_3_0, Set.of(TP_3_0)),
+            Map.entry(TASK_3_1, Set.of(TP_3_1)),
+            Map.entry(TASK_3_2, Set.of(TP_3_2))
         );
     }
 
     static Map<Subtopology, Set<TaskId>> getTasksForTopicGroup() {
         return mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_0_4, TASK_0_5, TASK_0_6)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2, TASK_2_3)),
-            mkEntry(new Subtopology(3, null), Set.of(TASK_3_0, TASK_3_1, TASK_3_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_0_4, TASK_0_5, TASK_0_6)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2, TASK_2_3)),
+            Map.entry(new Subtopology(3, null), Set.of(TASK_3_0, TASK_3_1, TASK_3_2))
         );
     }
 
     static Map<TaskId, Set<TopicPartition>> getTaskChangelogMapForAllTasks() {
         return mkMap(
-            mkEntry(TASK_0_0, Set.of(CHANGELOG_TP_0_0)),
-            mkEntry(TASK_0_1, Set.of(CHANGELOG_TP_0_1)),
-            mkEntry(TASK_0_2, Set.of(CHANGELOG_TP_0_2)),
-            mkEntry(TASK_0_3, Set.of(CHANGELOG_TP_0_3)),
-            mkEntry(TASK_0_4, Set.of(CHANGELOG_TP_0_4)),
-            mkEntry(TASK_0_5, Set.of(CHANGELOG_TP_0_5)),
-            mkEntry(TASK_0_6, Set.of(CHANGELOG_TP_0_6)),
-            mkEntry(TASK_1_0, Set.of(CHANGELOG_TP_1_0)),
-            mkEntry(TASK_1_1, Set.of(CHANGELOG_TP_1_1)),
-            mkEntry(TASK_1_2, Set.of(CHANGELOG_TP_1_2)),
-            mkEntry(TASK_1_3, Set.of(CHANGELOG_TP_1_3)),
-            mkEntry(TASK_2_0, Set.of(CHANGELOG_TP_2_0)),
-            mkEntry(TASK_2_1, Set.of(CHANGELOG_TP_2_1)),
-            mkEntry(TASK_2_2, Set.of(CHANGELOG_TP_2_2)),
-            mkEntry(TASK_2_3, Set.of(CHANGELOG_TP_2_3)),
-            mkEntry(TASK_3_0, Set.of(CHANGELOG_TP_3_0)),
-            mkEntry(TASK_3_1, Set.of(CHANGELOG_TP_3_1)),
-            mkEntry(TASK_3_2, Set.of(CHANGELOG_TP_3_2))
+            Map.entry(TASK_0_0, Set.of(CHANGELOG_TP_0_0)),
+            Map.entry(TASK_0_1, Set.of(CHANGELOG_TP_0_1)),
+            Map.entry(TASK_0_2, Set.of(CHANGELOG_TP_0_2)),
+            Map.entry(TASK_0_3, Set.of(CHANGELOG_TP_0_3)),
+            Map.entry(TASK_0_4, Set.of(CHANGELOG_TP_0_4)),
+            Map.entry(TASK_0_5, Set.of(CHANGELOG_TP_0_5)),
+            Map.entry(TASK_0_6, Set.of(CHANGELOG_TP_0_6)),
+            Map.entry(TASK_1_0, Set.of(CHANGELOG_TP_1_0)),
+            Map.entry(TASK_1_1, Set.of(CHANGELOG_TP_1_1)),
+            Map.entry(TASK_1_2, Set.of(CHANGELOG_TP_1_2)),
+            Map.entry(TASK_1_3, Set.of(CHANGELOG_TP_1_3)),
+            Map.entry(TASK_2_0, Set.of(CHANGELOG_TP_2_0)),
+            Map.entry(TASK_2_1, Set.of(CHANGELOG_TP_2_1)),
+            Map.entry(TASK_2_2, Set.of(CHANGELOG_TP_2_2)),
+            Map.entry(TASK_2_3, Set.of(CHANGELOG_TP_2_3)),
+            Map.entry(TASK_3_0, Set.of(CHANGELOG_TP_3_0)),
+            Map.entry(TASK_3_1, Set.of(CHANGELOG_TP_3_1)),
+            Map.entry(TASK_3_2, Set.of(CHANGELOG_TP_3_2))
         );
     }
 
@@ -870,7 +869,7 @@ public final class AssignmentTestUtils {
         final MockInternalTopicManager spyTopicManager = spy(mockInternalTopicManager);
         doReturn(
             mkMap(
-                mkEntry(
+                Map.entry(
                     CHANGELOG_TP_0_NAME, Arrays.asList(
                         new TopicPartitionInfo(0, NODE_0, Arrays.asList(REPLICA_0), Collections.emptyList()),
                         new TopicPartitionInfo(1, NODE_1, Arrays.asList(REPLICA_1), Collections.emptyList()),
@@ -881,7 +880,7 @@ public final class AssignmentTestUtils {
                         new TopicPartitionInfo(6, NODE_0, Arrays.asList(REPLICA_0), Collections.emptyList())
                     )
                 ),
-                mkEntry(
+                Map.entry(
                     CHANGELOG_TP_1_NAME, Arrays.asList(
                         new TopicPartitionInfo(0, NODE_2, Arrays.asList(REPLICA_2), Collections.emptyList()),
                         new TopicPartitionInfo(1, NODE_3, Arrays.asList(REPLICA_3), Collections.emptyList()),
@@ -889,7 +888,7 @@ public final class AssignmentTestUtils {
                         new TopicPartitionInfo(3, NODE_4, Arrays.asList(REPLICA_4), Collections.emptyList())
                     )
                 ),
-                mkEntry(
+                Map.entry(
                     CHANGELOG_TP_2_NAME, Arrays.asList(
                         new TopicPartitionInfo(0, NODE_1, Arrays.asList(REPLICA_1), Collections.emptyList()),
                         new TopicPartitionInfo(1, NODE_2, Arrays.asList(REPLICA_2), Collections.emptyList()),
@@ -897,7 +896,7 @@ public final class AssignmentTestUtils {
                         new TopicPartitionInfo(3, NODE_3, Arrays.asList(REPLICA_3), Collections.emptyList())
                     )
                 ),
-                mkEntry(
+                Map.entry(
                     CHANGELOG_TP_3_NAME, Arrays.asList(
                         new TopicPartitionInfo(0, NODE_4, Arrays.asList(REPLICA_4), Collections.emptyList()),
                         new TopicPartitionInfo(1, NODE_3, Arrays.asList(REPLICA_3), Collections.emptyList()),
@@ -971,13 +970,13 @@ public final class AssignmentTestUtils {
 
     static Map<ProcessId, Map<String, Optional<String>>> getProcessRacksForAllProcess() {
         return mkMap(
-            mkEntry(PID_1, mkMap(mkEntry("1", Optional.of(RACK_0)))),
-            mkEntry(PID_2, mkMap(mkEntry("1", Optional.of(RACK_1)))),
-            mkEntry(PID_3, mkMap(mkEntry("1", Optional.of(RACK_2)))),
-            mkEntry(PID_4, mkMap(mkEntry("1", Optional.of(RACK_3)))),
-            mkEntry(PID_5, mkMap(mkEntry("1", Optional.of(RACK_4)))),
-            mkEntry(PID_6, mkMap(mkEntry("1", Optional.of(RACK_0)))),
-            mkEntry(PID_7, mkMap(mkEntry("1", Optional.of(RACK_1))))
+            Map.entry(PID_1, mkMap(Map.entry("1", Optional.of(RACK_0)))),
+            Map.entry(PID_2, mkMap(Map.entry("1", Optional.of(RACK_1)))),
+            Map.entry(PID_3, mkMap(Map.entry("1", Optional.of(RACK_2)))),
+            Map.entry(PID_4, mkMap(Map.entry("1", Optional.of(RACK_3)))),
+            Map.entry(PID_5, mkMap(Map.entry("1", Optional.of(RACK_4)))),
+            Map.entry(PID_6, mkMap(Map.entry("1", Optional.of(RACK_0)))),
+            Map.entry(PID_7, mkMap(Map.entry("1", Optional.of(RACK_1))))
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
@@ -71,7 +70,7 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(
             Set.of(TASK_0_0, TASK_0_1),
             Set.of(TASK_0_2, TASK_0_3),
-            mkMap(mkEntry(TASK_0_0, 5L), mkEntry(TASK_0_2, -1L)),
+            mkMap(Map.entry(TASK_0_0, 5L), Map.entry(TASK_0_2, -1L)),
             EMPTY_CLIENT_TAGS,
             4
         );
@@ -348,8 +347,8 @@ public class ClientStateTest {
     @Test
     public void shouldReturnPreviousStatefulTasksForConsumer() {
         client.addPreviousTasksAndOffsetSums("c1", mkMap(
-                mkEntry(TASK_0_0, 100L),
-                mkEntry(TASK_0_1, Task.LATEST_OFFSET)
+                Map.entry(TASK_0_0, 100L),
+                Map.entry(TASK_0_1, Task.LATEST_OFFSET)
         ));
         client.addPreviousTasksAndOffsetSums("c2", Collections.singletonMap(TASK_0_2, 0L));
         client.addPreviousTasksAndOffsetSums("c3", Collections.emptyMap());
@@ -367,32 +366,32 @@ public class ClientStateTest {
         client.addOwnedPartitions(Set.of(TP_0_2, TP_1_2), "c2");
         client.initializePrevTasks(
             mkMap(
-                mkEntry(TP_0_0, TASK_0_0),
-                mkEntry(TP_0_1, TASK_0_1),
-                mkEntry(TP_0_2, TASK_0_2),
-                mkEntry(TP_1_0, TASK_0_0),
-                mkEntry(TP_1_1, TASK_0_1),
-                mkEntry(TP_1_2, TASK_0_2)),
+                Map.entry(TP_0_0, TASK_0_0),
+                Map.entry(TP_0_1, TASK_0_1),
+                Map.entry(TP_0_2, TASK_0_2),
+                Map.entry(TP_1_0, TASK_0_0),
+                Map.entry(TP_1_1, TASK_0_1),
+                Map.entry(TP_1_2, TASK_0_2)),
             false
         );
 
         client.addPreviousTasksAndOffsetSums("c1", mkMap(
-                mkEntry(TASK_0_1, Task.LATEST_OFFSET),
-                mkEntry(TASK_0_0, 10L)));
+                Map.entry(TASK_0_1, Task.LATEST_OFFSET),
+                Map.entry(TASK_0_0, 10L)));
         client.addPreviousTasksAndOffsetSums("c2", Collections.singletonMap(TASK_0_2, 0L));
 
         assertThat(client.prevOwnedStatefulTasksByConsumer("c1"), equalTo(Set.of(TASK_0_1, TASK_0_0)));
         assertThat(client.prevOwnedStatefulTasksByConsumer("c2"), equalTo(Set.of(TASK_0_2)));
         assertThat(client.prevOwnedActiveTasksByConsumer(), equalTo(
                 mkMap(
-                        mkEntry("c1", Collections.singleton(TASK_0_1)),
-                        mkEntry("c2", Collections.singleton(TASK_0_2))
+                        Map.entry("c1", Collections.singleton(TASK_0_1)),
+                        Map.entry("c2", Collections.singleton(TASK_0_2))
                 ))
         );
         assertThat(client.prevOwnedStandbyByConsumer(), equalTo(
                 mkMap(
-                        mkEntry("c1", Collections.singleton(TASK_0_0)),
-                        mkEntry("c2", Collections.emptySet())
+                        Map.entry("c1", Collections.singleton(TASK_0_0)),
+                        Map.entry("c2", Collections.emptySet())
                 ))
         );
     }
@@ -418,12 +417,12 @@ public class ClientStateTest {
         client.revokeActiveFromConsumer(TASK_0_1, "c1");
 
         assertThat(client.assignedActiveTasksByConsumer(), equalTo(mkMap(
-                mkEntry("c1", Set.of(TASK_0_0, TASK_0_1)),
-                mkEntry("c2", Set.of(TASK_0_2))
+                Map.entry("c1", Set.of(TASK_0_0, TASK_0_1)),
+                Map.entry("c2", Set.of(TASK_0_2))
         )));
         assertThat(client.assignedStandbyTasksByConsumer(), equalTo(mkMap(
-                mkEntry("c1", Set.of(TASK_0_2)),
-                mkEntry("c2", Set.of(TASK_0_0))
+                Map.entry("c1", Set.of(TASK_0_2)),
+                Map.entry("c2", Set.of(TASK_0_0))
         )));
         assertThat(client.revokingActiveTasksByConsumer(), equalTo(Collections.singletonMap("c1", Set.of(TASK_0_1))));
     }
@@ -431,8 +430,8 @@ public class ClientStateTest {
     @Test
     public void shouldAddTasksInOffsetSumsMapToPrevStandbyTasks() {
         final Map<TaskId, Long> taskOffsetSums = mkMap(
-            mkEntry(TASK_0_1, 0L),
-            mkEntry(TASK_0_2, 100L)
+            Map.entry(TASK_0_1, 0L),
+            Map.entry(TASK_0_2, 100L)
         );
         client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.initializePrevTasks(Collections.emptyMap(), false);
@@ -444,12 +443,12 @@ public class ClientStateTest {
     @Test
     public void shouldComputeTaskLags() {
         final Map<TaskId, Long> taskOffsetSums = mkMap(
-            mkEntry(TASK_0_1, 0L),
-            mkEntry(TASK_0_2, 100L)
+            Map.entry(TASK_0_1, 0L),
+            Map.entry(TASK_0_2, 100L)
         );
         final Map<TaskId, Long> allTaskEndOffsetSums = mkMap(
-            mkEntry(TASK_0_1, 500L),
-            mkEntry(TASK_0_2, 100L)
+            Map.entry(TASK_0_1, 500L),
+            Map.entry(TASK_0_2, 100L)
         );
         client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
@@ -461,8 +460,8 @@ public class ClientStateTest {
     @Test
     public void shouldNotTryToLookupTasksThatWerePreviouslyAssignedButNoLongerExist() {
         final Map<TaskId, Long> clientReportedTaskEndOffsetSums = mkMap(
-            mkEntry(NAMED_TASK_T0_0_0, 500L),
-            mkEntry(NAMED_TASK_T1_0_0, 500L)
+            Map.entry(NAMED_TASK_T0_0_0, 500L),
+            Map.entry(NAMED_TASK_T1_0_0, 500L)
             );
         final Map<TaskId, Long> allTaskEndOffsetSumsComputedByAssignor = Collections.singletonMap(NAMED_TASK_T0_0_0, 500L);
         client.addPreviousTasksAndOffsetSums("c1", clientReportedTaskEndOffsetSums);
@@ -540,7 +539,7 @@ public class ClientStateTest {
 
     @Test
     public void shouldReturnClientTags() {
-        final Map<String, String> clientTags = mkMap(mkEntry("k1", "v1"));
+        final Map<String, String> clientTags = mkMap(Map.entry("k1", "v1"));
         assertEquals(clientTags, new ClientState(null, 0, clientTags).clientTags());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
@@ -35,7 +35,6 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
@@ -90,17 +89,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         );
 
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)))),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            Map.entry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            Map.entry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_3)))),
+            Map.entry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -120,16 +119,16 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         final int numStandbyReplicas = 2;
         final Set<String> rackAwareAssignmentTags = Set.of(ZONE_TAG, CLUSTER_TAG);
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
-        final Map<TaskId, ProcessId> taskToClientId = mkMap(mkEntry(TASK_0_0, PID_1),
-                                                       mkEntry(TASK_0_1, PID_2),
-                                                       mkEntry(TASK_0_2, PID_3));
+        final Map<TaskId, ProcessId> taskToClientId = mkMap(Map.entry(TASK_0_0, PID_1),
+                                                       Map.entry(TASK_0_1, PID_2),
+                                                       Map.entry(TASK_0_2, PID_3));
 
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
         final Map<TagEntry, Set<ProcessId>> tagEntryToClients = new HashMap<>();
@@ -162,17 +161,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     public void shouldUpdateClientToRemainingStandbysAndPendingStandbyTasksToClientIdWhenNotAllStandbyTasksWereAssigned() {
         final Set<String> rackAwareAssignmentTags = Set.of(ZONE_TAG, CLUSTER_TAG);
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
         final int numStandbyReplicas = 3;
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
-        final Map<TaskId, ProcessId> taskToClientId = mkMap(mkEntry(TASK_0_0, PID_1),
-                                                       mkEntry(TASK_0_1, PID_2),
-                                                       mkEntry(TASK_0_2, PID_3));
+        final Map<TaskId, ProcessId> taskToClientId = mkMap(Map.entry(TASK_0_0, PID_1),
+                                                       Map.entry(TASK_0_1, PID_2),
+                                                       Map.entry(TASK_0_2, PID_3));
 
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
         final Map<TagEntry, Set<ProcessId>> tagEntryToClients = new HashMap<>();
@@ -216,29 +215,29 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldPermitTaskMovementWhenClientTagsMatch() {
-        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
 
         assertTrue(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
 
     @Test
     public void shouldDeclineTaskMovementWhenClientTagsDoNotMatch() {
-        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)));
 
         assertFalse(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
 
     @Test
     public void shouldPermitSingleTaskMoveWhenClientTagMatch() {
-        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)));
         final Map<ProcessId, ClientState> clientStateMap = mkMap(
-            mkEntry(PID_1, source),
-            mkEntry(PID_2, destination),
-            mkEntry(PID_3, clientState)
+            Map.entry(PID_1, source),
+            Map.entry(PID_2, destination),
+            Map.entry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -249,13 +248,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldPermitSingleTaskMoveWhenDifferentClientTagCountNotChange() {
-        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)));
         final Map<ProcessId, ClientState> clientStateMap = mkMap(
-            mkEntry(PID_1, source),
-            mkEntry(PID_2, destination),
-            mkEntry(PID_3, clientState)
+            Map.entry(PID_1, source),
+            Map.entry(PID_2, destination),
+            Map.entry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -266,13 +265,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldDeclineSingleTaskMoveWhenReduceClientTagCount() {
-        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)));
+        final ClientState source = createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState clientState = createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)));
         final Map<ProcessId, ClientState> clientStateMap = mkMap(
-            mkEntry(PID_1, source),
-            mkEntry(PID_2, destination),
-            mkEntry(PID_3, clientState)
+            Map.entry(PID_1, source),
+            Map.entry(PID_2, destination),
+            Map.entry(PID_3, clientState)
         );
         final TaskId taskId = new TaskId(0, 0);
         clientState.assignActive(taskId);
@@ -285,17 +284,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameZone() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)))),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            Map.entry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            Map.entry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_3)))),
+            Map.entry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -370,15 +369,15 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksUsingFunctionAndSupplierTags() {
         final Map<ProcessId, String> racksForProcess = mkMap(
-            mkEntry(PID_1, "rack1"),
-            mkEntry(PID_2, "rack2"),
-            mkEntry(PID_3, "rack3"),
-            mkEntry(PID_4, "rack1"),
-            mkEntry(PID_5, "rack2"),
-            mkEntry(PID_6, "rack3"),
-            mkEntry(PID_7, "rack1"),
-            mkEntry(PID_8, "rack2"),
-            mkEntry(PID_9, "rack3")
+            Map.entry(PID_1, "rack1"),
+            Map.entry(PID_2, "rack2"),
+            Map.entry(PID_3, "rack3"),
+            Map.entry(PID_4, "rack1"),
+            Map.entry(PID_5, "rack2"),
+            Map.entry(PID_6, "rack3"),
+            Map.entry(PID_7, "rack1"),
+            Map.entry(PID_8, "rack2"),
+            Map.entry(PID_9, "rack3")
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = mock(RackAwareTaskAssignor.class);
         when(rackAwareTaskAssignor.validClientRack()).thenReturn(true);
@@ -388,31 +387,31 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         verify(rackAwareTaskAssignor, times(1)).racksForProcess();
 
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(), TASK_0_0, TASK_1_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(), TASK_0_1, TASK_1_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(), TASK_0_2, TASK_1_2)),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(), TASK_0_0, TASK_1_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(), TASK_0_1, TASK_1_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(), TASK_0_2, TASK_1_2)),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap())),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap())),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap())),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap())),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap())),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap())),
 
-            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap())),
-            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap())),
-            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap()))
+            Map.entry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap())),
+            Map.entry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap())),
+            Map.entry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap()))
         );
 
         final Map<ProcessId, ClientState> clientStatesWithTags = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)), TASK_0_2, TASK_1_2)),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1)), TASK_0_0, TASK_1_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2)), TASK_0_1, TASK_1_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3)), TASK_0_2, TASK_1_2)),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)))),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1)))),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2)))),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3)))),
 
-            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3))))
+            Map.entry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1)))),
+            Map.entry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2)))),
+            Map.entry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -483,17 +482,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameCluster() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            Map.entry(PID_7, createClientStateWithCapacity(PID_7, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_3)))),
+            Map.entry(PID_8, createClientStateWithCapacity(PID_8, 2, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_3)))),
+            Map.entry(PID_9, createClientStateWithCapacity(PID_9, 2, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -568,13 +567,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDoThePartialRackAwareness() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_3)))),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_2)))),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_3)))),
 
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_3)), TASK_1_0))
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_2), Map.entry(ZONE_TAG, ZONE_1)))),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_2), Map.entry(ZONE_TAG, ZONE_2)))),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_2), Map.entry(ZONE_TAG, ZONE_3)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -633,12 +632,12 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeClientsOnDifferentZoneTagsEvenWhenClientsReachedCapacity() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
-            mkEntry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
-            mkEntry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 1, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 1, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
+            Map.entry(PID_5, createClientStateWithCapacity(PID_5, 1, mkMap(Map.entry(ZONE_TAG, ZONE_2), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
+            Map.entry(PID_6, createClientStateWithCapacity(PID_6, 1, mkMap(Map.entry(ZONE_TAG, ZONE_3), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -710,10 +709,10 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldIgnoreTagsThatAreNotPresentInRackAwareness() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_2)))),
 
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1))))
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 1, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_2), Map.entry(ZONE_TAG, ZONE_1))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -728,8 +727,8 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldHandleOverlappingTagValuesBetweenDifferentTagKeys() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(mkEntry(ZONE_TAG, CLUSTER_1), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 2, mkMap(Map.entry(ZONE_TAG, ZONE_1), Map.entry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 2, mkMap(Map.entry(ZONE_TAG, CLUSTER_1), Map.entry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -752,10 +751,10 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksOnLeastLoadedClientsWhenClientsAreNotOnDifferentTagDimensions() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(PID_2, createClientStateWithCapacity(PID_2, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_1)),
-            mkEntry(PID_3, createClientStateWithCapacity(PID_3, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_2)),
-            mkEntry(PID_4, createClientStateWithCapacity(PID_4, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_1_0))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            Map.entry(PID_2, createClientStateWithCapacity(PID_2, 3, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_1)),
+            Map.entry(PID_3, createClientStateWithCapacity(PID_3, 3, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_2)),
+            Map.entry(PID_4, createClientStateWithCapacity(PID_4, 3, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -773,7 +772,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldNotAssignStandbyTasksIfThereAreNoEnoughClients() {
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0))
+            Map.entry(PID_1, createClientStateWithCapacity(PID_1, 3, mkMap(Map.entry(CLUSTER_TAG, CLUSTER_1), Map.entry(ZONE_TAG, ZONE_1)), TASK_0_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_RACK_AWARE_ASSIGNMENT_TAGS;
@@ -150,9 +149,9 @@ public class HighAvailabilityTaskAssignorTest {
         );
 
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         );
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -166,9 +165,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -207,9 +206,9 @@ public class HighAvailabilityTaskAssignorTest {
         );
 
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         );
 
         final AssignmentConfigs configs = new AssignmentConfigs(
@@ -223,9 +222,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -274,9 +273,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -329,9 +328,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -382,9 +381,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -433,8 +432,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -491,7 +490,7 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -541,9 +540,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -599,8 +598,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -664,8 +663,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -711,9 +710,9 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0, TASK_2_1, TASK_2_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -748,7 +747,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -781,11 +780,11 @@ public class HighAvailabilityTaskAssignorTest {
         final ClientState client2 = new ClientState(emptySet(), emptySet(), singletonMap(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
             PID_2
         );
-        final Map<ProcessId, ClientState> clientStates = mkMap(mkEntry(PID_1, client1), mkEntry(PID_2, client2));
+        final Map<ProcessId, ClientState> clientStates = mkMap(Map.entry(PID_1, client1), Map.entry(PID_2, client2));
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -817,13 +816,13 @@ public class HighAvailabilityTaskAssignorTest {
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(
-            mkEntry(PID_1, client1),
-            mkEntry(PID_2, client2)
+            Map.entry(PID_1, client1),
+            Map.entry(PID_2, client2)
         );
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -858,14 +857,14 @@ public class HighAvailabilityTaskAssignorTest {
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(
-                mkEntry(PID_1, client1),
-                mkEntry(PID_2, client2),
-                mkEntry(PID_3, client3)
+                Map.entry(PID_1, client1),
+                Map.entry(PID_2, client2),
+                Map.entry(PID_3, client3)
         );
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -904,7 +903,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -939,7 +938,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -972,7 +971,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1016,7 +1015,7 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1064,7 +1063,7 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1099,7 +1098,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1127,7 +1126,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1160,7 +1159,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1199,8 +1198,8 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1243,9 +1242,9 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3)),
-            mkEntry(new Subtopology(2, null), Set.of(TASK_2_0))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3)),
+            Map.entry(new Subtopology(2, null), Set.of(TASK_2_0))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1279,7 +1278,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1310,7 +1309,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1336,7 +1335,7 @@ public class HighAvailabilityTaskAssignorTest {
 
         final AssignmentConfigs configs = getConfigWithoutStandbys(rackAwareStrategy);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1375,8 +1374,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1427,8 +1426,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1479,8 +1478,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 
@@ -1531,8 +1530,8 @@ public class HighAvailabilityTaskAssignorTest {
             rackAwareStrategy
         );
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1, TASK_1_2))
         );
         final RackAwareTaskAssignor rackAwareTaskAssignor = getRackAwareTaskAssignor(configs, tasksForTopicGroup);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
@@ -22,12 +22,12 @@ import org.apache.kafka.streams.processor.assignment.ProcessId;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_0;
@@ -47,13 +47,13 @@ public class KafkaStreamsStateTest {
             mkSortedSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1),
             mkSortedSet(),
             new TreeMap<>(mkMap(
-                mkEntry("c1", Set.of(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
+                Map.entry("c1", Set.of(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
             )),
             Optional.empty(),
             Optional.of(
                 mkMap(
-                    mkEntry(NAMED_TASK_T0_0_0, 2000L),
-                    mkEntry(NAMED_TASK_T0_0_1, 1000L)
+                    Map.entry(NAMED_TASK_T0_0_0, 2000L),
+                    Map.entry(NAMED_TASK_T0_0_1, 1000L)
                 )
             ),
             Optional.empty()
@@ -78,7 +78,7 @@ public class KafkaStreamsStateTest {
             mkSortedSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1),
             mkSortedSet(),
             new TreeMap<>(mkMap(
-                mkEntry("c1", Set.of(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
+                Map.entry("c1", Set.of(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
             )),
             Optional.empty(),
             Optional.empty(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -54,7 +54,6 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.CHANGELOG_TP_0_0;
@@ -286,7 +285,7 @@ public class RackAwareTaskAssignorTest {
             time
         );
         final Map<ProcessId, String> racksForProcess = assignor.racksForProcess();
-        assertEquals(mkMap(mkEntry(PID_1, RACK_1)), racksForProcess);
+        assertEquals(mkMap(Map.entry(PID_1, RACK_1)), racksForProcess);
     }
 
     @ParameterizedTest
@@ -426,8 +425,8 @@ public class RackAwareTaskAssignorTest {
 
         final Map<TopicPartition, Set<String>> racksForPartition = assignor.racksForPartition();
         final Map<TopicPartition, Set<String>> expected = mkMap(
-            mkEntry(TP_0_0, Set.of(RACK_1, RACK_2)),
-            mkEntry(CHANGELOG_TP_0_0, Set.of(RACK_1, RACK_2))
+            Map.entry(TP_0_0, Set.of(RACK_1, RACK_2)),
+            Map.entry(CHANGELOG_TP_0_0, Set.of(RACK_1, RACK_2))
         );
         assertEquals(expected, racksForPartition);
     }
@@ -510,7 +509,7 @@ public class RackAwareTaskAssignorTest {
         clientState1.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1)
+            Map.entry(PID_1, clientState1)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet();
 
@@ -529,8 +528,8 @@ public class RackAwareTaskAssignorTest {
     public void shouldOptimizeActiveTasks(final boolean stateful, final String assignmentStrategy) {
         setUp(stateful);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0, TASK_1_1))
         );
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForAllTopics(),
@@ -557,9 +556,9 @@ public class RackAwareTaskAssignorTest {
         // task_1_1 has same rack as ProcessId_2
         // Optimal assignment is ProcessId_1: {0_0, 1_0}, ProcessId_2: {1_1}, ProcessId_3: {0_1} which result in no cross rack traffic
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
 
@@ -671,8 +670,8 @@ public class RackAwareTaskAssignorTest {
     public void shouldOptimizeActiveTasksWithMoreClients(final boolean stateful, final String assignmentStrategy) {
         setUp(stateful);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0))
         );
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForAllTopics(),
@@ -697,9 +696,9 @@ public class RackAwareTaskAssignorTest {
         // Optimal assignment is ProcessId_1: {}, ProcessId_2: {0_0}, ProcessId_3: {1_0} which result in no cross rack traffic
         // and keeps ProcessId_1 empty since it was originally empty
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_1_0);
 
@@ -723,8 +722,8 @@ public class RackAwareTaskAssignorTest {
     public void shouldOptimizeActiveTasksWithMoreClientsWithMoreThanOneTask(final boolean stateful, final String assignmentStrategy) {
         setUp(stateful);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_0))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_0))
         );
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForAllTopics(),
@@ -749,9 +748,9 @@ public class RackAwareTaskAssignorTest {
         // task_1_0 has same rack as ProcessId_1 and ProcessId_3
         // Optimal assignment is ProcessId_1: {}, ProcessId_2: {0_0, 0_1}, ProcessId_3: {1_0} which result in no cross rack traffic
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0);
 
@@ -775,8 +774,8 @@ public class RackAwareTaskAssignorTest {
     public void shouldBalanceAssignmentWithMoreCost(final boolean stateful, final String assignmentStrategy) {
         setUp(stateful);
         final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(
-            mkEntry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
-            mkEntry(new Subtopology(1, null), Set.of(TASK_1_1))
+            Map.entry(new Subtopology(0, null), Set.of(TASK_0_0, TASK_0_1)),
+            Map.entry(new Subtopology(1, null), Set.of(TASK_1_1))
         );
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForAllTopics(),
@@ -800,8 +799,8 @@ public class RackAwareTaskAssignorTest {
         // task_1_1 has same rack as ProcessId_2
         // ProcessId_5 is not in same rack as any task
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_2, clientState1),
-            mkEntry(PID_5, clientState2)
+            Map.entry(PID_2, clientState1),
+            Map.entry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
 
@@ -846,8 +845,8 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActive(TASK_0_1);
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_2, clientState1),
-            mkEntry(PID_5, clientState2)
+            Map.entry(PID_2, clientState1),
+            Map.entry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         final Exception exception = assertThrows(IllegalStateException.class,
@@ -878,8 +877,8 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_2, clientState1),
-            mkEntry(PID_5, clientState2)
+            Map.entry(PID_2, clientState1),
+            Map.entry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
@@ -912,8 +911,8 @@ public class RackAwareTaskAssignorTest {
         clientState2.assignActive(TASK_0_1);
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_2, clientState1),
-            mkEntry(PID_5, clientState2)
+            Map.entry(PID_2, clientState1),
+            Map.entry(PID_5, clientState2)
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
@@ -953,9 +952,9 @@ public class RackAwareTaskAssignorTest {
         clientState3.assignActive(TASK_0_0);
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3)
         ));
 
         final long originalCost = assignor.standByTasksCost(new TreeSet<>(), clientStateMap, 10, 1);
@@ -1002,12 +1001,12 @@ public class RackAwareTaskAssignorTest {
         );
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3),
-            mkEntry(PID_4, clientState4),
-            mkEntry(PID_6, clientState5),
-            mkEntry(PID_7, clientState6)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3),
+            Map.entry(PID_4, clientState4),
+            Map.entry(PID_6, clientState5),
+            Map.entry(PID_7, clientState6)
         ));
 
         clientState1.assignActive(TASK_0_0);
@@ -1079,12 +1078,12 @@ public class RackAwareTaskAssignorTest {
         );
 
         final SortedMap<ProcessId, ClientState> clientStateMap = new TreeMap<>(mkMap(
-            mkEntry(PID_1, clientState1),
-            mkEntry(PID_2, clientState2),
-            mkEntry(PID_3, clientState3),
-            mkEntry(PID_4, clientState4),
-            mkEntry(PID_6, clientState5),
-            mkEntry(PID_7, clientState6)
+            Map.entry(PID_1, clientState1),
+            Map.entry(PID_2, clientState2),
+            Map.entry(PID_3, clientState3),
+            Map.entry(PID_4, clientState4),
+            Map.entry(PID_6, clientState5),
+            Map.entry(PID_7, clientState6)
         ));
 
         clientState1.assignActive(TASK_0_0);
@@ -1218,7 +1217,7 @@ public class RackAwareTaskAssignorTest {
 
     private Map<ProcessId, Map<String, Optional<String>>> getProcessWithNoConsumerRacks() {
         return mkMap(
-            mkEntry(PID_1, mkMap())
+            Map.entry(PID_1, mkMap())
         );
     }
 
@@ -1228,7 +1227,7 @@ public class RackAwareTaskAssignorTest {
 
     private Map<TaskId, Set<TopicPartition>> getTaskChangeLogTopicPartitionMapForTask0() {
         return mkMap(
-            mkEntry(TASK_0_0, Set.of(CHANGELOG_TP_0_0))
+            Map.entry(TASK_0_0, Set.of(CHANGELOG_TP_0_0))
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_0;
@@ -66,24 +65,24 @@ public class SubscriptionInfoTest {
         TASK_1_1,
         TASK_2_0));
     private static final Map<TaskId, Long> TASK_OFFSET_SUMS = mkMap(
-        mkEntry(TASK_0_0, Task.LATEST_OFFSET),
-        mkEntry(TASK_0_1, Task.LATEST_OFFSET),
-        mkEntry(TASK_1_0, Task.LATEST_OFFSET),
-        mkEntry(TASK_1_1, 0L),
-        mkEntry(TASK_2_0, 10L)
+        Map.entry(TASK_0_0, Task.LATEST_OFFSET),
+        Map.entry(TASK_0_1, Task.LATEST_OFFSET),
+        Map.entry(TASK_1_0, Task.LATEST_OFFSET),
+        Map.entry(TASK_1_1, 0L),
+        Map.entry(TASK_2_0, 10L)
     );
 
     private static final Map<TaskId, Long> NAMED_TASK_OFFSET_SUMS = mkMap(
-        mkEntry(NAMED_TASK_T0_0_0, Task.LATEST_OFFSET),
-        mkEntry(NAMED_TASK_T0_0_1, Task.LATEST_OFFSET),
-        mkEntry(NAMED_TASK_T0_1_0, 5L),
-        mkEntry(NAMED_TASK_T0_1_1, 10_000L),
-        mkEntry(NAMED_TASK_T1_0_0, Task.LATEST_OFFSET),
-        mkEntry(NAMED_TASK_T1_0_1, 0L),
-        mkEntry(NAMED_TASK_T2_0_0, 10L),
-        mkEntry(NAMED_TASK_T2_2_0, 5L)
+        Map.entry(NAMED_TASK_T0_0_0, Task.LATEST_OFFSET),
+        Map.entry(NAMED_TASK_T0_0_1, Task.LATEST_OFFSET),
+        Map.entry(NAMED_TASK_T0_1_0, 5L),
+        Map.entry(NAMED_TASK_T0_1_1, 10_000L),
+        Map.entry(NAMED_TASK_T1_0_0, Task.LATEST_OFFSET),
+        Map.entry(NAMED_TASK_T1_0_1, 0L),
+        Map.entry(NAMED_TASK_T2_0_0, 10L),
+        Map.entry(NAMED_TASK_T2_2_0, 5L)
         );
-    private static final Map<String, String> CLIENT_TAGS = mkMap(mkEntry("t1", "v1"), mkEntry("t2", "v2"));
+    private static final Map<String, String> CLIENT_TAGS = mkMap(Map.entry("t1", "v1"), Map.entry("t2", "v2"));
 
     private static final String IGNORED_USER_ENDPOINT = "ignoredUserEndpoint:80";
     private static final byte IGNORED_UNIQUE_FIELD = (byte) 0;
@@ -381,11 +380,11 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldConvertTaskSetsToTaskOffsetSumMapWithOlderSubscription() {
         final Map<TaskId, Long> expectedOffsetSumsMap = mkMap(
-            mkEntry(new TaskId(0, 0), Task.LATEST_OFFSET),
-            mkEntry(new TaskId(0, 1), Task.LATEST_OFFSET),
-            mkEntry(new TaskId(1, 0), Task.LATEST_OFFSET),
-            mkEntry(new TaskId(1, 1), UNKNOWN_OFFSET_SUM),
-            mkEntry(new TaskId(2, 0), UNKNOWN_OFFSET_SUM)
+            Map.entry(new TaskId(0, 0), Task.LATEST_OFFSET),
+            Map.entry(new TaskId(0, 1), Task.LATEST_OFFSET),
+            Map.entry(new TaskId(1, 0), Task.LATEST_OFFSET),
+            Map.entry(new TaskId(1, 1), UNKNOWN_OFFSET_SUM),
+            Map.entry(new TaskId(2, 0), UNKNOWN_OFFSET_SUM)
         );
 
         final SubscriptionInfo info = SubscriptionInfo.decode(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignmentUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignmentUtilsTest.java
@@ -48,7 +48,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
@@ -146,16 +145,16 @@ public class TaskAssignmentUtilsTest {
         );
         final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates = mkMap(
             mkStreamState(1, 2, Optional.empty(), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "1")
+                Map.entry("az", "1")
             )),
             mkStreamState(2, 2, Optional.empty(), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "1")
+                Map.entry("az", "1")
             )),
             mkStreamState(3, 2, Optional.empty(), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "2")
+                Map.entry("az", "2")
             )),
             mkStreamState(4, 2, Optional.empty(), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "3")
+                Map.entry("az", "3")
             ))
         );
         final ApplicationState applicationState = new TestApplicationState(
@@ -226,16 +225,16 @@ public class TaskAssignmentUtilsTest {
         );
         final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates = mkMap(
             mkStreamState(1, 2, Optional.of("r1"), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "1")
+                Map.entry("az", "1")
             )),
             mkStreamState(2, 2, Optional.of("r1"), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "2")
+                Map.entry("az", "2")
             )),
             mkStreamState(3, 2, Optional.of("r1"), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "3")
+                Map.entry("az", "3")
             )),
             mkStreamState(4, 2, Optional.of("r1"), Set.of(), Set.of(), mkMap(
-                mkEntry("az", "2")
+                Map.entry("az", "2")
             ))
         );
         final ApplicationState applicationState = new TestApplicationState(
@@ -482,7 +481,7 @@ public class TaskAssignmentUtilsTest {
                                                                         final Set<TaskId> previousStandbyTasks,
                                                                         final Map<String, String> clientTags) {
         final ProcessId processId = processIdForInt(id);
-        return mkEntry(processId, new DefaultKafkaStreamsState(
+        return Map.entry(processId, new DefaultKafkaStreamsState(
             processId,
             numProcessingThreads,
             clientTags,
@@ -506,7 +505,7 @@ public class TaskAssignmentUtilsTest {
         final Set<AssignedTask> assignedTasks = Arrays.stream(taskIds)
                 .map(taskId -> new AssignedTask(taskId, taskType))
                 .collect(Collectors.toSet());
-        return mkEntry(
+        return Map.entry(
             processId,
             KafkaStreamsAssignment.of(
                 processId,
@@ -518,7 +517,7 @@ public class TaskAssignmentUtilsTest {
     public static Map.Entry<ProcessId, KafkaStreamsAssignment> mkAssignment(final int client,
                                                                             final AssignedTask... tasks) {
         final ProcessId processId = processId(client);
-        return mkEntry(
+        return Map.entry(
             processId,
             KafkaStreamsAssignment.of(
                 processId,
@@ -533,7 +532,7 @@ public class TaskAssignmentUtilsTest {
 
     public static Map.Entry<TaskId, TaskInfo> mkTaskInfo(final TaskId taskId, final boolean isStateful, final Set<String> rackIds) {
         if (!isStateful) {
-            return mkEntry(
+            return Map.entry(
                 taskId,
                 new DefaultTaskInfo(taskId, false, Set.of(), Set.of())
             );
@@ -552,7 +551,7 @@ public class TaskAssignmentUtilsTest {
                 });
             }
         ));
-        return mkEntry(
+        return Map.entry(
             taskId,
             new DefaultTaskInfo(
                 taskId,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
@@ -51,7 +51,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.CHANGELOG_TOPIC_PREFIX;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_RACK_AWARE_ASSIGNMENT_TAGS;
@@ -183,7 +182,7 @@ public class TaskAssignorConvergenceTest {
                 final ProcessId uuid = processIdForInt(i);
                 clientStates.put(uuid, emptyInstance(uuid, statefulTaskEndOffsetSums));
                 final String rack = RACK_PREFIX + random.nextInt(nodes.size());
-                racksForProcessConsumer.put(uuid, mkMap(mkEntry("consumer", Optional.of(rack))));
+                racksForProcessConsumer.put(uuid, mkMap(Map.entry("consumer", Optional.of(rack))));
             }
 
             return new Harness(statelessTasks, statefulTaskEndOffsetSums, clientStates, cluster, partitionsForTask, changelogPartitionsForTask, tasksForTopicGroup, racksForProcessConsumer, spyTopicManager);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -35,7 +35,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
@@ -92,20 +91,20 @@ public class TaskMovementTest {
         final ClientState client3 = getClientStateWithActiveAssignment(Set.of(TASK_0_2, TASK_1_2), Set.of(), allTasks);
 
         final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, emptySortedSet()),
-            mkEntry(TASK_0_1, emptySortedSet()),
-            mkEntry(TASK_0_2, emptySortedSet()),
-            mkEntry(TASK_1_0, emptySortedSet()),
-            mkEntry(TASK_1_1, emptySortedSet()),
-            mkEntry(TASK_1_2, emptySortedSet())
+            Map.entry(TASK_0_0, emptySortedSet()),
+            Map.entry(TASK_0_1, emptySortedSet()),
+            Map.entry(TASK_0_2, emptySortedSet()),
+            Map.entry(TASK_1_0, emptySortedSet()),
+            Map.entry(TASK_1_1, emptySortedSet()),
+            Map.entry(TASK_1_2, emptySortedSet())
         );
         final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_0_2, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_1_0, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_1_1, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_1_2, mkOrderedSet(PID_1, PID_2, PID_3))
+            Map.entry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_0_1, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_0_2, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_1_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_1_1, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_1_2, mkOrderedSet(PID_1, PID_2, PID_3))
         );
         assertThat(
             assignActiveTaskMovements(
@@ -129,14 +128,14 @@ public class TaskMovementTest {
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(PID_1)),
-            mkEntry(TASK_0_1, mkSortedSet(PID_3)),
-            mkEntry(TASK_0_2, mkSortedSet(PID_2))
+            Map.entry(TASK_0_0, mkSortedSet(PID_1)),
+            Map.entry(TASK_0_1, mkSortedSet(PID_3)),
+            Map.entry(TASK_0_2, mkSortedSet(PID_2))
         );
         final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
-            mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
+            Map.entry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+            Map.entry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
         assertThat(
@@ -164,9 +163,9 @@ public class TaskMovementTest {
     @Test
     public void shouldMoveTasksToMostCaughtUpClientsAndAssignWarmupReplicasInTheirPlace() {
         final int maxWarmupReplicas = Integer.MAX_VALUE;
-        final Map<TaskId, Long> client1Lags = mkMap(mkEntry(TASK_0_0, 10000L), mkEntry(TASK_0_1, 20000L), mkEntry(TASK_0_2, 30000L));
-        final Map<TaskId, Long> client2Lags = mkMap(mkEntry(TASK_0_2, 10000L), mkEntry(TASK_0_0, 20000L), mkEntry(TASK_0_1, 30000L));
-        final Map<TaskId, Long> client3Lags = mkMap(mkEntry(TASK_0_1, 10000L), mkEntry(TASK_0_2, 20000L), mkEntry(TASK_0_0, 30000L));
+        final Map<TaskId, Long> client1Lags = mkMap(Map.entry(TASK_0_0, 10000L), Map.entry(TASK_0_1, 20000L), Map.entry(TASK_0_2, 30000L));
+        final Map<TaskId, Long> client2Lags = mkMap(Map.entry(TASK_0_2, 10000L), Map.entry(TASK_0_0, 20000L), Map.entry(TASK_0_1, 30000L));
+        final Map<TaskId, Long> client3Lags = mkMap(Map.entry(TASK_0_1, 10000L), Map.entry(TASK_0_2, 20000L), Map.entry(TASK_0_0, 30000L));
 
         final ClientState client1 = getClientStateWithLags(Set.of(TASK_0_0), client1Lags);
         final ClientState client2 = getClientStateWithLags(Set.of(TASK_0_1), client2Lags);
@@ -176,14 +175,14 @@ public class TaskMovementTest {
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
-                mkEntry(TASK_0_0, mkSortedSet()),
-                mkEntry(TASK_0_1, mkSortedSet()),
-                mkEntry(TASK_0_2, mkSortedSet())
+                Map.entry(TASK_0_0, mkSortedSet()),
+                Map.entry(TASK_0_1, mkSortedSet()),
+                Map.entry(TASK_0_2, mkSortedSet())
         );
         final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
-                mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
-                mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
-                mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_3, PID_1))
+                Map.entry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+                Map.entry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+                Map.entry(TASK_0_2, mkOrderedSet(PID_2, PID_3, PID_1))
         );
 
         assertThat(
@@ -218,14 +217,14 @@ public class TaskMovementTest {
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
         final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(PID_1)),
-            mkEntry(TASK_0_1, mkSortedSet(PID_3)),
-            mkEntry(TASK_0_2, mkSortedSet(PID_2))
+            Map.entry(TASK_0_0, mkSortedSet(PID_1)),
+            Map.entry(TASK_0_1, mkSortedSet(PID_3)),
+            Map.entry(TASK_0_2, mkSortedSet(PID_2))
         );
         final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
-            mkEntry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
-            mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
+            Map.entry(TASK_0_0, mkOrderedSet(PID_1, PID_2, PID_3)),
+            Map.entry(TASK_0_1, mkOrderedSet(PID_3, PID_1, PID_2)),
+            Map.entry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
         assertThat(
@@ -260,10 +259,10 @@ public class TaskMovementTest {
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2);
 
         final Map<TaskId, SortedSet<ProcessId>> tasksToCaughtUpClients = mkMap(
-            mkEntry(TASK_0_0, mkSortedSet(PID_1))
+            Map.entry(TASK_0_0, mkSortedSet(PID_1))
         );
         final Map<TaskId, SortedSet<ProcessId>> tasksToClientByLag = mkMap(
-            mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2))
+            Map.entry(TASK_0_0, mkOrderedSet(PID_1, PID_2))
         );
 
         assertThat(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.AVG_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CLIENT_ID_TAG;
@@ -111,9 +110,9 @@ public class StreamsMetricsImplTest {
     private static final String STORE_NAME1 = "store1";
     private static final String STORE_NAME2 = "store2";
     private static final Map<String, String> STORE_LEVEL_TAG_MAP = mkMap(
-        mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()),
-        mkEntry(TASK_ID_TAG, TASK_ID1),
-        mkEntry(SCOPE_NAME + STORE_ID_TAG, STORE_NAME1)
+        Map.entry(THREAD_ID_TAG, Thread.currentThread().getName()),
+        Map.entry(TASK_ID_TAG, TASK_ID1),
+        Map.entry(SCOPE_NAME + STORE_ID_TAG, STORE_NAME1)
     );
     private static final String RECORD_CACHE_ID_TAG = "record-cache-id";
     private static final String ENTITY_NAME = "test-entity";
@@ -132,8 +131,8 @@ public class StreamsMetricsImplTest {
     private final Sensor sensor = metrics.sensor("dummy");
     private final String metricNamePrefix = "metric";
     private final String group = "group";
-    private final Map<String, String> tags = mkMap(mkEntry("tag", "value"));
-    private final Map<String, String> clientLevelTags = mkMap(mkEntry(CLIENT_ID_TAG, CLIENT_ID), mkEntry(PROCESS_ID_TAG, PROCESS_ID));
+    private final Map<String, String> tags = mkMap(Map.entry("tag", "value"));
+    private final Map<String, String> clientLevelTags = mkMap(Map.entry(CLIENT_ID_TAG, CLIENT_ID), Map.entry(PROCESS_ID_TAG, PROCESS_ID));
     private final MetricName metricName1 =
         new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags);
     private final MetricName metricName2 =
@@ -761,13 +760,13 @@ public class StreamsMetricsImplTest {
 
         final String taskName = "taskName";
         final String operation = "operation";
-        final Map<String, String> taskTags = mkMap(mkEntry("tkey", "value"));
+        final Map<String, String> taskTags = mkMap(Map.entry("tkey", "value"));
 
         final String processorNodeName = "processorNodeName";
-        final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
+        final Map<String, String> nodeTags = mkMap(Map.entry("nkey", "value"));
 
         final String topicName = "topicName";
-        final Map<String, String> topicTags = mkMap(mkEntry("tkey", "value"));
+        final Map<String, String> topicTags = mkMap(Map.entry("tkey", "value"));
 
         final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID1, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
@@ -988,11 +987,11 @@ public class StreamsMetricsImplTest {
 
     private Map<String, String> tags(final StreamsMetricsImpl streamsMetrics) {
         return mkMap(
-            mkEntry(
+            Map.entry(
                 streamsMetrics.version() == Version.LATEST ? THREAD_ID_TAG : CLIENT_ID_TAG,
                 Thread.currentThread().getName()
             ),
-            mkEntry(SCOPE_NAME + "-id", ENTITY_NAME)
+            Map.entry(SCOPE_NAME + "-id", ENTITY_NAME)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -38,16 +37,16 @@ public class PositionTest {
     @Test
     public void shouldCreateFromMap() {
         final Map<String, Map<Integer, Long>> map = mkMap(
-            mkEntry("topic", mkMap(mkEntry(0, 5L))),
-            mkEntry("topic1", mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            Map.entry("topic", mkMap(Map.entry(0, 5L))),
+            Map.entry("topic1", mkMap(
+                Map.entry(0, 5L),
+                Map.entry(7, 0L)
             ))
         );
 
         final Position position = Position.fromMap(map);
         assertThat(position.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(Map.entry(0, 5L))));
 
         // Should be a copy of the constructor map
 
@@ -55,8 +54,8 @@ public class PositionTest {
 
         // so the position is still the original one
         assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
+            Map.entry(0, 5L),
+            Map.entry(7, 0L)
         )));
     }
 
@@ -69,29 +68,29 @@ public class PositionTest {
     @Test
     public void shouldMerge() {
         final Position position = Position.fromMap(mkMap(
-            mkEntry("topic", mkMap(mkEntry(0, 5L))),
-            mkEntry("topic1", mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            Map.entry("topic", mkMap(Map.entry(0, 5L))),
+            Map.entry("topic1", mkMap(
+                Map.entry(0, 5L),
+                Map.entry(7, 0L)
             ))
         ));
 
         final Position position1 = Position.fromMap(mkMap(
-            mkEntry("topic", mkMap(mkEntry(0, 7L))), // update offset
-            mkEntry("topic1", mkMap(mkEntry(8, 1L))), // add partition
-            mkEntry("topic2", mkMap(mkEntry(9, 5L))) // add topic
+            Map.entry("topic", mkMap(Map.entry(0, 7L))), // update offset
+            Map.entry("topic1", mkMap(Map.entry(8, 1L))), // add partition
+            Map.entry("topic2", mkMap(Map.entry(9, 5L))) // add topic
         ));
 
         final Position merged = position.merge(position1);
 
         assertThat(merged.getTopics(), equalTo(Set.of("topic", "topic1", "topic2")));
-        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 7L))));
+        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(Map.entry(0, 7L))));
         assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L),
-            mkEntry(8, 1L)
+            Map.entry(0, 5L),
+            Map.entry(7, 0L),
+            Map.entry(8, 1L)
         )));
-        assertThat(merged.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(9, 5L))));
+        assertThat(merged.getPartitionPositions("topic2"), equalTo(mkMap(Map.entry(9, 5L))));
     }
 
     @Test
@@ -107,10 +106,10 @@ public class PositionTest {
     @Test
     public void shouldCopy() {
         final Position position = Position.fromMap(mkMap(
-            mkEntry("topic", mkMap(mkEntry(0, 5L))),
-            mkEntry("topic1", mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            Map.entry("topic", mkMap(Map.entry(0, 5L))),
+            Map.entry("topic1", mkMap(
+                Map.entry(0, 5L),
+                Map.entry(7, 0L)
             ))
         ));
 
@@ -123,40 +122,40 @@ public class PositionTest {
 
         // copy has not changed
         assertThat(copy.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(copy.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(copy.getPartitionPositions("topic"), equalTo(mkMap(Map.entry(0, 5L))));
         assertThat(copy.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
+            Map.entry(0, 5L),
+            Map.entry(7, 0L)
         )));
 
         // original has changed
         assertThat(position.getTopics(), equalTo(Set.of("topic", "topic1", "topic2")));
-        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 6L))));
+        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(Map.entry(0, 6L))));
         assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L),
-            mkEntry(8, 1L)
+            Map.entry(0, 5L),
+            Map.entry(7, 0L),
+            Map.entry(8, 1L)
         )));
-        assertThat(position.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(2, 4L))));
+        assertThat(position.getPartitionPositions("topic2"), equalTo(mkMap(Map.entry(2, 4L))));
     }
 
     @Test
     public void shouldMergeNull() {
         final Position position = Position.fromMap(mkMap(
-            mkEntry("topic", mkMap(mkEntry(0, 5L))),
-            mkEntry("topic1", mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            Map.entry("topic", mkMap(Map.entry(0, 5L))),
+            Map.entry("topic1", mkMap(
+                Map.entry(0, 5L),
+                Map.entry(7, 0L)
             ))
         ));
 
         final Position merged = position.merge(null);
 
         assertThat(merged.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(Map.entry(0, 5L))));
         assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
+            Map.entry(0, 5L),
+            Map.entry(7, 0L)
         )));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -77,7 +77,6 @@ import java.util.Set;
 import java.util.SimpleTimeZone;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -1401,7 +1400,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 4, 0, "", new RecordHeaders()));
         bytesStore.put(serializeKey(new Windowed<>(keyC, windows[3])), serializeValue(200));
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 4L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 4L)))));
         final Position actual = bytesStore.getPosition();
         assertEquals(expected, actual);
     }
@@ -1674,8 +1673,8 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
 
@@ -1684,8 +1683,8 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -72,7 +72,6 @@ import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.stream.Stream;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -556,7 +555,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         context.setRecordContext(new ProcessorRecordContext(0, 4, 0, "", new RecordHeaders()));
         bytesStore.put(serializeKey(new Windowed<>(keyC, windows[3])), serializeValue(200));
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 4L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 4L)))));
         final Position actual = bytesStore.getPosition();
         assertEquals(expected, actual);
     }
@@ -841,8 +840,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
 
@@ -851,8 +850,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBWindowStoreTest.java
@@ -37,13 +37,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.time.Duration.ofMillis;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -777,7 +777,7 @@ public abstract class AbstractRocksDBWindowStoreTest extends AbstractWindowBytes
         context.setRecordContext(new ProcessorRecordContext(0, 4, 0, "", new RecordHeaders()));
         windowStore.put(3, "3", SEGMENT_INTERVAL);
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 4L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 4L)))));
         final Position actual = rocksDBWindowStore.getPosition();
         assertEquals(expected, actual);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -59,7 +59,6 @@ import java.util.Set;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.toList;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
@@ -869,8 +868,8 @@ public abstract class AbstractSessionBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
 
@@ -879,8 +878,8 @@ public abstract class AbstractSessionBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());
@@ -979,7 +978,7 @@ public abstract class AbstractSessionBytesStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 3, 0, "", new RecordHeaders()));
         sessionStore.put(new Windowed<String>("a", new SessionWindow(10, 20)), 3L);
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 3L)))));
         final Position actual = sessionStore.getPosition();
         assertThat(expected, is(actual));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -58,7 +58,6 @@ import java.util.Set;
 
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.apache.kafka.test.StreamsTestUtils.toSet;
@@ -1017,8 +1016,8 @@ public abstract class AbstractWindowBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
 
@@ -1027,8 +1026,8 @@ public abstract class AbstractWindowBytesStoreTest {
             "stream-task-metrics",
             "",
             mkMap(
-                mkEntry("thread-id", threadId),
-                mkEntry("task-id", "0_0")
+                Map.entry("thread-id", threadId),
+                Map.entry("task-id", "0_0")
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -48,8 +48,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -220,7 +220,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         );
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             store.getPosition()
         );
         assertEquals(Position.emptyPosition(), underlyingStore.getPosition());
@@ -228,11 +228,11 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         store.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             store.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -55,10 +55,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
@@ -171,11 +171,11 @@ public class CachingInMemorySessionStoreTest {
         cachingStore.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             cachingStore.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -55,10 +55,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
@@ -169,11 +169,11 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             cachingStore.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -63,6 +63,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -70,7 +71,6 @@ import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMinutes;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
@@ -288,11 +288,11 @@ public class CachingPersistentWindowStoreTest {
         cachingStore.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             cachingStore.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
@@ -33,7 +33,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
+import java.util.Map;
+
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,7 +54,7 @@ public class ChangeLoggingSessionBytesStoreTest {
     private final Bytes bytesKey = Bytes.wrap(value1);
     private final Windowed<Bytes> key1 = new Windowed<>(bytesKey, new SessionWindow(0, 0));
 
-    private static final Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
+    private static final Position POSITION = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 1L)))));
 
     @BeforeEach
     public void setUp() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
@@ -32,8 +32,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.Map;
+
 import static java.time.Instant.ofEpochMilli;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,7 +54,7 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
     private ProcessorContextImpl context;
     private ChangeLoggingTimestampedWindowBytesStore store;
 
-    private static final Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
+    private static final Position POSITION = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 1L)))));
 
     @BeforeEach
     public void setUp() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
@@ -32,8 +32,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.Map;
+
 import static java.time.Instant.ofEpochMilli;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,7 +53,7 @@ public class ChangeLoggingWindowBytesStoreTest {
     private ProcessorContextImpl context;
     private ChangeLoggingWindowBytesStore store;
 
-    private static final Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
+    private static final Position POSITION = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 1L)))));
 
     @BeforeEach
     public void setUp() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -49,7 +49,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -64,7 +63,7 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class GlobalStateStoreProviderTest {
     private final Map<String, StateStore> stores = new HashMap<>();
-    private static final Map<String, Object> CONFIGS =  mkMap(mkEntry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, "appId"));
+    private static final Map<String, Object> CONFIGS =  mkMap(Map.entry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, "appId"));
 
     @BeforeEach
     public void before() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -265,7 +265,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 3, 0, "", new RecordHeaders()));
         inMemoryKeyValueStore.put(bytesKey("key3"), bytesValue("value3"));
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 3L)))));
         final Position actual = inMemoryKeyValueStore.getPosition();
         assertEquals(expected, actual);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import static java.time.Duration.ofMillis;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.toStoreKeyBinary;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -180,7 +180,7 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 4, 0, "", new RecordHeaders()));
         windowStore.put(3, "3", SEGMENT_INTERVAL);
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 4L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 4L)))));
         final Position actual = inMemoryWindowStore.getPosition();
         assertEquals(expected, actual);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
@@ -34,9 +34,9 @@ import org.mockito.quality.Strictness;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -69,7 +69,7 @@ public class KeyValueSegmentTest {
         final File directory = new File(directoryPath);
 
         final ProcessorContext mockContext = mock(ProcessorContext.class);
-        when(mockContext.appConfigs()).thenReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
+        when(mockContext.appConfigs()).thenReturn(mkMap(Map.entry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
         when(mockContext.stateDir()).thenReturn(directory);
 
         segment.openDB(mockContext.appConfigs(), mockContext.stateDir());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -113,9 +112,9 @@ public class MeteredKeyValueStoreTest {
         );
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
         tags = mkMap(
-                mkEntry(THREAD_ID_TAG_KEY, threadId),
-                mkEntry("task-id", taskId.toString()),
-                mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
+                Map.entry(THREAD_ID_TAG_KEY, threadId),
+                Map.entry("task-id", taskId.toString()),
+                Map.entry(STORE_TYPE + "-state-id", STORE_NAME)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -56,7 +56,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -116,9 +115,9 @@ public class MeteredSessionStoreTest {
             mockTime
         );
         tags = mkMap(
-            mkEntry(THREAD_ID_TAG_KEY, threadId),
-            mkEntry("task-id", taskId.toString()),
-            mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
+            Map.entry(THREAD_ID_TAG_KEY, threadId),
+            Map.entry("task-id", taskId.toString()),
+            Map.entry(STORE_TYPE + "-state-id", STORE_NAME)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -98,7 +97,7 @@ public class MeteredTimestampedKeyValueStoreTest {
     private InternalProcessorContext context;
     private MockTime mockTime;
 
-    private static final Map<String, Object> CONFIGS =  mkMap(mkEntry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, APPLICATION_ID));
+    private static final Map<String, Object> CONFIGS =  mkMap(Map.entry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, APPLICATION_ID));
 
     private MeteredTimestampedKeyValueStore<String, String> metered;
     private final KeyValue<Bytes, byte[]> byteKeyValueTimestampPair = KeyValue.pair(KEY_BYTES,
@@ -118,9 +117,9 @@ public class MeteredTimestampedKeyValueStoreTest {
         );
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
         tags = mkMap(
-                mkEntry(THREAD_ID_TAG_KEY, threadId),
-                mkEntry("task-id", taskId.toString()),
-                mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
+                Map.entry(THREAD_ID_TAG_KEY, threadId),
+                Map.entry("task-id", taskId.toString()),
+                Map.entry(STORE_TYPE + "-state-id", STORE_NAME)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -117,9 +116,9 @@ public class MeteredVersionedKeyValueStoreTest {
 
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
         tags = mkMap(
-            mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry(METRICS_SCOPE + "-state-id", STORE_NAME)
+            Map.entry("thread-id", threadId),
+            Map.entry("task-id", TASK_ID.toString()),
+            Map.entry(METRICS_SCOPE + "-state-id", STORE_NAME)
         );
 
         store = newMeteredStore(inner);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -58,7 +58,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.time.Instant.ofEpochMilli;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -129,9 +128,9 @@ public class MeteredWindowStoreTest {
             Time.SYSTEM
         );
         tags = mkMap(
-            mkEntry(THREAD_ID_TAG_KEY, threadId),
-            mkEntry("task-id", context.taskId().toString()),
-            mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
+            Map.entry(THREAD_ID_TAG_KEY, threadId),
+            Map.entry("task-id", context.taskId().toString()),
+            Map.entry(STORE_TYPE + "-state-id", STORE_NAME)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -94,7 +94,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.RocksDBStore.DB_FILE_DIR;
 import static org.hamcrest.CoreMatchers.either;
@@ -456,7 +455,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 3, 0, "", new RecordHeaders()));
         rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "three")), stringSerializer.serialize(null, "C"));
 
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
+        final Position expected = Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 3L)))));
         final Position actual = rocksDBStore.getPosition();
         assertEquals(expected, actual);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED;
@@ -85,8 +84,8 @@ public class RocksDBVersionedStoreTest {
         context.setTime(BASE_TIMESTAMP);
 
         expectedMetricsTags = mkMap(
-            mkEntry("thread-id", Thread.currentThread().getName()),
-            mkEntry("task-id", context.taskId().toString())
+            Map.entry("thread-id", Thread.currentThread().getName()),
+            Map.entry("task-id", context.taskId().toString())
         );
 
         store = new RocksDBVersionedStore(STORE_NAME, METRICS_SCOPE, HISTORY_RETENTION, SEGMENT_INTERVAL);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -52,27 +51,27 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SessionKeySchemaTest {
     private static final Map<SchemaType, KeySchema> SCHEMA_TYPE_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, new SessionKeySchema()),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, new KeyFirstSessionKeySchema()),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, new TimeFirstSessionKeySchema())
+        Map.entry(SchemaType.SessionKeySchema, new SessionKeySchema()),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, new KeyFirstSessionKeySchema()),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, new TimeFirstSessionKeySchema())
     );
 
     private static final Map<SchemaType, Function<Windowed<Bytes>, Bytes>> WINDOW_TO_STORE_BINARY_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
     );
 
     private static final Map<SchemaType, Function<byte[], Long>> EXTRACT_END_TS_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractEndTimestamp),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractEndTimestamp),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractEndTimestamp)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::extractEndTimestamp),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractEndTimestamp),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractEndTimestamp)
     );
 
     private static final Map<SchemaType, Function<byte[], Long>> EXTRACT_START_TS_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractStartTimestamp),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractStartTimestamp),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractStartTimestamp)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::extractStartTimestamp),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractStartTimestamp),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractStartTimestamp)
     );
 
     @FunctionalInterface
@@ -81,33 +80,33 @@ public class SessionKeySchemaTest {
     }
 
     private static final Map<SchemaType, TriFunction<Windowed<String>, Serializer<String>, String, byte[]>> SERDE_TO_STORE_BINARY_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
     );
 
     private static final Map<SchemaType, TriFunction<byte[], Deserializer<String>, String, Windowed<String>>> SERDE_FROM_BYTES_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::from),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::from),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
     );
 
     private static final Map<SchemaType, Function<Bytes, Windowed<Bytes>>> FROM_BYTES_MAP = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::from),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::from),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
     );
 
     private static final Map<SchemaType, Function<byte[], Window>> EXTRACT_WINDOW = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractWindow),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractWindow),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractWindow)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::extractWindow),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractWindow),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractWindow)
     );
 
     private static final Map<SchemaType, Function<byte[], byte[]>> EXTRACT_KEY_BYTES = mkMap(
-        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractKeyBytes),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractKeyBytes),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractKeyBytes)
+        Map.entry(SchemaType.SessionKeySchema, SessionKeySchema::extractKeyBytes),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractKeyBytes),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractKeyBytes)
     );
 
     private final String key = "key";

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreFetchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreFetchTest.java
@@ -51,13 +51,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.CoreMatchers.is;
@@ -148,7 +148,7 @@ public class SessionStoreFetchTest {
     @BeforeEach
     public void setUp() {
         streamsConfig = mkProperties(mkMap(
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
@@ -62,6 +62,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -69,7 +70,6 @@ import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMinutes;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
@@ -311,11 +311,11 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
         cachingStore.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             cachingStore.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
@@ -61,6 +61,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -68,7 +69,6 @@ import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMinutes;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
@@ -317,11 +317,11 @@ public class TimeOrderedWindowStoreTest {
         cachingStore.flush();
 
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             cachingStore.getPosition()
         );
         assertEquals(
-            Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 2L))))),
+            Position.fromMap(mkMap(Map.entry("", mkMap(Map.entry(0, 2L))))),
             underlyingStore.getPosition()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
@@ -34,9 +34,9 @@ import org.mockito.quality.Strictness;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -69,7 +69,7 @@ public class TimestampedSegmentTest {
         final File directory = new File(directoryPath);
 
         final ProcessorContext mockContext = mock(ProcessorContext.class);
-        when(mockContext.appConfigs()).thenReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
+        when(mockContext.appConfigs()).thenReturn(mkMap(Map.entry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
         when(mockContext.stateDir()).thenReturn(directory);
 
         segment.openDB(mockContext.appConfigs(), mockContext.stateDir());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
@@ -43,7 +43,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -54,33 +53,33 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class WindowKeySchemaTest {
 
     private static final Map<SchemaType, KeySchema> SCHEMA_TYPE_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, new WindowKeySchema()),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, new KeyFirstWindowKeySchema()),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, new TimeFirstWindowKeySchema())
+        Map.entry(SchemaType.WindowKeySchema, new WindowKeySchema()),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, new KeyFirstWindowKeySchema()),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, new TimeFirstWindowKeySchema())
     );
 
     private static final Map<SchemaType, Function<byte[], byte[]>> EXTRACT_STORE_KEY_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreKeyBytes),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreKeyBytes),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreKeyBytes)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreKeyBytes),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreKeyBytes),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreKeyBytes)
     );
 
     private static final Map<SchemaType, BiFunction<byte[], Long, Windowed<Bytes>>> FROM_STORAGE_BYTES_KEY = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::fromStoreBytesKey),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::fromStoreBytesKey),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::fromStoreBytesKey)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::fromStoreBytesKey),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::fromStoreBytesKey),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::fromStoreBytesKey)
     );
 
     private static final Map<SchemaType, BiFunction<Windowed<Bytes>, Integer, Bytes>> WINDOW_TO_STORE_BINARY_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
     );
 
     private static final Map<SchemaType, BiFunction<byte[], Long, Window>> EXTRACT_STORE_WINDOW_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreWindow),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreWindow),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreWindow)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreWindow),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreWindow),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreWindow)
     );
 
     @FunctionalInterface
@@ -89,32 +88,32 @@ public class WindowKeySchemaTest {
     }
 
     private static final Map<SchemaType, TriFunction<byte[], Long, Integer, Bytes>> BYTES_TO_STORE_BINARY_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
     );
 
     private static final Map<SchemaType, TriFunction<Windowed<String>, Integer, StateSerdes<String, byte[]>, Bytes>> SERDE_TO_STORE_BINARY_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::toStoreKeyBinary),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::toStoreKeyBinary)
     );
 
     private static final Map<SchemaType, Function<byte[], Long>> EXTRACT_TS_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreTimestamp),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreTimestamp),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreTimestamp)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreTimestamp),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreTimestamp),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreTimestamp)
     );
 
     private static final Map<SchemaType, Function<byte[], Integer>> EXTRACT_SEQ_MAP = mkMap(
-        mkEntry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreSequence),
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreSequence),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreSequence)
+        Map.entry(SchemaType.WindowKeySchema, WindowKeySchema::extractStoreSequence),
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::extractStoreSequence),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::extractStoreSequence)
     );
 
     private static final Map<SchemaType, Function<byte[], byte[]>> FROM_WINDOW_KEY_MAP = mkMap(
-        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::fromNonPrefixWindowKey),
-        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::fromNonPrefixWindowKey)
+        Map.entry(SchemaType.PrefixedKeyFirstSchema, KeyFirstWindowKeySchema::fromNonPrefixWindowKey),
+        Map.entry(SchemaType.PrefixedTimeFirstSchema, TimeFirstWindowKeySchema::fromNonPrefixWindowKey)
     );
 
     private final String key = "key";

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreFetchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreFetchTest.java
@@ -52,13 +52,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.CoreMatchers.is;
@@ -149,7 +149,7 @@ public class WindowStoreFetchTest {
     @BeforeEach
     public void setup() {
         streamsConfig = mkProperties(mkMap(
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -25,7 +25,6 @@ import org.mockito.MockedStatic;
 
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,7 +43,7 @@ public class NamedCacheMetricsTest {
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
     private final Sensor expectedSensor = mock(Sensor.class);
-    private final Map<String, String> tagMap = mkMap(mkEntry("key", "value"));
+    private final Map<String, String> tagMap = mkMap(Map.entry("key", "value"));
 
     @Test
     public void shouldGetHitRatioSensorWithBuiltInMetricsVersionCurrent() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
@@ -32,7 +32,6 @@ import org.rocksdb.Statistics;
 import java.math.BigInteger;
 import java.util.Map;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STATE_STORE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STORE_ID_TAG;
@@ -256,9 +255,9 @@ public class RocksDBMetricsRecorderGaugesTest {
 
         final Map<MetricName, ? extends Metric> metrics = streamsMetrics.metrics();
         final Map<String, String> tagMap = mkMap(
-            mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()),
-            mkEntry(TASK_ID_TAG, TASK_ID.toString()),
-            mkEntry(METRICS_SCOPE + "-" + STORE_ID_TAG, STORE_NAME)
+            Map.entry(THREAD_ID_TAG, Thread.currentThread().getName()),
+            Map.entry(TASK_ID_TAG, TASK_ID.toString()),
+            Map.entry(METRICS_SCOPE + "-" + STORE_ID_TAG, STORE_NAME)
         );
         final KafkaMetric metric = (KafkaMetric) metrics.get(new MetricName(
             propertyName,

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -63,7 +63,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 
@@ -639,12 +638,12 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             final Properties properties =
                 mkProperties(
                     mkMap(
-                        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, broker),
-                        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, application),
-                        mkEntry(StreamsConfig.CLIENT_ID_CONFIG, id),
-                        mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee),
-                        mkEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
-                        mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir)
+                        Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, broker),
+                        Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, application),
+                        Map.entry(StreamsConfig.CLIENT_ID_CONFIG, id),
+                        Map.entry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee),
+                        Map.entry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
+                        Map.entry(StreamsConfig.STATE_DIR_CONFIG, stateDir)
                     )
                 );
             properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -467,7 +466,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                 .entrySet()
                 .stream()
-                .map(entry -> mkEntry(
+                .map(entry -> Map.entry(
                     entry.getKey(),
                     entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                 )

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -66,7 +66,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.tests.SmokeTestUtil.intSerde;
@@ -153,7 +152,7 @@ public class StreamsUpgradeTest {
     }
 
     public static class FutureStreamsPartitionAssignor extends StreamsPartitionAssignor {
-        private static final Map<String, String> CLIENT_TAGS = mkMap(mkEntry("t1", "v1"), mkEntry("t2", "v2"));
+        private static final Map<String, String> CLIENT_TAGS = mkMap(Map.entry("t1", "v1"), Map.entry("t2", "v2"));
         private static final Logger log = LoggerFactory.getLogger(FutureStreamsPartitionAssignor.class);
 
         private AtomicInteger usedSubscriptionMetadataVersionPeek;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 
@@ -213,8 +212,8 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
     public MockProcessorContext() {
         this(
             mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, ""),
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, ""),
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
             )),
             new TaskId(0, 0),
             null

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -75,7 +75,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -95,8 +94,8 @@ public abstract class TopologyTestDriverTest {
 
     TopologyTestDriverTest(final Map<String, String> overrides) {
         config = mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
+                Map.entry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
         ));
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
@@ -36,12 +36,12 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -241,8 +241,8 @@ public class MockProcessorContextAPITest {
     public void shouldCaptureApplicationAndRecordMetadata() {
         final Properties config = mkProperties(
             mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "testMetadata"),
-                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
+                Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, "testMetadata"),
+                Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
             )
         );
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
@@ -44,10 +44,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -165,8 +165,8 @@ public class MockProcessorContextStateStoreTest {
         try {
             final MockProcessorContext<Void, Void> context = new MockProcessorContext<>(
                 mkProperties(mkMap(
-                    mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, ""),
-                    mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
+                    Map.entry(StreamsConfig.APPLICATION_ID_CONFIG, ""),
+                    Map.entry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "")
                 )),
                 new TaskId(0, 0),
                 stateDir

--- a/streams/upgrade-system-tests-22/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-22/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] TOPICS = {
@@ -398,7 +397,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-23/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-23/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] TOPICS = {
@@ -388,7 +387,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-24/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-24/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -433,7 +432,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-25/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-25/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -434,7 +433,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-26/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-26/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-27/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-27/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -447,7 +446,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-28/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-28/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -434,7 +433,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-30/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-30/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -434,7 +433,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-31/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-31/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-32/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-32/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-33/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-33/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-34/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-34/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-35/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-35/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-36/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-36/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-37/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-37/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/streams/upgrade-system-tests-38/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/upgrade-system-tests-38/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
     private static final String[] NUMERIC_VALUE_TOPICS = {
@@ -436,7 +435,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             events.get("echo")
                   .entrySet()
                   .stream()
-                  .map(entry -> mkEntry(
+                  .map(entry -> Map.entry(
                       entry.getKey(),
                       entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                   )

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
@@ -85,8 +85,8 @@ class ConsumerGroupCommandTestUtils {
                 .setServerProperties(serverProperties)
                 .setTags(Collections.singletonList("kraftGroupCoordinator"))
                 .setFeatures(Utils.mkMap(
-                    Utils.mkEntry(Features.TRANSACTION_VERSION, (short) 2),
-                    Utils.mkEntry(Features.GROUP_VERSION, (short) 1)))
+                    Map.entry(Features.TRANSACTION_VERSION, (short) 2),
+                    Map.entry(Features.GROUP_VERSION, (short) 1)))
                 .build());
     }
 


### PR DESCRIPTION
Updates: Since there are still many tests using mkEntry to create entries with null values, this PR will migrate all the code that can be converted to use Map.entry. The remaining code that still uses mkEntry will only for creating null entries.

Removes `Utils#mkMap` and `Utils#mkEntry` as JDK 9+ allows `Map.ofEntries` and `Map.entry` for creating immutable map.

`Utils#mkMap` will be handled in [KAFKA-17820](https://issues.apache.org/jira/browse/KAFKA-17820)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
