### PR TITLE
KAFKA-17905: Remove the specified type of using lambda for BaseFunction

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -39,7 +39,7 @@ public class ListConsumerGroupsResult {
         this.all = new KafkaFutureImpl<>();
         this.valid = new KafkaFutureImpl<>();
         this.errors = new KafkaFutureImpl<>();
-        future.thenApply((KafkaFuture.BaseFunction<Collection<Object>, Void>) results -> {
+        future.thenApply(results -> {
             ArrayList<Throwable> curErrors = new ArrayList<>();
             ArrayList<ConsumerGroupListing> curValid = new ArrayList<>();
             for (Object resultObject : results) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupsResult.java
@@ -40,7 +40,7 @@ public class ListShareGroupsResult {
         this.all = new KafkaFutureImpl<>();
         this.valid = new KafkaFutureImpl<>();
         this.errors = new KafkaFutureImpl<>();
-        future.thenApply((KafkaFuture.BaseFunction<Collection<Object>, Void>) results -> {
+        future.thenApply(results -> {
             ArrayList<Throwable> curErrors = new ArrayList<>();
             ArrayList<ShareGroupListing> curValid = new ArrayList<>();
             for (Object resultObject : results) {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.common.security.oauthbearer.internals.secured;
 
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
 
@@ -298,7 +297,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         public <T> ScheduledFuture<T> schedule(final Callable<T> callable, long delayMs, Long period) {
 
             KafkaFutureImpl<Long> waiter = new KafkaFutureImpl<>();
-            waiter.thenApply((KafkaFuture.BaseFunction<Long, Void>) now -> {
+            waiter.thenApply(now -> {
                 try {
                     callable.call();
                 } catch (Throwable e) {

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import org.slf4j.Logger;
@@ -85,7 +84,7 @@ public class MockScheduler implements Scheduler, MockTime.Listener {
                                   final Callable<T> callable, long delayMs) {
         final KafkaFutureImpl<T> future = new KafkaFutureImpl<>();
         KafkaFutureImpl<Long> waiter = new KafkaFutureImpl<>();
-        waiter.thenApply((KafkaFuture.BaseFunction<Long, Void>) now -> {
+        waiter.thenApply(now -> {
             executor.submit((Callable<Void>) () -> {
                 // Note: it is possible that we'll execute Callable#call right after
                 // the future is cancelled.  This is a valid sequence of events

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -333,7 +333,7 @@ public final class WorkerManager {
                 return worker.doneFuture;
             }
             KafkaFutureImpl<String> haltFuture = new KafkaFutureImpl<>();
-            haltFuture.thenApply((KafkaFuture.BaseFunction<String, Void>) errorString -> {
+            haltFuture.thenApply(errorString -> {
                 if (errorString == null)
                     errorString = "";
                 if (errorString.isEmpty()) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-17905

Remove unnecessary casting when using lambda for BaseFunction.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
