### PR TITLE
MINOR: remove unnecessary main method in ProducerConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -647,9 +646,4 @@ public class ProducerConfig extends AbstractConfig {
     public static ConfigDef configDef() {
         return new ConfigDef(CONFIG);
     }
-
-    public static void main(String[] args) {
-        System.out.println(CONFIG.toHtml(4, config -> "producerconfigs_" + config));
-    }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -128,5 +127,12 @@ public class ProducerConfigTest {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, saslSslLowerCase);
         final ProducerConfig producerConfig = new ProducerConfig(configs);
         assertEquals(saslSslLowerCase, producerConfig.originals().get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    public void testToHtml() {
+        String html = ProducerConfig.configDef().toHtml(4, config -> "producerconfigs_" + config);
+        String expectedConfig = "<h4><a id=\"linger.ms\"></a><a id=\"producerconfigs_linger.ms\" href=\"#producerconfigs_linger.ms\">linger.ms</a></h4>";
+        assertTrue(html.contains(expectedConfig), "Could not find `" + expectedConfig + "` in:\n" + html);
     }
 }


### PR DESCRIPTION
Change:
Move the main test of ProducerConfig to ProducerConfigTest

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
