### PR TITLE
KAFKA-17128: Make node.id immutable after removing Zookeeper

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -328,10 +328,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   /** ********* General Configuration ***********/
   val brokerIdGenerationEnable: Boolean = getBoolean(ServerConfigs.BROKER_ID_GENERATION_ENABLE_CONFIG)
   val maxReservedBrokerId: Int = getInt(ServerConfigs.RESERVED_BROKER_MAX_ID_CONFIG)
-  private[server] var _brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
-  def brokerId: Int = _brokerId
-  private[server] var _nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
-  def nodeId: Int = _nodeId
+  var brokerId: Int = getInt(ServerConfigs.BROKER_ID_CONFIG)
+  val nodeId: Int = getInt(KRaftConfigs.NODE_ID_CONFIG)
   val initialRegistrationTimeoutMs: Int = getInt(KRaftConfigs.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG)
   val brokerHeartbeatIntervalMs: Int = getInt(KRaftConfigs.BROKER_HEARTBEAT_INTERVAL_MS_CONFIG)
   val brokerSessionTimeoutMs: Int = getInt(KRaftConfigs.BROKER_SESSION_TIMEOUT_MS_CONFIG)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -259,8 +259,7 @@ class KafkaServer(
         initialMetaPropsEnsemble.verify(Optional.of(_clusterId), verificationId, verificationFlags)
 
         /* generate brokerId */
-        config._brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
-        config._nodeId = config.brokerId
+        config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
         logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
         this.logIdent = logContext.logPrefix
 


### PR DESCRIPTION
JIRA: KAFKA-17128

Since we are removing zk, it's time to revert the changes in #16540.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
