### PR TITLE
KAFKA-17767 Store the test catalog in Git [2/n]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,14 +203,15 @@ jobs:
         with:
           persist-credentials: true  # Needed to commit and push later
           ref: test-catalog
+      - name: Reset Catalog
+        run: |
+          rm -rf test-catalog
       - name: Download Test Catalog
         uses: actions/download-artifact@v4
         with:
           name: test-catalog
       - name: Update Test Catalog
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog
           git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,6 @@ jobs:
 
   update-test-catalog:
     needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,8 @@ jobs:
           name: test-catalog
       - name: Update Test Catalog
         run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog
           git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,3 +191,27 @@ jobs:
           path: ~/.gradle/build-scan-data
           compression-level: 9
           if-no-files-found: ignore
+
+  update-test-catalog:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Test Catalog
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true  # Needed to commit and push later
+          ref: test-catalog
+      - name: Download Test Catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: test-catalog
+      - name: Update Test Catalog
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add test-catalog
+          git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
+          git push


### PR DESCRIPTION
Second part of #17397. This patch will take the extracted test catalog generate on trunk and commit it to an orphaned Git branch in the Apache Kafka repository