### PR TITLE
KAFKA-17788: During ZK migration, always include control.plane.listener.name in advertisedBrokerListeners

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -758,8 +758,20 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   }
 
   def effectiveAdvertisedBrokerListeners: Seq[EndPoint] = {
-    // Only expose broker listeners
-    advertisedListeners.filterNot(l => controllerListenerNames.contains(l.listenerName.value()))
+    advertisedListeners.filter(l => {
+      if (!controllerListenerNames.contains(l.listenerName.value())) {
+        true
+      } else if (migrationEnabled && Some(l.listenerName.value()).equals(controlPlaneListener.map(_.listenerName.value()))) {
+        // KAFKA-17788: during ZK migration, always include control.plane.listener.name
+        // in advertisedBrokerListeners.
+        true
+      } else {
+        System.out.println("WATERMELON: migrationEnabled = " + migrationEnabled  )
+        System.out.println("WATERMELON: Some(l) = " + Some(l))
+        System.out.println("WATERMELON: controlPlaneListener = " + controlPlaneListener)
+        false
+      }
+    })
   }
 
   // Use advertised listeners if defined, fallback to listeners otherwise


### PR DESCRIPTION
During ZK migration, always include control.plane.listener.name in advertisedBrokerListeners, to be
bug-compatible with earlier Apache Kafka versions that ignored this misconfiguration. (Just as
before, control.plane.listener.name is not supported in KRaft mode itself.)