### PR TITLE
KAFKA-17635: Ensure only committed offsets are returned for purging

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1078,7 +1078,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             if (topology.isRepartitionTopic(tp.topic())) {
                 // committedOffsets map is initialized at -1 so no purging until there's a committed offset
                 if (entry.getValue() > -1) {
-                    purgeableConsumedOffsets.put(tp, entry.getValue() + 1);
+                    purgeableConsumedOffsets.put(tp, entry.getValue());
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1076,7 +1076,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
             final TopicPartition tp = entry.getKey();
             if (topology.isRepartitionTopic(tp.topic())) {
-                purgeableConsumedOffsets.put(tp, entry.getValue() + 1);
+                final Long maybeCommitted = committedOffsets.get(tp);
+                if (maybeCommitted != null && maybeCommitted >= entry.getValue()) {
+                    purgeableConsumedOffsets.put(tp, entry.getValue() + 1);
+                }
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1073,11 +1073,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     @Override
     public Map<TopicPartition, Long> purgeableOffsets() {
         final Map<TopicPartition, Long> purgeableConsumedOffsets = new HashMap<>();
-        for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
+        for (final Map.Entry<TopicPartition, Long> entry : committedOffsets.entrySet()) {
             final TopicPartition tp = entry.getKey();
             if (topology.isRepartitionTopic(tp.topic())) {
-                final Long maybeCommitted = committedOffsets.get(tp);
-                if (maybeCommitted != null && maybeCommitted >= entry.getValue()) {
+                // committedOffsets map is initialized at -1 so no purging until there's a committed offset
+                if (entry.getValue() > -1) {
                     purgeableConsumedOffsets.put(tp, entry.getValue() + 1);
                 }
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -77,6 +77,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1845,8 +1847,9 @@ public class StreamTaskTest {
         verify(stateManager).close();
     }
 
-    @Test
-    public void shouldReturnOffsetsForRepartitionTopicsForPurging() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void shouldMaybeReturnOffsetsForRepartitionTopicsForPurging(final boolean doCommit) {
         when(stateManager.taskId()).thenReturn(taskId);
         when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);
         final TopicPartition repartition = new TopicPartition("repartition", 1);
@@ -1907,10 +1910,17 @@ public class StreamTaskTest {
         assertTrue(task.process(0L));
 
         task.prepareCommit();
+        if (doCommit) {
+            task.updateCommittedOffsets(repartition, 10L);
+        }
 
         final Map<TopicPartition, Long> map = task.purgeableOffsets();
 
-        assertThat(map, equalTo(singletonMap(repartition, 11L)));
+        if (doCommit) {
+            assertThat(map, equalTo(singletonMap(repartition, 11L)));
+        } else {
+            assertThat(map, equalTo(Collections.emptyMap()));
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1917,7 +1917,7 @@ public class StreamTaskTest {
         final Map<TopicPartition, Long> map = task.purgeableOffsets();
 
         if (doCommit) {
-            assertThat(map, equalTo(singletonMap(repartition, 11L)));
+            assertThat(map, equalTo(singletonMap(repartition, 10L)));
         } else {
             assertThat(map, equalTo(Collections.emptyMap()));
         }


### PR DESCRIPTION
Kafka Streams actively purges records from repartition topics.  Prior to this PR, Kafka Streams would retrieve the offset from the `consumedOffsets` map, but here are a couple of edge cases where the `consumedOffsets` can get ahead of the `commitedOffsets` map.  In these cases, this means Kafka Streams will potentially purge a repartition record before it's committed.

Updated the current `StreamTask` test to cover this case

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
