### PR TITLE
KAFKA-17767 Store the test catalog in Git [2/n] (2nd attempt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,5 +215,5 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog
-          git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
+          git diff --quiet && git diff --staged --quiet || git commit -m 'Update test catalog data for GHA workflow run ${{ github.run_id }}'
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,7 @@ jobs:
           name: test-catalog
           path: test-catalog
       - name: Update Test Catalog
+        # Git user.name and user.email come from https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
         run: |
           pwd
           ls -R

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,14 +203,15 @@ jobs:
         with:
           persist-credentials: true  # Needed to commit and push later
           ref: test-catalog
+      - name: Reset Catalog
+        run: |
+          rm -rf test-catalog
       - name: Download Test Catalog
         uses: actions/download-artifact@v4
         with:
           name: test-catalog
       - name: Update Test Catalog
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog
           git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,12 +211,10 @@ jobs:
       - name: Download Test Catalog
         id: download-test-catalog
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: test-catalog
           path: test-catalog
       - name: Update Test Catalog
-        if: steps.download-test-catalog.outcome == 'success'
         # Git user.name and user.email come from https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
         run: |
           pwd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,6 @@ jobs:
           TIMEOUT_MINUTES: 180  # 3 hours
         run: |
           set +e
-          exit
           ./.github/scripts/thread-dump.sh &
           timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,6 @@ jobs:
 
   update-test-catalog:
     needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,8 @@ jobs:
           name: test-catalog
       - name: Update Test Catalog
         run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog
           git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
           TIMEOUT_MINUTES: 180  # 3 hours
         run: |
           set +e
+          exit
           ./.github/scripts/thread-dump.sh &
           timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
           -PtestLoggingEvents=started,passed,skipped,failed \
@@ -194,6 +195,7 @@ jobs:
 
   update-test-catalog:
     needs: test
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,3 +191,27 @@ jobs:
           path: ~/.gradle/build-scan-data
           compression-level: 9
           if-no-files-found: ignore
+
+  update-test-catalog:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Test Catalog
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true  # Needed to commit and push later
+          ref: test-catalog
+      - name: Download Test Catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: test-catalog
+      - name: Update Test Catalog
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add test-catalog
+          git diff --quiet && git diff --staged --quiet || git commit -m 'Update all-tests data for Run ${{ github.run_id }}'
+          git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
           TIMEOUT_MINUTES: 180  # 3 hours
         run: |
           set +e
+          exit
           ./.github/scripts/thread-dump.sh &
           timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
           -PtestLoggingEvents=started,passed,skipped,failed \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,8 +210,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-catalog
+          path: test-catalog
       - name: Update Test Catalog
         run: |
+          pwd
+          ls -R
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add test-catalog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,6 @@ jobs:
         run: |
           rm -rf test-catalog
       - name: Download Test Catalog
-        id: download-test-catalog
         uses: actions/download-artifact@v4
         with:
           name: test-catalog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,13 +209,14 @@ jobs:
         run: |
           rm -rf test-catalog
       - name: Download Test Catalog
+        id: download-test-catalog
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: test-catalog
           path: test-catalog
       - name: Update Test Catalog
-        if: success()
+        if: steps.download-test-catalog.outcome == 'success'
         # Git user.name and user.email come from https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
         run: |
           pwd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,10 +209,12 @@ jobs:
           rm -rf test-catalog
       - name: Download Test Catalog
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: test-catalog
           path: test-catalog
       - name: Update Test Catalog
+        if: success()
         # Git user.name and user.email come from https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
         run: |
           pwd


### PR DESCRIPTION
(Re-opened this as a branch PR instead of fork)

Second part of https://github.com/apache/kafka/pull/17397. This patch will take the extracted test catalog generate on trunk and commit it to an orphaned Git branch in the Apache Kafka repository