### PR TITLE
KAFKA-17812: upgrade base image of e2e from JDK 11 to JDK 17

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,11 +45,11 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-openjdk-17" bash tests/docker/run_tests.sh
+image_name="ducker-ak-openjdk:17-buster" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```
-bash tests/docker/ducker-ak up -j 'openjdk:17'; tests/docker/run_tests.sh
+bash tests/docker/ducker-ak up -j 'openjdk:17-buster'; tests/docker/run_tests.sh
 ```
 * Remove ducker-ak containers
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,11 +45,11 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-openjdk-11" bash tests/docker/run_tests.sh
+image_name="ducker-ak-openjdk-17" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```
-bash tests/docker/ducker-ak up -j 'openjdk:11'; tests/docker/run_tests.sh
+bash tests/docker/ducker-ak up -j 'openjdk:17'; tests/docker/run_tests.sh
 ```
 * Remove ducker-ak containers
 ```

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG jdk_version=openjdk:17
+ARG jdk_version=openjdk:17.0.2-buster
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG jdk_version=openjdk:11
+ARG jdk_version=openjdk:17
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG jdk_version=openjdk:17.0.2-buster
+# The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
+# Therefore, use openjdk:17-buster instead.
+ARG jdk_version=openjdk:17-buster
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,7 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:11"
+default_jdk="openjdk:17"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,7 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:17"
+default_jdk="openjdk:17.0.2-buster"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,7 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:17.0.2-buster"
+default_jdk="openjdk:17-buster"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17812

Due to we want upgrade to Jarkata, thus we should update the java version, this PR is upgrade the e2e base image version from java 11 to java 17

After I upgrade the java version to 17, e2e test also can run 
![CleanShot 2024-10-17 at 09 13 32@2x](https://github.com/user-attachments/assets/e2d0bc6c-490f-4187-a1f2-5fd0d7331224)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
