### PR TITLE
KAFKA-17911: Fix handling of env variables in KafkaDockerWrapper

### DIFF
--- a/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
+++ b/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
@@ -173,7 +173,7 @@ object KafkaDockerWrapper extends Logging {
     env.map {
         case (key, value) =>
           if (key.startsWith("KAFKA_") && !ExcludeServerPropsEnv.contains(key)) {
-            val final_key = key.replace("KAFKA_", "").toLowerCase()
+            val final_key = key.replaceFirst("KAFKA_", "").toLowerCase()
               .replace("_", ".")
               .replace("...", "-")
               .replace("..", "_")

--- a/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
+++ b/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
@@ -28,8 +28,9 @@ class KafkaDockerWrapperTest {
     val envVars = Map("KAFKA_TOOLS_LOG4J_LOGLEVEL" -> "TRACE",
       "KAFKA_VALID_PROPERTY" -> "Value",
       "SOME_VARIABLE" -> "Some Value",
-      "KAFKA_VALID___PROPERTY__ALL_CASES" -> "All Cases Value")
-    val expected = List("valid.property=Value", "valid-property_all.cases=All Cases Value")
+      "KAFKA_VALID___PROPERTY__ALL_CASES" -> "All Cases Value",
+      "KAFKA_KAFKA_VALID_PROPERTY" -> "Value")
+    val expected = List("valid.property=Value", "valid-property_all.cases=All Cases Value", "kafka.valid.property=Value")
     val actual = KafkaDockerWrapper.getServerConfigsFromEnv(envVars)
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
The call to `replace()` was replacing all instances of `KAFKA_`. This was an issue when handling the `kafka.metrics.reporters` broker configuration as `KAFKA_KAFKA_METRICS_REPORTERS` was incorrectly converted to `metrics.reporters` which is not a valid configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
