### PR TITLE
MINOR: Remove unused method zkBrokerEpoch in BrokerRegistration

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -142,14 +142,6 @@ public class BrokerRegistration {
         }
     }
 
-    public static Optional<Long> zkBrokerEpoch(long value) {
-        if (value == -1) {
-            return Optional.empty();
-        } else {
-            return Optional.of(value);
-        }
-    }
-
     private final int id;
     private final long epoch;
     private final Uuid incarnationId;


### PR DESCRIPTION
after 0bb05d8, zk broker epoch was removed,  making `zkBrokerEpoch` method unused in BrokerRegistration

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
