### PR TITLE
MINOR: Use JDK 11 in Vagrant after dropping JDK 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ ec2_iam_instance_profile_name = nil
 ebs_volume_type = 'gp3'
 
 jdk_major = '11'
-jdk_full="11.0.2-linux-x64"
+jdk_full = '11.0.2-linux-x64'
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,8 +55,8 @@ ec2_iam_instance_profile_name = nil
 
 ebs_volume_type = 'gp3'
 
-jdk_major = '8'
-jdk_full = '8u202-linux-x64'
+jdk_major = '11'
+jdk_full="11.0.2-linux-x64"
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -36,8 +36,8 @@ fetch_jdk_tgz() {
   fi
 }
 
-JDK_MAJOR="${JDK_MAJOR:-8}"
-JDK_FULL="${JDK_FULL:-8u202-linux-x64}"
+JDK_MAJOR="${JDK_MAJOR:-11}"
+JDK_FULL="${JDK_FULL:-11.0.2-linux-x64}"
 
 if [ -z `which javac` ]; then
     apt-get -y update


### PR DESCRIPTION
We have dropped JDK 8 and now use JDK 11 as the minimum version. This PR updates the `jdk_major` and `jdk_full` versions used by Vagrant to JDK 11.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
