### PR TITLE
MINOR: Fix the dangling javadoc comment 

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -41,17 +41,17 @@ import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * This benchmark calculates the empirical evidence of different implementation for encoding/decoding a protobuf
+ * <a href="https://protobuf.dev/programming-guides/encoding/#varints">VarInt</a> and VarLong.
+ * </p>
+ * The benchmark uses JMH and calculates results for different sizes of variable length integer. We expect most of the
+ * usage in Kafka code base to be 1 or 2 byte integers.
+ */
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(3)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-/**
- * This benchmark calculates the empirical evidence of different implementation for encoding/decoding a protobuf
- * <a href="https://protobuf.dev/programming-guides/encoding/#varints">VarInt</a> and VarLong.
- *
- * The benchmark uses JMH and calculates results for different sizes of variable length integer. We expect most of the
- * usage in Kafka code base to be 1 or 2 byte integers.
- */
 public class ByteUtilsBenchmark {
     private static final int DATA_SET_SAMPLE_SIZE = 16384;
 


### PR DESCRIPTION
Fix the dangling java doc comment for `ByteUtilsBenchmark`  class, by putting the comment block on the header of class declaration and annotations


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
