### PR TITLE
MINOR: Fix strange if statements

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
@@ -268,7 +268,7 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
             final NavigableMap<K, V> kvMap = data.get(now);
             if (kvMap != null) {
                 final NavigableMap<K, V> kvSubMap;
-                if (keyFrom == null && keyFrom == null) {
+                if (keyTo == null && keyFrom == null) {
                     kvSubMap = kvMap;
                 } else if (keyFrom == null) {
                     kvSubMap = kvMap.headMap(keyTo, true);
@@ -324,7 +324,7 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
             final NavigableMap<K, V> kvMap = data.get(now);
             if (kvMap != null) {
                 final NavigableMap<K, V> kvSubMap;
-                if (keyFrom == null && keyFrom == null) {
+                if (keyTo == null && keyFrom == null) {
                     kvSubMap = kvMap;
                 } else if (keyFrom == null) {
                     kvSubMap = kvMap.headMap(keyTo, true);


### PR DESCRIPTION
I have discovered two strange if statements, so I have committed a fix.

I would like to suggest you check the 'handleDeleteTopicsUsingNames' method in the 'MockAdminClient' class. At the moment, on line 584, an item is deleted from the collection iterated over 'Iterator'. In the same line, a UUID object is deleted from the 'topicIds' collection when it handles the 'String' objects.

In the 'LogicalKeyValueSegment' class, the 'prefixKeyFormatter' object is executed through both synchronized and unsynchronized methods. The code seems suspicious.

In the 'Sensor' class, the 'metrics' collection is executed through both synchronized and unsynchronized methods. I would recommend paying attention to this code too.

The PVS Studio static analyzer has detected these suspicious code fragments. They were described in the following article: https://pvs-studio.com/en/blog/posts/java/1171/.

The fixes of potential NPEs from the article have already been committed: https://github.com/apache/kafka/pull/17541.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
