### PR TITLE
KAFKA-17832: Remove all EnabledForJreRange

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/internals/SecurityManagerCompatibilityTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/internals/SecurityManagerCompatibilityTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SecurityManagerCompatibilityTest {
 
-    @EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_22)
+    @EnabledForJreRange(max = JRE.JAVA_22)
     @Test
     public void testLegacyStrategyLoadable() throws ClassNotFoundException, NoSuchMethodException {
         new LegacyStrategy(ReflectiveStrategy.Loader.forName());

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.JRE;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.io.IOException;
@@ -70,7 +69,6 @@ public class SslTransportTls12Tls13Test {
      * Tests that connections fails if TLSv1.3 enabled but cipher suite suitable only for TLSv1.2 used.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     public void testCiphersSuiteForTls12FailsForTls13() throws Exception {
         String cipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384";
 
@@ -89,7 +87,6 @@ public class SslTransportTls12Tls13Test {
      * Tests that connections can't be made if server uses TLSv1.2 with custom cipher suite and client uses TLSv1.3.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     public void testCiphersSuiteFailForServerTls12ClientTls13() throws Exception {
         String tls12CipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384";
         String tls13CipherSuite = "TLS_AES_128_GCM_SHA256";
@@ -110,7 +107,6 @@ public class SslTransportTls12Tls13Test {
      * Tests that connections can be made with TLSv1.3 cipher suite.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     public void testCiphersSuiteForTls13() throws Exception {
         String cipherSuite = "TLS_AES_128_GCM_SHA256";
 

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.JRE;
 
 import java.io.File;
 import java.io.IOException;

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.io.File;
@@ -38,7 +37,6 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnabledForJreRange(min = JRE.JAVA_11) // TLS 1.3 is only supported with Java 11 and newer
 public class Tls13SelectorTest extends SslSelectorTest {
 
     @Override


### PR DESCRIPTION
We are dropping support for JDK 8.  Remove and update EnabledForJreRange without accounting for JDK 8.

You can refer to the full plan for dropping JDK 8 here: [KAFKA-12894](https://issues.apache.org/jira/browse/KAFKA-12894)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
