### PR TITLE
KAFKA-17845: Do not omit tagged entity with implicit defaults

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/StructSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/StructSpec.java
@@ -104,4 +104,13 @@ public final class StructSpec {
     boolean hasKeys() {
         return hasKeys;
     }
+
+    public boolean allExplicitDefaults() {
+        for (FieldSpec field : fields) {
+            if (!field.hasExplicitDefault) {
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Only omit tagged struct field values when all of their values have _explicit_ defaults.

This only has an affect for the `UpdateRaftVoterResponseData.currentLeader` field, and the only effect for that field is that a value of `CurrentLeader(leaderId=-1, leaderEpoch=-1, host="", port=0)` will not be written from serialized bytes. As `host=""` and `port=0` are invalid values, this will practically have no impact on performance.