### PR TITLE
MINOR: fix broken link in javadoc

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -42,7 +42,7 @@ import static org.apache.kafka.connect.runtime.rest.RestServerConfig.LISTENERS_C
 
 /**
  * Start an embedded Connect cluster that can be used for integration tests. Internally, this class also spins up a
- * backing Kafka KRaft cluster for the Connect cluster leveraging {@link kafka.testkit.KafkaClusterTestKit}. Methods
+ * backing Kafka KRaft cluster for the Connect cluster leveraging {@link org.apache.kafka.common.test.KafkaClusterTestKit}. Methods
  * on the same {@code EmbeddedConnectCluster} are not guaranteed to be thread-safe. This class also provides various
  * utility methods to perform actions on the Connect cluster such as connector creation, config validation, connector
  * restarts, pause / resume, connector deletion etc.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -91,7 +91,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Setup an embedded Kafka KRaft cluster (using {@link kafka.testkit.KafkaClusterTestKit} internally) with the
+ * Setup an embedded Kafka KRaft cluster (using {@link org.apache.kafka.common.test.KafkaClusterTestKit} internally) with the
  * specified number of brokers and the specified broker properties. This can be used for integration tests and is
  * typically used in conjunction with {@link EmbeddedConnectCluster}. Additional Kafka client properties can also be
  * supplied if required. This class also provides various utility methods to easily create Kafka topics, produce data,

--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterConfigProperty.java
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterConfigProperty.java
@@ -30,14 +30,14 @@ public @interface ClusterConfigProperty {
     /**
      * The config applies to the controller/broker with specified id. Default is -1, indicating the property applied to
      * all controller/broker servers. Note that the "controller" here refers to the KRaft quorum controller.
-     * The id can vary depending on the different {@link kafka.test.annotation.Type}.
+     * The id can vary depending on the different {@link org.apache.kafka.common.test.api.Type}.
      * <ul>
-     *  <li> Under {@link kafka.test.annotation.Type#KRAFT}, the broker id starts from
-     *  {@link kafka.testkit.TestKitNodes#BROKER_ID_OFFSET 0}, the controller id
-     *  starts from {@link kafka.testkit.TestKitNodes#CONTROLLER_ID_OFFSET 3000}
+     *  <li> Under {@link org.apache.kafka.common.test.api.Type#KRAFT}, the broker id starts from
+     *  {@link org.apache.kafka.common.test.TestKitNodes#BROKER_ID_OFFSET 0}, the controller id
+     *  starts from {@link org.apache.kafka.common.test.TestKitNodes#CONTROLLER_ID_OFFSET 3000}
      *  and increases by 1 with each addition broker/controller.</li>
-     *  <li> Under {@link kafka.test.annotation.Type#CO_KRAFT}, the broker id and controller id both start from
-     *  {@link kafka.testkit.TestKitNodes#BROKER_ID_OFFSET 0}
+     *  <li> Under {@link org.apache.kafka.common.test.api.Type#CO_KRAFT}, the broker id and controller id both start from
+     *  {@link org.apache.kafka.common.test.TestKitNodes#BROKER_ID_OFFSET 0}
      *  and increases by 1 with each additional broker/controller.</li>
      * </ul>
      *

--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/Type.java
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/Type.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
 
 /**
- * The type of cluster config being requested. Used by {@link kafka.test.ClusterConfig} and the test annotations.
+ * The type of cluster config being requested. Used by {@link org.apache.kafka.common.test.api.ClusterConfig} and the test annotations.
  */
 public enum Type {
     KRAFT {


### PR DESCRIPTION
as title, some code link is broken after https://github.com/apache/kafka/commit/979740b49d32db4ca7dfb212f913d0842001ea92, this pr aims to fix them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
