### PR TITLE
KAFKA-17805: Deprecate named topologies in Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1799,6 +1799,7 @@ public class KafkaStreams implements AutoCloseable {
      *  Note that pause() can be called before start() in order to start a KafkaStreams instance
      *  in a manner where the processing is paused as described, but the consumers are started up.
      */
+    @SuppressWarnings("deprecation")
     public void pause() {
         if (topologyMetadata.hasNamedTopologies()) {
             for (final NamedTopology namedTopology : topologyMetadata.allNamedTopologies()) {
@@ -1812,6 +1813,7 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * @return true when the KafkaStreams instance has its processing paused.
      */
+    @SuppressWarnings("deprecation")
     public boolean isPaused() {
         if (topologyMetadata.hasNamedTopologies()) {
             return topologyMetadata.allNamedTopologies().stream()
@@ -1825,6 +1827,7 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * This method resumes processing for the KafkaStreams instance.
      */
+    @SuppressWarnings("deprecation")
     public void resume() {
         if (topologyMetadata.hasNamedTopologies()) {
             for (final NamedTopology namedTopology : topologyMetadata.allNamedTopologies()) {

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
@@ -66,8 +66,8 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.totalCacheSi
 
 /**
  * Streams configs that apply at the topology level. The values in the {@link StreamsConfig} parameter of the
- * {@link org.apache.kafka.streams.KafkaStreams} or {@link KafkaStreamsNamedTopologyWrapper} constructors will
- * determine the defaults, which can then be overridden for specific topologies by passing them in when creating the
+ * {@link org.apache.kafka.streams.KafkaStreams} constructor or the {@link KafkaStreamsNamedTopologyWrapper} constructor (deprecated)
+ * will determine the defaults, which can then be overridden for specific topologies by passing them in when creating the
  * topology builders via the {@link org.apache.kafka.streams.StreamsBuilder#StreamsBuilder(TopologyConfig) StreamsBuilder(TopologyConfig)} method.
  */
 @SuppressWarnings("deprecation")

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -153,7 +153,8 @@ public class InternalTopologyBuilder {
 
     // The name of the topology this builder belongs to, or null if this is not a NamedTopology
     private final String topologyName;
-    // TODO KAFKA-13336: we can remove this reference once we make the Topology/NamedTopology class into an interface and implement it
+
+    @SuppressWarnings("deprecation")
     private NamedTopology namedTopology;
 
     // TODO KAFKA-13283: once we enforce all configs be passed in when constructing the topology builder then we can set
@@ -369,6 +370,7 @@ public class InternalTopologyBuilder {
         topologyConfigs = new TopologyConfig(applicationConfig);
     }
 
+    @SuppressWarnings("deprecation")
     public final synchronized void setNamedTopology(final NamedTopology namedTopology) {
         this.namedTopology = namedTopology;
     }
@@ -381,6 +383,7 @@ public class InternalTopologyBuilder {
         return topologyName;
     }
 
+    @SuppressWarnings("deprecation")
     public NamedTopology namedTopology() {
         return namedTopology;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -385,9 +385,6 @@ public class StreamsMetadataState {
                         activeStoresOnHost.addAll(getStoresOnHost(storeToSourceTopics, activePartitionsOnHost));
                     }
 
-                    // TODO KAFKA-13281: when we add support for global stores with named topologies we will
-                    //  need to add the global stores to the activeStoresOnHost set
-
                     final Set<TopicPartition> standbyPartitionsOnHost = new HashSet<>();
                     final Set<String> standbyStoresOnHost = new HashSet<>();
                     if (standbyPartitionHostMap.containsKey(hostInfo)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -614,6 +614,7 @@ public class TopologyMetadata {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public Collection<NamedTopology> allNamedTopologies() {
         return builders.values()
             .stream()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 
 import java.util.concurrent.ExecutionException;
 
+@Deprecated
 public class AddNamedTopologyResult {
 
     private final KafkaFuture<Void> addTopologyFuture;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata;
+
 import org.slf4j.Logger;
 
 import java.util.ArrayList;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals.namedtopology;
 
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
@@ -42,7 +41,6 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata;
-
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -62,13 +60,14 @@ import java.util.stream.Collectors;
  * This is currently an internal and experimental feature for enabling certain kinds of topology upgrades. Use at
  * your own risk.
  *
- * Status: additive upgrades possible, removal of NamedTopologies not yet supported
+ * Status: deprecated and planned for removal. PLEASE REACH OUT IF YOU ARE USING THIS FEATURE. Any concerns about
+ *         the deprecation can be raised by filing a ticket at https://issues.apache.org/jira/projects/KAFKA/issues
  *
  * Note: some standard features of Kafka Streams are not yet supported with NamedTopologies. These include:
  *       - global state stores
  *       - TopologyTestDriver (TTD)
  */
-@Unstable
+@Deprecated
 public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
     private final Logger log;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
 import java.util.List;
 
+@Deprecated
 public class NamedTopology extends Topology {
 
     NamedTopology(final InternalTopologyBuilder internalTopologyBuilder) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyBuilder.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
 import java.util.Properties;
 
+@Deprecated
 public class NamedTopologyBuilder extends StreamsBuilder {
 
     NamedTopologyBuilder(final String topologyName, final StreamsConfig applicationConfigs, final Properties topologyOverrides) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 
 import java.util.Objects;
 
+@Deprecated
 public class NamedTopologyStoreQueryParameters<T> extends StoreQueryParameters<T> {
 
     final String topologyName;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/RemoveNamedTopologyResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/RemoveNamedTopologyResult.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
+@Deprecated
 public class RemoveNamedTopologyResult {
     private final KafkaFutureImpl<Void> removeTopologyFuture;
     private final KafkaFutureImpl<Void> resetOffsetsFuture;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -41,7 +41,7 @@ public class StreamThreadStateStoreProvider {
         this.streamThread = streamThread;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecation"})
     public <T> List<T> stores(final StoreQueryParameters storeQueryParams) {
         final StreamThread.State state = streamThread.state();
         if (state == StreamThread.State.DEAD) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -95,6 +95,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Timeout(600)
 @Tag("integration")
+@SuppressWarnings("deprecation")
 public class NamedTopologyIntegrationTest {
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -99,6 +99,7 @@ public class PauseResumeIntegrationTest {
 
     private String appId;
     private KafkaStreams kafkaStreams, kafkaStreams2;
+    @SuppressWarnings("deprecation")
     private KafkaStreamsNamedTopologyWrapper streamsNamedTopologyWrapper;
 
     @BeforeAll
@@ -198,6 +199,7 @@ public class PauseResumeIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @SuppressWarnings("deprecation")
     public void shouldPauseAndResumeKafkaStreamsWithNamedTopologies(final boolean stateUpdaterEnabled) throws Exception {
         streamsNamedTopologyWrapper = new KafkaStreamsNamedTopologyWrapper(props(stateUpdaterEnabled));
         final NamedTopologyBuilder builder1 = getNamedTopologyBuilder1();
@@ -233,6 +235,7 @@ public class PauseResumeIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @SuppressWarnings("deprecation")
     public void shouldPauseAndResumeAllKafkaStreamsWithNamedTopologies(final boolean stateUpdaterEnabled) throws Exception {
         streamsNamedTopologyWrapper = new KafkaStreamsNamedTopologyWrapper(props(stateUpdaterEnabled));
         final NamedTopologyBuilder builder1 = getNamedTopologyBuilder1();
@@ -269,6 +272,7 @@ public class PauseResumeIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @SuppressWarnings("deprecation")
     public void shouldAllowForNamedTopologiesToStartPaused(final boolean stateUpdaterEnabled) throws Exception {
         streamsNamedTopologyWrapper = new KafkaStreamsNamedTopologyWrapper(props(stateUpdaterEnabled));
         final NamedTopologyBuilder builder1 = getNamedTopologyBuilder1();
@@ -395,12 +399,14 @@ public class PauseResumeIntegrationTest {
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, topicName, count), CoreMatchers.equalTo(output));
     }
 
+    @SuppressWarnings("deprecation")
     private NamedTopologyBuilder getNamedTopologyBuilder1() {
         final NamedTopologyBuilder builder1 = streamsNamedTopologyWrapper.newNamedTopologyBuilder(TOPOLOGY1);
         builder1.stream(INPUT_STREAM_1).groupByKey().count().toStream().to(OUTPUT_STREAM_1);
         return builder1;
     }
 
+    @SuppressWarnings("deprecation")
     private NamedTopologyBuilder getNamedTopologyBuilder2() {
         final NamedTopologyBuilder builder2 = streamsNamedTopologyWrapper.newNamedTopologyBuilder(TOPOLOGY2);
         builder2.stream(INPUT_STREAM_2)

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -416,6 +416,7 @@ public class StoreQueryIntegrationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldQuerySpecificStalePartitionStoresMultiStreamThreadsNamedTopology() throws Exception {
         final int batch1NumMessages = 100;
         final int key = 1;
@@ -635,6 +636,7 @@ public class StoreQueryIntegrationTest {
         return streams;
     }
 
+    @SuppressWarnings("deprecation")
     private KafkaStreamsNamedTopologyWrapper createNamedTopologyKafkaStreams(final Properties config) {
         final KafkaStreamsNamedTopologyWrapper streams = new KafkaStreamsNamedTopologyWrapper(config);
         streamsToCleanup.add(streams);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1066,6 +1066,7 @@ public class IntegrationTestUtils {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static StateListener getStateListener(final KafkaStreams streams) {
         try {
             if (streams instanceof KafkaStreamsNamedTopologyWrapper) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("deprecation")
 public class NamedTopologyTest {
     private static final String UNKNOWN_TOPOLOGY = "not-a-real-topology";
     private static final String UNKNOWN_STORE = "not-a-real-store";


### PR DESCRIPTION
Deprecate for 4.0. This feature will be phased out, with new functionality generally not supporting named topologies, so users are encouraged to migrate off of named topologies as soon as possible.

Though who are using this experimental feature are encouraged to reach out by filing a jira ticket so we can better understand your use case and how to support it going forward.