### PR TITLE
MINOR: Set sourceCompatibility/targetCompatibility properties to Scala Compile task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -767,6 +767,8 @@ subprojects {
     scalaCompileOptions.additionalParameters += ["-opt-warnings", "-Xlint:strict-unsealed-patmat"]
     // Scala 2.13.2 introduces compiler warnings suppression, which is a pre-requisite for -Xfatal-warnings
     scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
+
+    scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
     sourceCompatibility = minJavaVersion
     targetCompatibility = minJavaVersion
     addParametersForTests(name, options)

--- a/build.gradle
+++ b/build.gradle
@@ -767,9 +767,8 @@ subprojects {
     scalaCompileOptions.additionalParameters += ["-opt-warnings", "-Xlint:strict-unsealed-patmat"]
     // Scala 2.13.2 introduces compiler warnings suppression, which is a pre-requisite for -Xfatal-warnings
     scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
-
-    scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
-
+    sourceCompatibility = minJavaVersion
+    targetCompatibility = minJavaVersion
     addParametersForTests(name, options)
 
     configure(scalaCompileOptions.forkOptions) {

--- a/build.gradle
+++ b/build.gradle
@@ -769,8 +769,8 @@ subprojects {
     scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
 
     scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
-    sourceCompatibility = minJavaVersion
-    targetCompatibility = minJavaVersion
+    options.compilerArgs += ["--release", String.valueOf(minJavaVersion)]
+
     addParametersForTests(name, options)
 
     configure(scalaCompileOptions.forkOptions) {


### PR DESCRIPTION
looks like removal of sourceCompatibility, targetCompatibility Java compile options from `build.gradle` in https://github.com/apache/kafka/commit/9b62c861fa4650e58a393384ed16dcec9df32fc5 is not setting the expected Java compile target version to Java classes present in core module.

I have added sourceCompatibility/targetCompatibility properties to ScalaCompile task to fix the issue.