### PR TITLE
[KAFKA-17870] Fail CreateTopicsRequest if total number of partitions exceeds 10k

### DIFF
--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -1289,7 +1289,7 @@ class KRaftClusterTest {
             () => admin.createTopics(newTopics).all().get())
         assertNotNull(executionException.getCause)
         assertEquals(classOf[PolicyViolationException], executionException.getCause.getClass)
-        assertEquals("Unable to perform excessively large batch operation.",
+        assertEquals("Excessively large number of partitions per request.",
           executionException.getCause.getMessage)
       } finally {
         admin.close()

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -607,13 +607,12 @@ public class ReplicationControlManager {
 
         int totalPartitions = 0;
         for (CreatableTopic topic: request.topics()) {
-            // Negative numPartitions are possible, so exclude them from the total.
             if (topic.numPartitions() > 0) {
                 totalPartitions += topic.numPartitions();
             }
         }
         if (totalPartitions > 10_000) {
-            throw new PolicyViolationException("Number of partitions across all topics should be less than 10000");
+            throw new PolicyViolationException("Excessively large number of partitions per request.");
         }
 
         // Try to create whatever topics are needed.

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -593,7 +593,7 @@ public class ReplicationControlManager {
         Map<String, ApiError> topicErrors = new HashMap<>();
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
 
-        validateEstimatedTotalNumberOfPartitions(request, defaultNumPartitions);
+        validateTotalNumberOfPartitions(request, defaultNumPartitions);
 
         // Check the topic names.
         validateNewTopicNames(topicErrors, request.topics(), topicsWithCollisionChars);
@@ -1142,13 +1142,13 @@ public class ReplicationControlManager {
     /**
      * Validates that a batch of topics will create less than {@value MAX_PARTITIONS_PER_BATCH}. Exceeding this number of topics per batch
      * has led to out-of-memory exceptions. We use this validation to fail earlier to avoid allocating the memory.
-     * This validation assumes that all the topics in the batch are valid and can be created.
+     * Validates an upper bound number of partitions. The actual number may be smaller if some topics are misconfigured.
      *
      * @param request a batch of topics to create.
      * @param defaultNumPartitions default number of partitions to assign if unspecified.
      * @throws PolicyViolationException if total number of partitions exceeds {@value MAX_PARTITIONS_PER_BATCH}.
      */
-    static void validateEstimatedTotalNumberOfPartitions(CreateTopicsRequestData request, int defaultNumPartitions) {
+    static void validateTotalNumberOfPartitions(CreateTopicsRequestData request, int defaultNumPartitions) {
         int totalPartitions = 0;
         for (CreatableTopic topic: request.topics()) {
             if (topic.assignments().isEmpty()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -605,6 +605,17 @@ public class ReplicationControlManager {
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges =
             computeConfigChanges(topicErrors, request.topics());
 
+        int totalPartitions = 0;
+        for (CreatableTopic topic: request.topics()) {
+            // Negative numPartitions are possible, so exclude them from the total.
+            if (topic.numPartitions() > 0) {
+                totalPartitions += topic.numPartitions();
+            }
+        }
+        if (totalPartitions > 10_000) {
+            throw new PolicyViolationException("Number of partitions across all topics should be less than 10000");
+        }
+
         // Try to create whatever topics are needed.
         Map<String, CreatableTopicResult> successes = new HashMap<>();
         for (CreatableTopic topic : request.topics()) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -570,19 +570,17 @@ public class ReplicationControlManagerTest {
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
         CreateTopicsRequestData request = new CreateTopicsRequestData();
-        // Create two topics with 5k partitions each
         request.topics().add(new CreatableTopic().setName("foo").
                 setNumPartitions(5000).setReplicationFactor((short) 1));
         request.topics().add(new CreatableTopic().setName("bar").
                 setNumPartitions(5001).setReplicationFactor((short) 1));
-        // Add one topic with -2 partitions, if we don't ignore it we can still potentially exceed the cutoff
         request.topics().add(new CreatableTopic().setName("baz").
                 setNumPartitions(-2).setReplicationFactor((short) 1));
         ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
         PolicyViolationException error = assertThrows(
                 PolicyViolationException.class,
                 () -> replicationControl.createTopics(requestContext, request, Set.of("foo", "bar", "baz")));
-        assertEquals(error.getMessage(), "Number of partitions across all topics should be less than 10000");
+        assertEquals(error.getMessage(), "Excessively large number of partitions per request.");
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -566,21 +566,39 @@ public class ReplicationControlManagerTest {
     }
 
     @Test
-    public void testCreate10KTopics() {
+    public void testExcessiveNumberOfTopicsCannotBeCreated() {
+        // number of partitions is explicitly set without assignments
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
-        CreateTopicsRequestData request = new CreateTopicsRequestData();
-        request.topics().add(new CreatableTopic().setName("foo").
+        CreateTopicsRequestData request1 = new CreateTopicsRequestData();
+        request1.topics().add(new CreatableTopic().setName("foo").
                 setNumPartitions(5000).setReplicationFactor((short) 1));
-        request.topics().add(new CreatableTopic().setName("bar").
-                setNumPartitions(5001).setReplicationFactor((short) 1));
-        request.topics().add(new CreatableTopic().setName("baz").
-                setNumPartitions(-2).setReplicationFactor((short) 1));
+        request1.topics().add(new CreatableTopic().setName("bar").
+                setNumPartitions(5000).setReplicationFactor((short) 1));
+        request1.topics().add(new CreatableTopic().setName("baz").
+                setNumPartitions(1).setReplicationFactor((short) 1));
         ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
-        PolicyViolationException error = assertThrows(
+        PolicyViolationException error1 = assertThrows(
                 PolicyViolationException.class,
-                () -> replicationControl.createTopics(requestContext, request, Set.of("foo", "bar", "baz")));
-        assertEquals(error.getMessage(), "Excessively large number of partitions per request.");
+                () -> replicationControl.createTopics(requestContext, request1, Set.of("foo", "bar", "baz")));
+        assertEquals(error1.getMessage(), "Excessively large number of partitions per request.");
+
+        // use defaultNumberOfPartitions and count number of assignments
+        CreateTopicsRequestData request2 = new CreateTopicsRequestData();
+        request2.topics().add(new CreatableTopic().setName("foo").
+                setNumPartitions(-1).setReplicationFactor((short) 1));
+        CreateTopicsRequestData.CreatableReplicaAssignmentCollection assignments =
+                new CreateTopicsRequestData.CreatableReplicaAssignmentCollection();
+        assignments.add(new CreatableReplicaAssignment().setPartitionIndex(1));
+        assignments.add(new CreatableReplicaAssignment().setPartitionIndex(2));
+        request2.topics().add(new CreatableTopic()
+                .setName("baz")
+                .setAssignments(assignments));
+        PolicyViolationException error2 = assertThrows(
+                PolicyViolationException.class,
+                () -> ReplicationControlManager.validateEstimatedTotalNumberOfPartitions(request2, 9999)
+        );
+        assertEquals(error2.getMessage(), "Excessively large number of partitions per request.");
     }
 
     @Test


### PR DESCRIPTION
We fail the entire `CreateTopicsRequest` action if there are more than `10k` total partitions being created in this topic for this specific request. The usual pattern for this `API` to try and succeed with some topics. Since the `10k` limit applies to all `topics` then no topic should be created if they all exceede it. 

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
