### PR TITLE
KAFKA-17854 Improve tests for ReadOnlyWindowStoreStub#fetch and #backwardFetch

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -362,9 +362,8 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
-            StreamsTestUtils.toList(windowStore.fetch("a", null, ofEpochMilli(0), ofEpochMilli(10)));
+            StreamsTestUtils.toList(windowStore.fetch("b", null, ofEpochMilli(0), ofEpochMilli(10)));
         assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
             KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
             KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"))));
     }
@@ -377,11 +376,10 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
-            StreamsTestUtils.toList(windowStore.fetch(null, "c", ofEpochMilli(0), ofEpochMilli(10)));
+            StreamsTestUtils.toList(windowStore.fetch(null, "b", ofEpochMilli(0), ofEpochMilli(10)));
         assertThat(results, equalTo(Arrays.asList(
             KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"))));
+            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
     }
 
     @Test
@@ -407,9 +405,8 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
-            StreamsTestUtils.toList(windowStore.backwardFetch("a", null, ofEpochMilli(0), ofEpochMilli(10)));
+            StreamsTestUtils.toList(windowStore.backwardFetch("b", null, ofEpochMilli(0), ofEpochMilli(10)));
         assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
             KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
             KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
     }
@@ -422,10 +419,9 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
-            StreamsTestUtils.toList(windowStore.backwardFetch(null, "c", ofEpochMilli(0), ofEpochMilli(10)));
+            StreamsTestUtils.toList(windowStore.backwardFetch(null, "b", ofEpochMilli(0), ofEpochMilli(10)));
         assertThat(results, equalTo(Arrays.asList(
             KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
             KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")
             )));
     }


### PR DESCRIPTION
[KAFKA-17854](https://issues.apache.org/jira/browse/KAFKA-17854)

https://github.com/apache/kafka/pull/17540 fixed the **incorrect check**, but our test cases did not properly detect the **incorrect check** before it was merged.

PR [#17540](https://github.com/apache/kafka/pull/17540) corrected the check, but the test cases did not correctly capture the **incorrect check** before the PR was merged. This is because the expected result asserted in `shouldFetchKeyRangeAcrossStoresWithNullKeyFrom()` coincidentally matched the result obtained at [line 272](https://github.com/apache/kafka/pull/17540/files#diff-77f6b10146a50b25e538ab71c9ffe18fd981d717b666c94d7c811af690cea1eeR272).

To demonstrate what my change covers, I reverted the changes from [#17540](https://github.com/apache/kafka/pull/17540) and applied my fix. The test fails as expected, as shown below:
```
$ ./gradlew streams:test --tests CompositeReadOnlyWindowStoreTest
----snip----
org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldFetchKeyRangeAcrossStoresWithNullKeyFrom() failed, log available in /home/yungh/kafka/kafka_fork/kafka/streams/build/reports/testOutput/org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldFetchKeyRangeAcrossStoresWithNullKeyFrom().test.stdout

Gradle Test Run :streams:test > Gradle Test Executor 57 > CompositeReadOnlyWindowStoreTest > shouldFetchKeyRangeAcrossStoresWithNullKeyFrom() FAILED
    java.lang.AssertionError: 
    Expected: <[KeyValue([a@0/30000], a), KeyValue([b@10/30010], b)]>
         but: was <[KeyValue([a@0/30000], a), KeyValue([b@10/30010], b), KeyValue([c@10/30010], c)]>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldFetchKeyRangeAcrossStoresWithNullKeyFrom(CompositeReadOnlyWindowStoreTest.java:380)

----snip----

org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldBackwardFetchKeyRangeAcrossStoresWithNullKeyFrom() failed, log available in /home/yungh/kafka/kafka_fork/kafka/streams/build/reports/testOutput/org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldBackwardFetchKeyRangeAcrossStoresWithNullKeyFrom().test.stdout

Gradle Test Run :streams:test > Gradle Test Executor 57 > CompositeReadOnlyWindowStoreTest > shouldBackwardFetchKeyRangeAcrossStoresWithNullKeyFrom() FAILED
    java.lang.AssertionError: 
    Expected: <[KeyValue([a@0/30000], a), KeyValue([b@10/30010], b)]>
         but: was <[KeyValue([a@0/30000], a), KeyValue([c@10/30010], c), KeyValue([b@10/30010], b)]>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest.shouldBackwardFetchKeyRangeAcrossStoresWithNullKeyFrom(CompositeReadOnlyWindowStoreTest.java:423)

----snip----

32 tests completed, 2 failed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':streams:test'.
> There were failing tests. See the report at: file:///home/yungh/kafka/kafka_fork/kafka/streams/build/reports/tests/test/index.html

BUILD FAILED in 6s
97 actionable tasks: 3 executed, 94 up-to-date
```

The **incorrect check** can be detected after applying my change. Additionally, I think this change covers more possible cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
