### PR TITLE
KAFKA-17798 : Adding forbiddenApi check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ plugins {
   id 'org.scoverage' version '8.0.3' apply false
   id 'io.github.goooler.shadow' version '8.1.3' apply false
   id 'com.diffplug.spotless' version "6.25.0"
+  id 'de.thetaphi.forbiddenapis' version '3.8'
 }
 
 ext {
@@ -794,7 +795,14 @@ subprojects {
     description = 'Run checkstyle on all test Java sources'
   }
 
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
+  // All available signatures https://github.com/policeman-tools/forbidden-apis/wiki/BundledSignatures
+  apply plugin: 'de.thetaphi.forbiddenapis'
+  forbiddenApis {
+    bundledSignatures = ['jdk-unsafe']
+    ignoreFailures = true
+  }
+
+  test.dependsOn('checkstyleMain', 'checkstyleTest', 'forbiddenApisMain')
 
   spotbugs {
     toolVersion = versions.spotbugs


### PR DESCRIPTION
Jira : https://issues.apache.org/jira/browse/KAFKA-17798

- Check to verify if any forbidden apis are used in sources
- ignoring failures for now
- Part of signatures, only added jdk-unsafe, which looks for Locale, Charset, Timezone kind of classes

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
