### PR TITLE
KAFKA-17908: Tweak log messages in group metadata manager

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1498,7 +1498,7 @@ public class GroupMetadataManager {
         if (member.memberEpoch() != LEAVE_GROUP_STATIC_MEMBER_EPOCH) {
             // The new member can't join.
             log.info("[GroupId {}] Static member {} with instance id {} cannot join the group because the instance id is" +
-                    " is owned by member {}.", groupId, receivedMemberId, receivedInstanceId, member.memberId());
+                    " owned by member {}.", groupId, receivedMemberId, receivedInstanceId, member.memberId());
             throw Errors.UNRELEASED_INSTANCE_ID.exception("Static member " + receivedMemberId + " with instance id "
                 + receivedInstanceId + " cannot join the group because the instance id is owned by " + member.memberId() + " member.");
         }
@@ -2702,11 +2702,11 @@ public class GroupMetadataManager {
             throwIfStaticMemberIsUnknown(member, instanceId);
             throwIfInstanceIdIsFenced(member, groupId, memberId, instanceId);
             if (memberEpoch == LEAVE_GROUP_STATIC_MEMBER_EPOCH) {
-                log.info("[GroupId {}] Static Member {} with instance id {} temporarily left the consumer group.",
+                log.info("[GroupId {}] Static member {} with instance id {} temporarily left the consumer group.",
                     group.groupId(), memberId, instanceId);
                 return consumerGroupStaticMemberGroupLeave(group, member);
             } else {
-                log.info("[GroupId {}] Static Member {} with instance id {} left the consumer group.",
+                log.info("[GroupId {}] Static member {} with instance id {} left the consumer group.",
                     group.groupId(), memberId, instanceId);
                 return consumerGroupFenceMember(group, member, response);
             }
@@ -3025,7 +3025,7 @@ public class GroupMetadataManager {
             sessionTimeoutMs,
             TimeUnit.MILLISECONDS,
             true,
-            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the member session expired.")
+            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the member session expired")
         );
     }
 
@@ -3045,7 +3045,7 @@ public class GroupMetadataManager {
             sessionTimeoutMs,
             TimeUnit.MILLISECONDS,
             true,
-            () -> shareGroupFenceMemberOperation(groupId, memberId, "the member session expired.")
+            () -> shareGroupFenceMemberOperation(groupId, memberId, "the member session expired")
         );
     }
 
@@ -3135,7 +3135,7 @@ public class GroupMetadataManager {
             rebalanceTimeoutMs,
             TimeUnit.MILLISECONDS,
             true,
-            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the classic member failed to join within the rebalance timeout.")
+            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the classic member failed to join within the rebalance timeout")
         );
     }
 
@@ -3169,7 +3169,7 @@ public class GroupMetadataManager {
             rebalanceTimeoutMs,
             TimeUnit.MILLISECONDS,
             true,
-            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the member failed to sync within timeout.")
+            () -> consumerGroupFenceMemberOperation(groupId, memberId, "the member failed to sync within timeout")
         );
     }
 
@@ -5735,7 +5735,7 @@ public class GroupMetadataManager {
                     member = group.getOrMaybeCreateMember(memberId, false);
                     throwIfMemberDoesNotUseClassicProtocol(member);
 
-                    log.info("[Group {}] Dynamic Member {} has left group " +
+                    log.info("[Group {}] Dynamic member {} has left group " +
                             "through explicit `LeaveGroup` request; client reason: {}",
                         groupId, memberId, reason);
                 } else {
@@ -5749,7 +5749,7 @@ public class GroupMetadataManager {
                     throwIfMemberDoesNotUseClassicProtocol(member);
 
                     memberId = member.memberId();
-                    log.info("[Group {}] Static Member {} with instance id {} has left group " +
+                    log.info("[Group {}] Static member {} with instance id {} has left group " +
                             "through explicit `LeaveGroup` request; client reason: {}",
                         groupId, memberId, instanceId, reason);
                 }


### PR DESCRIPTION
While testing a combination of consumer and share groups, I noticed a few instances of log messages from the group metadata manager which were untidy. Given that it takes seconds to fix them, here's a PR.

```
[2024-10-31 13:12:21,183] INFO [GroupCoordinator id=1 topic=__consumer_offsets partition=40] [GroupId console-consumer] Static Member BXDs--2-T3iqwmYQIcJ-uQ with instance id console temporarily left the consumer group. (org.apache.kafka.coordinator.group.GroupMetadataManager)
```
Capitalisation of Static Member should be Static member to match other records in the log, such as the following one.

```
[2024-10-31 13:14:20,616] INFO [GroupCoordinator id=1 topic=__consumer_offsets partition=40] [GroupId console-consumer] Static member aSyX1dJmQcWimg8CS0ZRNw with instance id console cannot join the group because the instance id is is owned by member xCB-bmz9RnCDH3hQX_1U0w. (org.apache.kafka.coordinator.group.GroupMetadataManager)
```
"is is"

```
[2024-10-31 13:31:05,236] INFO [GroupCoordinator id=1 topic=__consumer_offsets partition=40] [GroupId console-consumer] Member j1VGU6MqTOSUYAlDFhCYJw fenced from the group because the member session expired.. (org.apache.kafka.coordinator.group.GroupMetadataManager)
```
Double "." because the reason "the member session expired" contained a "." and was inserted into a sentence that already ends in ".".

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
