### PR TITLE
KAFKA-17852: Add help message to the --ignore-formatted flag of StorageTool

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -304,6 +304,7 @@ object StorageTool extends Logging {
               |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
 
     formatParser.addArgument("--ignore-formatted", "-g")
+      .help("When this option is passed, the format command will skip over already formatted directories rather than failing.")
       .action(storeTrue())
 
     formatParser.addArgument("--release-version", "-r")


### PR DESCRIPTION
This patch simply adds the missing help message to the `--ignore-formatted` flag of StorageTool.

Example:

```sh
$ bin/kafka-storage.sh format -h | grep -A1 ignore-formatted,
  --ignore-formatted, -g
                         When this option is passed, the format command will skip over already formatted directories rather than failing.
```
