### PR TITLE
MINOR: Improve Debugging and Logging in testElectPreferredLeaders

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2284,7 +2284,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           partition2UpdatedPreferredLeader = preferredLeader(partition2)
           partition1UpdatedPreferredLeader == preferred && partition2UpdatedPreferredLeader == preferred
         },
-        s"Expected preferred leader $preferred for both topic-partitions; found $partition1UpdatedPreferredLeader for topic-partition $partition1 and $partition2UpdatedPreferredLeader for topic-partition $partition2",
+        s"""Expected preferred leader $preferred for both topic-partitions;
+           |found $partition1UpdatedPreferredLeader for topic-partition $partition1 and
+           |$partition2UpdatedPreferredLeader for topic-partition $partition2""".stripMargin,
         10000
       )
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2275,10 +2275,19 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         m += partition2 -> Optional.of(new NewPartitionReassignment(newAssignment.map(Int.box).asJava))
       client.alterPartitionReassignments(m.asJava).all().get()
 
+      var partition1UpdatedPreferredLeader = -1
+      var partition2UpdatedPreferredLeader = -1
+
       TestUtils.waitUntilTrue(
-        () => preferredLeader(partition1) == preferred && preferredLeader(partition2) == preferred,
-        s"Expected preferred leader to become $preferred, but is ${preferredLeader(partition1)} and ${preferredLeader(partition2)}",
-        10000)
+        () => {
+          partition1UpdatedPreferredLeader = preferredLeader(partition1)
+          partition2UpdatedPreferredLeader = preferredLeader(partition2)
+          partition1UpdatedPreferredLeader == preferred && partition2UpdatedPreferredLeader == preferred
+        },
+        s"Expected preferred leader $preferred for both topic-partitions; found $partition1UpdatedPreferredLeader for topic-partition $partition1 and $partition2UpdatedPreferredLeader for topic-partition $partition2",
+        10000
+      )
+
       // Check the leader hasn't moved
       TestUtils.assertLeader(client, partition1, prior1)
       TestUtils.assertLeader(client, partition2, prior2)


### PR DESCRIPTION
This change is aimed at improving test logging and aiding in debugging a flaky test.

I noticed that `testElectPreferredLeaders()` has been flaky or has failed recently, [Develocity](https://ge.apache.org/scans/tests?search.names=CI%20workflow,Git%20repository&search.relativeStartTime=P90D&search.rootProjectNames=kafka&search.tags=github,trunk&search.tasks=test&search.timeZoneId=America%2FLos_Angeles&search.values=CI,https:%2F%2Fgithub.com%2Fapache%2Fkafka&tests.container=kafka.api.PlaintextAdminIntegrationTest&tests.test=testElectPreferredLeaders(String)%5B1%5D). 

Previously, the test made calls to the `preferredLeader()` method within both the lambda and the error message in the `TestUtils.waitUntilTrue` block. These repeated calls could potentially be misleading (or even inaccurate) when diagnosing test failures, as they might reflect different leader states.

This update simplifies the test by storing the result of `preferredLeader()` in temporary variables, which are then consistently used in both the lambda and error message. This should make the test output clearer and more reliable for debugging.
