### PR TITLE
KAFKA-17802 Update Bouncy castle from 1.75 to 1.78.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.75",
+  bcpkix: "1.78.1",
   caffeine: "2.9.3", // 3.x supports JDK 11 and above
   // when updating checkstyle, check whether the exclusion of
   // CVE-2023-2976 and CVE-2020-8908 can be dropped from


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17802

org.bouncycastle : bcprov-jdk18on version 1.75 contains vulnerabilities which can be remediated by version bump to 1.78
List of Vulnerabilities can be found here: https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on/1.75
