### PR TITLE
KAFKA-17919: enable back the failing testShareGroups test

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -44,7 +44,6 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, 
 import org.apache.kafka.common.requests.DeleteRecordsRequest
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
-import org.apache.kafka.common.test.api.Flaky
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{ConsumerGroupState, ElectionType, GroupType, IsolationLevel, ShareGroupState, TopicCollection, TopicPartition, TopicPartitionInfo, TopicPartitionReplica, Uuid}
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
@@ -2088,7 +2087,6 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     }
   }
 
-  @Flaky("KAFKA-17463")
   @ParameterizedTest
   @ValueSource(strings = Array("kraft+kip932"))
   def testShareGroups(quorum: String): Unit = {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-17919

I have looped the test 40 times on my local, all pass.

Command:
`I=0; while ./gradlew core:test --tests PlaintextAdminIntegrationTest.testShareGroups --rerun --fail-fast; do (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
