### PR TITLE
KAFKA-17818: Add log4j.properties to test-common and test-common-api

### DIFF
--- a/test-common/src/test/resources/log4j.properties
+++ b/test-common/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka=INFO

--- a/test-common/test-common-api/src/test/resources/log4j.properties
+++ b/test-common/test-common-api/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka=INFO


### PR DESCRIPTION
Add log4j.properties for test-common and test-common-api module to provide more flexible debug option

## Test Report

### test-common module

```bash
./gradlew cleanTest test-common:test --rerun-tasks --tests KafkaClusterTestKitTest
```

#### Before

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.apache.kafka.common.test.KafkaClusterTestKitTest" tests="7" skipped="0" failures="0" errors="0" timestamp="2024-10-19T16:12:34" hostname="MacBook-Pro-4.local" time="0.382">
  <properties/>
  <testcase name="&quot;testCreateClusterWithBadNumDisksThrows(int).disks=0&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.041"/>
  <testcase name="&quot;testCreateClusterWithBadNumDisksThrows(int).disks=-1&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.0"/>
  <testcase name="testCreateClusterWithBadNumOfBrokers()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.0"/>
  <testcase name="testCreateClusterWithBadNumOfControllers()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.0"/>
  <testcase name="testCreateClusterWithBadPerServerProperties()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.005"/>
  <testcase name="&quot;testCreateClusterAndCloseWithMultipleLogDirs(boolean).combined=true&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.298"/>
  <testcase name="&quot;testCreateClusterAndCloseWithMultipleLogDirs(boolean).combined=false&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.031"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[log4j:WARN No appenders could be found for logger (kafka.utils.Log4jControllerRegistration$).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
]]></system-err>
</testsuite>
```

#### After

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.apache.kafka.common.test.KafkaClusterTestKitTest" tests="7" skipped="0" failures="0" errors="0" timestamp="2024-10-19T15:54:09" hostname="MacBook-Pro-4.local" time="0.4">
  <properties/>
  <testcase name="&quot;testCreateClusterWithBadNumDisksThrows(int).disks=0&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.054"/>
  <testcase name="&quot;testCreateClusterWithBadNumDisksThrows(int).disks=-1&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.001"/>
  <testcase name="testCreateClusterWithBadNumOfBrokers()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.001"/>
  <testcase name="testCreateClusterWithBadNumOfControllers()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.001"/>
  <testcase name="testCreateClusterWithBadPerServerProperties()" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.006"/>
  <testcase name="&quot;testCreateClusterAndCloseWithMultipleLogDirs(boolean).combined=true&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.299"/>
  <testcase name="&quot;testCreateClusterAndCloseWithMultipleLogDirs(boolean).combined=false&quot;" classname="org.apache.kafka.common.test.KafkaClusterTestKitTest" time="0.031"/>
  <system-out><![CDATA[[2024-10-19 23:54:09,731] INFO Registered kafka:type=kafka.Log4jController MBean (kafka.utils.Log4jControllerRegistration$:31)
[2024-10-19 23:54:09,785] INFO Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation (org.apache.zookeeper.common.X509Util:78)
]]></system-out>
  <system-err><![CDATA[]]></system-err>
</testsuite>
```

### test-common-api module


```bash
./gradlew cleanTest test-common:test-common-api:test --rerun-tasks --tests ClusterTestExtensionsTest
```

#### Before

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" tests="24" skipped="0" failures="0" errors="0" timestamp="2024-10-19T16:09:02" hostname="MacBook-Pro-4.local" time="19.059">
  <properties/>
  <testcase name="testClusterTest [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="1.168"/>
  <testcase name="testNoAutoStart [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.669"/>
  <testcase name="testCreateTopic [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="1.016"/>
  <testcase name="testCreateTopic [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.795"/>
  <testcase name="testNotSupportedNewGroupProtocols [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.595"/>
  <testcase name="testNotSupportedNewGroupProtocols [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.441"/>
  <testcase name="testNotSupportedNewGroupProtocols [3] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.557"/>
  <testcase name="testNotSupportedNewGroupProtocols [4] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.243"/>
  <testcase name="testClusterTestWithDisksPerBroker [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.551"/>
  <testcase name="testClusterTestWithDisksPerBroker [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.236"/>
  <testcase name="testClusterTestWithDisksPerBroker [3] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.563"/>
  <testcase name="testClusterTestWithDisksPerBroker [4] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.248"/>
  <testcase name="testShutdownAndSyncMetadata [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="2.963"/>
  <testcase name="testShutdownAndSyncMetadata [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="3.001"/>
  <testcase name="testClusterTests [1] Type=Raft-Isolated, default.display.key1,default.display.key2,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.566"/>
  <testcase name="testClusterTests [2] Type=Raft-Combined, default.display.key1,default.display.key2,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.24"/>
  <testcase name="testClusterAliveBrokers [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.795"/>
  <testcase name="testClusterAliveBrokers [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.792"/>
  <testcase name="testClusterTemplate [1] Type=Raft-Isolated, Generated Test,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.591"/>
  <testcase name="testSupportedNewGroupProtocols [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.604"/>
  <testcase name="testSupportedNewGroupProtocols [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.234"/>
  <testcase name="testDefaults [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.565"/>
  <testcase name="testVerifyTopicDeletion [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.801"/>
  <testcase name="testVerifyTopicDeletion [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.811"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[log4j:WARN No appenders could be found for logger (kafka.utils.Log4jControllerRegistration$).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
]]></system-err>
</testsuite>
```

#### After
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" tests="24" skipped="0" failures="0" errors="0" timestamp="2024-10-19T16:00:35" hostname="MacBook-Pro-4.local" time="19.483">
  <properties/>
  <testcase name="testClusterTest [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="1.304"/>
  <testcase name="testNoAutoStart [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.484"/>
  <testcase name="testCreateTopic [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="1.111"/>
  <testcase name="testCreateTopic [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.796"/>
  <testcase name="testNotSupportedNewGroupProtocols [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.582"/>
  <testcase name="testNotSupportedNewGroupProtocols [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.249"/>
  <testcase name="testNotSupportedNewGroupProtocols [3] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.553"/>
  <testcase name="testNotSupportedNewGroupProtocols [4] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.241"/>
  <testcase name="testClusterTestWithDisksPerBroker [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.561"/>
  <testcase name="testClusterTestWithDisksPerBroker [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.242"/>
  <testcase name="testClusterTestWithDisksPerBroker [3] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.591"/>
  <testcase name="testClusterTestWithDisksPerBroker [4] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.242"/>
  <testcase name="testShutdownAndSyncMetadata [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="3.125"/>
  <testcase name="testShutdownAndSyncMetadata [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="3.2"/>
  <testcase name="testClusterTests [1] Type=Raft-Isolated, default.display.key1,default.display.key2,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.458"/>
  <testcase name="testClusterTests [2] Type=Raft-Combined, default.display.key1,default.display.key2,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.239"/>
  <testcase name="testClusterAliveBrokers [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.903"/>
  <testcase name="testClusterAliveBrokers [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.997"/>
  <testcase name="testClusterTemplate [1] Type=Raft-Isolated, Generated Test,MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.605"/>
  <testcase name="testSupportedNewGroupProtocols [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.474"/>
  <testcase name="testSupportedNewGroupProtocols [2] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.368"/>
  <testcase name="testDefaults [1] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.481"/>
  <testcase name="testVerifyTopicDeletion [1] Type=Raft-Combined, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.873"/>
  <testcase name="testVerifyTopicDeletion [2] Type=Raft-Isolated, MetadataVersion=4.0-IV3,BrokerSecurityProtocol=PLAINTEXT,BrokerListenerName=ListenerName(EXTERNAL)" classname="org.apache.kafka.common.test.api.ClusterTestExtensionsTest" time="0.791"/>
  <system-out><![CDATA[[2024-10-20 00:00:35,677] INFO Registered kafka:type=kafka.Log4jController MBean (kafka.utils.Log4jControllerRegistration$:31)
[2024-10-20 00:00:35,726] INFO Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation (org.apache.zookeeper.common.X509Util:78)
[2024-10-20 00:00:35,819] INFO Formatting /var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/controller_3000. (org.apache.kafka.common.test.KafkaClusterTestKit:420)
[2024-10-20 00:00:35,819] INFO Formatting /var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/broker_0_data0. (org.apache.kafka.common.test.KafkaClusterTestKit:420)
[2024-10-20 00:00:35,868] INFO [ControllerServer id=3000] Starting controller (kafka.server.ControllerServer:66)
[2024-10-20 00:00:35,868] INFO [BrokerServer id=0] Transition from SHUTDOWN to STARTING (kafka.server.BrokerServer:66)
[2024-10-20 00:00:35,870] INFO [SharedServer id=0] Starting SharedServer (kafka.server.SharedServer:66)
[2024-10-20 00:00:35,933] INFO [LogLoader partition=__cluster_metadata-0, dir=/var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/broker_0_data0] Loading producer state till offset 0 with message format version 2 (org.apache.kafka.storage.internals.log.UnifiedLog:75)
[2024-10-20 00:00:35,933] INFO [LogLoader partition=__cluster_metadata-0, dir=/var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/broker_0_data0] Reloading from producer snapshot and rebuilding producer state from offset 0 (org.apache.kafka.storage.internals.log.UnifiedLog:101)
[2024-10-20 00:00:35,935] INFO [LogLoader partition=__cluster_metadata-0, dir=/var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/broker_0_data0] Producer state recovery took 0ms for snapshot load and 0ms for segment recovery from offset 0 (org.apache.kafka.storage.internals.log.UnifiedLog:137)
[2024-10-20 00:00:35,957] INFO Initialized snapshots with IDs SortedSet() from /var/folders/bg/0qbb_r0d62301q8ynbdssjq40000gp/T/kafka-13449902677015093617/broker_0_data0/__cluster_metadata-0 (kafka.raft.KafkaMetadataLog$:556)
[2024-10-20 00:00:35,974] INFO [raft-expiration-reaper]: Starting (kafka.raft.TimingWheelExpirationService$ExpiredOperationReaper:133)
[2024-10-20 00:00:36,073] INFO Updated connection-accept-rate max connection creation rate to 2147483647 (kafka.network.ConnectionQuotas:66)
[2024-10-20 00:00:36,079] INFO Awaiting socket connections on localhost:53504. (kafka.network.DataPlaneAcceptor:66)
[2024-10-20 00:00:36,080] INFO Opened wildcard endpoint localhost:53504 (kafka.network.DataPlaneAcceptor:66)
...
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
