### PR TITLE
MINOR: Fix the broken javadoc in ConsumerNetworkThread

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThread.java
@@ -189,7 +189,7 @@ public class ConsumerNetworkThread extends KafkaThread implements Closeable {
      *
      * <ol>
      *     <li>
-     *         Iterate through the {@link RequestManager} list and invoke {@link RequestManager#pollOnClose()}
+     *         Iterate through the {@link RequestManager} list and invoke {@link RequestManager#pollOnClose(long)}
      *         to get the {@link NetworkClientDelegate.UnsentRequest} list and the poll time for the network poll
      *     </li>
      *     <li>


### PR DESCRIPTION
We have refactored `RequestManager#pollOnClose` in #16974 , which caused the referenced Javadoc of the method to break.
This PR aims to fix this small issue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
