### PR TITLE
KAFKA-17816: Add testRuntimeOnly runtimeTestLibs to test-common-api module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1612,9 +1612,12 @@ project(':test-common:test-common-api') {
     implementation project(':server')
     implementation project(':server-common')
     implementation project(':test-common')
-    implementation libs.junitJupiter
+    implementation libs.junitJupiterApi
+
     testImplementation libs.mockitoCore
+
     testRuntimeOnly libs.junitPlatformLanucher
+    testRuntimeOnly runtimeTestLibs
   }
 
   sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -1614,9 +1614,9 @@ project(':test-common:test-common-api') {
     implementation project(':test-common')
     implementation libs.junitJupiterApi
 
+    testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
 
-    testRuntimeOnly libs.junitPlatformLanucher
     testRuntimeOnly runtimeTestLibs
   }
 


### PR DESCRIPTION
# Changes
* Add `testRuntimeOnly runtimeTestLibs` to `test-common-api` module
* Use `implementation libs.junitJupiterApi` instead of `implementation libs.junitJupiter` in module `test-common-api`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
