### PR TITLE
KAFKA-17923: Remove old kafka version from e2e

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -77,15 +77,6 @@ RUN echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config
 # Install binary test dependencies.
 # we use the same versions as in vagrant/base.sh
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
-RUN mkdir -p "/opt/kafka-0.8.2.2" && chmod a+rw /opt/kafka-0.8.2.2 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.8.2.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.8.2.2"
-RUN mkdir -p "/opt/kafka-0.9.0.1" && chmod a+rw /opt/kafka-0.9.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.9.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.9.0.1"
-RUN mkdir -p "/opt/kafka-0.10.0.1" && chmod a+rw /opt/kafka-0.10.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.10.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.10.0.1"
-RUN mkdir -p "/opt/kafka-0.10.1.1" && chmod a+rw /opt/kafka-0.10.1.1 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.10.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.10.1.1"
-RUN mkdir -p "/opt/kafka-0.10.2.2" && chmod a+rw /opt/kafka-0.10.2.2 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.10.2.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.10.2.2"
-RUN mkdir -p "/opt/kafka-0.11.0.3" && chmod a+rw /opt/kafka-0.11.0.3 && curl -s "$KAFKA_MIRROR/kafka_2.11-0.11.0.3.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.11.0.3"
-RUN mkdir -p "/opt/kafka-1.0.2" && chmod a+rw /opt/kafka-1.0.2 && curl -s "$KAFKA_MIRROR/kafka_2.11-1.0.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-1.0.2"
-RUN mkdir -p "/opt/kafka-1.1.1" && chmod a+rw /opt/kafka-1.1.1 && curl -s "$KAFKA_MIRROR/kafka_2.11-1.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-1.1.1"
-RUN mkdir -p "/opt/kafka-2.0.1" && chmod a+rw /opt/kafka-2.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.0.1"
 RUN mkdir -p "/opt/kafka-2.1.1" && chmod a+rw /opt/kafka-2.1.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.1.1"
 RUN mkdir -p "/opt/kafka-2.2.2" && chmod a+rw /opt/kafka-2.2.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.2.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.2.2"
 RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.3.1"
@@ -106,13 +97,6 @@ RUN mkdir -p "/opt/kafka-3.8.1" && chmod a+rw /opt/kafka-3.8.1 && curl -s "$KAFK
 
 
 # Streams test dependencies
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.10.0.1-test.jar" -o /opt/kafka-0.10.0.1/libs/kafka-streams-0.10.0.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.10.1.1-test.jar" -o /opt/kafka-0.10.1.1/libs/kafka-streams-0.10.1.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.10.2.2-test.jar" -o /opt/kafka-0.10.2.2/libs/kafka-streams-0.10.2.2-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.11.0.3-test.jar" -o /opt/kafka-0.11.0.3/libs/kafka-streams-0.11.0.3-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-1.0.2-test.jar" -o /opt/kafka-1.0.2/libs/kafka-streams-1.0.2-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-1.1.1-test.jar" -o /opt/kafka-1.1.1/libs/kafka-streams-1.1.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.0.1-test.jar" -o /opt/kafka-2.0.1/libs/kafka-streams-2.0.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.1.1-test.jar" -o /opt/kafka-2.1.1/libs/kafka-streams-2.1.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.2.2-test.jar" -o /opt/kafka-2.2.2/libs/kafka-streams-2.2.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.3.1-test.jar" -o /opt/kafka-2.3.1/libs/kafka-streams-2.3.1-test.jar

--- a/tests/kafkatest/directory_layout/kafka_path.py
+++ b/tests/kafkatest/directory_layout/kafka_path.py
@@ -16,7 +16,7 @@
 import importlib
 import os
 
-from kafkatest.version import get_version, KafkaVersion, DEV_BRANCH, LATEST_0_9, LATEST_3_5
+from kafkatest.version import get_version, KafkaVersion, DEV_BRANCH, LATEST_3_5
 
 
 """This module serves a few purposes:
@@ -55,11 +55,6 @@ JARS = {
     # This version of the file connectors does not contain ServiceLoader manifests
     LATEST_3_5.__str__(): {
         CONNECT_FILE_JAR: "libs/connect-file*.jar"
-    },
-    # TODO: This is only used in 0.8.2.x system tests, remove with KAFKA-14762
-    LATEST_0_9.__str__(): {
-        TOOLS_JAR_NAME: "libs/kafka-tools*.jar",
-        TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME: "libs/{argparse4j,jackson}*.jar"
     }
 }
 

--- a/tests/kafkatest/sanity_checks/test_console_consumer.py
+++ b/tests/kafkatest/sanity_checks/test_console_consumer.py
@@ -22,10 +22,8 @@ from ducktape.utils.util import wait_until
 
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import KafkaService, quorum
-from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.utils.remote_account import line_count, file_exists
-from kafkatest.version import LATEST_0_8_2
 
 
 class ConsoleConsumerTest(Test):
@@ -77,24 +75,3 @@ class ConsoleConsumerTest(Test):
         assert line_count(node, ConsoleConsumer.STDOUT_CAPTURE) == 0
 
         self.consumer.stop_node(node)
-
-    @cluster(num_nodes=4)
-    def test_version(self):
-        """Check that console consumer v0.8.2.X successfully starts and consumes messages."""
-        self.kafka.start()
-
-        num_messages = 1000
-        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
-                                           max_messages=num_messages, throughput=1000)
-        self.producer.start()
-        self.producer.wait()
-
-        self.consumer.nodes[0].version = LATEST_0_8_2
-        self.consumer.new_consumer = False
-        self.consumer.consumer_timeout_ms = 1000
-        self.consumer.start()
-        self.consumer.wait()
-
-        num_consumed = len(self.consumer.messages_consumed[1])
-        num_produced = self.producer.num_acked
-        assert num_produced == num_consumed, "num_produced: %d, num_consumed: %d" % (num_produced, num_consumed)

--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -21,7 +21,7 @@ from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.performance import ProducerPerformanceService, ConsumerPerformanceService, EndToEndLatencyService
 from kafkatest.services.performance import latency, compute_aggregate_throughput
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.version import DEV_BRANCH, LATEST_0_8_2, LATEST_0_9, LATEST_1_1, KafkaVersion
+from kafkatest.version import DEV_BRANCH, LATEST_2_1, KafkaVersion
 
 
 class PerformanceServiceTest(Test):
@@ -38,15 +38,8 @@ class PerformanceServiceTest(Test):
             self.zk.start()
 
     @cluster(num_nodes=5)
-    # We are keeping 0.8.2 here so that we don't inadvertently break support for it. Since this is just a sanity check,
-    # the overhead should be manageable.
-    @parametrize(version=str(LATEST_0_8_2), new_consumer=False)
-    @parametrize(version=str(LATEST_0_9), new_consumer=False)
-    @parametrize(version=str(LATEST_0_9))
-    @parametrize(version=str(LATEST_1_1), new_consumer=False)
-    @cluster(num_nodes=5)
-    @matrix(version=[str(DEV_BRANCH)], metadata_quorum=quorum.all)
-    def test_version(self, version=str(LATEST_0_9), new_consumer=True, metadata_quorum=quorum.zk):
+    @matrix(version=[str(LATEST_2_1), str(DEV_BRANCH)], metadata_quorum=quorum.all)
+    def test_version(self, version=str(LATEST_2_1), metadata_quorum=quorum.zk):
         """
         Sanity check out producer performance service - verify that we can run the service with a small
         number of messages. The actual stats here are pretty meaningless since the number of messages is quite small.
@@ -80,7 +73,7 @@ class PerformanceServiceTest(Test):
 
         # check basic run of consumer performance service
         self.consumer_perf = ConsumerPerformanceService(
-            self.test_context, 1, self.kafka, new_consumer=new_consumer,
+            self.test_context, 1, self.kafka,
             topic=self.topic, version=version, messages=self.num_records)
         self.consumer_perf.group = "test-consumer-group"
         self.consumer_perf.run()

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -41,12 +41,7 @@ listener.security.protocol.map={{ listener_security_protocol_map }}
 {% if quorum_info.using_zk or quorum_info.has_brokers %}
 advertised.host.name={{ node.account.hostname }}
 advertised.listeners={{ advertised_listeners }}
-
-{% if node.version.supports_named_listeners() %}
 inter.broker.listener.name={{ interbroker_listener.name }}
-{% else %}
-security.inter.broker.protocol={{ interbroker_listener.security_protocol }}
-{% endif %}
 {% endif %}
 
 {% for k, v in listener_security_config.client_listener_overrides.items() %}

--- a/tests/kafkatest/services/kafka/util.py
+++ b/tests/kafkatest/services/kafka/util.py
@@ -16,11 +16,8 @@
 from collections import namedtuple
 
 from kafkatest.utils.remote_account import java_version
-from kafkatest.version import LATEST_0_8_2, LATEST_0_9, LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
-
-new_jdk_not_supported = frozenset([str(LATEST_0_8_2), str(LATEST_0_9), str(LATEST_0_10_0), str(LATEST_0_10_1), str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0)])
 
 def fix_opts_for_new_jvm(node):
     # Startup scripts for early versions of Kafka contains options
@@ -31,12 +28,6 @@ def fix_opts_for_new_jvm(node):
     if java_ver <= 9:
         return ""
 
-    cmd = ""
-    # check kafka version for kafka node types
-    if hasattr(node, 'version'):
-        if node.version == LATEST_0_8_2 or node.version == LATEST_0_9 or node.version == LATEST_0_10_0 or node.version == LATEST_0_10_1 or node.version == LATEST_0_10_2 or node.version == LATEST_0_11_0 or node.version == LATEST_1_0:
-            cmd += "export KAFKA_GC_LOG_OPTS=\"-Xlog:gc*:file=kafka-gc.log:time,tags:filecount=10,filesize=102400\"; "
-            cmd += "export KAFKA_JVM_PERFORMANCE_OPTS=\"-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true\"; "
-    return cmd
+    return ""
 
 

--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -19,7 +19,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.util import wait_until
 
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
-from kafkatest.version import get_version, V_0_11_0_0, V_3_4_0, DEV_BRANCH
+from kafkatest.version import get_version, V_3_4_0, DEV_BRANCH
 
 class JmxMixin(object):
     """This mixin helps existing service subclasses start JmxTool on their worker nodes and collect jmx stats.
@@ -139,10 +139,7 @@ class JmxMixin(object):
         # To correctly wait for requested JMX metrics to be added we need the --wait option for JmxTool. This option was
         # not added until 0.11.0.1, so any earlier versions need to use JmxTool from a newer version.
         version = get_version(node)
-        if version <= V_0_11_0_0:
-            return DEV_BRANCH
-        else:
-            return version
+        return version
 
     def jmx_class_name(self, version):
         if version <= V_3_4_0:

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -55,10 +55,6 @@ class ProducerPerformanceService(HttpMetricsCollector, PerformanceService):
         self.kafka = kafka
         self.security_config = kafka.security_config.client_config()
 
-        security_protocol = self.security_config.security_protocol
-        assert version.consumer_supports_bootstrap_server() or security_protocol == SecurityConfig.PLAINTEXT, \
-            "Security protocol %s is only supported if version >= 0.9.0.0, version %s" % (self.security_config, str(version))
-
         self.args = {
             'topic': topic,
             'kafka_opts': self.security_config.kafka_opts,

--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kafkatest.directory_layout.kafka_path import TOOLS_JAR_NAME, TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME
-from kafkatest.version import DEV_BRANCH, LATEST_0_8_2, LATEST_0_9
 from ducktape.cluster.remoteaccount import RemoteCommandError
 
 import importlib
@@ -249,17 +247,7 @@ class VerifiableClientJava (VerifiableClient):
     def exec_cmd (self, node):
         """ :return: command to execute to start instance
         Translates Verifiable* to the corresponding Java client class name """
-        cmd = ""
-        if self.java_class_name == 'VerifiableProducer' and node.version <= LATEST_0_8_2:
-            # 0.8.2.X releases do not have VerifiableProducer.java, so cheat and add
-            # the tools jar from 0.9.x to the classpath
-            # TODO remove with KAFKA-14762
-            tools_jar = self.parent.path.jar(TOOLS_JAR_NAME, LATEST_0_9)
-            tools_dependant_libs_jar = self.parent.path.jar(TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME, LATEST_0_9)
-            cmd += "for file in %s; do CLASSPATH=$CLASSPATH:$file; done; " % tools_jar
-            cmd += "for file in %s; do CLASSPATH=$CLASSPATH:$file; done; " % tools_dependant_libs_jar
-            cmd += "export CLASSPATH; "
-        cmd += fix_opts_for_new_jvm(node)
+        cmd = fix_opts_for_new_jvm(node)
         cmd += self.parent.path.script("kafka-run-class.sh", node) + " org.apache.kafka.tools." + self.java_class_name
         return cmd
 

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -21,7 +21,7 @@ from ducktape.services.background_thread import BackgroundThreadService
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka import TopicPartition, consumer_group
 from kafkatest.services.verifiable_client import VerifiableClientMixin
-from kafkatest.version import DEV_BRANCH, V_2_3_0, V_2_3_1, V_3_7_0, V_0_10_0_0, V_4_0_0
+from kafkatest.version import DEV_BRANCH, V_2_3_0, V_2_3_1, V_3_7_0, V_4_0_0
 
 
 class ConsumerState:
@@ -316,10 +316,6 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
             assert node.version >= V_2_3_0, \
                 "Version %s does not support static membership (must be 2.3 or higher)" % str(node.version)
             node.group_instance_id = self.group_id + "-instance-" + str(idx)
-
-        if self.assignment_strategy:
-            assert node.version >= V_0_10_0_0, \
-                "Version %s does not setting an assignment strategy (must be 0.10.0 or higher)" % str(node.version)
 
         cmd = self.start_cmd(node)
         self.logger.debug("VerifiableConsumer %d command: %s" % (idx, cmd))

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -26,8 +26,8 @@ from ducktape.tests.test import TestContext
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService, quorum
 from ducktape.tests.test import Test
-from kafkatest.version import DEV_BRANCH, LATEST_1_0, LATEST_1_1, \
-    LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
+from kafkatest.version import DEV_BRANCH, \
+    LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
     LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, LATEST_3_7, LATEST_3_8, KafkaVersion
 
 def get_broker_features(broker_version):
@@ -107,9 +107,6 @@ class ClientCompatibilityFeaturesTest(Test):
 
     @cluster(num_nodes=7)
     @matrix(broker_version=[str(DEV_BRANCH)], metadata_quorum=quorum.all_non_upgrade)
-    @parametrize(broker_version=str(LATEST_1_0))
-    @parametrize(broker_version=str(LATEST_1_1))
-    @parametrize(broker_version=str(LATEST_2_0))
     @parametrize(broker_version=str(LATEST_2_1))
     @parametrize(broker_version=str(LATEST_2_2))
     @parametrize(broker_version=str(LATEST_2_3))

--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -23,8 +23,8 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int_with_prefix
-from kafkatest.version import DEV_BRANCH, LATEST_1_0, LATEST_1_1, \
-    LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
+from kafkatest.version import DEV_BRANCH, \
+    LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
     LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, LATEST_3_7, LATEST_3_8, KafkaVersion
 
 class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
@@ -58,9 +58,6 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
 
     @cluster(num_nodes=9)
     @matrix(broker_version=[str(DEV_BRANCH)], metadata_quorum=quorum.all_non_upgrade)
-    @parametrize(broker_version=str(LATEST_1_0))
-    @parametrize(broker_version=str(LATEST_1_1))
-    @parametrize(broker_version=str(LATEST_2_0))
     @parametrize(broker_version=str(LATEST_2_1))
     @parametrize(broker_version=str(LATEST_2_2))
     @parametrize(broker_version=str(LATEST_2_3))

--- a/tests/kafkatest/tests/client/quota_test.py
+++ b/tests/kafkatest/tests/client/quota_test.py
@@ -21,7 +21,7 @@ from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.performance import ProducerPerformanceService
 from kafkatest.services.console_consumer import ConsoleConsumer
-from kafkatest.version import DEV_BRANCH, LATEST_1_1
+from kafkatest.version import DEV_BRANCH
 
 class QuotaConfig(object):
     CLIENT_ID = 'client-id'
@@ -129,24 +129,14 @@ class QuotaTest(Test):
     @cluster(num_nodes=5)
     @matrix(quota_type=[QuotaConfig.CLIENT_ID, QuotaConfig.USER, QuotaConfig.USER_CLIENT], override_quota=[True, False])
     @parametrize(quota_type=QuotaConfig.CLIENT_ID, consumer_num=2)
-    @parametrize(quota_type=QuotaConfig.CLIENT_ID, old_broker_throttling_behavior=True)
-    @parametrize(quota_type=QuotaConfig.CLIENT_ID, old_client_throttling_behavior=True)
-    def test_quota(self, quota_type, override_quota=True, producer_num=1, consumer_num=1,
-                   old_broker_throttling_behavior=False, old_client_throttling_behavior=False):
-        # Old (pre-2.0) throttling behavior for broker throttles before sending a response to the client.
-        if old_broker_throttling_behavior:
-            self.kafka.set_version(LATEST_1_1)
+    def test_quota(self, quota_type, override_quota=True, producer_num=1, consumer_num=1):
         self.kafka.start()
 
         self.quota_config = QuotaConfig(quota_type, override_quota, self.kafka)
         producer_client_id = self.quota_config.client_id
         consumer_client_id = self.quota_config.client_id
 
-        # Old (pre-2.0) throttling behavior for client does not throttle upon receiving a response with a non-zero throttle time.
-        if old_client_throttling_behavior:
-            client_version = LATEST_1_1
-        else:
-            client_version = DEV_BRANCH
+        client_version = DEV_BRANCH
 
         # Produce all messages
         producer = ProducerPerformanceService(

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -24,7 +24,7 @@ from kafkatest.services.kafka import KafkaService, config_property, quorum, cons
 from kafkatest.services.connect import ConnectDistributedService, ConnectServiceBase, VerifiableSource, VerifiableSink, ConnectRestError, MockSink, MockSource
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.security.security_config import SecurityConfig
-from kafkatest.version import DEV_BRANCH, LATEST_2_3, LATEST_2_2, LATEST_2_1, LATEST_2_0, LATEST_1_1, LATEST_1_0, KafkaVersion
+from kafkatest.version import DEV_BRANCH, LATEST_2_3, LATEST_2_2, LATEST_2_1, KafkaVersion
 
 from functools import reduce
 from collections import Counter, namedtuple

--- a/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
+++ b/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
@@ -21,8 +21,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import LATEST_0_8_2, LATEST_0_9, LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, \
-    LATEST_1_0, LATEST_1_1, LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, \
+from kafkatest.version import LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, \
     LATEST_2_7, LATEST_2_8, LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, \
     LATEST_3_7, LATEST_3_8, DEV_BRANCH, KafkaVersion
 
@@ -48,8 +47,7 @@ class ClientCompatibilityTestNewBroker(ProduceConsumeValidateTest):
     @cluster(num_nodes=6)
     @matrix(producer_version=[str(DEV_BRANCH)], consumer_version=[str(DEV_BRANCH)], compression_types=[["snappy"]], timestamp_type=[str("LogAppendTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(DEV_BRANCH)], consumer_version=[str(DEV_BRANCH)], compression_types=[["none"]], timestamp_type=[str("LogAppendTime")], metadata_quorum=quorum.all_non_upgrade)
-    @parametrize(producer_version=str(DEV_BRANCH), consumer_version=str(LATEST_0_9), compression_types=["none"], new_consumer=False, timestamp_type=None)
-    @matrix(producer_version=[str(DEV_BRANCH)], consumer_version=[str(LATEST_0_9)], compression_types=[["snappy"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
+    @matrix(producer_version=[str(DEV_BRANCH)], consumer_version=[str(LATEST_2_1)], compression_types=[["snappy"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_2_2)], consumer_version=[str(LATEST_2_2)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_2_3)], consumer_version=[str(LATEST_2_3)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_2_4)], consumer_version=[str(LATEST_2_4)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
@@ -67,17 +65,6 @@ class ClientCompatibilityTestNewBroker(ProduceConsumeValidateTest):
     @matrix(producer_version=[str(LATEST_3_7)], consumer_version=[str(LATEST_3_7)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_3_8)], consumer_version=[str(LATEST_3_8)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_2_1)], consumer_version=[str(LATEST_2_1)], compression_types=[["zstd"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_2_0)], consumer_version=[str(LATEST_2_0)], compression_types=[["snappy"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_1_1)], consumer_version=[str(LATEST_1_1)], compression_types=[["lz4"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_1_0)], consumer_version=[str(LATEST_1_0)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_11_0)], consumer_version=[str(LATEST_0_11_0)], compression_types=[["gzip"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_10_2)], consumer_version=[str(LATEST_0_10_2)], compression_types=[["lz4"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_10_1)], consumer_version=[str(LATEST_0_10_1)], compression_types=[["snappy"]], timestamp_type=[str("LogAppendTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_10_0)], consumer_version=[str(LATEST_0_10_0)], compression_types=[["snappy"]], timestamp_type=[str("LogAppendTime")], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_9)], consumer_version=[str(DEV_BRANCH)], compression_types=[["none"]], timestamp_type=[None], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_9)], consumer_version=[str(DEV_BRANCH)], compression_types=[["snappy"]], timestamp_type=[None], metadata_quorum=quorum.all_non_upgrade)
-    @matrix(producer_version=[str(LATEST_0_9)], consumer_version=[str(LATEST_0_9)], compression_types=[["snappy"]], timestamp_type=[str("LogAppendTime")], metadata_quorum=quorum.all_non_upgrade)
-    @parametrize(producer_version=str(LATEST_0_8_2), consumer_version=str(LATEST_0_8_2), compression_types=["none"], new_consumer=False, timestamp_type=None)
     def test_compatibility(self, producer_version, consumer_version, compression_types, new_consumer=True, timestamp_type=None, metadata_quorum=quorum.zk):
         if not new_consumer and metadata_quorum != quorum.zk:
             raise Exception("ZooKeeper-based consumers are not supported when using a KRaft metadata quorum")

--- a/tests/kafkatest/tests/streams/streams_cooperative_rebalance_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_cooperative_rebalance_upgrade_test.py
@@ -19,8 +19,7 @@ from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
 from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.version import LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, \
-    LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3
+from kafkatest.version import LATEST_2_1, LATEST_2_2, LATEST_2_3
 from kafkatest.services.streams import CooperativeRebalanceUpgradeService
 from kafkatest.tests.streams.utils import verify_stopped, stop_processors, verify_running
 
@@ -44,9 +43,7 @@ class StreamsCooperativeRebalanceUpgradeTest(Test):
     second_bounce_phase = "second_bounce_phase-"
 
     # !!CAUTION!!: THIS LIST OF VERSIONS IS FIXED, NO VERSIONS MUST BE ADDED
-    streams_eager_rebalance_upgrade_versions = [str(LATEST_0_10_2), str(LATEST_0_11_0),
-                                                str(LATEST_1_0), str(LATEST_1_1), str(LATEST_2_0), str(LATEST_2_1), str(LATEST_2_2),
-                                                str(LATEST_2_3)]
+    streams_eager_rebalance_upgrade_versions = [str(LATEST_2_1), str(LATEST_2_2), str(LATEST_2_3)]
 
     def __init__(self, test_context):
         super(StreamsCooperativeRebalanceUpgradeTest, self).__init__(test_context)

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -22,8 +22,7 @@ from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService, \
     StreamsUpgradeTestJobRunnerService
 from kafkatest.tests.streams.utils import extract_generation_from_logs, extract_generation_id
-from kafkatest.version import LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, \
-    LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
+from kafkatest.version import LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
     LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, LATEST_3_7, LATEST_3_8, DEV_BRANCH, DEV_VERSION, \
     KafkaVersion
 
@@ -33,8 +32,7 @@ broker_upgrade_versions = [str(LATEST_2_8), str(LATEST_3_0), str(LATEST_3_1), st
                            str(LATEST_3_3), str(LATEST_3_4), str(LATEST_3_5), str(LATEST_3_6),
                            str(LATEST_3_7), str(LATEST_3_8), str(DEV_BRANCH)]
 
-metadata_2_versions = [str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0), str(LATEST_1_1),
-                       str(LATEST_2_4), str(LATEST_2_5), str(LATEST_2_6), str(LATEST_2_7), str(LATEST_2_8),
+metadata_2_versions = [str(LATEST_2_4), str(LATEST_2_5), str(LATEST_2_6), str(LATEST_2_7), str(LATEST_2_8),
                        str(LATEST_3_0), str(LATEST_3_1), str(LATEST_3_2), str(LATEST_3_3)]
 # upgrading from version (2.4...3.3) is broken and only fixed later in 3.3.3 (unreleased) and 3.4.0
 # -> https://issues.apache.org/jira/browse/KAFKA-14646

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -62,21 +62,6 @@ class KafkaVersion(LooseVersion):
 
         return LooseVersion._cmp(self, other)
 
-    def consumer_supports_bootstrap_server(self):
-        """
-        Kafka supported a new consumer beginning with v0.9.0 where
-        we can specify --bootstrap-server instead of --zookeeper.
-
-        This version also allowed a --consumer-config file where we could specify
-        a security protocol other than PLAINTEXT.
-
-        :return: true if the version of Kafka supports a new consumer with --bootstrap-server
-        """
-        return self >= V_0_9_0_0
-
-    def supports_named_listeners(self):
-        return self >= V_0_10_2_0
-
     def acl_command_supports_bootstrap_server(self):
         return self >= V_2_1_0
 
@@ -126,58 +111,6 @@ DEV_VERSION = KafkaVersion("4.0.0-SNAPSHOT")
 
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
 LATEST_STABLE_METADATA_VERSION = "4.0-IV0"
-
-# 0.8.2.x versions
-V_0_8_2_1 = KafkaVersion("0.8.2.1")
-V_0_8_2_2 = KafkaVersion("0.8.2.2")
-LATEST_0_8_2 = V_0_8_2_2
-
-# 0.9.0.x versions
-V_0_9_0_0 = KafkaVersion("0.9.0.0")
-V_0_9_0_1 = KafkaVersion("0.9.0.1")
-LATEST_0_9 = V_0_9_0_1
-
-# 0.10.0.x versions
-V_0_10_0_0 = KafkaVersion("0.10.0.0")
-V_0_10_0_1 = KafkaVersion("0.10.0.1")
-LATEST_0_10_0 = V_0_10_0_1
-
-# 0.10.1.x versions
-V_0_10_1_0 = KafkaVersion("0.10.1.0")
-V_0_10_1_1 = KafkaVersion("0.10.1.1")
-LATEST_0_10_1 = V_0_10_1_1
-
-# 0.10.2.x versions
-V_0_10_2_0 = KafkaVersion("0.10.2.0")
-V_0_10_2_1 = KafkaVersion("0.10.2.1")
-V_0_10_2_2 = KafkaVersion("0.10.2.2")
-LATEST_0_10_2 = V_0_10_2_2
-
-LATEST_0_10 = LATEST_0_10_2
-
-# 0.11.0.x versions
-V_0_11_0_0 = KafkaVersion("0.11.0.0")
-V_0_11_0_1 = KafkaVersion("0.11.0.1")
-V_0_11_0_2 = KafkaVersion("0.11.0.2")
-V_0_11_0_3 = KafkaVersion("0.11.0.3")
-LATEST_0_11_0 = V_0_11_0_3
-LATEST_0_11 = LATEST_0_11_0
-
-# 1.0.x versions
-V_1_0_0 = KafkaVersion("1.0.0")
-V_1_0_1 = KafkaVersion("1.0.1")
-V_1_0_2 = KafkaVersion("1.0.2")
-LATEST_1_0 = V_1_0_2
-
-# 1.1.x versions
-V_1_1_0 = KafkaVersion("1.1.0")
-V_1_1_1 = KafkaVersion("1.1.1")
-LATEST_1_1 = V_1_1_1
-
-# 2.0.x versions
-V_2_0_0 = KafkaVersion("2.0.0")
-V_2_0_1 = KafkaVersion("2.0.1")
-LATEST_2_0 = V_2_0_1
 
 # 2.1.x versions
 V_2_1_0 = KafkaVersion("2.1.0")

--- a/tests/unit/directory_layout/check_project_paths.py
+++ b/tests/unit/directory_layout/check_project_paths.py
@@ -16,7 +16,7 @@
 
 from kafkatest.directory_layout.kafka_path import create_path_resolver, KafkaSystemTestPathResolver, \
     KAFKA_PATH_RESOLVER_KEY
-from kafkatest.version import V_0_9_0_1, DEV_BRANCH, KafkaVersion
+from kafkatest.version import V_2_1_0, DEV_BRANCH, KafkaVersion
 
 
 class DummyContext(object):
@@ -64,9 +64,9 @@ class CheckCreatePathResolver(object):
         """Check expected paths when using versions."""
         resolver = create_path_resolver(DummyContext())
 
-        assert resolver.home(V_0_9_0_1) == "/opt/kafka-0.9.0.1"
-        assert resolver.bin(V_0_9_0_1) == "/opt/kafka-0.9.0.1/bin"
-        assert resolver.script("kafka-run-class.sh", V_0_9_0_1) == "/opt/kafka-0.9.0.1/bin/kafka-run-class.sh"
+        assert resolver.home(V_2_1_0) == "/opt/kafka-2.1.0"
+        assert resolver.bin(V_2_1_0) == "/opt/kafka-2.1.0/bin"
+        assert resolver.script("kafka-run-class.sh", V_2_1_0) == "/opt/kafka-2.1.0/bin/kafka-run-class.sh"
 
     def check_node_or_version_helper(self):
         """KafkaSystemTestPathResolver has a helper method which can take a node or version, and returns the version.
@@ -79,8 +79,8 @@ class CheckCreatePathResolver(object):
         assert resolver._version(node) == DEV_BRANCH
 
         # Node with version attribute should resolve to the version attribute
-        node.version = V_0_9_0_1
-        assert resolver._version(node) == V_0_9_0_1
+        node.version = V_2_1_0
+        assert resolver._version(node) == V_2_1_0
 
         # A KafkaVersion object should resolve to itself
         assert resolver._version(DEV_BRANCH) == DEV_BRANCH

--- a/tests/unit/version/check_version.py
+++ b/tests/unit/version/check_version.py
@@ -15,7 +15,7 @@
 
 from mock import Mock
 
-from kafkatest.version import DEV_BRANCH, V_0_8_2_2, get_version
+from kafkatest.version import DEV_BRANCH, V_2_1_0, get_version
 
 
 class CheckVersion(object):
@@ -29,5 +29,5 @@ class CheckVersion(object):
         assert get_version(node) == DEV_BRANCH
 
         node = Mock()
-        node.version = V_0_8_2_2
-        assert get_version(node) == V_0_8_2_2
+        node.version = V_2_1_0
+        assert get_version(node) == V_2_1_0

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -114,24 +114,6 @@ apt-get install -y iperf traceroute
 # We want to use the latest Scala version per Kafka version
 # Previously we could not pull in Scala 2.12 builds, because Scala 2.12 requires Java 8 and we were running the system
 # tests with Java 7. We have since switched to Java 8, so 2.0.0 and later use Scala 2.12.
-get_kafka 0.8.2.2 2.11
-chmod a+rw /opt/kafka-0.8.2.2
-get_kafka 0.9.0.1 2.11
-chmod a+rw /opt/kafka-0.9.0.1
-get_kafka 0.10.0.1 2.11
-chmod a+rw /opt/kafka-0.10.0.1
-get_kafka 0.10.1.1 2.11
-chmod a+rw /opt/kafka-0.10.1.1
-get_kafka 0.10.2.2 2.11
-chmod a+rw /opt/kafka-0.10.2.2
-get_kafka 0.11.0.3 2.11
-chmod a+rw /opt/kafka-0.11.0.3
-get_kafka 1.0.2 2.11
-chmod a+rw /opt/kafka-1.0.2
-get_kafka 1.1.1 2.11
-chmod a+rw /opt/kafka-1.1.1
-get_kafka 2.0.1 2.12
-chmod a+rw /opt/kafka-2.0.1
 get_kafka 2.1.1 2.12
 chmod a+rw /opt/kafka-2.1.1
 get_kafka 2.2.2 2.12


### PR DESCRIPTION
```
> TC_PATHS="tests/kafkatest/sanity_checks/test_console_consumer.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--001
run time:         3 minutes 53.831 seconds
tests run:        12
passed:           12
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/sanity_checks/test_performance_services.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-09--008
run time:         2 minutes 45.572 seconds
tests run:        6
passed:           6
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/sanity_checks/test_verifiable_producer.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--003
run time:         9 minutes 32.044 seconds
tests run:        21
passed:           21
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/tests/client/client_compatibility_features_test.py" /bin/bash tests/docker/run_tests.s
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--004
run time:         15 minutes 28.550 seconds
tests run:        18
passed:           15
flaky:            0
failed:           3
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.client_compatibility_features_test.ClientCompatibilityFeaturesTest.run_compatibility_test.broker_version=2.1.1
status:     FAIL
run time:   1 minute 24.023 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_features_test.py", line 131, in run_compatibility_test
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_features_test.ClientCompatibilityFeaturesTest.run_compatibility_test.broker_version=2.2.2
status:     FAIL
run time:   1 minute 23.877 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_features_test.py", line 131, in run_compatibility_test
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_features_test.ClientCompatibilityFeaturesTest.run_compatibility_test.broker_version=2.3.1
status:     FAIL
run time:   1 minute 23.904 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_features_test.py", line 131, in run_compatibility_test
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds
--------------------------------------------------------------------------------

> TC_PATHS="tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--005
run time:         34 minutes 51.144 seconds
tests run:        18
passed:           15
flaky:            0
failed:           3
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.1.1
status:     FAIL
run time:   1 minute 26.146 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.2.2
status:     FAIL
run time:   1 minute 25.949 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.3.1
status:     FAIL
run time:   1 minute 26.108 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------

> TC_PATHS="tests/kafkatest/tests/client/quota_test.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--006
run time:         23 minutes 31.180 seconds
tests run:        7
passed:           7
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/tests/core/compatibility_test_new_broker_test.py::ClientCompatibilityTestNewBroker.test_compatibility" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--009
run time:         21 minutes 55.895 seconds
tests run:        20
passed:           20
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/tests/streams/streams_cooperative_rebalance_upgrade_test.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--010
run time:         7 minutes 32.118 seconds
tests run:        3
passed:           3
flaky:            0
failed:           0
ignored:          0
================================================================================

> TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-07--011
run time:         42 minutes 55.985 seconds
tests run:        19
passed:           14
flaky:            0
failed:           5
ignored:          0
================================================================================
test_id:    kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces.from_version=3.4.1.metadata_quorum=COMBINED_KRAFT
status:     FAIL
run time:   3 minutes 46.742 seconds


    TimeoutError("Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker06")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 136, in test_rolling_upgrade_with_2_bounces
    self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 401, in do_stop_start_bounce
    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker06

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces.from_version=3.5.2.metadata_quorum=COMBINED_KRAFT
status:     FAIL
run time:   3 minutes 44.195 seconds


    TimeoutError("Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker12")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 136, in test_rolling_upgrade_with_2_bounces
    self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 401, in do_stop_start_bounce
    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker12

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces.from_version=3.6.2.metadata_quorum=COMBINED_KRAFT
status:     FAIL
run time:   3 minutes 47.483 seconds


    TimeoutError("Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker06")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 136, in test_rolling_upgrade_with_2_bounces
    self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 401, in do_stop_start_bounce
    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker06

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces.from_version=3.7.1.metadata_quorum=COMBINED_KRAFT
status:     FAIL
run time:   3 minutes 44.812 seconds


    TimeoutError("Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker11")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 136, in test_rolling_upgrade_with_2_bounces
    self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 401, in do_stop_start_bounce
    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker11

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces.from_version=3.8.1.metadata_quorum=COMBINED_KRAFT
status:     FAIL
run time:   3 minutes 46.018 seconds


    TimeoutError("Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker05")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 136, in test_rolling_upgrade_with_2_bounces
    self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 401, in do_stop_start_bounce
    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Never saw output 'processed [0-9]* records from topic=data' on ducker@ducker05
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
