### PR TITLE
KAFKA-17879: test_performance_services.py should use DEV version to run kafka service

### DIFF
--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -54,7 +54,7 @@ class PerformanceServiceTest(Test):
         version = KafkaVersion(version)
         self.kafka = KafkaService(
             self.test_context, 1,
-            self.zk, topics={self.topic: {'partitions': 1, 'replication-factor': 1}}, version=version)
+            self.zk, topics={self.topic: {'partitions': 1, 'replication-factor': 1}}, version=DEV_BRANCH)
         self.kafka.start()
 
         # check basic run of producer performance


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-17879

Test with the following log:
`
$ TC_PATHS="kafka/tests/kafkatest/sanity_checks/test_performance_services.py" bash tests/docker/run_tests.sh
`

Before:
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-10-25--009
run time:         3 minutes 17.601 seconds
tests run:        7
passed:           6
flaky:            0
failed:           1
ignored:          0
================================================================================
test_id:    kafkatest.sanity_checks.test_performance_services.PerformanceServiceTest.test_version.version=0.8.2.2.new_consumer=False
status:     FAIL
run time:   35.519 seconds
```

After:
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-10-25--010
run time:         3 minutes 18.154 seconds
tests run:        7
passed:           6
flaky:            0
failed:           1
ignored:          0
================================================================================
test_id:    kafkatest.sanity_checks.test_performance_services.PerformanceServiceTest.test_version.version=0.8.2.2.new_consumer=False
status:     FAIL
run time:   37.388 seconds
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
