### PR TITLE
KAFKA-17883: Fix jvm error caused by UseParNewGC when running old kafka client in e2e

### DIFF
--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -16,6 +16,7 @@
 
 import os
 
+from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 from kafkatest.services.performance import PerformanceService
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.version import DEV_BRANCH, V_2_0_0, LATEST_0_10_0
@@ -123,7 +124,8 @@ class ConsumerPerformanceService(PerformanceService):
         return args
 
     def start_cmd(self, node):
-        cmd = "export LOG_DIR=%s;" % ConsumerPerformanceService.LOG_DIR
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "export LOG_DIR=%s;" % ConsumerPerformanceService.LOG_DIR
         cmd += " export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
         cmd += " export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\";" % ConsumerPerformanceService.LOG4J_CONFIG
         cmd += " %s" % self.path.script("kafka-consumer-perf-test.sh", node)

--- a/tests/kafkatest/services/performance/end_to_end_latency.py
+++ b/tests/kafkatest/services/performance/end_to_end_latency.py
@@ -15,6 +15,7 @@
 
 import os
 
+from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 from kafkatest.services.performance import PerformanceService
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.version import get_version, V_3_4_0, DEV_BRANCH
@@ -86,7 +87,8 @@ class EndToEndLatencyService(PerformanceService):
                 'zk_connect': self.kafka.zk_connect_setting(),
             })
 
-        cmd = "export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % EndToEndLatencyService.LOG4J_CONFIG
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % EndToEndLatencyService.LOG4J_CONFIG
         if node.version.consumer_supports_bootstrap_server():
             cmd += "KAFKA_OPTS=%(kafka_opts)s %(kafka_run_class)s %(java_class_name)s " % args
             cmd += "%(bootstrap_servers)s %(topic)s %(num_records)d %(acks)d %(message_bytes)d %(config_file)s" % args

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -19,6 +19,7 @@ from ducktape.utils.util import wait_until
 from ducktape.cluster.remoteaccount import RemoteCommandError
 
 from kafkatest.directory_layout.kafka_path import TOOLS_JAR_NAME, TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME
+from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 from kafkatest.services.monitor.http import HttpMetricsCollector
 from kafkatest.services.performance import PerformanceService
 from kafkatest.services.security.security_config import SecurityConfig
@@ -81,7 +82,7 @@ class ProducerPerformanceService(HttpMetricsCollector, PerformanceService):
             'metrics_props': ' '.join("%s=%s" % (k, v) for k, v in self.http_metrics_client_configs.items())
             })
 
-        cmd = ""
+        cmd = fix_opts_for_new_jvm(node)
 
         if node.version < DEV_BRANCH:
             # In order to ensure more consistent configuration between versions, always use the ProducerPerformance


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17883

Add suitable JVM configurations for the old Kafka client to ConsumerPerformanceService, EndToEndLatencyService, and ProducerPerformanceService.

Command:
`$ TC_PATHS="kafka/tests/kafkatest/sanity_checks/test_performance_services.py" bash tests/docker/run_tests.sh`

Before:
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-10-27--014
run time:         3 minutes 17.806 seconds
tests run:        7
passed:           6
flaky:            0
failed:           1
ignored:          0
================================================================================
test_id:    kafkatest.sanity_checks.test_performance_services.PerformanceServiceTest.test_version.version=0.8.2.2.new_consumer=False
status:     FAIL
run time:   37.666 seconds
```

After:
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-10-27--001
run time:         3 minutes 16.096 seconds
tests run:        7
passed:           7
flaky:            0
failed:           0
ignored:          0
================================================================================
```

As we can see, the failed test has been fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
