### PR TITLE
KAFKA-17920: GroupType.parse should return Optional<GroupType> to represent the null or empty

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3571,12 +3571,7 @@ public class KafkaAdminClient extends AdminClient {
 
                         private void maybeAddGroup(ListGroupsResponseData.ListedGroup group) {
                             final String groupId = group.groupId();
-                            final Optional<GroupType> type;
-                            if (group.groupType() == null || group.groupType().isEmpty()) {
-                                type = Optional.empty();
-                            } else {
-                                type = Optional.of(GroupType.parse(group.groupType()));
-                            }
+                            final Optional<GroupType> type = GroupType.parse(group.groupType());
                             final String protocolType = group.protocolType();
                             final GroupListing groupListing = new GroupListing(
                                 groupId,
@@ -3727,9 +3722,7 @@ public class KafkaAdminClient extends AdminClient {
                                 final Optional<ConsumerGroupState> state = group.groupState().isEmpty()
                                         ? Optional.empty()
                                         : Optional.of(ConsumerGroupState.parse(group.groupState()));
-                                final Optional<GroupType> type = group.groupType().isEmpty()
-                                        ? Optional.empty()
-                                        : Optional.of(GroupType.parse(group.groupType()));
+                                final Optional<GroupType> type = GroupType.parse(group.groupType());
                                 final ConsumerGroupListing groupListing = new ConsumerGroupListing(
                                         groupId,
                                         protocolType.isEmpty(),

--- a/clients/src/main/java/org/apache/kafka/common/GroupType.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupType.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,12 +41,13 @@ public enum GroupType {
     /**
      * Parse a string into a consumer group type, in a case-insensitive manner.
      */
-    public static GroupType parse(String name) {
-        if (name == null) {
-            return UNKNOWN;
+    public static Optional<GroupType> parse(String name) {
+        if (name == null || name.isEmpty()) {
+            return Optional.empty();
         }
+
         GroupType type = NAME_TO_ENUM.get(name.toLowerCase(Locale.ROOT));
-        return type == null ? UNKNOWN : type;
+        return type == null ? Optional.of(UNKNOWN) : Optional.of(type);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
@@ -251,7 +251,7 @@ public class GroupsCommand {
         }
 
         public Optional<GroupType> groupType() {
-            return valueAsOption(groupTypeOpt).map(GroupType::parse).filter(gt -> gt != GroupType.UNKNOWN);
+            return valueAsOption(groupTypeOpt).flatMap(GroupType::parse).filter(gt -> gt != GroupType.UNKNOWN);
         }
 
         public Optional<String> protocol() {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -141,7 +141,7 @@ public class ConsumerGroupCommand {
 
     @SuppressWarnings("Regexp")
     static Set<GroupType> consumerGroupTypesFromString(String input) {
-        Set<GroupType> parsedTypes = Stream.of(input.toLowerCase().split(",")).map(s -> GroupType.parse(s.trim())).collect(Collectors.toSet());
+        Set<GroupType> parsedTypes = Stream.of(input.toLowerCase().split(",")).map(s -> GroupType.parse(s.trim()).orElseThrow(() -> new IllegalArgumentException("Required name is not defined"))).collect(Collectors.toSet());
         if (parsedTypes.contains(GroupType.UNKNOWN)) {
             List<String> validTypes = Arrays.stream(GroupType.values()).filter(t -> t != GroupType.UNKNOWN).map(Object::toString).collect(Collectors.toList());
             throw new IllegalArgumentException("Invalid types list '" + input + "'. Valid types are: " + String.join(", ", validTypes));

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -144,7 +144,7 @@ public class ListConsumerGroupTest {
                                 protocolGroup,
                                 false,
                                 Optional.of(ConsumerGroupState.STABLE),
-                                Optional.of(GroupType.parse(groupProtocol.name()))
+                                GroupType.parse(groupProtocol.name())
                         )
                 );
 
@@ -160,7 +160,7 @@ public class ListConsumerGroupTest {
                                 protocolGroup,
                                 false,
                                 Optional.of(ConsumerGroupState.STABLE),
-                                Optional.of(GroupType.parse(groupProtocol.name()))
+                                GroupType.parse(groupProtocol.name())
                         )
                 );
 


### PR DESCRIPTION
Modify GroupType#parse to return an Optional\<GroupType\>, and update the related code accordingly.

To distinguish between 'null or empty' and 'unknown group type', we return Optional.empty() for null or empty values, eliminating the need for additional null or empty checks when calling GroupType.parse

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
