### PR TITLE
KAFKA-17785: Add tagged field information to protocol docs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -128,6 +128,14 @@ public class Protocol {
                         b.append("</td>");
                         b.append("<td>");
                         b.append(taggedField.docString);
+                        if (taggedField.type.isArray()) {
+                            Type innerType = taggedField.type.arrayElementType().get();
+                            if (innerType instanceof Schema) {
+                                schemaToFieldTableHtml((Schema) innerType, b);
+                            }
+                        } else if (taggedField.type instanceof Schema) {
+                            schemaToFieldTableHtml((Schema) taggedField.type, b);
+                        }
                         b.append("</td>");
                         b.append("</tr>\n");
                     });

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -191,7 +191,7 @@ public class Protocol {
                     schemaToBnfHtml(requests[i], b, 2);
                     b.append("</pre>");
 
-                    if (!key.isVersionEnabled((short)i, false)) {
+                    if (!key.isVersionEnabled((short) i, false)) {
                         b.append("<p>This version of the request is unstable.</p>");
                     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -52,7 +52,7 @@ public class Protocol {
                     subTypes.put(field.def.name, type.arrayElementType().get());
                 }
             } else if (type instanceof TaggedFields) {
-                b.append("TAG_BUFFER ");
+                b.append("_tagged_fields ");
             } else {
                 b.append(field.def.name);
                 b.append(" ");
@@ -103,15 +103,15 @@ public class Protocol {
         b.append("<th>Description</th>\n");
         b.append("</tr>");
         for (BoundField field : fields) {
+            b.append("<tr>\n");
+            b.append("<td>");
+            b.append(field.def.name);
+            b.append("</td>");
+            b.append("<td>");
             if (field.def.type instanceof TaggedFields) {
                 TaggedFields taggedFields = (TaggedFields) field.def.type;
                 // Only include the field in the table if there are actually tags defined
                 if (taggedFields.numFields() > 0) {
-                    b.append("<tr>\n");
-                    b.append("<td>");
-                    b.append(field.def.name);
-                    b.append("</td>");
-                    b.append("<td>");
                     b.append("<table class=\"data-table\"><tbody>\n");
                     b.append("<tr>");
                     b.append("<th>Tag</th>\n");
@@ -132,19 +132,14 @@ public class Protocol {
                         b.append("</tr>\n");
                     });
                     b.append("</tbody></table>\n");
-                    b.append("</td>");
-                    b.append("</tr>\n");
+                } else {
+                    b.append(field.def.docString);
                 }
             } else {
-                b.append("<tr>\n");
-                b.append("<td>");
-                b.append(field.def.name);
-                b.append("</td>");
-                b.append("<td>");
                 b.append(field.def.docString);
-                b.append("</td>");
-                b.append("</tr>\n");
             }
+            b.append("</td>");
+            b.append("</tr>\n");
         }
         b.append("</tbody></table>\n");
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -103,17 +103,9 @@ public class Protocol {
         b.append("<th>Description</th>\n");
         b.append("</tr>");
         for (BoundField field : fields) {
-            if (!(field.def.type instanceof TaggedFields)) {
-                b.append("<tr>\n");
-                b.append("<td>");
-                b.append(field.def.name);
-                b.append("</td>");
-                b.append("<td>");
-                b.append(field.def.docString);
-                b.append("</td>");
-                b.append("</tr>\n");
-            } else {
+            if (field.def.type instanceof TaggedFields) {
                 TaggedFields taggedFields = (TaggedFields) field.def.type;
+                // Only include the field in the table if there are actually tags defined
                 if (taggedFields.numFields() > 0) {
                     b.append("<tr>\n");
                     b.append("<td>");
@@ -143,6 +135,15 @@ public class Protocol {
                     b.append("</td>");
                     b.append("</tr>\n");
                 }
+            } else {
+                b.append("<tr>\n");
+                b.append("<td>");
+                b.append(field.def.name);
+                b.append("</td>");
+                b.append("<td>");
+                b.append(field.def.docString);
+                b.append("</td>");
+                b.append("</tr>\n");
             }
         }
         b.append("</tbody></table>\n");

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -103,14 +103,47 @@ public class Protocol {
         b.append("<th>Description</th>\n");
         b.append("</tr>");
         for (BoundField field : fields) {
-            b.append("<tr>\n");
-            b.append("<td>");
-            b.append(field.def.name);
-            b.append("</td>");
-            b.append("<td>");
-            b.append(field.def.docString);
-            b.append("</td>");
-            b.append("</tr>\n");
+            if (!(field.def.type instanceof TaggedFields)) {
+                b.append("<tr>\n");
+                b.append("<td>");
+                b.append(field.def.name);
+                b.append("</td>");
+                b.append("<td>");
+                b.append(field.def.docString);
+                b.append("</td>");
+                b.append("</tr>\n");
+            } else {
+                TaggedFields taggedFields = (TaggedFields) field.def.type;
+                if (taggedFields.numFields() > 0) {
+                    b.append("<tr>\n");
+                    b.append("<td>");
+                    b.append(field.def.name);
+                    b.append("</td>");
+                    b.append("<td>");
+                    b.append("<table class=\"data-table\"><tbody>\n");
+                    b.append("<tr>");
+                    b.append("<th>Tag</th>\n");
+                    b.append("<th>Tagged field</th>\n");
+                    b.append("<th>Description</th>\n");
+                    b.append("</tr>");
+                    taggedFields.fields().forEach((tag, taggedField) -> {
+                        b.append("<tr>\n");
+                        b.append("<td>");
+                        b.append(tag);
+                        b.append("</td>");
+                        b.append("<td>");
+                        b.append(taggedField.name);
+                        b.append("</td>");
+                        b.append("<td>");
+                        b.append(taggedField.docString);
+                        b.append("</td>");
+                        b.append("</tr>\n");
+                    });
+                    b.append("</tbody></table>\n");
+                    b.append("</td>");
+                    b.append("</tr>\n");
+                }
+            }
         }
         b.append("</tbody></table>\n");
     }
@@ -157,6 +190,10 @@ public class Protocol {
                     b.append(") => ");
                     schemaToBnfHtml(requests[i], b, 2);
                     b.append("</pre>");
+
+                    if (!key.isVersionEnabled((short)i, false)) {
+                        b.append("<p>This version of the request is unstable.</p>");
+                    }
 
                     b.append("<p><b>Request header version:</b> ");
                     b.append(key.requestHeaderVersion((short) i));

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -183,4 +183,11 @@ public class TaggedFields extends DocumentedType {
     public int numFields() {
         return this.fields.size();
     }
+
+    /**
+     * The fields
+     */
+    public Map<Integer, Field> fields() {
+        return this.fields;
+    }
 }


### PR DESCRIPTION
The Kafka documentation includes a description of the Kafka protocol (https://kafka.apache.org/protocol). This is useful to someone wanting to understand the details of the protocol. However, in the area of tagged fields, the documentation is not helpful.

Tagged fields provide a way of supplying optional data in a request or response. Modern requests and responses usually permit tagged fields, although they are relatively rarely used in practice.

One RPC in which tagged fields contain important information is the APIVersionsResponse. In v3 and above, the response contains the set of supported and finalised features, which can be used by a client to determine whether a broker supports a feature. This information is carried as tagged fields, but if you read the documentation of the protocol, you would be entirely in the dark.

This improvement adds tagged field information into the protocol documentation.

Here's an example before the change. Each of the TAG_BUFFER fields is included in the table of fields, even ones for which there are no tagged fields defined.

![APIVersionsResponse_before](https://github.com/user-attachments/assets/17ba1ee6-a914-4ddd-9f81-2b58ef046e8e)

Here's the same RPC response in which only the TAG_BUFFER which actually has tagged fields defined is in the table, and the tagged field descriptions are included in the table in a sub-table.

<img width="997" alt="APIVersionsResponse_after" src="https://github.com/user-attachments/assets/e47c3381-8994-4de9-9469-646c37311520">

This change also indicates which RPC request versions are unstable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
