### PR TITLE
KAFKA-16617: Add KRaft info for the `advertised.listeners` doc description

### DIFF
--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -78,8 +78,11 @@ public class SocketServerConfigs {
             " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>%n";
 
     public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
-    public static final String ADVERTISED_LISTENERS_DOC = String.format(
-            "Listeners to publish to ZooKeeper for clients to use, if different than the <code>%s</code> config property." +
+    public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
+                    " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
+                    " use to connect, such as in cloud environments. In environments using ZooKeeper, these addresses are published to ZooKeeper." +
+                    " In KRaft mode, these information are managed internally by the Kafka brokers themselves with KRaftMetadataCache." +
+                    " The address would be publish to kraft controller by KRaftMetadataCachePublisher and managed by kraft controller" +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -81,8 +81,7 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
                     " use to connect, such as in cloud environments. In environments using ZooKeeper, these addresses are published to ZooKeeper." +
-                    " In KRaft mode, these information are managed internally by the Kafka brokers themselves." +
-                    " The address would be publish to and managed by kraft controller" +
+                    " In Kraft mode, the address would be published to and managed by kraft controller, the brokers would pull these data from controller as needed." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -81,8 +81,8 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
                     " use to connect, such as in cloud environments. In environments using ZooKeeper, these addresses are published to ZooKeeper." +
-                    " In KRaft mode, these information are managed internally by the Kafka brokers themselves with KRaftMetadataCache." +
-                    " The address would be publish to kraft controller by KRaftMetadataCachePublisher and managed by kraft controller" +
+                    " In KRaft mode, these information are managed internally by the Kafka brokers themselves." +
+                    " The address would be publish to and managed by kraft controller" +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +


### PR DESCRIPTION
As titled, this pr add advertised listeners info into current doc, please see [KAFKA-16617](https://issues.apache.org/jira/browse/KAFKA-16617) for more details. thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
