### PR TITLE
remove unnecessary connect module from publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,7 +293,10 @@ subprojects {
 
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it
-  def shouldPublish = !project.name.equals('jmh-benchmarks')
+  def shouldPublish = !([
+      'connect',
+      'jmh-benchmarks',
+    ].contains(project.name))
   def shouldPublishWithShadow = (['clients'].contains(project.name))
 
   if (shouldPublish) {


### PR DESCRIPTION
The connect module is just an empty jar and empty pom. It doesn't need to be published.
[repo1.maven.org/maven2/org/apache/kafka/connect/3.8.1/connect-3.8.1.pom](https://repo1.maven.org/maven2/org/apache/kafka/connect/3.8.1/connect-3.8.1.pom)

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
