### PR TITLE
KAFKA-17755 AbstractPartitionAssignor can not enable RackAwareAssignm…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/LeaderRackAwareCooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/LeaderRackAwareCooperativeStickyAssignor.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+/**
+ * A leader rack-aware based cooperative version of the {@link CooperativeStickyAssignor CooperativeStickyAssignor}.
+ * This follows the same assignment logic as {@link CooperativeStickyAssignor CooperativeStickyAssignor}
+ * but rack-aware is base on partition leader's rack only
+ */
+public class LeaderRackAwareCooperativeStickyAssignor extends CooperativeStickyAssignor {
+    @Override
+    public RackAwareType rackAwareType() {
+        return RackAwareType.AWARE_LEADER_RACK;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/LeaderRackAwareRangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/LeaderRackAwareRangeAssignor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+/**
+ * A leader rack-aware based range assignor {@link RangeAssignor RangeAssignor}.
+ * This follows the same assignment logic as {@link RangeAssignor RangeAssignor}
+ * but rack-aware is base on partition leader's rack only
+ */
+public class LeaderRackAwareRangeAssignor extends RangeAssignor {
+
+    @Override
+    public RackAwareType rackAwareType() {
+        return RackAwareType.AWARE_LEADER_RACK;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/AbstractLeaderRackAwareAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/AbstractLeaderRackAwareAssignorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractLeaderRackAwareAssignorTest {
+
+    private String topic = "test-leader-rack--aware-topic";
+    public abstract AbstractPartitionAssignor getAssignor();
+    @Test
+    public void testFullBalancedLeaderRackAssign() {
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, Arrays.asList(
+                new PartitionInfo(topic, 0,
+                        new Node(0, "node-0", 8888, "rack-a"),
+                        new Node[]{
+                            new Node(1, "node-1", 8888, "rack-b"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 1,
+                        new Node(0, "node-0", 8888, "rack-a"),
+                        new Node[]{
+                            new Node(1, "node-1", 8888, "rack-b"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 2,
+                        new Node(1, "node-1", 8888, "rack-b"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 3,
+                        new Node(1, "node-1", 8888, "rack-b"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 4,
+                        new Node(2, "node-2", 8888, "rack-c"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(1, "node-1", 8888, "rack-b")
+                        }, null),
+                new PartitionInfo(topic, 5,
+                        new Node(1, "node-1", 8888, "rack-b"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null)
+        ));
+
+        // Simulate two consumers subscribing to the topic
+        Map<String, Subscription> subscriptions = new HashMap<>();
+        subscriptions.put("consumer-a",
+                new Subscription(Collections.singletonList(topic), null, Collections.emptyList(), 1, Optional.of("rack-a")));
+        subscriptions.put("consumer-b",
+                new Subscription(Collections.singletonList(topic), null, Collections.emptyList(), 1, Optional.of("rack-b")));
+        subscriptions.put("consumer-c",
+                new Subscription(Collections.singletonList(topic), null, Collections.emptyList(), 1, Optional.of("rack-c")));
+
+        // Call the assignPartitions method
+        Map<String, List<TopicPartition>> assignment = getAssignor().assignPartitions(partitionsPerTopic,
+                subscriptions);
+
+        assertEquals(assignment.get("consumer-a"), Arrays.asList(new TopicPartition(topic, 0), new TopicPartition(topic, 1)));
+        assertEquals(assignment.get("consumer-b"), Arrays.asList(new TopicPartition(topic, 2), new TopicPartition(topic, 3)));
+        assertEquals(assignment.get("consumer-c"), Arrays.asList(new TopicPartition(topic, 4), new TopicPartition(topic, 5)));
+
+    }
+    @Test
+    public void testUnbalancedLeaderRackAssign() {
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, Arrays.asList(
+                new PartitionInfo(topic, 0,
+                        new Node(0, "node-0", 8888, "rack-a"),
+                        new Node[]{
+                            new Node(1, "node-1", 8888, "rack-b"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 1,
+                        new Node(0, "node-0", 8888, "rack-a"),
+                        new Node[]{
+                            new Node(1, "node-1", 8888, "rack-b"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 2,
+                        new Node(1, "node-1", 8888, "rack-b"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 3,
+                        new Node(1, "node-1", 8888, "rack-b"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-c")
+                        }, null),
+                new PartitionInfo(topic, 4,
+                        new Node(2, "node-2", 8888, "rack-c"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(1, "node-1", 8888, "rack-b")
+                        }, null),
+                new PartitionInfo(topic, 5,
+                        new Node(1, "node-1", 8888, "rack-c"),
+                        new Node[]{
+                            new Node(0, "node-0", 8888, "rack-a"),
+                            new Node(2, "node-2", 8888, "rack-b")
+                        }, null)
+        ));
+
+        // Simulate two consumers subscribing to the topic
+        Map<String, Subscription> subscriptions = new HashMap<>();
+        subscriptions.put("consumer-a",
+                new Subscription(Collections.singletonList(topic), null, Collections.emptyList(), 1, Optional.of("rack-a")));
+        subscriptions.put("consumer-b",
+                new Subscription(Collections.singletonList(topic), null, Collections.emptyList(), 1, Optional.of("rack-b")));
+
+        // Call the assignPartitions method
+        Map<String, List<TopicPartition>> assignment = getAssignor().assignPartitions(partitionsPerTopic,
+                subscriptions);
+
+        assertEquals(assignment.get("consumer-a"), Arrays.asList(new TopicPartition(topic, 0), new TopicPartition(topic, 1), new TopicPartition(topic, 4)));
+        assertEquals(assignment.get("consumer-b"), Arrays.asList(new TopicPartition(topic, 2), new TopicPartition(topic, 3), new TopicPartition(topic, 5)));
+
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/LeaderRackAwareCooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/LeaderRackAwareCooperativeStickyAssignorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
+
+public class LeaderRackAwareCooperativeStickyAssignorTest extends AbstractLeaderRackAwareAssignorTest {
+    @Override
+    public AbstractStickyAssignor getAssignor() {
+
+        return new LeaderRackAwareCooperativeStickyAssignor();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/LeaderRackAwareRangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/LeaderRackAwareRangeAssignorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+
+public class LeaderRackAwareRangeAssignorTest extends AbstractLeaderRackAwareAssignorTest {
+    @Override
+    public AbstractPartitionAssignor getAssignor() {
+
+        return new LeaderRackAwareRangeAssignor();
+    }
+}


### PR DESCRIPTION
currently rack-aware partition assignor's design have obvious two significant flaws:

1. Rely on the Kafka broker side to enable the configuration: replica.selector.class -> RackAwareReplicaSelector. This breaks the agreement that the Partition Assignor can be customized independently by the client.
2. It destroys the read-write consistency principle of Kafka, leading to load imbalance and many other side effects.

This improvement of merge request is based on the following ideas:
Always read messages from the leader of the broker, that is, do not enable replica.selector.class
, it can be aligned based only on the rack information of the leader, so that balance can be achieved first. In the case of balance, the same rack partition allocation strategy as the leader should be given priority as much as possible.


### Committer Checklist (excluded from commit message)
- [* ] Verify design and implementation 
- [* ] Verify test coverage and CI build status
- [* ] Verify documentation (including upgrade notes)
