### PR TITLE
KAFKA-17938: Removed Set.of usage in ReplicationControlManagerTest

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -123,6 +123,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -588,7 +589,7 @@ public class ReplicationControlManagerTest {
         ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
         PolicyViolationException error = assertThrows(
                 PolicyViolationException.class,
-                () -> replicationControl.createTopics(requestContext, request, Set.of("foo", "bar", "baz")));
+                () -> replicationControl.createTopics(requestContext, request, Stream.of("foo", "bar", "baz").collect(Collectors.toSet())));
         assertEquals(error.getMessage(), "Excessively large number of partitions per request.");
     }
 


### PR DESCRIPTION
*What*
Removed Set.of usage in ReplicationControlManagerTest as it is not compatible with java 8. This was causing build failures with 3.9 trunk.