### PR TITLE
KAFKA-17791 Dockerfile should use `requirements.txt` to ensure dependencies

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -65,7 +65,8 @@ LABEL ducker.creator=$ducker_creator
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 iputils-ping && apt-get -y clean
 RUN python3 -m pip install -U pip==21.1.1;
 # NOTE: ducktape 0.12.0 supports py 3.9, 3.10, 3.11 and 3.12
-RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 debugpy psutil && pip3 install --upgrade "ducktape==0.12.0"
+COPY requirements.txt requirements.txt
+RUN pip3 install --upgrade -r requirements.txt
 
 COPY --from=build-native-image /build/kafka-binary/ /opt/kafka-binary/
 # Set up ssh

--- a/tests/docker/requirements.txt
+++ b/tests/docker/requirements.txt
@@ -1,0 +1,10 @@
+cffi 
+virtualenv 
+pyasn1 
+boto3 
+pycrypto 
+pywinrm 
+ipaddress 
+debugpy 
+psutil
+ducktape==0.12.0

--- a/tests/docker/requirements.txt
+++ b/tests/docker/requirements.txt
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cffi 
 virtualenv 
 pyasn1 


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17791 

We should use `requirements.txt` to control python dependencies, it will make easier to control the plugin version

It would work on my local machine
![CleanShot 2024-10-18 at 23 13 06@2x](https://github.com/user-attachments/assets/475677b5-7a44-4662-8177-b027b3339403)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
