### PR TITLE
KAFKA-16780: Test to assert txn consumer exerts pressure on remote storage

### DIFF
--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
@@ -92,12 +92,16 @@ public abstract class TieredStorageTestHarness extends IntegrationTestHarness {
 
     protected abstract void writeTestSpecifications(TieredStorageTestBuilder builder);
 
+    protected void overrideConsumerConfig(Properties consumerConfig) {
+    }
+
     @BeforeEach
     @Override
     public void setUp(TestInfo testInfo) {
         testClassName = testInfo.getTestClass().get().getSimpleName().toLowerCase(Locale.getDefault());
         storageDirPath = TestUtils.tempDirectory("kafka-remote-tier-" + testClassName).getAbsolutePath();
         super.setUp(testInfo);
+        overrideConsumerConfig(consumerConfig());
         context = new TieredStorageTestContext(this);
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
@@ -25,20 +25,26 @@ import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageHistory;
 import org.apache.kafka.tiered.storage.TieredStorageTestAction;
 import org.apache.kafka.tiered.storage.TieredStorageTestContext;
+import org.apache.kafka.tiered.storage.specs.RemoteFetchCount;
 import org.apache.kafka.tiered.storage.specs.RemoteFetchSpec;
 
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.FETCH_OFFSET_INDEX;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.FETCH_SEGMENT;
+import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.FETCH_TIME_INDEX;
+import static org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent.EventType.FETCH_TRANSACTION_INDEX;
 import static org.apache.kafka.tiered.storage.utils.RecordsKeyValueMatcher.correspondTo;
 import static org.apache.kafka.tiered.storage.utils.TieredStorageTestUtils.tieredStorageRecords;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public final class ConsumeAction implements TieredStorageTestAction {
@@ -75,6 +81,9 @@ public final class ConsumeAction implements TieredStorageTestAction {
         // type has yet to happen.
         LocalTieredStorageHistory history = context.tieredStorageHistory(remoteFetchSpec.getSourceBrokerId());
         Optional<LocalTieredStorageEvent> latestEventSoFar = history.latestEvent(FETCH_SEGMENT, topicPartition);
+        Optional<LocalTieredStorageEvent> latestOffsetIdxEventSoFar = history.latestEvent(FETCH_OFFSET_INDEX, topicPartition);
+        Optional<LocalTieredStorageEvent> latestTimeIdxEventSoFar = history.latestEvent(FETCH_TIME_INDEX, topicPartition);
+        Optional<LocalTieredStorageEvent> latestTxnIdxEventSoFar = history.latestEvent(FETCH_TRANSACTION_INDEX, topicPartition);
 
         // Records are consumed here
         List<ConsumerRecord<String, String>> consumedRecords =
@@ -119,16 +128,59 @@ public final class ConsumeAction implements TieredStorageTestAction {
         assertThat(storedRecords, correspondTo(readRecords, topicPartition, serde, serde));
 
         // (B) Assessment of the interactions between the source broker and the second-tier storage.
-        List<LocalTieredStorageEvent> events = history.getEvents(FETCH_SEGMENT, topicPartition);
-        List<LocalTieredStorageEvent> eventsInScope = latestEventSoFar
-                .map(latestEvent ->
-                        events.stream().filter(event -> event.isAfter(latestEvent)).collect(Collectors.toList()))
-                .orElse(events);
+        for (LocalTieredStorageEvent.EventType eventType : Arrays.asList(FETCH_SEGMENT, FETCH_OFFSET_INDEX, FETCH_TIME_INDEX, FETCH_TRANSACTION_INDEX)) {
+            Optional<LocalTieredStorageEvent> latestEvent;
+            switch (eventType) {
+                case FETCH_SEGMENT:
+                    latestEvent = latestEventSoFar;
+                    break;
+                case FETCH_OFFSET_INDEX:
+                    latestEvent = latestOffsetIdxEventSoFar;
+                    break;
+                case FETCH_TIME_INDEX:
+                    latestEvent = latestTimeIdxEventSoFar;
+                    break;
+                case FETCH_TRANSACTION_INDEX:
+                    latestEvent = latestTxnIdxEventSoFar;
+                    break;
+                default:
+                    latestEvent = Optional.empty();
+            }
 
-        assertEquals(remoteFetchSpec.getCount(), eventsInScope.size(),
-                "Number of fetch requests from broker " + remoteFetchSpec.getSourceBrokerId() + " to the " +
-                        "tier storage does not match the expected value for topic-partition "
-                        + remoteFetchSpec.getTopicPartition());
+            List<LocalTieredStorageEvent> events = history.getEvents(eventType, topicPartition);
+            List<LocalTieredStorageEvent> eventsInScope = latestEvent
+                    .map(e -> events.stream().filter(event -> event.isAfter(e)).collect(Collectors.toList()))
+                    .orElse(events);
+
+            RemoteFetchCount remoteFetchCount = remoteFetchSpec.getRemoteFetchCount();
+            RemoteFetchCount.FetchCountAndOp expectedCountAndOp;
+            switch (eventType) {
+                case FETCH_SEGMENT:
+                    expectedCountAndOp = remoteFetchCount.getSegmentFetchCountAndOp();
+                    break;
+                case FETCH_OFFSET_INDEX:
+                    expectedCountAndOp = remoteFetchCount.getOffsetIdxFetchCountAndOp();
+                    break;
+                case FETCH_TIME_INDEX:
+                    expectedCountAndOp = remoteFetchCount.getTimeIdxFetchCountAndOp();
+                    break;
+                case FETCH_TRANSACTION_INDEX:
+                    expectedCountAndOp = remoteFetchCount.getTxnIdxFetchCountAndOp();
+                    break;
+                default:
+                    expectedCountAndOp = new RemoteFetchCount.FetchCountAndOp(-1);
+            }
+
+            String message = String.format("Number of %s requests from broker %d to the tier storage does not match the expected value for topic-partition %s",
+                    eventType, remoteFetchSpec.getSourceBrokerId(), remoteFetchSpec.getTopicPartition());
+            if (expectedCountAndOp.getCount() != -1) {
+                if (expectedCountAndOp.getOperationType() == RemoteFetchCount.OperationType.EQUALS_TO) {
+                    assertEquals(expectedCountAndOp.getCount(), eventsInScope.size(), message);
+                } else {
+                    assertTrue(eventsInScope.size() >= expectedCountAndOp.getCount(), message);
+                }
+            }
+        }
     }
 
     @Override
@@ -138,5 +190,6 @@ public final class ConsumeAction implements TieredStorageTestAction {
         output.println("  fetch-offset = " + fetchOffset);
         output.println("  expected-record-count = " + expectedTotalCount);
         output.println("  expected-record-from-tiered-storage = " + expectedFromSecondTierCount);
+        output.println("  remote-fetch-spec = " + remoteFetchSpec);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tiered.storage.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.tiered.storage.TieredStorageTestBuilder;
+import org.apache.kafka.tiered.storage.TieredStorageTestHarness;
+import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
+import org.apache.kafka.tiered.storage.specs.RemoteFetchCount;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Test Cases:
+ *    Elementary offloads and fetches from tiered storage using consumer with read_committed isolation level.
+ */
+public final class OffloadAndTxnConsumeFromLeaderTest extends TieredStorageTestHarness {
+
+    /**
+     * Cluster of one broker
+     * @return number of brokers in the cluster
+     */
+    @Override
+    public int brokerCount() {
+        return 1;
+    }
+
+    @Override
+    public Properties overridingProps() {
+        Properties props = super.overridingProps();
+        // Configure the remote-log index cache size to hold one entry to simulate eviction of cached index entries.
+        props.put(RemoteLogManagerConfig.REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP, "1");
+        return props;
+    }
+
+    @Override
+    protected void overrideConsumerConfig(Properties consumerConfig) {
+        consumerConfig.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString());
+    }
+
+    @Override
+    protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
+        final RemoteFetchCount remoteFetchCount = new RemoteFetchCount(
+                new RemoteFetchCount.FetchCountAndOp(6, RemoteFetchCount.OperationType.EQUALS_TO),
+                // Using >= for the assertion as the cache might evict the entries much before reaching the maximum
+                // size and to make the test deterministic.
+                new RemoteFetchCount.FetchCountAndOp(20, RemoteFetchCount.OperationType.GREATER_THAN_OR_EQUALS_TO),
+                new RemoteFetchCount.FetchCountAndOp(20, RemoteFetchCount.OperationType.GREATER_THAN_OR_EQUALS_TO),
+                new RemoteFetchCount.FetchCountAndOp(20, RemoteFetchCount.OperationType.GREATER_THAN_OR_EQUALS_TO)
+        );
+
+        final Integer broker = 0;
+        final String topicA = "topicA";
+        final Integer p0 = 0;
+        final Integer partitionCount = 1;
+        final Integer replicationFactor = 1;
+        final Integer oneBatchPerSegment = 1;
+        final Map<Integer, List<Integer>> replicaAssignment = null;
+        final boolean enableRemoteLogStorage = true;
+
+        builder
+                .createTopic(topicA, partitionCount, replicationFactor, oneBatchPerSegment, replicaAssignment,
+                        enableRemoteLogStorage)
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 0, new KeyValueSpec("k0", "v0"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 1, new KeyValueSpec("k1", "v1"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 2, new KeyValueSpec("k2", "v2"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 3, new KeyValueSpec("k3", "v3"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 4, new KeyValueSpec("k4", "v4"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 5, new KeyValueSpec("k5", "v5"))
+                .expectEarliestLocalOffsetInLogDirectory(topicA, p0, 6L)
+                .produce(topicA, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
+                        new KeyValueSpec("k2", "v2"), new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"),
+                        new KeyValueSpec("k5", "v5"), new KeyValueSpec("k6", "v6"))
+                // When reading with transactional consumer, the consecutive remote fetch indexes are fetched until the
+                // LSO found is higher than the fetch-offset.
+                // summation(n) = (n * (n + 1)) / 2
+                // Total number of uploaded remote segments = 6. Total number of index fetches = (6 * (6 + 1)) / 2 = 21
+                // The last-index entry might already be cached, so the effective index fetch count = 21 - 1 = 20
+                .expectFetchFromTieredStorage(broker, topicA, p0, remoteFetchCount)
+                .consume(topicA, p0, 0L, 7, 6);
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
@@ -21,10 +21,10 @@ import java.util.Objects;
 public final class FetchableSpec {
 
     private final Integer sourceBrokerId;
-    private final Integer fetchCount;
+    private final RemoteFetchCount fetchCount;
 
     public FetchableSpec(Integer sourceBrokerId,
-                         Integer fetchCount) {
+                         RemoteFetchCount fetchCount) {
         this.sourceBrokerId = sourceBrokerId;
         this.fetchCount = fetchCount;
     }
@@ -33,7 +33,7 @@ public final class FetchableSpec {
         return sourceBrokerId;
     }
 
-    public Integer getFetchCount() {
+    public RemoteFetchCount getFetchCount() {
         return fetchCount;
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tiered.storage.specs;
+
+import java.util.Objects;
+
+public class RemoteFetchCount {
+    private FetchCountAndOp segmentFetchCountAndOp;
+    private FetchCountAndOp offsetIdxFetchCountAndOp = new FetchCountAndOp(-1);
+    private FetchCountAndOp timeIdxFetchCountAndOp = new FetchCountAndOp(-1);
+    private FetchCountAndOp txnIdxFetchCountAndOp = new FetchCountAndOp(-1);
+
+    public RemoteFetchCount(int segmentFetchCountAndOp) {
+        this.segmentFetchCountAndOp = new FetchCountAndOp(segmentFetchCountAndOp);
+    }
+
+    public RemoteFetchCount(int segmentFetchCountAndOp,
+                            int offsetIdxFetchCountAndOp,
+                            int timeIdxFetchCountAndOp,
+                            int txnIdxFetchCountAndOp) {
+        this.segmentFetchCountAndOp = new FetchCountAndOp(segmentFetchCountAndOp);
+        this.offsetIdxFetchCountAndOp = new FetchCountAndOp(offsetIdxFetchCountAndOp);
+        this.timeIdxFetchCountAndOp = new FetchCountAndOp(timeIdxFetchCountAndOp);
+        this.txnIdxFetchCountAndOp = new FetchCountAndOp(txnIdxFetchCountAndOp);
+    }
+
+    public RemoteFetchCount(FetchCountAndOp segmentFetchCountAndOp,
+                            FetchCountAndOp offsetIdxFetchCountAndOp,
+                            FetchCountAndOp timeIdxFetchCountAndOp,
+                            FetchCountAndOp txnIdxFetchCountAndOp) {
+        this.segmentFetchCountAndOp = segmentFetchCountAndOp;
+        this.offsetIdxFetchCountAndOp = offsetIdxFetchCountAndOp;
+        this.timeIdxFetchCountAndOp = timeIdxFetchCountAndOp;
+        this.txnIdxFetchCountAndOp = txnIdxFetchCountAndOp;
+    }
+
+    public FetchCountAndOp getSegmentFetchCountAndOp() {
+        return segmentFetchCountAndOp;
+    }
+
+    public void setSegmentFetchCountAndOp(FetchCountAndOp segmentFetchCountAndOp) {
+        this.segmentFetchCountAndOp = segmentFetchCountAndOp;
+    }
+
+    public FetchCountAndOp getOffsetIdxFetchCountAndOp() {
+        return offsetIdxFetchCountAndOp;
+    }
+
+    public void setOffsetIdxFetchCountAndOp(FetchCountAndOp offsetIdxFetchCountAndOp) {
+        this.offsetIdxFetchCountAndOp = offsetIdxFetchCountAndOp;
+    }
+
+    public FetchCountAndOp getTimeIdxFetchCountAndOp() {
+        return timeIdxFetchCountAndOp;
+    }
+
+    public void setTimeIdxFetchCountAndOp(FetchCountAndOp timeIdxFetchCountAndOp) {
+        this.timeIdxFetchCountAndOp = timeIdxFetchCountAndOp;
+    }
+
+    public FetchCountAndOp getTxnIdxFetchCountAndOp() {
+        return txnIdxFetchCountAndOp;
+    }
+
+    public void setTxnIdxFetchCountAndOp(FetchCountAndOp txnIdxFetchCountAndOp) {
+        this.txnIdxFetchCountAndOp = txnIdxFetchCountAndOp;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteFetchCount{" +
+                "segmentFetchCountAndOp=" + segmentFetchCountAndOp +
+                ", offsetIdxFetchCountAndOp=" + offsetIdxFetchCountAndOp +
+                ", timeIdxFetchCountAndOp=" + timeIdxFetchCountAndOp +
+                ", txnIdxFetchCountAndOp=" + txnIdxFetchCountAndOp +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemoteFetchCount that = (RemoteFetchCount) o;
+        return Objects.equals(segmentFetchCountAndOp, that.segmentFetchCountAndOp) &&
+                Objects.equals(offsetIdxFetchCountAndOp, that.offsetIdxFetchCountAndOp) &&
+                Objects.equals(timeIdxFetchCountAndOp, that.timeIdxFetchCountAndOp) &&
+                Objects.equals(txnIdxFetchCountAndOp, that.txnIdxFetchCountAndOp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segmentFetchCountAndOp, offsetIdxFetchCountAndOp, timeIdxFetchCountAndOp, txnIdxFetchCountAndOp);
+    }
+
+    public enum OperationType {
+        EQUALS_TO,
+        GREATER_THAN_OR_EQUALS_TO,
+    }
+
+    public static class FetchCountAndOp {
+        private final int count;
+        private final OperationType operationType;
+
+        public FetchCountAndOp(int count) {
+            this.count = count;
+            this.operationType = OperationType.EQUALS_TO;
+        }
+
+        public FetchCountAndOp(int count, OperationType operationType) {
+            this.count = count;
+            this.operationType = operationType;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public OperationType getOperationType() {
+            return operationType;
+        }
+
+        @Override
+        public String toString() {
+            return "FetchCountAndOp{" +
+                    "count=" + count +
+                    ", operationType=" + operationType +
+                    '}';
+        }
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchSpec.java
@@ -24,7 +24,7 @@ public final class RemoteFetchSpec {
 
     private final int sourceBrokerId;
     private final TopicPartition topicPartition;
-    private final int count;
+    private final RemoteFetchCount remoteFetchCount;
 
     /**
      * Specifies a fetch (download) event from a second-tier storage. This is used to ensure the
@@ -32,14 +32,14 @@ public final class RemoteFetchSpec {
      *
      * @param sourceBrokerId The broker which fetched (a) remote log segment(s) from the second-tier storage.
      * @param topicPartition The topic-partition which segment(s) were fetched.
-     * @param count The number of remote log segment(s) fetched.
+     * @param remoteFetchCount The number of remote log segment(s) and indexes fetched.
      */
     public RemoteFetchSpec(int sourceBrokerId,
                            TopicPartition topicPartition,
-                           int count) {
+                           RemoteFetchCount remoteFetchCount) {
         this.sourceBrokerId = sourceBrokerId;
         this.topicPartition = topicPartition;
-        this.count = count;
+        this.remoteFetchCount = remoteFetchCount;
     }
 
     public int getSourceBrokerId() {
@@ -50,14 +50,14 @@ public final class RemoteFetchSpec {
         return topicPartition;
     }
 
-    public int getCount() {
-        return count;
+    public RemoteFetchCount getRemoteFetchCount() {
+        return remoteFetchCount;
     }
 
     @Override
     public String toString() {
-        return String.format("RemoteFetch[source-broker-id=%d topic-partition=%s count=%d]",
-                sourceBrokerId, topicPartition, count);
+        return String.format("RemoteFetch[source-broker-id=%d topic-partition=%s remote-fetch-count=%s]",
+                sourceBrokerId, topicPartition, remoteFetchCount);
     }
 
     @Override
@@ -66,12 +66,12 @@ public final class RemoteFetchSpec {
         if (o == null || getClass() != o.getClass()) return false;
         RemoteFetchSpec that = (RemoteFetchSpec) o;
         return sourceBrokerId == that.sourceBrokerId
-                && count == that.count
+                && Objects.equals(remoteFetchCount, that.remoteFetchCount)
                 && Objects.equals(topicPartition, that.topicPartition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceBrokerId, topicPartition, count);
+        return Objects.hash(sourceBrokerId, topicPartition, remoteFetchCount);
     }
 }


### PR DESCRIPTION
- Added a test to demonstrate the impact of pressure on remote storage by consumers using READ_COMMITTED isolation level which reads the index files repeatedly. 
- Configured the remote-log index cache size to 1 to simulate eviction of cached index entries.
- In integration tests, we asserted the number of remote calls made to fetch the segment. Extended the logic to assert the number of remote calls made to download the offset-index, time-index, and transaction-index auxiliary files to serve the FETCH request. Verified the number of fetch requests from tiered storage matches the expected value.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
