### PR TITLE
KAFKA-17847: Avoid the extra bytes copy when compressing telemetry payload

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -191,12 +191,11 @@ public class ClientTelemetryUtils {
         return CompressionType.NONE;
     }
 
-    public static byte[] compress(byte[] raw, CompressionType compressionType) throws IOException {
+    public static byte[] compress(MetricsData metrics, CompressionType compressionType) throws IOException {
         try (ByteBufferOutputStream compressedOut = new ByteBufferOutputStream(512)) {
             Compression compression = Compression.of(compressionType).build();
             try (OutputStream out = compression.wrapForOutput(compressedOut, RecordBatch.CURRENT_MAGIC_VALUE)) {
-                out.write(raw);
-                out.flush();
+                metrics.writeTo(out);
             }
             compressedOut.buffer().flip();
             return Utils.toArray(compressedOut.buffer());

--- a/clients/src/test/java/org/apache/kafka/common/requests/PushTelemetryRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/PushTelemetryRequestTest.java
@@ -70,8 +70,8 @@ public class PushTelemetryRequestTest {
     }
 
     private PushTelemetryRequest getPushTelemetryRequest(MetricsData metricsData, CompressionType compressionType) throws IOException {
+        byte[] compressedData = ClientTelemetryUtils.compress(metricsData, compressionType);
         byte[] data = metricsData.toByteArray();
-        byte[] compressedData = ClientTelemetryUtils.compress(data, compressionType);
         if (compressionType != CompressionType.NONE) {
             assertTrue(compressedData.length < data.length);
         } else {

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.kafka.common.telemetry.internals;
 
-import io.opentelemetry.proto.metrics.v1.Metric;
-import io.opentelemetry.proto.metrics.v1.MetricsData;
-import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
-import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
-import io.opentelemetry.proto.resource.v1.Resource;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
@@ -40,6 +35,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.proto.resource.v1.Resource;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Avoid using AbstractMessageLite to initialize bytes with serialized size, it can lead to adding extra bytes.
Instead, ByteArrayOutputStream is used for the buffer capacity, which is initially 32 bytes, though its size increases if necessary.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
