### PR TITLE
KAFKA-17728 KAFKA-17728 Add missing config `replica-directory-id` to raft README

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -7,7 +7,7 @@ This is used by Apache Kafka in the KRaft (Kafka Raft Metadata) mode. We
 also have a standalone test server which can be used for performance testing. We describe the details to set this up below.
 
 ### Run Single Quorum ###
-    bin/test-kraft-server-start.sh --config config/kraft.properties
+    bin/test-kraft-server-start.sh --config config/kraft.properties --replica-directory-id b8tRS7h4TJ2Vt43Dp85v2A
 
 ### Run Multi Node Quorum ###
 Create 3 separate KRaft quorum properties as the following:
@@ -41,9 +41,9 @@ Create 3 separate KRaft quorum properties as the following:
  
 Open up 3 separate terminals, and run individual commands:
 
-    bin/test-kraft-server-start.sh --config config/kraft-quorum-1.properties
-    bin/test-kraft-server-start.sh --config config/kraft-quorum-2.properties
-    bin/test-kraft-server-start.sh --config config/kraft-quorum-3.properties
+    bin/test-kraft-server-start.sh --config config/kraft-quorum-1.properties --replica-directory-id b8tRS7h4TJ2Vt43Dp85v2A
+    bin/test-kraft-server-start.sh --config config/kraft-quorum-2.properties --replica-directory-id Nkij_D9XRiYKNb41SiJo7Q
+    bin/test-kraft-server-start.sh --config config/kraft-quorum-3.properties --replica-directory-id 4-e97nI7eHPYKfEDtW8rtQ
 
 Once a leader is elected, it will begin writing to an internal
 `__raft_performance_test` topic with a steady workload of random data.


### PR DESCRIPTION
related to https://issues.apache.org/jira/browse/KAFKA-17728

> Currently, all the commands in the README at [raft/README.md](https://github.com/apache/kafka/blob/trunk/raft/README.md) are outdated because they lack the new replica-directory-id configuration, which was introduced by the significant feature in [KIP-853](https://github.com/apache/kafka/commit/056d232f4e28bf8e67e00f8ed2c103fdb0f3b78e).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
