### PR TITLE
KAFKA-17627: ConfigProvider TTLs do not restart Tasks

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -275,6 +275,14 @@ public interface Herder {
 
     /**
      * Restart the connector and optionally its tasks.
+     * @param delayMs delay before restart
+     * @param request the details of the restart request
+     * @param cb      callback to invoke upon completion with the connector state info
+     */
+    HerderRequest restartConnectorAndTasks(long delayMs, RestartRequest request, Callback<ConnectorStateInfo> cb);
+
+    /**
+     * Restart the connector and optionally its tasks.
      * @param request the details of the restart request
      * @param cb      callback to invoke upon completion with the connector state info
      */

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -258,6 +258,15 @@ public interface Herder {
     void restartTask(ConnectorTaskId id, Callback<Void> cb);
 
     /**
+     * Restart the task with the given id.
+     * @param delayMs delay before restart
+     * @param id id of the task
+     * @param cb callback to invoke upon completion
+     * @return The id of the request
+     */
+    HerderRequest restartTask(long delayMs, ConnectorTaskId id, Callback<Void> cb);
+
+    /**
      * Restart the connector.
      * @param connName name of the connector
      * @param cb callback to invoke upon completion

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -284,14 +284,6 @@ public interface Herder {
 
     /**
      * Restart the connector and optionally its tasks.
-     * @param delayMs delay before restart
-     * @param request the details of the restart request
-     * @param cb      callback to invoke upon completion with the connector state info
-     */
-    HerderRequest restartConnectorAndTasks(long delayMs, RestartRequest request, Callback<ConnectorStateInfo> cb);
-
-    /**
-     * Restart the connector and optionally its tasks.
      * @param request the details of the restart request
      * @param cb      callback to invoke upon completion with the connector state info
      */

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
@@ -131,18 +131,12 @@ public class WorkerConfigTransformer implements AutoCloseable {
                 previousRequest.cancel();
             }
             log.info("Scheduling a restart of connector {} in {} ms", connectorName, ttl);
-            FutureCallback<ConnectorStateInfo> cb = new FutureCallback<>();
-            //TODO: Check a best way to add this error message
-            //TODO: Why callback for connector is void but for connector and tasks it's callback with connector state info?
-            //Callback<Void> cb = (error, result) -> {
-            //    if (error != null) {
-            //        log.error("Unexpected error during connector restart: ", error);
-            //    }
-            //};
-            //TODO: Check if doing this in Standalone also makes sense?
-            RestartRequest restartRequest = new RestartRequest(connectorName, false, false);
-            worker.herder().restartConnectorAndTasks(ttl, restartRequest, cb);
-            return null;
+            Callback<Void> cb = (error, result) -> {
+                if (error != null) {
+                    log.error("Unexpected error during connector restart: ", error);
+                }
+            };
+            return worker.herder().restartConnector(ttl, connectorName, cb);
         });
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
@@ -24,6 +24,9 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Herder.ConfigReloadAction;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.FutureCallback;
+import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +44,8 @@ public class WorkerConfigTransformer implements AutoCloseable {
 
     private final Worker worker;
     private final ConfigTransformer configTransformer;
-    private final ConcurrentMap<String, Map<String, HerderRequest>> requests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Map<String, HerderRequest>> connectorRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ConnectorTaskId, Map<String, HerderRequest>> taskRequests = new ConcurrentHashMap<>();
     private final Map<String, ConfigProvider> configProviders;
 
     public WorkerConfigTransformer(Worker worker, Map<String, ConfigProvider> configProviders) {
@@ -51,7 +55,7 @@ public class WorkerConfigTransformer implements AutoCloseable {
     }
 
     public Map<String, String> transform(Map<String, String> configs) {
-        return transform(null, configs);
+        return transform((String) null, configs);
     }
 
     public Map<String, String> transform(String connectorName, Map<String, String> configs) {
@@ -72,6 +76,47 @@ public class WorkerConfigTransformer implements AutoCloseable {
         return result.data();
     }
 
+    public Map<String, String> transform(ConnectorTaskId taskId, Map<String, String> configs) {
+        if (configs == null) return null;
+        ConfigTransformerResult result = configTransformer.transform(configs);
+        if (taskId != null) {
+            String key = ConnectorConfig.CONFIG_RELOAD_ACTION_CONFIG;
+            String action = (String) ConfigDef.parseType(key, configs.get(key), ConfigDef.Type.STRING);
+            if (action == null) {
+                // The default action is "restart".
+                action = ConnectorConfig.CONFIG_RELOAD_ACTION_RESTART;
+            }
+            ConfigReloadAction reloadAction = ConfigReloadAction.valueOf(action.toUpperCase(Locale.ROOT));
+            if (reloadAction == ConfigReloadAction.RESTART) {
+                scheduleReload(taskId, result.ttls());
+            }
+        }
+        return result.data();
+    }
+
+    private void scheduleReload(ConnectorTaskId taskId, Map<String, Long> ttls) {
+        for (Map.Entry<String, Long> entry : ttls.entrySet()) {
+            scheduleReload(taskId, entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void scheduleReload(ConnectorTaskId taskId, String path, long ttl) {
+        Map<String, HerderRequest> requests = this.taskRequests.computeIfAbsent(taskId, s -> new ConcurrentHashMap<>());
+        requests.compute(path, (s, previousRequest) -> {
+            if (previousRequest != null) {
+                // Delete previous request for ttl which is now stale
+                previousRequest.cancel();
+            }
+            log.info("Scheduling a restart of task {} in {} ms", taskId, ttl);
+            Callback<Void> cb = (error, result) -> {
+                if (error != null) {
+                    log.error("Unexpected error during connector restart: ", error);
+                }
+            };
+            return worker.herder().restartTask(ttl, taskId, cb);
+        });
+    }
+
     private void scheduleReload(String connectorName, Map<String, Long> ttls) {
         for (Map.Entry<String, Long> entry : ttls.entrySet()) {
             scheduleReload(connectorName, entry.getKey(), entry.getValue());
@@ -79,8 +124,8 @@ public class WorkerConfigTransformer implements AutoCloseable {
     }
 
     private void scheduleReload(String connectorName, String path, long ttl) {
-        Map<String, HerderRequest> connectorRequests = requests.computeIfAbsent(connectorName, s -> new ConcurrentHashMap<>());
-        connectorRequests.compute(path, (s, previousRequest) -> {
+        Map<String, HerderRequest> requests = this.connectorRequests.computeIfAbsent(connectorName, s -> new ConcurrentHashMap<>());
+        requests.compute(path, (s, previousRequest) -> {
             if (previousRequest != null) {
                 // Delete previous request for ttl which is now stale
                 previousRequest.cancel();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfigTransformer.java
@@ -22,8 +22,6 @@ import org.apache.kafka.common.config.ConfigTransformerResult;
 import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Herder.ConfigReloadAction;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
-import org.apache.kafka.connect.util.FutureCallback;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1511,9 +1511,15 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     @Override
-    public void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> callback) {
+    public void restartConnectorAndTasks(final RestartRequest request, final Callback<ConnectorStateInfo> callback) {
+        restartConnectorAndTasks(0, request, callback);
+    }
+
+    @Override
+    public HerderRequest restartConnectorAndTasks(long delayMs, RestartRequest request, Callback<ConnectorStateInfo> callback) {
         final String connectorName = request.connectorName();
-        addRequest(
+        return addRequest(
+                delayMs,
                 () -> {
                     if (checkRebalanceNeeded(callback)) {
                         return null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1310,7 +1310,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     @Override
     public void restartTask(ConnectorTaskId id, Callback<Void> cb) {
-        restartTask(0,id,cb);
+        restartTask(0, id, cb);
     }
 
     // A task on this worker requires a round of zombie fencing

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1517,15 +1517,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     @Override
-    public void restartConnectorAndTasks(final RestartRequest request, final Callback<ConnectorStateInfo> callback) {
-        restartConnectorAndTasks(0, request, callback);
-    }
-
-    @Override
-    public HerderRequest restartConnectorAndTasks(long delayMs, RestartRequest request, Callback<ConnectorStateInfo> callback) {
+    public void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> callback) {
         final String connectorName = request.connectorName();
-        return addRequest(
-                delayMs,
+        addRequest(
                 () -> {
                     if (checkRebalanceNeeded(callback)) {
                         return null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1308,6 +1308,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         fenceZombieSourceTasks(connName, callback);
     }
 
+    @Override
+    public void restartTask(ConnectorTaskId id, Callback<Void> cb) {
+        restartTask(0,id,cb);
+    }
+
     // A task on this worker requires a round of zombie fencing
     void fenceZombieSourceTasks(final ConnectorTaskId id, Callback<Void> callback) {
         log.trace("Performing preflight zombie check for task {}", id);
@@ -1469,9 +1474,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     @Override
-    public void restartTask(final ConnectorTaskId id, final Callback<Void> callback) {
-        addRequest(
-            () -> {
+    public HerderRequest restartTask(final long delayMs, final ConnectorTaskId id, final Callback<Void> callback) {
+        return addRequest(
+                delayMs,
+                () -> {
                 if (checkRebalanceNeeded(callback))
                     return null;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.AbstractHerder;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.HerderRequest;
 import org.apache.kafka.connect.runtime.RestartPlan;
@@ -344,6 +345,14 @@ public class StandaloneHerder extends AbstractHerder {
             cb.onCompletion(null, null);
         else
             cb.onCompletion(new ConnectException("Failed to start task: " + taskId), null);
+    }
+
+    @Override
+    public synchronized HerderRequest restartTask(long delayMs, ConnectorTaskId taskId, Callback<Void> cb) {
+        ScheduledFuture<?> future = requestExecutorService.schedule(
+                () -> restartTask(taskId, cb), delayMs, TimeUnit.MILLISECONDS);
+
+        return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -379,13 +379,6 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
-    public synchronized HerderRequest restartConnectorAndTasks(long delayMs, final RestartRequest request, final Callback<ConnectorStateInfo> cb) {
-        ScheduledFuture<?> future = requestExecutorService.schedule(() -> restartConnectorAndTasks(request, cb), delayMs, TimeUnit.MILLISECONDS);
-
-        return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
-    }
-
-    @Override
     public synchronized void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> cb) {
         // Ensure the connector exists
         String connectorName = request.connectorName();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -370,6 +370,13 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
+    public synchronized HerderRequest restartConnectorAndTasks(long delayMs, final RestartRequest request, final Callback<ConnectorStateInfo> cb) {
+        ScheduledFuture<?> future = requestExecutorService.schedule(() -> restartConnectorAndTasks(request, cb), delayMs, TimeUnit.MILLISECONDS);
+
+        return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
+    }
+
+    @Override
     public synchronized void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> cb) {
         // Ensure the connector exists
         String connectorName = request.connectorName();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -24,7 +24,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.AbstractHerder;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.HerderRequest;
 import org.apache.kafka.connect.runtime.RestartPlan;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
@@ -197,7 +197,7 @@ public class ClusterConfigState {
     public Map<String, String> taskConfig(ConnectorTaskId task) {
         Map<String, String> configs = taskConfigs.get(task);
         if (configTransformer != null) {
-            configs = configTransformer.transform(task.connector(), configs);
+            configs = configTransformer.transform(task, configs);
         }
         return configs;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
@@ -71,7 +71,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariable() {
+    public void connectorTestReplaceVariable() {
         // Execution
         Map<String, String> result = configTransformer.transform(MY_CONNECTOR, Collections.singletonMap(MY_KEY, "${test:testPath:testKey}"));
 
@@ -89,7 +89,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariableWithTTL() {
+    public void connectorTestReplaceVariableWithTTL() {
         // Execution
         Map<String, String> props = new HashMap<>();
         props.put(MY_KEY, "${test:testPath:testKeyWithTTL}");
@@ -113,7 +113,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariableWithTTLAndScheduleRestart() {
+    public void connectorTestReplaceVariableWithTTLAndScheduleRestart() {
         // Setup
         when(worker.herder()).thenReturn(herder);
         when(herder.restartConnector(eq(1L), eq(MY_CONNECTOR), notNull())).thenReturn(requestId);
@@ -141,7 +141,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariableWithTTLFirstCancelThenScheduleRestart() {
+    public void connectorTestReplaceVariableWithTTLFirstCancelThenScheduleRestart() {
         // Setup
         when(worker.herder()).thenReturn(herder);
         when(herder.restartConnector(eq(1L), eq(MY_CONNECTOR), notNull())).thenReturn(requestId);
@@ -187,7 +187,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testTransformNullConfiguration() {
+    public void connectorTestTransformNullConfiguration() {
         assertNull(configTransformer.transform(MY_CONNECTOR, null));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
@@ -18,8 +18,8 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.provider.ConfigProvider;
-
 import org.apache.kafka.connect.util.ConnectorTaskId;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WorkerConfigTransformerTest {
- public static final String MY_KEY = "myKey";
+    public static final String MY_KEY = "myKey";
     public static final String MY_CONNECTOR = "myConnector";
     public static final ConnectorTaskId MY_TASK = new ConnectorTaskId(MY_CONNECTOR, 0);
     public static final String TEST_KEY = "testKey";


### PR DESCRIPTION
When WorkerConfigTransformer got TTLs in config provided it only scheduled connector restart, this PR schedules restart for Tasks too.

*Testing rationale*
I implemented similar testing as existing test cases for connector. Overall processing for task and connector is quite similar.

@gharris1727
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

I state the contribution is my original work and I license the work to the project under the project's open source license.