### PR TITLE
MINOR: Update clientInstanceIds from EOS_V2 refactor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -92,6 +92,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -1929,10 +1930,18 @@ public class KafkaStreams implements AutoCloseable {
 
             // could be `null` if telemetry is disabled on the consumer itself
             if (instanceId != null) {
-                clientInstanceIds.addConsumerInstanceId(
-                    clientFuture.getKey(),
-                    instanceId
-                );
+                final String clientFutureKey = clientFuture.getKey();
+                if (clientFutureKey.toLowerCase(Locale.getDefault()).contains("producer")) {
+                    clientInstanceIds.addProducerInstanceId(
+                            clientFutureKey,
+                            instanceId
+                    );
+                } else {
+                    clientInstanceIds.addConsumerInstanceId(
+                            clientFutureKey,
+                            instanceId
+                    );
+                }
             } else {
                 log.debug(String.format("Telemetry is disabled for %s.", clientFuture.getKey()));
             }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1931,7 +1931,7 @@ public class KafkaStreams implements AutoCloseable {
             // could be `null` if telemetry is disabled on the consumer itself
             if (instanceId != null) {
                 final String clientFutureKey = clientFuture.getKey();
-                if (clientFutureKey.toLowerCase(Locale.getDefault()).contains("producer")) {
+                if (clientFutureKey.toLowerCase(Locale.getDefault()).endsWith("-producer")) {
                     clientInstanceIds.addProducerInstanceId(
                             clientFutureKey,
                             instanceId

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -1673,7 +1673,7 @@ public class KafkaStreamsTest {
     public void shouldReturnProducerAndConsumerInstanceIds() {
         prepareStreams();
         prepareStreamThread(streamThreadOne, 1);
-        prepareStreamThread(streamThreadTwo, 2);
+        props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
         final Uuid mainConsumerInstanceId = Uuid.randomUuid();
         final Uuid producerInstanceId = Uuid.randomUuid();
         final KafkaFutureImpl<Uuid> consumerFuture = new KafkaFutureImpl<>();
@@ -1683,7 +1683,7 @@ public class KafkaStreamsTest {
         final Uuid adminInstanceId = Uuid.randomUuid();
         adminClient.setClientInstanceId(adminInstanceId);
         
-        final Map<String, KafkaFuture<Uuid>> expectedClientIds = Map.of("main-consumer", consumerFuture, "some-thread-producer-id", producerFuture);
+        final Map<String, KafkaFuture<Uuid>> expectedClientIds = Map.of("main-consumer", consumerFuture, "some-thread-producer", producerFuture);
         when(streamThreadOne.clientInstanceIds(any())).thenReturn(expectedClientIds);
 
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
@@ -1692,7 +1692,8 @@ public class KafkaStreamsTest {
             assertThat(clientInstanceIds.consumerInstanceIds().size(), equalTo(1));
             assertThat(clientInstanceIds.consumerInstanceIds().get("main-consumer"), equalTo(mainConsumerInstanceId));
             assertThat(clientInstanceIds.producerInstanceIds().size(),  equalTo(1));
-            assertThat(clientInstanceIds.producerInstanceIds().get("some-thread-producer-id"), equalTo(producerInstanceId));
+            assertThat(clientInstanceIds.producerInstanceIds().get("some-thread-producer"), equalTo(producerInstanceId));
+            assertThat(clientInstanceIds.adminInstanceId(), equalTo(adminInstanceId));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -1665,6 +1666,33 @@ public class KafkaStreamsTest {
                 streams.clientInstanceIds(Duration.ZERO).adminInstanceId(),
                 equalTo(instanceId)
             );
+        }
+    }
+
+    @Test
+    public void shouldReturnProducerAndConsumerInstanceIds() {
+        prepareStreams();
+        prepareStreamThread(streamThreadOne, 1);
+        prepareStreamThread(streamThreadTwo, 2);
+        final Uuid mainConsumerInstanceId = Uuid.randomUuid();
+        final Uuid producerInstanceId = Uuid.randomUuid();
+        final KafkaFutureImpl<Uuid> consumerFuture = new KafkaFutureImpl<>();
+        final KafkaFutureImpl<Uuid> producerFuture = new KafkaFutureImpl<>();
+        consumerFuture.complete(mainConsumerInstanceId);
+        producerFuture.complete(producerInstanceId);
+        final Uuid adminInstanceId = Uuid.randomUuid();
+        adminClient.setClientInstanceId(adminInstanceId);
+        
+        final Map<String, KafkaFuture<Uuid>> expectedClientIds = Map.of("main-consumer", consumerFuture, "some-thread-producer-id", producerFuture);
+        when(streamThreadOne.clientInstanceIds(any())).thenReturn(expectedClientIds);
+
+        try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
+            streams.start();
+            final ClientInstanceIds clientInstanceIds = streams.clientInstanceIds(Duration.ZERO);
+            assertThat(clientInstanceIds.consumerInstanceIds().size(), equalTo(1));
+            assertThat(clientInstanceIds.consumerInstanceIds().get("main-consumer"), equalTo(mainConsumerInstanceId));
+            assertThat(clientInstanceIds.producerInstanceIds().size(),  equalTo(1));
+            assertThat(clientInstanceIds.producerInstanceIds().get("some-thread-producer-id"), equalTo(producerInstanceId));
         }
     }
 


### PR DESCRIPTION
Updates `KafkaStreams.clientInstanceIds` method to correctly populate the client-id -> clientInstanceId map that was altered in a previous refactoring.

Added a test that confirms `ClientInstanceIds` is correctly storing consumer and producer instance ids

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
