### PR TITLE
MINOR: Fix coordinator logging in system tests

### DIFF
--- a/tests/kafkatest/services/kafka/templates/log4j.properties
+++ b/tests/kafkatest/services/kafka/templates/log4j.properties
@@ -132,10 +132,10 @@ log4j.additivity.kafka.log.LogCleaner=false
 log4j.logger.state.change.logger={{ log_level|default("DEBUG") }}, stateChangeInfoAppender, stateChangeDebugAppender
 log4j.additivity.state.change.logger=false
 
-#Change this to debug to get the actual audit log for authorizer.
+# Change this to debug to get the actual audit log for authorizer.
 log4j.logger.kafka.authorizer.logger={{ log_level|default("DEBUG") }}, authorizerInfoAppender, authorizerDebugAppender
 log4j.additivity.kafka.authorizer.logger=false
 
-#Group Coordinator logging.
+# Group Coordinator logging.
 log4j.logger.org.apache.kafka.coordinator={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
 log4j.additivity.org.apache.kafka.coordinator=false

--- a/tests/kafkatest/services/kafka/templates/log4j.properties
+++ b/tests/kafkatest/services/kafka/templates/log4j.properties
@@ -136,6 +136,6 @@ log4j.additivity.state.change.logger=false
 log4j.logger.kafka.authorizer.logger={{ log_level|default("DEBUG") }}, authorizerInfoAppender, authorizerDebugAppender
 log4j.additivity.kafka.authorizer.logger=false
 
-#New Group Coordinator logging.
-log4j.logger.org.apache.kafka.coordinator.group={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
-log4j.additivity.org.apache.kafka.coordinator.group=false
+#Group Coordinator logging.
+log4j.logger.org.apache.kafka.coordinator={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
+log4j.additivity.org.apache.kafka.coordinator=false


### PR DESCRIPTION
We moved the coordinator runtime to `coordinator-common` package and it broke the logging in the system tests because the package changed. This patch fixes it. It uses `org.apache.kafka.coordinator` to ensure that all the coordinator related classes are included.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
