### PR TITLE
KAFKA-17829: Verify ShareFetch requests return a completed future on purgatory close

### DIFF
--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -216,5 +217,22 @@ public class DelayedShareFetch extends DelayedOperation {
             }
             sharePartition.releaseFetchLock();
         });
+    }
+
+    public ShareFetchData shareFetchData() {
+        return shareFetchData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DelayedShareFetch that = (DelayedShareFetch) o;
+        return shareFetchData.equals(that.shareFetchData) && sharePartitionManager == that.sharePartitionManager && replicaManager.equals(that.replicaManager);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shareFetchData, sharePartitionManager, replicaManager);
     }
 }

--- a/core/src/main/java/kafka/server/share/DelayedShareFetchGroupKey.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetchGroupKey.java
@@ -30,7 +30,7 @@ public class DelayedShareFetchGroupKey implements  DelayedShareFetchKey, Delayed
     private final Uuid topicId;
     private final int partition;
 
-    DelayedShareFetchGroupKey(String groupId, Uuid topicId, int partition) {
+    public DelayedShareFetchGroupKey(String groupId, Uuid topicId, int partition) {
         this.groupId = groupId;
         this.topicId = topicId;
         this.partition = partition;

--- a/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
+++ b/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
@@ -438,12 +438,12 @@ public class DelayedShareFetchTest {
         Mockito.verify(sp0, times(1)).releaseFetchLock();
     }
 
-    static class DelayedShareFetchBuilder {
+    public static class DelayedShareFetchBuilder {
         ShareFetchData shareFetchData = mock(ShareFetchData.class);
         private ReplicaManager replicaManager = mock(ReplicaManager.class);
         private SharePartitionManager sharePartitionManager = mock(SharePartitionManager.class);
 
-        DelayedShareFetchBuilder withShareFetchData(ShareFetchData shareFetchData) {
+        public DelayedShareFetchBuilder withShareFetchData(ShareFetchData shareFetchData) {
             this.shareFetchData = shareFetchData;
             return this;
         }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6836,9 +6836,9 @@ class ReplicaManagerTest {
     assertEquals(6, replicaManager.delayedShareFetchPurgatory.watched)
 
     replicaManager.shutdown()
-    assertTrue(future1.isDone)
-    assertTrue(future2.isDone)
-    assertEquals(0, replicaManager.delayedShareFetchPurgatory.watched)
+    assertTrue(future1.isCompletedExceptionally)
+    assertTrue(future2.isCompletedExceptionally)
+    assertEquals(6, replicaManager.delayedShareFetchPurgatory.watched)
   }
 
   private def readFromLogWithOffsetOutOfRange(tp: TopicPartition): Seq[(TopicIdPartition, LogReadResult)] = {


### PR DESCRIPTION
### About
We need to verify that on shutdown of the delayed share fetch purgatory, the share fetch requests which are present inside the purgatory return with an erroneous future or a completed future.

### Testing
The added code has been tested with the help of unit test.