### PR TITLE
MINOR: Correct the wrong behavior of TestUtils#verifyTopicDeletion

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -84,7 +84,7 @@ import java.time.Duration
 import java.util
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Arrays, Collections, Optional, Properties}
+import java.util.{Collections, Optional, Properties}
 import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Seq, mutable}
@@ -1294,9 +1294,11 @@ object TestUtils extends Logging {
     waitUntilTrue(() => brokers.forall(broker =>
       broker.config.logDirs.forall { logDir =>
         topicPartitions.forall { tp =>
-          !Arrays.asList(new File(logDir).list()).asScala.exists { partitionDirectoryName =>
-            partitionDirectoryName.startsWith(tp.topic + "-" + tp.partition) &&
-              partitionDirectoryName.endsWith(UnifiedLog.DeleteDirSuffix)
+          !util.Arrays.asList(new File(logDir).list()).asScala.exists { partitionDirectoryNames =>
+            partitionDirectoryNames.exists { directoryName =>
+              directoryName.startsWith(tp.topic + "-" + tp.partition) &&
+                directoryName.endsWith(UnifiedLog.DeleteDirSuffix)
+            }
           }
         }
       }


### PR DESCRIPTION
The current implementation of `TestUtils#verifyTopicDeletion` contained an incorrect logic when verifying the hard-deletion of topic directories. 
Specifically, the logic was erroneously applying startsWith and endsWith checks on an array of partition directory names rather than on each individual directory name. This caused the validation to pass even when the target directories were still present, which could lead to data consistency issues during topic deletion operations.

If `Array[String].startsWith()` receives a `String` as a parameter, it implicitly converts the `String` into an `Array[Char]` and then compares it against the array of strings. 

As a result, the actual comparison was mistakenly happening between:
- **`partitionDirectoryNames` values (example):**  
  `Array(".lock", "bootstrap.checkpoint", "recovery-point-offset-checkpoint", "recovery-point-offset-checkpoint.tmp", "__cluster_metadata-0", "topic-0.9e1caebe9f5d499c9694032104eebe95-delete", "log-start-offset-checkpoint", "cleaner-offset-checkpoint", "replication-offset-checkpoint", "meta.properties")`

- **`tp` converted to an `Array[Char]`:**  
  `Array('t', 'o', 'p', 'i', 'c', '-', '0')`

This implicit conversion led to incorrect behavior where the logic was not checking the directory names as intended.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
