### PR TITLE
KAFKA-17593; [4/N] Introduce ConsumerGroupRegularExpression record & related bookkeeping in ConsumerGroup

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
@@ -29,6 +29,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -51,6 +53,7 @@ import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMe
 import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.modern.TopicMetadata;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.modern.consumer.ResolvedRegularExpression;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -403,6 +406,61 @@ public class GroupCoordinatorRecordHelpers {
                     .setGroupId(groupId)
                     .setMemberId(memberId),
                 (short) 8
+            ),
+            null // Tombstone
+        );
+    }
+
+    /**
+     * Creates a ConsumerGroupRegularExpression record.
+     *
+     * @param groupId   The consumer group id.
+     * @param regex     The regular expression.
+     * @param metadata  The metadata associated with the regular expression.
+     * @return The record.
+     */
+    public static CoordinatorRecord newConsumerGroupRegularExpressionRecord(
+        String groupId,
+        String regex,
+        ResolvedRegularExpression metadata
+    ) {
+        List<String> topics = new ArrayList<>(metadata.topics);
+        Collections.sort(topics);
+
+        return new CoordinatorRecord(
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionKey()
+                    .setGroupId(groupId)
+                    .setRegularExpression(regex),
+                (short) 15
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionValue()
+                    .setTopics(topics)
+                    .setVersion(metadata.version)
+                    .setTimestamp(metadata.timestamp),
+                (short) 0
+            )
+        );
+    }
+
+    /**
+     * Creates a ConsumerGroupRegularExpression tombstone.
+     *
+     * @param groupId   The consumer group id.
+     * @param regex     The regular expression.
+     * @return The record.
+     */
+    public static CoordinatorRecord newConsumerGroupRegularExpressionTombstone(
+        String groupId,
+        String regex
+    ) {
+        return new CoordinatorRecord(
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionKey()
+                    .setGroupId(groupId)
+                    .setRegularExpression(regex),
+                (short) 15
             ),
             null // Tombstone
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
@@ -432,7 +432,7 @@ public class GroupCoordinatorRecordHelpers {
                 new ConsumerGroupRegularExpressionKey()
                     .setGroupId(groupId)
                     .setRegularExpression(regex),
-                (short) 15
+                (short) 16
             ),
             new ApiMessageAndVersion(
                 new ConsumerGroupRegularExpressionValue()
@@ -460,7 +460,7 @@ public class GroupCoordinatorRecordHelpers {
                 new ConsumerGroupRegularExpressionKey()
                     .setGroupId(groupId)
                     .setRegularExpression(regex),
-                (short) 15
+                (short) 16
             ),
             null // Tombstone
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
@@ -414,17 +414,17 @@ public class GroupCoordinatorRecordHelpers {
     /**
      * Creates a ConsumerGroupRegularExpression record.
      *
-     * @param groupId   The consumer group id.
-     * @param regex     The regular expression.
-     * @param metadata  The metadata associated with the regular expression.
+     * @param groupId                       The consumer group id.
+     * @param regex                         The regular expression.
+     * @param resolvedRegularExpression     The metadata associated with the regular expression.
      * @return The record.
      */
     public static CoordinatorRecord newConsumerGroupRegularExpressionRecord(
         String groupId,
         String regex,
-        ResolvedRegularExpression metadata
+        ResolvedRegularExpression resolvedRegularExpression
     ) {
-        List<String> topics = new ArrayList<>(metadata.topics);
+        List<String> topics = new ArrayList<>(resolvedRegularExpression.topics);
         Collections.sort(topics);
 
         return new CoordinatorRecord(
@@ -437,8 +437,8 @@ public class GroupCoordinatorRecordHelpers {
             new ApiMessageAndVersion(
                 new ConsumerGroupRegularExpressionValue()
                     .setTopics(topics)
-                    .setVersion(metadata.version)
-                    .setTimestamp(metadata.timestamp),
+                    .setVersion(resolvedRegularExpression.version)
+                    .setTimestamp(resolvedRegularExpression.timestamp),
                 (short) 0
             )
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -875,7 +875,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 );
                 break;
 
-            case 15:
+            case 16:
                 groupMetadataManager.replay(
                     (ConsumerGroupRegularExpressionKey) key.message(),
                     (ConsumerGroupRegularExpressionValue) Utils.messageOrNull(value)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -63,6 +63,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -760,6 +762,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
      * @param record        The record to apply to the state machine.
      * @throws RuntimeException
      */
+    @SuppressWarnings({"CyclomaticComplexity"})
     @Override
     public void replay(
         long offset,
@@ -869,6 +872,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 groupMetadataManager.replay(
                     (ShareGroupCurrentMemberAssignmentKey) key.message(),
                     (ShareGroupCurrentMemberAssignmentValue) Utils.messageOrNull(value)
+                );
+                break;
+
+            case 15:
+                groupMetadataManager.replay(
+                    (ConsumerGroupRegularExpressionKey) key.message(),
+                    (ConsumerGroupRegularExpressionValue) Utils.messageOrNull(value)
                 );
                 break;
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -82,6 +82,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -109,6 +111,7 @@ import org.apache.kafka.coordinator.group.modern.TopicMetadata;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.modern.consumer.CurrentAssignmentBuilder;
+import org.apache.kafka.coordinator.group.modern.consumer.ResolvedRegularExpression;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupAssignmentBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
@@ -3605,6 +3608,40 @@ public class GroupMetadataManager {
                 .setPartitionsPendingRevocation(Collections.emptyMap())
                 .build();
             group.updateMember(newMember);
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupRegularExpressionKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupRegularExpressionKey key.
+     * @param value A ConsumerGroupRegularExpressionValue record.
+     */
+    public void replay(
+        ConsumerGroupRegularExpressionKey key,
+        ConsumerGroupRegularExpressionValue value
+    ) {
+        String groupId = key.groupId();
+        String regex = key.regularExpression();
+
+        if (value != null) {
+            ConsumerGroup group = getOrMaybeCreatePersistedConsumerGroup(groupId, true);
+            group.updateRegularExpression(
+                regex,
+                new ResolvedRegularExpression(
+                    new HashSet<>(value.topics()),
+                    value.version(),
+                    value.timestamp()
+                )
+            );
+        } else {
+            try {
+                ConsumerGroup group = getOrMaybeCreatePersistedConsumerGroup(groupId, false);
+                group.removeRegularExpression(regex);
+            } catch (GroupIdNotFoundException ex) {
+                // If the group does not exist, we can ignore the tombstone.
+            }
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3627,7 +3627,7 @@ public class GroupMetadataManager {
 
         if (value != null) {
             ConsumerGroup group = getOrMaybeCreatePersistedConsumerGroup(groupId, true);
-            group.updateRegularExpression(
+            group.updateResolvedRegularExpression(
                 regex,
                 new ResolvedRegularExpression(
                     new HashSet<>(value.topics()),
@@ -3638,7 +3638,7 @@ public class GroupMetadataManager {
         } else {
             try {
                 ConsumerGroup group = getOrMaybeCreatePersistedConsumerGroup(groupId, false);
-                group.removeRegularExpression(regex);
+                group.removeResolvedRegularExpression(regex);
             } catch (GroupIdNotFoundException ex) {
                 // If the group does not exist, we can ignore the tombstone.
             }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
@@ -80,7 +80,7 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
     protected final TimelineHashMap<String, T> members;
 
     /**
-     * The number of subscribers per topic.
+     * The number of subscribers or regular expressions per topic.
      */
     protected final TimelineHashMap<String, Integer> subscribedTopicNames;
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -351,17 +351,17 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     /**
      * Update the regular expression.
      *
-     * @param regex         The regular expression.
-     * @param newMetadata   The regular expression's metadata.
+     * @param regex                         The regular expression.
+     * @param newResolvedRegularExpression  The regular expression's metadata.
      */
     public void updateRegularExpression(
         String regex,
-        ResolvedRegularExpression newMetadata
+        ResolvedRegularExpression newResolvedRegularExpression
     ) {
         removeRegularExpression(regex);
-        if (newMetadata != null) {
-            resolvedRegularExpressions.put(regex, newMetadata);
-            newMetadata.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::incValue));
+        if (newResolvedRegularExpression != null) {
+            resolvedRegularExpressions.put(regex, newResolvedRegularExpression);
+            newResolvedRegularExpression.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::incValue));
         }
     }
 
@@ -373,9 +373,9 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     public void removeRegularExpression(
         String regex
     ) {
-        ResolvedRegularExpression oldMetadata = resolvedRegularExpressions.remove(regex);
-        if (oldMetadata != null) {
-            oldMetadata.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::decValue));
+        ResolvedRegularExpression oldResolvedRegularExpression = resolvedRegularExpressions.remove(regex);
+        if (oldResolvedRegularExpression != null) {
+            oldResolvedRegularExpression.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::decValue));
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -349,16 +349,16 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     }
 
     /**
-     * Update the regular expression.
+     * Update the resolved regular expression.
      *
      * @param regex                         The regular expression.
      * @param newResolvedRegularExpression  The regular expression's metadata.
      */
-    public void updateRegularExpression(
+    public void updateResolvedRegularExpression(
         String regex,
         ResolvedRegularExpression newResolvedRegularExpression
     ) {
-        removeRegularExpression(regex);
+        removeResolvedRegularExpression(regex);
         if (newResolvedRegularExpression != null) {
             resolvedRegularExpressions.put(regex, newResolvedRegularExpression);
             newResolvedRegularExpression.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::incValue));
@@ -366,13 +366,11 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     }
 
     /**
-     * Remove the regular expression.
+     * Remove the resolved regular expression.
      *
      * @param regex The regular expression.
      */
-    public void removeRegularExpression(
-        String regex
-    ) {
+    public void removeResolvedRegularExpression(String regex) {
         ResolvedRegularExpression oldResolvedRegularExpression = resolvedRegularExpressions.remove(regex);
         if (oldResolvedRegularExpression != null) {
             oldResolvedRegularExpression.topics.forEach(topicName -> subscribedTopicNames.compute(topicName, Utils::decValue));
@@ -380,12 +378,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     }
 
     /**
-     * @return An optional containing the resolved regular expression corresponding to the provided regex
+     * Return an optional containing the resolved regular expression corresponding to the provided regex
      * or an empty optional.
+     *
+     * @param regex The regular expression.
+     * @return The optional containing the resolved regular expression or an empty optional.
      */
-    public Optional<ResolvedRegularExpression> regularExpression(
-        String regex
-    ) {
+    public Optional<ResolvedRegularExpression> regularExpression(String regex) {
         return Optional.ofNullable(resolvedRegularExpressions.get(regex));
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpression.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpression.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.modern.consumer;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The metadata associated with a regular expression in a Consumer Group.
+ */
+public class ResolvedRegularExpression {
+    /**
+     * The set of resolved topics.
+     */
+    public final Set<String> topics;
+
+    /**
+     * The version of the metadata image used to resolve the topics.
+     */
+    public final long version;
+
+    /**
+     * The timestamp at the time of the resolution.
+     */
+    public final long timestamp;
+
+    public ResolvedRegularExpression(
+        Set<String> topics,
+        long version,
+        long timestamp
+    ) {
+        this.topics = Collections.unmodifiableSet(Objects.requireNonNull(topics));
+        this.version = version;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ResolvedRegularExpression that = (ResolvedRegularExpression) o;
+
+        if (version != that.version) return false;
+        if (timestamp != that.timestamp) return false;
+        return topics.equals(that.topics);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = topics.hashCode();
+        result = 31 * result + (int) (version ^ (version >>> 32));
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RegularExpressionMetadata(" +
+            "topics=" + topics +
+            ", version=" + version +
+            ", timestamp=" + timestamp +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
@@ -17,12 +17,12 @@
 {
   "type": "data",
   "name": "ConsumerGroupRegularExpressionKey",
-  "validVersions": "15",
+  "validVersions": "16",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "15",
+    { "name": "GroupId", "type": "string", "versions": "16",
       "about": "The group id." },
-    { "name": "RegularExpression", "type": "string", "versions": "15",
+    { "name": "RegularExpression", "type": "string", "versions": "16",
       "about": "The regular expression." }
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupRegularExpressionKey",
+  "validVersions": "15",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "15",
+      "about": "The group id." },
+    { "name": "RegularExpression", "type": "string", "versions": "15",
+      "about": "The regular expression." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionValue.json
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ConsumerGroupRegularExpressionValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "versions": "0+", "type": "[]string" },
+    { "name": "Version", "versions": "0+", "type": "int64" },
+    { "name": "Timestamp", "versions": "0+", "type": "int64" }
+  ]
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
@@ -817,7 +817,7 @@ public class GroupCoordinatorRecordHelpersTest {
                 new ConsumerGroupRegularExpressionKey()
                     .setGroupId("group-id")
                     .setRegularExpression("ab*"),
-                (short) 15
+                (short) 16
             ),
             new ApiMessageAndVersion(
                 new ConsumerGroupRegularExpressionValue()
@@ -848,7 +848,7 @@ public class GroupCoordinatorRecordHelpersTest {
                 new ConsumerGroupRegularExpressionKey()
                     .setGroupId("group-id")
                     .setRegularExpression("ab*"),
-                (short) 15
+                (short) 16
             ),
             null
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -46,6 +48,7 @@ import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
 import org.apache.kafka.coordinator.group.modern.MemberState;
 import org.apache.kafka.coordinator.group.modern.TopicMetadata;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.modern.consumer.ResolvedRegularExpression;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
@@ -804,6 +807,57 @@ public class GroupCoordinatorRecordHelpersTest {
             null);
 
         CoordinatorRecord record = GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("group-id", "foo", 1);
+        assertEquals(expectedRecord, record);
+    }
+
+    @Test
+    public void testNewConsumerGroupRegularExpressionRecord() {
+        CoordinatorRecord expectedRecord = new CoordinatorRecord(
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionKey()
+                    .setGroupId("group-id")
+                    .setRegularExpression("ab*"),
+                (short) 15
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionValue()
+                    .setTopics(Arrays.asList("abc", "abcd"))
+                    .setVersion(10L)
+                    .setTimestamp(12345L),
+                (short) 0
+            )
+        );
+
+        CoordinatorRecord record = GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionRecord(
+            "group-id",
+            "ab*",
+            new ResolvedRegularExpression(
+                Set.of("abc", "abcd"),
+                10L,
+                12345L
+            )
+        );
+
+        assertEquals(expectedRecord, record);
+    }
+
+    @Test
+    public void testNewConsumerGroupRegularExpressionTombstone() {
+        CoordinatorRecord expectedRecord = new CoordinatorRecord(
+            new ApiMessageAndVersion(
+                new ConsumerGroupRegularExpressionKey()
+                    .setGroupId("group-id")
+                    .setRegularExpression("ab*"),
+                (short) 15
+            ),
+            null
+        );
+
+        CoordinatorRecord record = GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone(
+            "group-id",
+            "ab*"
+        );
+
         assertEquals(expectedRecord, record);
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -47,6 +47,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -94,6 +96,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"ClassFanOutComplexity"})
 public class GroupCoordinatorShardTest {
 
     @Test
@@ -1267,6 +1270,69 @@ public class GroupCoordinatorShardTest {
 
         coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new CoordinatorRecord(
             new ApiMessageAndVersion(key, (short) 10),
+            null
+        ));
+
+        verify(groupMetadataManager, times(1)).replay(key, null);
+    }
+
+    @Test
+    public void testReplayConsumerGroupRegularExpression() {
+        GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
+        OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
+        CoordinatorMetrics coordinatorMetrics = mock(CoordinatorMetrics.class);
+        CoordinatorMetricsShard metricsShard = mock(CoordinatorMetricsShard.class);
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
+            groupMetadataManager,
+            offsetMetadataManager,
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
+            mock(GroupCoordinatorConfig.class),
+            coordinatorMetrics,
+            metricsShard
+        );
+
+        ConsumerGroupRegularExpressionKey key = new ConsumerGroupRegularExpressionKey()
+            .setGroupId("group")
+            .setRegularExpression("ab*");
+
+        ConsumerGroupRegularExpressionValue value = new ConsumerGroupRegularExpressionValue()
+            .setTopics(Arrays.asList("abc", "abcd"))
+            .setVersion(10L)
+            .setTimestamp(12345L);
+
+        coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new CoordinatorRecord(
+            new ApiMessageAndVersion(key, (short) 15),
+            new ApiMessageAndVersion(value, (short) 0)
+        ));
+
+        verify(groupMetadataManager, times(1)).replay(key, value);
+    }
+
+    @Test
+    public void testReplayConsumerGroupRegularExpressionTombestone() {
+        GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
+        OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
+        CoordinatorMetrics coordinatorMetrics = mock(CoordinatorMetrics.class);
+        CoordinatorMetricsShard metricsShard = mock(CoordinatorMetricsShard.class);
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
+            groupMetadataManager,
+            offsetMetadataManager,
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
+            mock(GroupCoordinatorConfig.class),
+            coordinatorMetrics,
+            metricsShard
+        );
+
+        ConsumerGroupRegularExpressionKey key = new ConsumerGroupRegularExpressionKey()
+            .setGroupId("group")
+            .setRegularExpression("ab*");
+
+        coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new CoordinatorRecord(
+            new ApiMessageAndVersion(key, (short) 15),
             null
         ));
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -1303,7 +1303,7 @@ public class GroupCoordinatorShardTest {
             .setTimestamp(12345L);
 
         coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new CoordinatorRecord(
-            new ApiMessageAndVersion(key, (short) 15),
+            new ApiMessageAndVersion(key, (short) 16),
             new ApiMessageAndVersion(value, (short) 0)
         ));
 
@@ -1311,7 +1311,7 @@ public class GroupCoordinatorShardTest {
     }
 
     @Test
-    public void testReplayConsumerGroupRegularExpressionTombestone() {
+    public void testReplayConsumerGroupRegularExpressionTombstone() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         CoordinatorMetrics coordinatorMetrics = mock(CoordinatorMetrics.class);
@@ -1332,7 +1332,7 @@ public class GroupCoordinatorShardTest {
             .setRegularExpression("ab*");
 
         coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new CoordinatorRecord(
-            new ApiMessageAndVersion(key, (short) 15),
+            new ApiMessageAndVersion(key, (short) 16),
             null
         ));
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -15115,7 +15115,7 @@ public class GroupMetadataManagerTest {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
 
-        // The group may not exist at all. Replaying the ConsumerGroupMetadata tombstone
+        // The group may not exist at all. Replaying the ConsumerGroupRegularExpression tombstone
         // should be a no-op.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone("foo", "abc*"));
         assertThrows(GroupIdNotFoundException.class, () -> context.groupMetadataManager.consumerGroup("foo"));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -15092,7 +15092,7 @@ public class GroupMetadataManagerTest {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
 
-        ResolvedRegularExpression regex = new ResolvedRegularExpression(
+        ResolvedRegularExpression resolvedRegularExpression = new ResolvedRegularExpression(
             Set.of("abc", "abcd"),
             10L,
             12345L
@@ -15101,11 +15101,11 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionRecord(
             "foo",
             "abc*",
-            regex
+            resolvedRegularExpression
         ));
 
         assertEquals(
-            Optional.of(regex),
+            Optional.of(resolvedRegularExpression),
             context.groupMetadataManager.consumerGroup("foo").regularExpression("abc*")
         );
     }
@@ -15121,7 +15121,7 @@ public class GroupMetadataManagerTest {
         assertThrows(GroupIdNotFoundException.class, () -> context.groupMetadataManager.consumerGroup("foo"));
 
         // Otherwise, it should remove the regular expression.
-        ResolvedRegularExpression regex = new ResolvedRegularExpression(
+        ResolvedRegularExpression resolvedRegularExpression = new ResolvedRegularExpression(
             Set.of("abc", "abcd"),
             10L,
             12345L
@@ -15130,7 +15130,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionRecord(
             "foo",
             "abc*",
-            regex
+            resolvedRegularExpression
         ));
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -63,6 +63,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
@@ -1554,6 +1556,13 @@ public class GroupMetadataManagerTestContext {
                 groupMetadataManager.replay(
                     (ShareGroupCurrentMemberAssignmentKey) key.message(),
                     (ShareGroupCurrentMemberAssignmentValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupRegularExpressionKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupRegularExpressionKey) key.message(),
+                    (ConsumerGroupRegularExpressionValue) messageOrNull(value)
                 );
                 break;
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -58,9 +58,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -1663,5 +1665,114 @@ public class ConsumerGroupTest {
         assertEquals(0, consumerGroup.numSubscribedMembers("regex1"));
         assertEquals(0, consumerGroup.numSubscribedMembers("regex2"));
         assertEquals(0, consumerGroup.numSubscribedMembers("regex3"));
+    }
+
+    @Test
+    public void testUpdateAndRemoveRegularExpression() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+            .build();
+        consumerGroup.updateMember(member1);
+
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member2")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .build();
+        consumerGroup.updateMember(member2);
+
+        // Verify initial state.
+        assertEquals(
+            Map.of(
+                "foo", 2,
+                "bar", 2,
+                "zar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
+
+        // Add a regex.
+        consumerGroup.updateRegularExpression(
+            "foo|bar",
+            new ResolvedRegularExpression(
+                Set.of("foo", "bar"),
+                10L,
+                12345L
+            )
+        );
+
+        assertEquals(
+            Map.of(
+                "foo", 3,
+                "bar", 3,
+                "zar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
+
+        // Add a regex.
+        consumerGroup.updateRegularExpression(
+            "foobar",
+            new ResolvedRegularExpression(
+                Set.of("foobar"),
+                10L,
+                12345L
+            )
+        );
+
+        assertEquals(
+            Map.of(
+                "foo", 3,
+                "bar", 3,
+                "zar", 1,
+                "foobar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
+
+        // Update a regex.
+        consumerGroup.updateRegularExpression(
+            "foo|bar",
+            new ResolvedRegularExpression(
+                Set.of("foo"),
+                10L,
+                12345L
+            )
+        );
+
+        assertEquals(
+            Map.of(
+                "foo", 3,
+                "bar", 2,
+                "zar", 1,
+                "foobar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
+
+        // Remove a regex.
+        consumerGroup.removeRegularExpression("foo|bar");
+
+        assertEquals(
+            Map.of(
+                "foo", 2,
+                "bar", 2,
+                "zar", 1,
+                "foobar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
+
+        // Remove another regex.
+        consumerGroup.removeRegularExpression("foobar");
+
+        assertEquals(
+            Map.of(
+                "foo", 2,
+                "bar", 2,
+                "zar", 1
+            ),
+            consumerGroup.subscribedTopicNames()
+        );
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1692,7 +1692,7 @@ public class ConsumerGroupTest {
         );
 
         // Add a regex.
-        consumerGroup.updateRegularExpression(
+        consumerGroup.updateResolvedRegularExpression(
             "foo|bar",
             new ResolvedRegularExpression(
                 Set.of("foo", "bar"),
@@ -1711,7 +1711,7 @@ public class ConsumerGroupTest {
         );
 
         // Add a regex.
-        consumerGroup.updateRegularExpression(
+        consumerGroup.updateResolvedRegularExpression(
             "foobar",
             new ResolvedRegularExpression(
                 Set.of("foobar"),
@@ -1731,7 +1731,7 @@ public class ConsumerGroupTest {
         );
 
         // Update a regex.
-        consumerGroup.updateRegularExpression(
+        consumerGroup.updateResolvedRegularExpression(
             "foo|bar",
             new ResolvedRegularExpression(
                 Set.of("foo"),
@@ -1751,7 +1751,7 @@ public class ConsumerGroupTest {
         );
 
         // Remove a regex.
-        consumerGroup.removeRegularExpression("foo|bar");
+        consumerGroup.removeResolvedRegularExpression("foo|bar");
 
         assertEquals(
             Map.of(
@@ -1764,7 +1764,7 @@ public class ConsumerGroupTest {
         );
 
         // Remove another regex.
-        consumerGroup.removeRegularExpression("foobar");
+        consumerGroup.removeResolvedRegularExpression("foobar");
 
         assertEquals(
             Map.of(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpressionTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpressionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.modern.consumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ResolvedRegularExpressionTest {
+    @Test
+    public void testConstructor() {
+        ResolvedRegularExpression regex = new ResolvedRegularExpression(
+            Set.of("foo", "bar"),
+            10L,
+            12345L
+        );
+
+        assertEquals(Set.of("foo", "bar"), regex.topics);
+        assertEquals(10L, regex.version);
+        assertEquals(12345L, regex.timestamp);
+    }
+
+    @Test
+    public void testEquals() {
+        assertEquals(
+            new ResolvedRegularExpression(
+                Set.of("foo", "bar"),
+                10L,
+                12345L
+            ),
+            new ResolvedRegularExpression(
+                Set.of("foo", "bar"),
+                10L,
+                12345L
+            )
+        );
+
+        assertNotEquals(
+            new ResolvedRegularExpression(
+                Set.of("foo", "bar"),
+                10L,
+                12345L
+            ),
+            new ResolvedRegularExpression(
+                Set.of("foo"),
+                10L,
+                12345L
+            )
+        );
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpressionTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ResolvedRegularExpressionTest.java
@@ -26,15 +26,15 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class ResolvedRegularExpressionTest {
     @Test
     public void testConstructor() {
-        ResolvedRegularExpression regex = new ResolvedRegularExpression(
+        ResolvedRegularExpression resolvedRegularExpression = new ResolvedRegularExpression(
             Set.of("foo", "bar"),
             10L,
             12345L
         );
 
-        assertEquals(Set.of("foo", "bar"), regex.topics);
-        assertEquals(10L, regex.version);
-        assertEquals(12345L, regex.timestamp);
+        assertEquals(Set.of("foo", "bar"), resolvedRegularExpression.topics);
+        assertEquals(10L, resolvedRegularExpression.version);
+        assertEquals(12345L, resolvedRegularExpression.timestamp);
     }
 
     @Test


### PR DESCRIPTION
This patch introduces the ConsumerGroupRegularExpression record (key + value) and updates the `GroupMatadataManager` and the `ConsumerGroup` to bookkeep it appropriately. Note that with this change, regular expressions are counted as subscribers in the `subscribedTopicNames` data structure. This is important because the topic metadata of the group is computed based on it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
