### PR TITLE
KAFKA-17912: Align string representations of SharePartitionKey

### DIFF
--- a/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+++ b/clients/src/main/resources/common/message/FindCoordinatorRequest.json
@@ -29,6 +29,7 @@
   // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   //
   // Version 6 adds support for share groups (KIP-932).
+  // For key type SHARE (2), the coordinator key format is "groupId:topicId:partition".
   "validVersions": "0-6",
   "deprecatedVersions": "0",
   "flexibleVersions": "3+",

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -539,7 +539,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private TopicPartition topicPartitionFor(SharePartitionKey key) {
-        return new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, partitionFor(key.toString()));
+        return new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, partitionFor(key.asCoordinatorKey()));
     }
 
     private static <P> boolean isEmpty(List<P> list) {

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -538,7 +538,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         this.runtime.onNewMetadataImage(newImage, delta);
     }
 
-    private TopicPartition topicPartitionFor(SharePartitionKey key) {
+    TopicPartition topicPartitionFor(SharePartitionKey key) {
         return new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, partitionFor(key.asCoordinatorKey()));
     }
 


### PR DESCRIPTION
The recent test failure documented by https://github.com/apache/kafka/pull/17649 seems to be related to the string representation of SharePartitionKey. This is a combination of group-id:topic-id:partition used by share groups to refer to a "share-partition" which is a particular share group's view of a topic-partition. The SharePartitionKey is used to find the share coordinator responsible for a share-partition.

It looks like some code was using a simple concatenation of the fields, while others was using toString which is human-readable. This mismatch seems to have caused requests to be sent to the wrong share coordinator, resulting in tests timing out.

This PR aligns all lookup-based uses of SharePartitionKey on the simple concatenation of its constituent parts.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
