### PR TITLE
KAFKA-17824: Upgrade protobuf-java version to 4.28.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -328,4 +328,4 @@ BSD 3-Clause
 jline-3.25.1, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
-protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
+protobuf-java-4.28.2, see: licenses/protobuf-java-BSD-3-clause

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -133,7 +133,7 @@ versions += [
   metrics: "2.2.0",
   netty: "4.1.111.Final",
   opentelemetryProto: "1.0.0-alpha",
-  protobuf: "3.25.5", // a dependency of opentelemetryProto
+  protobuf: "4.28.2", // a dependency of opentelemetryProto
   pcollections: "4.0.1",
   reload4j: "1.2.25",
   rocksDB: "7.9.2",


### PR DESCRIPTION
Upgrade protobuf-java library to version 4.28.2, that bring much enhancements and bug fixing comparing to the existing 3.X one the version 4.x is backward compatible with Protobuf 3.x at the wire format level. This means that data serialized using Protobuf 3.x can be deserialized using Protobuf 4.x, and vice versa, without issues 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
