### PR TITLE
Support for base64 encode string keystore

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -89,11 +89,6 @@ public class SslConfigs {
     public static final String SSL_KEYSTORE_LOCATION_DOC = "The location of the key store file. "
         + "This is optional for client and can be used for two-way authentication for client.";
 
-    public static final String SSL_KEYSTORE_ALIAS_CONFIG = "ssl.keystore.alias";
-    public static final String SSL_KEYSTORE_ALIAS_DOC = "This is config is used to pick named alias from the keystore to build the SSL engine and authenticate the client with broker. " +
-            "This is an optional config and used only when you have multiple keys in the keystore and you need to control which key needs to be presented to server.";
-
-
     public static final String SSL_KEYSTORE_PASSWORD_CONFIG = "ssl.keystore.password";
     public static final String SSL_KEYSTORE_PASSWORD_DOC = "The store password for the key store file. "
         + "This is optional for client and only needed if 'ssl.keystore.location' is configured. "
@@ -153,7 +148,6 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, ConfigDef.Type.LIST, SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_ENABLED_PROTOCOLS_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_KEYSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_LOCATION_DOC)
-                .define(SslConfigs.SSL_KEYSTORE_ALIAS_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_ALIAS_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEY_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEY_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_KEY_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -89,6 +89,11 @@ public class SslConfigs {
     public static final String SSL_KEYSTORE_LOCATION_DOC = "The location of the key store file. "
         + "This is optional for client and can be used for two-way authentication for client.";
 
+    public static final String SSL_KEYSTORE_ALIAS_CONFIG = "ssl.keystore.alias";
+    public static final String SSL_KEYSTORE_ALIAS_DOC = "The Alias of key in the key store file. "
+            + "This is optional for client and can be used for two-way authentication for client.";
+
+
     public static final String SSL_KEYSTORE_PASSWORD_CONFIG = "ssl.keystore.password";
     public static final String SSL_KEYSTORE_PASSWORD_DOC = "The store password for the key store file. "
         + "This is optional for client and only needed if 'ssl.keystore.location' is configured. "
@@ -148,6 +153,7 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, ConfigDef.Type.LIST, SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_ENABLED_PROTOCOLS_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_KEYSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_LOCATION_DOC)
+                .define(SslConfigs.SSL_KEYSTORE_ALIAS_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_ALIAS_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEY_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEY_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_KEY_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -90,8 +90,8 @@ public class SslConfigs {
         + "This is optional for client and can be used for two-way authentication for client.";
 
     public static final String SSL_KEYSTORE_ALIAS_CONFIG = "ssl.keystore.alias";
-    public static final String SSL_KEYSTORE_ALIAS_DOC = "The Alias of key in the key store file. "
-            + "This is optional for client and can be used for two-way authentication for client.";
+    public static final String SSL_KEYSTORE_ALIAS_DOC = "This is config is used to pick named alias from the keystore to build the SSL engine and authenticate the client with broker. " +
+            "This is an optional config and used only when you have multiple keys in the keystore and you need to control which key needs to be presented to server.";
 
 
     public static final String SSL_KEYSTORE_PASSWORD_CONFIG = "ssl.keystore.password";

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -94,6 +94,12 @@ public class SslConfigs {
         + "This is optional for client and only needed if 'ssl.keystore.location' is configured. "
         + "Key store password is not supported for PEM format.";
 
+    public static final String SSL_KEYSTORE_AS_STRING = "ssl.keystore.as.string";
+    public static final String SSL_KEYSTORE_AS_STRING_DOC = "True when using a base64 encoded keystore string";
+
+    public static final String SSL_TRUSTSTORE_AS_STRING = "ssl.truststore.as.string";
+    public static final String SSL_TRUSTSTORE_AS_STRING_DOC = "True when using a base64 encoded truststore string";
+
     public static final String SSL_KEY_PASSWORD_CONFIG = "ssl.key.password";
     public static final String SSL_KEY_PASSWORD_DOC = "The password of the private key in the key store file or "
         + "the PEM key specified in 'ssl.keystore.key'.";
@@ -154,7 +160,9 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_DOC)
-                .define(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, ConfigDef.Type.CLASS, null, ConfigDef.Importance.LOW, SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC);
+                .define(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, ConfigDef.Type.CLASS, null, ConfigDef.Importance.LOW, SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC)
+                .define(SslConfigs.SSL_KEYSTORE_AS_STRING, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW,SslConfigs.SSL_KEYSTORE_AS_STRING_DOC)
+                .define(SslConfigs.SSL_TRUSTSTORE_AS_STRING, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW,SslConfigs.SSL_TRUSTSTORE_AS_STRING_DOC);
     }
 
     public static final Set<String> RECONFIGURABLE_CONFIGS = Utils.mkSet(

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.utils.Utils;
-
+import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,7 @@ import org.apache.kafka.common.utils.Base64;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import java.security.PrivateKey;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -54,7 +54,8 @@ import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509KeyManager;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -198,7 +199,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
                 (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)),
                 Boolean.parseBoolean((String) configs.get(SslConfigs.SSL_TRUSTSTORE_AS_STRING)));
 
-        this.sslContext = createSSLContext(keystore, truststore);
+        this.sslContext = createSSLContext(keystore, truststore, configs);
     }
 
     @Override
@@ -261,7 +262,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         }
     }
 
-    private SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore) {
+    private SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore, Map<String, ?> configs) {
         try {
             SSLContext sslContext;
             if (provider != null)
@@ -285,13 +286,70 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
             String tmfAlgorithm = this.tmfAlgorithm != null ? this.tmfAlgorithm : TrustManagerFactory.getDefaultAlgorithm();
             TrustManager[] trustManagers = getTrustManagers(truststore, tmfAlgorithm);
 
-            sslContext.init(keyManagers, trustManagers, this.secureRandomImplementation);
+            sslContext.init(applyAliasToKM(keyManagers, (String)configs.get("ssl.keystore.alias")), trustManagers, this.secureRandomImplementation);
             log.debug("Created SSL context with keystore {}, truststore {}, provider {}.",
                     keystore, truststore, sslContext.getProvider().getName());
             return sslContext;
         } catch (Exception e) {
             throw new KafkaException(e);
         }
+    }
+
+    private KeyManager[] applyAliasToKM(KeyManager[] kms, final String alias) {
+        if(alias == null || alias.isEmpty()){
+            return kms;
+        }
+
+        log.debug("Applying the custom KeyManagers for alias: {}", alias);
+
+        KeyManager[] updatedKMs = new KeyManager[kms.length];
+
+        int i=0;
+        for(KeyManager km : kms){
+            final X509KeyManager origKM = (X509KeyManager)km;
+            X509ExtendedKeyManager exKM = new X509ExtendedKeyManager() {
+                /* (non-Javadoc)
+                 * @see javax.net.ssl.X509ExtendedKeyManager#chooseEngineClientAlias(java.lang.String[], java.security.Principal[], javax.net.ssl.SSLEngine)
+                 */
+                @Override
+                public String chooseEngineClientAlias(String[] arg0,
+                                                      Principal[] arg1, SSLEngine arg2) {
+                    return alias;
+                }
+
+                @Override
+                public String[] getServerAliases(String arg0, Principal[] arg1) {
+                    return origKM.getServerAliases(arg0, arg1);
+                }
+
+                @Override
+                public PrivateKey getPrivateKey(String arg0) {
+                    return origKM.getPrivateKey(arg0);
+                }
+
+                @Override
+                public String[] getClientAliases(String arg0, Principal[] arg1) {
+                    return origKM.getClientAliases(arg0, arg1);
+                }
+
+                @Override
+                public X509Certificate[] getCertificateChain(String arg0) {
+                    return origKM.getCertificateChain(arg0);
+                }
+
+                @Override
+                public String chooseServerAlias(String arg0, Principal[] arg1, Socket arg2) {
+                    return origKM.chooseServerAlias(arg0, arg1, arg2);
+                }
+
+                @Override
+                public String chooseClientAlias(String[] arg0, Principal[] arg1, Socket arg2) {
+                    return alias;
+                }
+            };
+            updatedKMs[i++] = exKM;
+        }
+        return updatedKMs;
     }
 
     protected TrustManager[] getTrustManagers(SecurityStore truststore, String tmfAlgorithm) throws NoSuchAlgorithmException, KeyStoreException {

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -286,7 +286,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
             String tmfAlgorithm = this.tmfAlgorithm != null ? this.tmfAlgorithm : TrustManagerFactory.getDefaultAlgorithm();
             TrustManager[] trustManagers = getTrustManagers(truststore, tmfAlgorithm);
 
-            sslContext.init(applyAliasToKM(keyManagers, (String)configs.get("ssl.keystore.alias")), trustManagers, this.secureRandomImplementation);
+            sslContext.init(applyAliasToKM(keyManagers, (String)configs.get(SslConfigs.SSL_KEYSTORE_ALIAS_CONFIG)), trustManagers, this.secureRandomImplementation);
             log.debug("Created SSL context with keystore {}, truststore {}, provider {}.",
                     keystore, truststore, sslContext.getProvider().getName());
             return sslContext;

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -30,6 +30,31 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Reconfigurable;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.utils.Base64;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509KeyManager;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -164,12 +189,14 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
                 (Password) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
                 (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG),
                 (Password) configs.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG),
-                (Password) configs.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG));
+                (Password) configs.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG)),
+                Boolean.parseBoolean((String) configs.get(SslConfigs.SSL_KEYSTORE_AS_STRING)));
 
         this.truststore = createTruststore((String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
                 (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
                 (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG),
-                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG));
+                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)),
+                Boolean.parseBoolean((String) configs.get(SslConfigs.SSL_TRUSTSTORE_AS_STRING)));
 
         this.sslContext = createSSLContext(keystore, truststore);
     }
@@ -275,7 +302,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
     }
 
     // Visibility to override for testing
-    protected SecurityStore createKeystore(String type, String path, Password password, Password keyPassword, Password privateKey, Password certificateChain) {
+    protected SecurityStore createKeystore(String type, String path, Password password, Password keyPassword, Password privateKey, Password certificateChain, boolean pathAsBase64EncodedString) {
         if (privateKey != null) {
             if (!PEM_TYPE.equals(type))
                 throw new InvalidConfigurationException("SSL private key can be specified only for PEM, but key store type is " + type + ".");
@@ -299,12 +326,12 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         } else if (path != null && password == null) {
             throw new InvalidConfigurationException("SSL key store is specified, but key store password is not specified.");
         } else if (path != null && password != null) {
-            return new FileBasedStore(type, path, password, keyPassword, true);
+            return new FileBasedStore(type, path, password, keyPassword, true, pathAsBase64EncodedString);
         } else
             return null; // path == null, clients may use this path with brokers that don't require client auth
     }
 
-    private static SecurityStore createTruststore(String type, String path, Password password, Password trustStoreCerts) {
+    private static SecurityStore createTruststore(String type, String path, Password password, Password trustStoreCerts, boolean pathAsBase64EncodedString) {
         if (trustStoreCerts != null) {
             if (!PEM_TYPE.equals(type))
                 throw new InvalidConfigurationException("SSL trust store certs can be specified only for PEM, but trust store type is " + type + ".");
@@ -322,7 +349,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         } else if (path == null && password != null) {
             throw new InvalidConfigurationException("SSL trust store is not specified, but trust store password is specified.");
         } else if (path != null) {
-            return new FileBasedStore(type, path, password, null, false);
+            return new FileBasedStore(type, path, password, null, false, pathAsBase64EncodedString);
         } else
             return null;
     }
@@ -341,8 +368,9 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         protected final Password keyPassword;
         private final Long fileLastModifiedMs;
         private final KeyStore keyStore;
+        private final boolean pathAsBase64EncodedString;
 
-        FileBasedStore(String type, String path, Password password, Password keyPassword, boolean isKeyStore) {
+        FileBasedStore(String type, String path, Password password, Password keyPassword, boolean isKeyStore, boolean pathAsBase64EncodedString) {
             Objects.requireNonNull(type, "type must not be null");
             this.type = type;
             this.path = path;
@@ -350,6 +378,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
             this.keyPassword = keyPassword;
             fileLastModifiedMs = lastModifiedMs(path);
             this.keyStore = load(isKeyStore);
+            this.pathAsBase64EncodedString = pathAsBase64EncodedString;
         }
 
         @Override
@@ -370,11 +399,24 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
          *   using the specified configs (e.g. if the password or keystore type is invalid)
          */
         protected KeyStore load(boolean isKeyStore) {
-            try (InputStream in = Files.newInputStream(Paths.get(path))) {
+            if (path == null) {
+                throw new KafkaException("Failed to load SSL keystore: path was null");
+            }
+            InputStream in;
+            try {
+                if (pathAsBase64EncodedString) {
+                    String encodedKeyStore = System.getenv(path);
+                    in = new ByteArrayInputStream(Base64.decoder().decode(encodedKeyStore));
+                } else if (type.equalsIgnoreCase(TruststoreUtility.CRT)) {
+                    return TruststoreUtility.createTrustStore(path, password.value());
+                } else {
+                    in = new FileInputStream(path);
+                }
                 KeyStore ks = KeyStore.getInstance(type);
                 // If a password is not set access to the truststore is still available, but integrity checking is disabled.
                 char[] passwordChars = password != null ? password.value().toCharArray() : null;
                 ks.load(in, passwordChars);
+                in.close();
                 return ks;
             } catch (GeneralSecurityException | IOException e) {
                 throw new KafkaException("Failed to load SSL keystore " + path + " of type " + type, e);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/PcfTruststoreUtility.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/PcfTruststoreUtility.java
@@ -1,0 +1,36 @@
+package org.apache.kafka.common.security.ssl;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+
+public class PcfTruststoreUtility {
+
+    public static final String CRT = "CRT";
+
+    public static KeyStore createTrustStore(String locationOfCerts, String trustStorePass) throws GeneralSecurityException, IOException {
+        if(!new File(locationOfCerts).exists()){
+            locationOfCerts = System.getenv(locationOfCerts);
+        }
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, trustStorePass.toCharArray());
+        try (FileInputStream fis = new FileInputStream(locationOfCerts)) {
+            try (BufferedInputStream bis = new BufferedInputStream(fis)) {
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                Certificate cert = null;
+
+                while (bis.available() > 0) {
+                    cert = cf.generateCertificate(bis);
+                    ks.setCertificateEntry(String.valueOf(bis.available()), cert);
+                }
+                ks.setCertificateEntry(String.valueOf(bis.available()), cert);
+                return ks;
+            }
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/TruststoreUtility.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/TruststoreUtility.java
@@ -9,7 +9,7 @@ import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 
-public class PcfTruststoreUtility {
+public class TruststoreUtility {
 
     public static final String CRT = "CRT";
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -591,7 +591,8 @@ public abstract class SslFactoryTest {
                     (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
                     (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
                     (Password) sslConfig.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG),
-                    true
+                    true,
+                    Boolean.parseBoolean((String) sslConfig.get(SslConfigs.SSL_KEYSTORE_AS_STRING))
             );
         } else {
             store = new PemStore(


### PR DESCRIPTION
Client applications use SSL/TLS to connect with Kafka brokers in order to implement secured communication. The clients initiate SSL communication with Kafka brokers using the SSL Engine constructed from the ssl.* properties pointing to key store and trust store. This PR addresses couple of important enhancements related to how the key store is loaded for secured communication with Kafka brokers.

**Problem :**
Most of the container platforms such as PCF where the client applications are deployed set key store and trust store are environment variables with Base64 encoded PEM. Kafka clients expect the key store and trust store to be file system artefacts. This introduces custom logic to read these environment variables and create a key store / trust store out of that.

**Solution :**
This can be solved by implementing loading the key store directly from environment variables as input stream. Two new configs ssl.keystore.as.string and ssl.truststore.as.string are added to indicate loading the key stores from these environment variables. When the values are true, it indicates the ssl.keystore.location and ssl.trustore.location are pointing to environment variables instead of paths.

Example configuration:
ssl.truststore.as.string=true
ssl.keystore.type=JKS
ssl.truststore.location=${KEYSTORE} // populate this as an environment variable
ssl.keystore.as.string=true
ssl.truststore.type=JKS
ssl.keystore.location= ${TRUSTSTORE} // populate this as an environment variable

All unit tests are passing and added a new test to verify that the base64 encoded string works with the code changes. No changes were made to any other unit tests.