### PR TITLE
KAFKA-17896: Admin.describeClassicGroups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1844,6 +1844,28 @@ public interface Admin extends AutoCloseable {
         return listShareGroups(new ListShareGroupsOptions());
     }
 
+    /**
+     * Describe some classic groups in the cluster.
+     *
+     * @param groupIds The IDs of the groups to describe.
+     * @param options  The options to use when describing the groups.
+     * @return The DescribeClassicGroupsResult.
+     */
+    DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds,
+                                                      DescribeClassicGroupsOptions options);
+
+    /**
+     * Describe some classic groups in the cluster, with the default options.
+     * <p>
+     * This is a convenience method for {@link #describeClassicGroups(Collection, DescribeClassicGroupsOptions)}
+     * with default options. See the overload for more details.
+     *
+     * @param groupIds The IDs of the groups to describe.
+     * @return The DescribeClassicGroupsResult.
+     */
+    default DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds) {
+        return describeClassicGroups(groupIds, new DescribeClassicGroupsOptions());
+    }
 
     /**
      * Add the provided application metric for subscription.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClassicGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClassicGroupDescription.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.ClassicGroupState;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.acl.AclOperation;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A detailed description of a single classic group in the cluster.
+ */
+public class ClassicGroupDescription {
+    private final String groupId;
+    private final String protocol;
+    private final Collection<MemberDescription> members;
+    private final String partitionAssignor;
+    private final ClassicGroupState state;
+    private final Node coordinator;
+    private final Set<AclOperation> authorizedOperations;
+
+    public ClassicGroupDescription(String groupId,
+                                   String protocol,
+                                   Collection<MemberDescription> members,
+                                   String partitionAssignor,
+                                   ClassicGroupState state,
+                                   Node coordinator) {
+        this(groupId, protocol, members, partitionAssignor, state, coordinator, Set.of());
+    }
+
+    public ClassicGroupDescription(String groupId,
+                                   String protocol,
+                                   Collection<MemberDescription> members,
+                                   String partitionAssignor,
+                                   ClassicGroupState state,
+                                   Node coordinator,
+                                   Set<AclOperation> authorizedOperations) {
+        this.groupId = groupId == null ? "" : groupId;
+        this.protocol = protocol;
+        this.members = members == null ? List.of() : List.copyOf(members);
+        this.partitionAssignor = partitionAssignor == null ? "" : partitionAssignor;
+        this.state = state;
+        this.coordinator = coordinator;
+        this.authorizedOperations = authorizedOperations;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ClassicGroupDescription that = (ClassicGroupDescription) o;
+        return Objects.equals(groupId, that.groupId) &&
+            Objects.equals(protocol, that.protocol) &&
+            Objects.equals(members, that.members) &&
+            Objects.equals(partitionAssignor, that.partitionAssignor) &&
+            state == that.state &&
+            Objects.equals(coordinator, that.coordinator) &&
+            Objects.equals(authorizedOperations, that.authorizedOperations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, protocol, members, partitionAssignor, state, coordinator, authorizedOperations);
+    }
+
+    /**
+     * The id of the classic group.
+     */
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * If the group is a simple consumer group or not.
+     */
+    public boolean isSimpleConsumerGroup() {
+        return protocol.isEmpty();
+    }
+
+    /**
+     * A list of the members of the classic group.
+     */
+    public Collection<MemberDescription> members() {
+        return members;
+    }
+
+    /**
+     * The classic group partition assignor.
+     */
+    public String partitionAssignor() {
+        return partitionAssignor;
+    }
+
+    /**
+     * The classic group state, or UNKNOWN if the state is too new for us to parse.
+     */
+    public ClassicGroupState state() {
+        return state;
+    }
+
+    /**
+     * The classic group coordinator, or null if the coordinator is not known.
+     */
+    public Node coordinator() {
+        return coordinator;
+    }
+
+    /**
+     * authorizedOperations for this group, or null if that information is not known.
+     */
+    public  Set<AclOperation> authorizedOperations() {
+        return authorizedOperations;
+    }
+
+    @Override
+    public String toString() {
+        return "(groupId=" + groupId +
+            ", protocol='" + protocol + '\'' +
+            ", members=" + members.stream().map(MemberDescription::toString).collect(Collectors.joining(",")) +
+            ", partitionAssignor=" + partitionAssignor +
+            ", state=" + state +
+            ", coordinator=" + coordinator +
+            ", authorizedOperations=" + authorizedOperations +
+            ")";
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClassicGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClassicGroupDescription.java
@@ -33,32 +33,32 @@ import java.util.stream.Collectors;
 public class ClassicGroupDescription {
     private final String groupId;
     private final String protocol;
+    private final String protocolData;
     private final Collection<MemberDescription> members;
-    private final String partitionAssignor;
     private final ClassicGroupState state;
     private final Node coordinator;
     private final Set<AclOperation> authorizedOperations;
 
     public ClassicGroupDescription(String groupId,
                                    String protocol,
+                                   String protocolData,
                                    Collection<MemberDescription> members,
-                                   String partitionAssignor,
                                    ClassicGroupState state,
                                    Node coordinator) {
-        this(groupId, protocol, members, partitionAssignor, state, coordinator, Set.of());
+        this(groupId, protocol, protocolData, members, state, coordinator, Set.of());
     }
 
     public ClassicGroupDescription(String groupId,
                                    String protocol,
+                                   String protocolData,
                                    Collection<MemberDescription> members,
-                                   String partitionAssignor,
                                    ClassicGroupState state,
                                    Node coordinator,
                                    Set<AclOperation> authorizedOperations) {
         this.groupId = groupId == null ? "" : groupId;
         this.protocol = protocol;
+        this.protocolData = protocolData == null ? "" : protocolData;
         this.members = members == null ? List.of() : List.copyOf(members);
-        this.partitionAssignor = partitionAssignor == null ? "" : partitionAssignor;
         this.state = state;
         this.coordinator = coordinator;
         this.authorizedOperations = authorizedOperations;
@@ -71,8 +71,8 @@ public class ClassicGroupDescription {
         final ClassicGroupDescription that = (ClassicGroupDescription) o;
         return Objects.equals(groupId, that.groupId) &&
             Objects.equals(protocol, that.protocol) &&
+            Objects.equals(protocolData, that.protocolData) &&
             Objects.equals(members, that.members) &&
-            Objects.equals(partitionAssignor, that.partitionAssignor) &&
             state == that.state &&
             Objects.equals(coordinator, that.coordinator) &&
             Objects.equals(authorizedOperations, that.authorizedOperations);
@@ -80,7 +80,7 @@ public class ClassicGroupDescription {
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, protocol, members, partitionAssignor, state, coordinator, authorizedOperations);
+        return Objects.hash(groupId, protocol, protocolData, members, state, coordinator, authorizedOperations);
     }
 
     /**
@@ -88,6 +88,22 @@ public class ClassicGroupDescription {
      */
     public String groupId() {
         return groupId;
+    }
+
+    /**
+     * The group protocol type.
+     */
+    public String protocol() {
+        return protocol;
+    }
+
+    /**
+     * The group protocol data. The meaning depends on the group protocol type.
+     * For a classic consumer group, this is the partition assignor name.
+     * For a classic connect group, this indicates which Connect protocols are enabled.
+     */
+    public String protocolData() {
+        return protocolData;
     }
 
     /**
@@ -102,13 +118,6 @@ public class ClassicGroupDescription {
      */
     public Collection<MemberDescription> members() {
         return members;
-    }
-
-    /**
-     * The classic group partition assignor.
-     */
-    public String partitionAssignor() {
-        return partitionAssignor;
     }
 
     /**
@@ -136,8 +145,8 @@ public class ClassicGroupDescription {
     public String toString() {
         return "(groupId=" + groupId +
             ", protocol='" + protocol + '\'' +
+            ", protocolData=" + protocolData +
             ", members=" + members.stream().map(MemberDescription::toString).collect(Collectors.joining(",")) +
-            ", partitionAssignor=" + partitionAssignor +
             ", state=" + state +
             ", coordinator=" + coordinator +
             ", authorizedOperations=" + authorizedOperations +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link Admin#describeClassicGroups(Collection, DescribeClassicGroupsOptions)}.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeClassicGroupsOptions extends AbstractOptions<DescribeClassicGroupsOptions> {
+    private boolean includeAuthorizedOperations;
+
+    public DescribeClassicGroupsOptions includeAuthorizedOperations(boolean includeAuthorizedOperations) {
+        this.includeAuthorizedOperations = includeAuthorizedOperations;
+        return this;
+    }
+
+    public boolean includeAuthorizedOperations() {
+        return includeAuthorizedOperations;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * The result of the {@link Admin#describeClassicGroups(Collection, DescribeClassicGroupsOptions)}} call.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeClassicGroupsResult {
+
+    private final Map<String, KafkaFuture<ClassicGroupDescription>> futures;
+
+    public DescribeClassicGroupsResult(final Map<String, KafkaFuture<ClassicGroupDescription>> futures) {
+        this.futures = futures;
+    }
+
+    /**
+     * Return a map from group id to futures which yield group descriptions.
+     */
+    public Map<String, KafkaFuture<ClassicGroupDescription>> describedGroups() {
+        return new HashMap<>(futures);
+    }
+
+    /**
+     * Return a future which yields all ClassicGroupDescription objects, if all the describes succeed.
+     */
+    public KafkaFuture<Map<String, ClassicGroupDescription>> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
+            nil -> {
+                Map<String, ClassicGroupDescription> descriptions = new HashMap<>(futures.size());
+                futures.forEach((key, future) -> {
+                    try {
+                        descriptions.put(key, future.get());
+                    } catch (InterruptedException | ExecutionException e) {
+                        // This should be unreachable, since the KafkaFuture#allOf already ensured
+                        // that all of the futures completed successfully.
+                        throw new RuntimeException(e);
+                    }
+                });
+                return descriptions;
+            });
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -315,6 +315,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds, DescribeClassicGroupsOptions options) {
+        return delegate.describeClassicGroups(groupIds, options);
+    }
+
+    @Override
     public void registerMetricForSubscription(KafkaMetric metric) {
         throw new UnsupportedOperationException();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -49,6 +49,7 @@ import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.admin.internals.DeleteConsumerGroupOffsetsHandler;
 import org.apache.kafka.clients.admin.internals.DeleteConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DeleteRecordsHandler;
+import org.apache.kafka.clients.admin.internals.DescribeClassicGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeProducersHandler;
 import org.apache.kafka.clients.admin.internals.DescribeShareGroupsHandler;
@@ -3950,6 +3951,17 @@ public class KafkaAdminClient extends AdminClient {
         }, nowMetadata);
 
         return new ListShareGroupsResult(all);
+    }
+
+    @Override
+    public DescribeClassicGroupsResult describeClassicGroups(final Collection<String> groupIds,
+                                                             final DescribeClassicGroupsOptions options) {
+        SimpleAdminApiFuture<CoordinatorKey, ClassicGroupDescription> future =
+            DescribeClassicGroupsHandler.newFuture(groupIds);
+        DescribeClassicGroupsHandler handler = new DescribeClassicGroupsHandler(options.includeAuthorizedOperations(), logContext);
+        invokeDriver(handler, future, options.timeoutMs);
+        return new DescribeClassicGroupsResult(future.all().entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
@@ -16,25 +16,28 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
+import org.apache.kafka.clients.admin.ClassicGroupDescription;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
-import org.apache.kafka.clients.admin.ShareGroupDescription;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.ClassicGroupState;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.ShareGroupState;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
-import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
+import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.DescribeGroupsRequest;
+import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
-import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
-import org.apache.kafka.common.requests.ShareGroupDescribeResponse;
 import org.apache.kafka.common.utils.LogContext;
 
 import org.slf4j.Logger;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,22 +45,24 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.admin.internals.AdminUtils.validAclOperations;
 
-public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, ShareGroupDescription> {
+public class DescribeClassicGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, ClassicGroupDescription> {
 
     private final boolean includeAuthorizedOperations;
     private final Logger log;
     private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
 
-    public DescribeShareGroupsHandler(
-          boolean includeAuthorizedOperations,
-          LogContext logContext) {
+    public DescribeClassicGroupsHandler(
+        boolean includeAuthorizedOperations,
+        LogContext logContext
+    ) {
         this.includeAuthorizedOperations = includeAuthorizedOperations;
-        this.log = logContext.logger(DescribeShareGroupsHandler.class);
+        this.log = logContext.logger(DescribeConsumerGroupsHandler.class);
         this.lookupStrategy = new CoordinatorStrategy(CoordinatorType.GROUP, logContext);
     }
 
@@ -67,13 +72,13 @@ public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<Coordina
             .collect(Collectors.toSet());
     }
 
-    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ShareGroupDescription> newFuture(Collection<String> groupIds) {
+    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ClassicGroupDescription> newFuture(Collection<String> groupIds) {
         return AdminApiFuture.forKeys(buildKeySet(groupIds));
     }
 
     @Override
     public String apiName() {
-        return "describeShareGroups";
+        return "describeClassicGroups";
     }
 
     @Override
@@ -82,116 +87,98 @@ public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<Coordina
     }
 
     @Override
-    public ShareGroupDescribeRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> keys) {
+    public DescribeGroupsRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> keys) {
         List<String> groupIds = keys.stream().map(key -> {
             if (key.type != FindCoordinatorRequest.CoordinatorType.GROUP) {
                 throw new IllegalArgumentException("Invalid group coordinator key " + key +
-                    " when building `DescribeShareGroups` request");
+                    " when building `DescribeGroups` request");
             }
             return key.idValue;
         }).collect(Collectors.toList());
-        ShareGroupDescribeRequestData data = new ShareGroupDescribeRequestData()
-            .setGroupIds(groupIds)
+        DescribeGroupsRequestData data = new DescribeGroupsRequestData()
+            .setGroups(groupIds)
             .setIncludeAuthorizedOperations(includeAuthorizedOperations);
-        return new ShareGroupDescribeRequest.Builder(data, true);
+        return new DescribeGroupsRequest.Builder(data);
     }
 
     @Override
-    public ApiResult<CoordinatorKey, ShareGroupDescription> handleResponse(
+    public ApiResult<CoordinatorKey, ClassicGroupDescription> handleResponse(
             Node coordinator,
             Set<CoordinatorKey> groupIds,
             AbstractResponse abstractResponse) {
-        final ShareGroupDescribeResponse response = (ShareGroupDescribeResponse) abstractResponse;
-        final Map<CoordinatorKey, ShareGroupDescription> completed = new HashMap<>();
+        final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
+        final Map<CoordinatorKey, ClassicGroupDescription> completed = new HashMap<>();
         final Map<CoordinatorKey, Throwable> failed = new HashMap<>();
         final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
 
-        for (ShareGroupDescribeResponseData.DescribedGroup describedGroup : response.data().groups()) {
+        for (DescribeGroupsResponseData.DescribedGroup describedGroup : response.data().groups()) {
             CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
             Errors error = Errors.forCode(describedGroup.errorCode());
             if (error != Errors.NONE) {
-                handleError(groupIdKey, describedGroup, coordinator, error, describedGroup.errorMessage(), completed, failed, groupsToUnmap);
+                handleError(groupIdKey, error, error.message(), failed, groupsToUnmap);
                 continue;
             }
 
             final List<MemberDescription> memberDescriptions = new ArrayList<>(describedGroup.members().size());
             final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
 
-            describedGroup.members().forEach(groupMember ->
+            describedGroup.members().forEach(groupMember -> {
+                Set<TopicPartition> partitions = Collections.emptySet();
+                if (groupMember.memberAssignment().length > 0) {
+                    final Assignment assignment = ConsumerProtocol.deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
+                    partitions = new HashSet<>(assignment.partitions());
+                }
                 memberDescriptions.add(new MemberDescription(
                     groupMember.memberId(),
+                    Optional.of(groupMember.groupInstanceId()),
                     groupMember.clientId(),
                     groupMember.clientHost(),
-                    new MemberAssignment(convertAssignment(groupMember.assignment()))
-                ))
-            );
-
-            final ShareGroupDescription shareGroupDescription =
-                new ShareGroupDescription(groupIdKey.idValue,
+                    new MemberAssignment(partitions)));
+            });
+            final ClassicGroupDescription classicGroupDescription =
+                new ClassicGroupDescription(
+                    groupIdKey.idValue,
+                    describedGroup.protocolType(),
                     memberDescriptions,
-                    ShareGroupState.parse(describedGroup.groupState()),
+                    describedGroup.protocolData(),
+                    ClassicGroupState.parse(describedGroup.groupState()),
                     coordinator,
                     authorizedOperations);
-            completed.put(groupIdKey, shareGroupDescription);
+            completed.put(groupIdKey, classicGroupDescription);
         }
 
-        return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
-    }
-
-    private Set<TopicPartition> convertAssignment(ShareGroupDescribeResponseData.Assignment assignment) {
-        return assignment.topicPartitions().stream().flatMap(topic ->
-            topic.partitions().stream().map(partition ->
-                new TopicPartition(topic.topicName(), partition)
-            )
-        ).collect(Collectors.toSet());
+        return new ApiResult<>(completed, failed, List.copyOf(groupsToUnmap));
     }
 
     private void handleError(
             CoordinatorKey groupId,
-            ShareGroupDescribeResponseData.DescribedGroup describedGroup,
-            Node coordinator,
             Errors error,
             String errorMsg,
-            Map<CoordinatorKey, ShareGroupDescription> completed,
             Map<CoordinatorKey, Throwable> failed,
             Set<CoordinatorKey> groupsToUnmap) {
         switch (error) {
             case GROUP_AUTHORIZATION_FAILED:
-                log.debug("`DescribeShareGroups` request for group id {} failed due to error {}", groupId.idValue, error);
+                log.debug("`DescribeGroups` request for group id {} failed due to error {}.", groupId.idValue, error);
                 failed.put(groupId, error.exception(errorMsg));
                 break;
 
             case COORDINATOR_LOAD_IN_PROGRESS:
                 // If the coordinator is in the middle of loading, then we just need to retry
-                log.debug("`DescribeShareGroups` request for group id {} failed because the coordinator " +
-                    "is still in the process of loading state. Will retry", groupId.idValue);
+                log.debug("`DescribeGroups` request for group id {} failed because the coordinator " +
+                    "is still in the process of loading state. Will retry.", groupId.idValue);
                 break;
 
             case COORDINATOR_NOT_AVAILABLE:
             case NOT_COORDINATOR:
                 // If the coordinator is unavailable or there was a coordinator change, then we unmap
                 // the key so that we retry the `FindCoordinator` request
-                log.debug("`DescribeShareGroups` request for group id {} returned error {}. " +
-                    "Will attempt to find the coordinator again and retry", groupId.idValue, error);
+                log.debug("`DescribeGroups` request for group id {} returned error {}. " +
+                    "Will attempt to find the coordinator again and retry.", groupId.idValue, error);
                 groupsToUnmap.add(groupId);
                 break;
 
-            case GROUP_ID_NOT_FOUND:
-                // In order to maintain compatibility with describeConsumerGroups, an unknown group ID is
-                // reported as a DEAD share group, and the admin client operation did not fail
-                log.debug("`DescribeShareGroups` request for group id {} failed because the group does not exist. {}",
-                    groupId.idValue, errorMsg != null ? errorMsg : "");
-                final ShareGroupDescription shareGroupDescription =
-                    new ShareGroupDescription(groupId.idValue,
-                        Collections.emptySet(),
-                        ShareGroupState.DEAD,
-                        coordinator,
-                        validAclOperations(describedGroup.authorizedOperations()));
-                completed.put(groupId, shareGroupDescription);
-                break;
-
             default:
-                log.error("`DescribeShareGroups` request for group id {} failed due to unexpected error {}", groupId.idValue, error);
+                log.error("`DescribeGroups` request for group id {} failed due to unexpected error {}.", groupId.idValue, error);
                 failed.put(groupId, error.exception(errorMsg));
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/ClassicGroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/ClassicGroupState.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The classic group state.
+ */
+public enum ClassicGroupState {
+    UNKNOWN("Unknown"),
+    PREPARING_REBALANCE("PreparingRebalance"),
+    COMPLETING_REBALANCE("CompletingRebalance"),
+    STABLE("Stable"),
+    DEAD("Dead"),
+    EMPTY("Empty");
+
+    private static final Map<String, ClassicGroupState> NAME_TO_ENUM = Arrays.stream(values())
+        .collect(Collectors.toMap(state -> state.name.toUpperCase(Locale.ROOT), Function.identity()));
+
+    private final String name;
+
+    ClassicGroupState(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Case-insensitive classic group state lookup by string name.
+     */
+    public static ClassicGroupState parse(String name) {
+        ClassicGroupState state = NAME_TO_ENUM.get(name.toUpperCase(Locale.ROOT));
+        return state == null ? UNKNOWN : state;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.ClassicGroupState;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.ElectionType;
@@ -5283,6 +5284,177 @@ public class KafkaAdminClientTest {
             ListShareGroupsOptions options = new ListShareGroupsOptions();
             ListShareGroupsResult result = env.adminClient().listShareGroups(options);
             TestUtils.assertFutureThrows(result.all(), UnsupportedVersionException.class);
+        }
+    }
+
+    @Test
+    public void testDescribeClassicGroups() throws Exception {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            // Retriable FindCoordinatorResponse errors should be retried
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_NOT_AVAILABLE,  Node.noNode()));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_LOAD_IN_PROGRESS,  Node.noNode()));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
+
+            // Retriable errors should be retried
+            data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            /*
+             * We need to return two responses here, one with NOT_COORDINATOR error when calling describe classic group
+             * api using coordinator that has moved. This will retry whole operation. So we need to again respond with a
+             * FindCoordinatorResponse.
+             *
+             * And the same reason for COORDINATOR_NOT_AVAILABLE error response
+             */
+            data = new DescribeGroupsResponseData();
+            data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setErrorCode(Errors.NOT_COORDINATOR.code()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            data = new DescribeGroupsResponseData();
+            data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            final List<TopicPartition> topicPartitions = List.of(
+                new TopicPartition("my_topic", 0),
+                new TopicPartition("my_topic", 1),
+                new TopicPartition("my_topic", 2));
+            final ByteBuffer memberAssignment = ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(topicPartitions));
+            final byte[] memberAssignmentBytes = new byte[memberAssignment.remaining()];
+            memberAssignment.get(memberAssignmentBytes);
+
+            data = new DescribeGroupsResponseData();
+            DescribeGroupsResponseData.DescribedGroupMember memberOne = new DescribeGroupsResponseData.DescribedGroupMember()
+                .setMemberId("0")
+                .setClientId("clientId0")
+                .setClientHost("clientHost")
+                .setMemberAssignment(memberAssignmentBytes);
+            DescribeGroupsResponseData.DescribedGroupMember memberTwo = new DescribeGroupsResponseData.DescribedGroupMember()
+                .setMemberId("1")
+                .setClientId("clientId1")
+                .setClientHost("clientHost")
+                .setGroupInstanceId("static")
+                .setMemberAssignment(memberAssignmentBytes);
+
+            final List<TopicPartition> expectedTopicPartitions = new ArrayList<>();
+            expectedTopicPartitions.add(0, new TopicPartition("my_topic", 0));
+            expectedTopicPartitions.add(1, new TopicPartition("my_topic", 1));
+            expectedTopicPartitions.add(2, new TopicPartition("my_topic", 2));
+
+            List<MemberDescription> expectedMemberDescriptions = new ArrayList<>();
+            expectedMemberDescriptions.add(convertToMemberDescriptions(memberOne,
+                new MemberAssignment(new HashSet<>(expectedTopicPartitions))));
+            expectedMemberDescriptions.add(convertToMemberDescriptions(memberTwo,
+                new MemberAssignment(new HashSet<>(expectedTopicPartitions))));
+            data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setGroupState(ClassicGroupState.STABLE.toString())
+                .setMembers(List.of(memberOne, memberTwo)));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            final DescribeClassicGroupsResult result = env.adminClient().describeClassicGroups(List.of(GROUP_ID));
+            final ClassicGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
+
+            assertEquals(1, result.describedGroups().size());
+            assertEquals(GROUP_ID, groupDescription.groupId());
+            assertEquals(2, groupDescription.members().size());
+            assertEquals(expectedMemberDescriptions, groupDescription.members());
+        }
+    }
+
+    @Test
+    public void testDescribeClassicGroupsWithAuthorizedOperationsOmitted() throws Exception {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            env.kafkaClient().prepareResponse(
+                prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
+
+            data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setProtocolType("")
+                .setAuthorizedOperations(MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            final DescribeClassicGroupsResult result = env.adminClient().describeClassicGroups(List.of(GROUP_ID));
+            final ClassicGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
+
+            assertNull(groupDescription.authorizedOperations());
+        }
+    }
+
+    @Test
+    public void testDescribeMultipleClassicGroups() {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            final List<TopicPartition> topicPartitions = List.of(
+                new TopicPartition("my_topic", 0),
+                new TopicPartition("my_topic", 1),
+                new TopicPartition("my_topic", 2));
+            final ByteBuffer memberAssignment = ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(topicPartitions));
+            final byte[] memberAssignmentBytes = new byte[memberAssignment.remaining()];
+            memberAssignment.get(memberAssignmentBytes);
+
+            DescribeGroupsResponseData group0Data = new DescribeGroupsResponseData();
+            group0Data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId(GROUP_ID)
+                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setGroupState(ClassicGroupState.STABLE.toString())
+                .setMembers(List.of(
+                    new DescribeGroupsResponseData.DescribedGroupMember()
+                        .setMemberId("0")
+                        .setClientId("clientId0")
+                        .setClientHost("clientHost")
+                        .setMemberAssignment(memberAssignmentBytes),
+                    new DescribeGroupsResponseData.DescribedGroupMember()
+                        .setMemberId("1")
+                        .setClientId("clientId1")
+                        .setClientHost("clientHost")
+                        .setMemberAssignment(memberAssignmentBytes))));
+
+            DescribeGroupsResponseData group1Data = new DescribeGroupsResponseData();
+            group1Data.groups().add(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId("group-1")
+                .setProtocolType("other")
+                .setGroupState(ClassicGroupState.STABLE.toString())
+                .setMembers(List.of(
+                    new DescribeGroupsResponseData.DescribedGroupMember()
+                        .setMemberId("0")
+                        .setClientId("clientId0")
+                        .setClientHost("clientHost"),
+                    new DescribeGroupsResponseData.DescribedGroupMember()
+                        .setMemberId("1")
+                        .setClientId("clientId1")
+                        .setClientHost("clientHost"))));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(group0Data));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(group1Data));
+
+            Collection<String> groups = new HashSet<>();
+            groups.add(GROUP_ID);
+            groups.add("group-1");
+            final DescribeClassicGroupsResult result = env.adminClient().describeClassicGroups(groups);
+            assertEquals(2, result.describedGroups().size());
+            assertEquals(groups, result.describedGroups().keySet());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1400,6 +1400,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public synchronized DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds, DescribeClassicGroupsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public synchronized void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -58,6 +58,8 @@ import org.apache.kafka.clients.admin.DeleteTopicsOptions;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeAclsOptions;
 import org.apache.kafka.clients.admin.DescribeAclsResult;
+import org.apache.kafka.clients.admin.DescribeClassicGroupsOptions;
+import org.apache.kafka.clients.admin.DescribeClassicGroupsResult;
 import org.apache.kafka.clients.admin.DescribeClientQuotasOptions;
 import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
 import org.apache.kafka.clients.admin.DescribeClusterOptions;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -425,8 +425,7 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
         return adminDelegate.listShareGroups(options);
     }
 
-
-    @Overrride
+    @Override
     public DescribeClassicGroupsResult describeClassicGroups(final Collection<String> groupIds, final DescribeClassicGroupsOptions options) {
         return adminDelegate.describeClassicGroups(groupId, options);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -429,7 +429,7 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
 
     @Override
     public DescribeClassicGroupsResult describeClassicGroups(final Collection<String> groupIds, final DescribeClassicGroupsOptions options) {
-        return adminDelegate.describeClassicGroups(groupId, options);
+        return adminDelegate.describeClassicGroups(groupIds, options);
     }
 
     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -425,6 +425,12 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
         return adminDelegate.listShareGroups(options);
     }
 
+
+    @Overrride
+    public DescribeClassicGroupsResult describeClassicGroups(final Collection<String> groupIds, final DescribeClassicGroupsOptions options) {
+        return adminDelegate.describeClassicGroups(groupId, options);
+    }
+
     @Override
     public void registerMetricForSubscription(final KafkaMetric metric) {
         throw new UnsupportedOperationException("not implemented");


### PR DESCRIPTION
The implementation of `Admin.describeClassicGroups` from KIP-1043.

This PR does not contain integration tests. Those will be added in a follow-on PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
