### PR TITLE
MINOR: add psutil to setup.py

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.12.0", "requests==2.31.0"],
+      install_requires=["ducktape==0.12.0", "requests==2.31.0", "psutil==5.7.2"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Ducktape 0.12 added psutil as a requirement, and while we fixed the Dockerfile in https://github.com/apache/kafka/commit/bb7c0830496f5dbb01a29bcf27cb77b7d83fe939, we did not add the requirement in setup.py