### PR TITLE
KAFKA-17455: fix stuck producer when throttling or retrying

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -72,12 +72,14 @@ public final class NetworkClientUtils {
             }
             long pollTimeout = timeoutMs - (attemptStartTime - startTime); // initialize in this order to avoid overflow
 
-            // If the network client is delayed for some reason (eg. throttling or retry backoff), polling longer than
-            // that is potentially dangerous as the producer will get stuck waiting with potential for some pending
-            // requests to just not get sent. This fixes KAFKA-17455. This is the way.
-            long timeUntilCanSendDataAgain = client.pollDelayMs(node, startTime);
-            if (timeUntilCanSendDataAgain > 0 && pollTimeout > timeUntilCanSendDataAgain) {
-                pollTimeout = timeUntilCanSendDataAgain;
+            // If the network client is waiting to send data for some reason (eg. throttling or retry backoff),
+            // polling longer than that is potentially dangerous as the producer will not attempt to send
+            // any pending requests.
+            long waitingTime = client.pollDelayMs(node, startTime);
+            if (waitingTime > 0 && pollTimeout > waitingTime) {
+                // Block only until the next-scheduled time that it's okay to send data to the producer,
+                // wake up, and try again. This is the way.
+                pollTimeout = waitingTime;
             }
 
             client.poll(pollTimeout, attemptStartTime);

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -142,7 +142,7 @@ public class MockClient implements KafkaClient {
         return connectionState(node.idString()).pollDelayMs(now);
     }
 
-    public void setAdvanceTimeDuringPoll(boolean advanceTimeDuringPoll) {
+    public void advanceTimeDuringPoll(boolean advanceTimeDuringPoll) {
         this.advanceTimeDuringPoll = advanceTimeDuringPoll;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -71,6 +71,7 @@ public class MockClient implements KafkaClient {
 
     private int correlation;
     private Runnable wakeupHook;
+    private boolean advanceTimeDuringPoll;
     private final Time time;
     private final MockMetadataUpdater metadataUpdater;
     private final Map<String, ConnectionState> connections = new HashMap<>();
@@ -139,6 +140,10 @@ public class MockClient implements KafkaClient {
     @Override
     public long pollDelayMs(Node node, long now) {
         return connectionState(node.idString()).pollDelayMs(now);
+    }
+
+    public void setAdvanceTimeDuringPoll(boolean advanceTimeDuringPoll) {
+        this.advanceTimeDuringPoll = advanceTimeDuringPoll;
     }
 
     public void backoff(Node node, long durationMs) {
@@ -336,9 +341,9 @@ public class MockClient implements KafkaClient {
             copy.add(response);
         }
 
-        if (copy.isEmpty()) {
-            // Simulate time advancing. If no responses are received, then we know that
-            // we waited for the whole timeoutMs.
+        // In real life, if poll() is called and we get to the end with no responses,
+        // time equal to timeoutMs would have passed.
+        if (advanceTimeDuringPoll) {
             time.sleep(timeoutMs);
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -568,6 +568,37 @@ public class SenderTest {
     }
 
     @Test
+    public void senderThreadShouldNotBlockWhenBackingOffAndAddingPartitionsToTxn() {
+        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
+        apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
+        TransactionManager txnManager = new TransactionManager(logContext, "testUnresolvedSeq", 60000, 100, apiVersions);
+
+        setupWithTransactionState(txnManager);
+        doInitTransactions(txnManager, producerIdAndEpoch);
+
+        int backoffTimeMs = 10;
+        long now = time.milliseconds();
+        Node nodeToThrottle = metadata.fetch().nodeById(0);
+        // client.throttle(nodeToThrottle, backoffTimeMs);
+        client.backoff(nodeToThrottle, backoffTimeMs);
+        assertTrue(client.isConnected(nodeToThrottle.idString()));
+        client.disconnect(nodeToThrottle.idString());
+        assertFalse(client.isConnected(nodeToThrottle.idString()));
+
+        // Verify node is throttled about 10ms. In real-life Apache Kafka, we observe that this can happen
+        // as done above (with a disconnect and a backoff) or if the producer receives a response with
+        // throttleTimeMs > 0.
+        long currentPollDelay = client.pollDelayMs(nodeToThrottle, now);
+        assertTrue(currentPollDelay > 0);
+        assertTrue(currentPollDelay <= backoffTimeMs);
+
+        txnManager.beginTransaction();
+        txnManager.maybeAddPartition(tp0);
+
+        // sender.runOnce();
+    }
+
+    @Test
     public void testNodeLatencyStats() throws Exception {
         try (Metrics m = new Metrics()) {
             // Create a new record accumulator with non-0 partitionAvailabilityTimeoutMs

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -570,7 +570,7 @@ public class SenderTest {
     @Test
     public void senderThreadShouldNotGetStuckWhenThrottledAndAddingPartitionsToTxn() {
         // We want MockClient#poll() to advance time so that eventually the backoff expires.
-        client.setAdvanceTimeDuringPoll(true);
+        client.advanceTimeDuringPoll(true);
 
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
@@ -602,7 +602,7 @@ public class SenderTest {
         // It should have blocked roughly only the backoffTimeMs and some change.
         assertTrue(totalTimeToRunOnce < REQUEST_TIMEOUT);
 
-        client.setAdvanceTimeDuringPoll(false);
+        client.advanceTimeDuringPoll(false);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -588,8 +588,7 @@ public class SenderTest {
             // Verify node is throttled a little bit. In real-life Apache Kafka, we observe that this can happen
             // as done above by throttling or with a disconnect / backoff.
             long currentPollDelay = client.pollDelayMs(nodeToThrottle, startTime);
-            assertTrue(currentPollDelay > 0);
-            assertTrue(currentPollDelay == throttleTimeMs);
+            assertEquals(currentPollDelay, throttleTimeMs);
 
             txnManager.beginTransaction();
             txnManager.maybeAddPartition(tp0);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -570,39 +570,42 @@ public class SenderTest {
     @Test
     public void senderThreadShouldNotGetStuckWhenThrottledAndAddingPartitionsToTxn() {
         // We want MockClient#poll() to advance time so that eventually the backoff expires.
-        client.advanceTimeDuringPoll(true);
+        try {
+            client.advanceTimeDuringPoll(true);
 
-        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
-        apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
-        TransactionManager txnManager = new TransactionManager(logContext, "testUnresolvedSeq", 60000, 100, apiVersions);
+            ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
+            apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
+            TransactionManager txnManager = new TransactionManager(logContext, "testUnresolvedSeq", 60000, 100, apiVersions);
 
-        setupWithTransactionState(txnManager);
-        doInitTransactions(txnManager, producerIdAndEpoch);
+            setupWithTransactionState(txnManager);
+            doInitTransactions(txnManager, producerIdAndEpoch);
 
-        int throttleTimeMs = 1000;
-        long startTime = time.milliseconds();
-        Node nodeToThrottle = metadata.fetch().nodeById(0);
-        client.throttle(nodeToThrottle, throttleTimeMs);
+            int throttleTimeMs = 1000;
+            long startTime = time.milliseconds();
+            Node nodeToThrottle = metadata.fetch().nodeById(0);
+            client.throttle(nodeToThrottle, throttleTimeMs);
 
-        // Verify node is throttled a little bit. In real-life Apache Kafka, we observe that this can happen
-        // as done above by throttling or with a disconnect / backoff.
-        long currentPollDelay = client.pollDelayMs(nodeToThrottle, startTime);
-        assertTrue(currentPollDelay > 0);
-        assertTrue(currentPollDelay <= throttleTimeMs);
+            // Verify node is throttled a little bit. In real-life Apache Kafka, we observe that this can happen
+            // as done above by throttling or with a disconnect / backoff.
+            long currentPollDelay = client.pollDelayMs(nodeToThrottle, startTime);
+            assertTrue(currentPollDelay > 0);
+            assertTrue(currentPollDelay == throttleTimeMs);
 
-        txnManager.beginTransaction();
-        txnManager.maybeAddPartition(tp0);
+            txnManager.beginTransaction();
+            txnManager.maybeAddPartition(tp0);
 
-        assertFalse(txnManager.hasInFlightRequest());
-        sender.runOnce();
-        assertTrue(txnManager.hasInFlightRequest());
+            assertFalse(txnManager.hasInFlightRequest());
+            sender.runOnce();
+            assertTrue(txnManager.hasInFlightRequest());
 
-        long totalTimeToRunOnce = time.milliseconds() - startTime;
+            long totalTimeToRunOnce = time.milliseconds() - startTime;
 
-        // It should have blocked roughly only the backoffTimeMs and some change.
-        assertTrue(totalTimeToRunOnce < REQUEST_TIMEOUT);
+            // It should have blocked roughly only the backoffTimeMs and some change.
+            assertTrue(totalTimeToRunOnce < REQUEST_TIMEOUT);
 
-        client.advanceTimeDuringPoll(false);
+        } finally {
+            client.advanceTimeDuringPoll(false);
+        }
     }
 
     @Test


### PR DESCRIPTION
fixes stuck producer by polling again after pollDelayMs in NetworkUtils#awaitReady()
