### PR TITLE
KAFKA-17632: Fix RoundRobinPartitioner for even partition counts

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1075,6 +1075,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
             if (result.abortForNewBatch) {
                 int prevPartition = partition;
+                // IMPORTANT NOTE: the following onNewBatch and partition calls should not interrupted to allow
+                // the custom partitioner to correctly track its state
                 onNewBatch(record.topic(), cluster, prevPartition);
                 partition = partition(record, serializedKey, serializedValue, cluster);
                 if (log.isTraceEnabled()) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java
@@ -49,6 +49,9 @@ public interface Partitioner extends Configurable, Closeable {
      * <p>
      * Notifies the partitioner a new batch is about to be created. When using the sticky partitioner,
      * this method can change the chosen sticky partition for the new batch.
+     * <p>
+     * After onNewBatch, the {@link #partition(String, Object, byte[], Object, byte[], Cluster)} method is called again
+     * which allows the implementation to "redirect" the message on new batch creation.
      * @param topic The topic name
      * @param cluster The current cluster metadata
      * @param prevPartition The partition previously selected for the record that triggered a new batch

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -68,6 +68,19 @@ public class RoundRobinPartitioner implements Partitioner {
         return counter.getAndIncrement();
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+        topicCounterMap.compute(topic, (k, counter) -> {
+            if (counter != null) {
+                // On new batches, partition() will be called again, effectively incrementing the counter twice
+                // To avoid skipping partitions, decrement once
+                counter.decrementAndGet();
+            }
+            return counter;
+        });
+    }
+
     public void close() {}
 
 }


### PR DESCRIPTION
RoundRobinPartitioner does not handle the fact that on new batch creation, the partition method is called twice.

Change-Id: Icbdb42e402c5073b1487691361962dcd57c21d05

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
