### PR TITLE
KAFKA-17769 Fix flaky PlaintextConsumerSubscriptionTest.testSubscribeInvalidTopicCanUnsubscribe

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
@@ -232,6 +232,11 @@ class PlaintextConsumerSubscriptionTest extends AbstractConsumerTest {
     val consumer = createConsumer()
 
     setupSubscribeInvalidTopic(consumer)
+    if(groupProtocol == "consumer") {
+      // Must ensure memberId is not empty before sending leave group heartbeat. This is a temporary solution before KIP-1082.
+      TestUtils.waitUntilTrue(() => consumer.groupMetadata().memberId().nonEmpty,
+        waitTimeMs = 30000, msg = "Timeout waiting for first consumer group heartbeat response")
+    }
     assertDoesNotThrow(new Executable {
       override def execute(): Unit = consumer.unsubscribe()
     })


### PR DESCRIPTION
The error `org.apache.kafka.common.errors.InvalidRequestException: MemberId can't be empty.` was caused by racing between the `first consumer group heartbeat` and the `leave consumer group heartbeat`. 

This PR checks for the existence of `memberId` before calling `unsubscribe()`, ensuring that there is no leave group heartbeat with an empty memberId.

Tested it for 1000 loops in my local environment without any error. (Before this PR, it will fail within 50 loops.)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
