### PR TITLE
KAFKA-17931 Revise the `specifying-test-retries` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ to `log4j.logger.org.apache.kafka=INFO` and then run:
 And you should see `INFO` level logs in the file under the `clients/build/test-results/test` directory.
 
 ### Specifying test retries ###
-By default, retry-related configurations have a value of zero, meaning tests are not retried unless specified.
-We should set non-default values to enable retries in tests. Each failed test is retried once up to a maximum of three total retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:
+Retries are disabled by default, but you can set maxTestRetryFailures and maxTestRetries to enable retries.
+
+he following example declares -PmaxTestRetries=1 and -PmaxTestRetryFailures=3 to enable a failed test to be retried once, with a total retry limit of 3.
 
     ./gradlew test -PmaxTestRetries=1 -PmaxTestRetryFailures=3
 
-The default value of `-PmaxQuarantineTestRetryFailures` is zero.
-Additionally, quarantined tests are automatically retried three times up to a total of 20 retries per run. This is controlled by similar parameters.
+The quarantinedTest task also has no retries by default, but you can set maxQuarantineTestRetries and maxQuarantineTestRetryFailures to enable retries, similar to the test task.
 
     ./gradlew quarantinedTest -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=20
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ And you should see `INFO` level logs in the file under the `clients/build/test-r
 ### Specifying test retries ###
 Retries are disabled by default, but you can set maxTestRetryFailures and maxTestRetries to enable retries.
 
-he following example declares -PmaxTestRetries=1 and -PmaxTestRetryFailures=3 to enable a failed test to be retried once, with a total retry limit of 3.
+The following example declares -PmaxTestRetries=1 and -PmaxTestRetryFailures=3 to enable a failed test to be retried once, with a total retry limit of 3.
 
     ./gradlew test -PmaxTestRetries=1 -PmaxTestRetryFailures=3
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In the CI environment, we set non-default values to enable retries. Each failed 
 
     ./gradlew test -PmaxTestRetries=1 -PmaxTestRetryFailures=3
 
-In the CI environment, the value of `-PmaxQuarantineTestRetryFailures` is "zero
+In the CI environment, the value of `-PmaxQuarantineTestRetryFailures` is "zero"
 Additionally, quarantined tests are automatically retried three times up to a total of
 20 retries per run. This is controlled by similar parameters.
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ And you should see `INFO` level logs in the file under the `clients/build/test-r
 
 ### Specifying test retries ###
 By default, retry-related configurations have a value of zero, meaning tests are not retried unless specified.
-In the CI environment, we set non-default values to enable retries. Each failed test is retried once up to a maximum of three total retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:
+We should set non-default values to enable retries in tests. Each failed test is retried once up to a maximum of three total retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:
 
     ./gradlew test -PmaxTestRetries=1 -PmaxTestRetryFailures=3
 
-In the CI environment, the value of `-PmaxQuarantineTestRetryFailures` is "zero"
-Additionally, quarantined tests are automatically retried three times up to a total of
-20 retries per run. This is controlled by similar parameters.
+The default value of `-PmaxQuarantineTestRetryFailures` is zero.
+Additionally, quarantined tests are automatically retried three times up to a total of 20 retries per run. This is controlled by similar parameters.
 
     ./gradlew quarantinedTest -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=20
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,16 @@ to `log4j.logger.org.apache.kafka=INFO` and then run:
 And you should see `INFO` level logs in the file under the `clients/build/test-results/test` directory.
 
 ### Specifying test retries ###
-By default, each failed test is retried once up to a maximum of three total retries per test run. 
-Tests are retried at the end of the test task. Adjust these parameters in the following way:
+By default, retry-related configurations have a value of zero, meaning tests are not retried unless specified.
+In the CI environment, we set non-default values to enable retries. Each failed test is retried once up to a maximum of three total retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:
 
     ./gradlew test -PmaxTestRetries=1 -PmaxTestRetryFailures=3
 
+In the CI environment, the value of `-PmaxQuarantineTestRetryFailures` is "zero
 Additionally, quarantined tests are automatically retried three times up to a total of
 20 retries per run. This is controlled by similar parameters.
 
-    ./gradlew test -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=20
+    ./gradlew quarantinedTest -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=20
 
 See [Test Retry Gradle Plugin](https://github.com/gradle/test-retry-gradle-plugin) for and [build.yml](.github/workflows/build.yml) more details.
 


### PR DESCRIPTION
MINOR: 
revise the Specifying test retries section, highlight the default value of test retry parameters

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
