### PR TITLE
KAFKA-17924: Remove `bufferpool-wait-time-total`, `io-waittime-total`, and `iotime-total`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -80,9 +80,6 @@ public class BufferPool {
         MetricName rateMetricName = metrics.metricName("bufferpool-wait-ratio",
                                                    metricGrpName,
                                                    "The fraction of time an appender waits for space allocation.");
-        MetricName totalMetricName = metrics.metricName("bufferpool-wait-time-total",
-                                                   metricGrpName,
-                                                   "*Deprecated* The total time an appender waits for space allocation.");
         MetricName totalNsMetricName = metrics.metricName("bufferpool-wait-time-ns-total",
                                                     metricGrpName,
                                                     "The total time in nanoseconds an appender waits for space allocation.");
@@ -92,7 +89,6 @@ public class BufferPool {
         MetricName bufferExhaustedTotalMetricName = metrics.metricName("buffer-exhausted-total", metricGrpName, "The total number of record sends that are dropped due to buffer exhaustion");
         bufferExhaustedRecordSensor.add(new Meter(bufferExhaustedRateMetricName, bufferExhaustedTotalMetricName));
 
-        this.waitTime.add(new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName));
         this.waitTime.add(new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalNsMetricName));
         this.closed = false;
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1231,13 +1231,11 @@ public class Selector implements Selectable, AutoCloseable {
                     new WindowedCount(), "select", "times the I/O layer checked for new I/O to perform"));
             metricName = metrics.metricName("io-wait-time-ns-avg", metricGrpName, "The average length of time the I/O thread spent waiting for a socket ready for reads or writes in nanoseconds.", metricTags);
             this.selectTime.add(metricName, new Avg());
-            this.selectTime.add(createIOThreadRatioMeterLegacy(metrics, metricGrpName, metricTags, "io-wait", "waiting"));
             this.selectTime.add(createIOThreadRatioMeter(metrics, metricGrpName, metricTags, "io-wait", "waiting"));
 
             this.ioTime = sensor("io-time:" + tagsSuffix);
             metricName = metrics.metricName("io-time-ns-avg", metricGrpName, "The average length of time for I/O per select call in nanoseconds.", metricTags);
             this.ioTime.add(metricName, new Avg());
-            this.ioTime.add(createIOThreadRatioMeterLegacy(metrics, metricGrpName, metricTags, "io", "doing I/O"));
             this.ioTime.add(createIOThreadRatioMeter(metrics, metricGrpName, metricTags, "io", "doing I/O"));
 
             this.connectionsByCipher = new IntGaugeSuite<>(log, "sslCiphers", metrics,
@@ -1278,23 +1276,6 @@ public class Selector implements Selectable, AutoCloseable {
         private Meter createMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,
                 String baseName, String descriptiveName) {
             return createMeter(metrics, groupName, metricTags, null, baseName, descriptiveName);
-        }
-
-        /**
-         * This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
-         * and `time-total` suffix.
-         * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
-         */
-        @Deprecated
-        private Meter createIOThreadRatioMeterLegacy(Metrics metrics, String groupName,  Map<String, String> metricTags,
-                String baseName, String action) {
-            // this name remains relevant, non-deprecated descendant method uses the same 
-            MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
-                    String.format("The fraction of time the I/O thread spent %s", action), metricTags);
-            // this name is deprecated
-            MetricName totalMetricName = metrics.metricName(baseName + "time-total", groupName,
-                    String.format("*Deprecated* The total time the I/O thread spent %s", action), metricTags);
-            return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);
         }
 
         private Meter createIOThreadRatioMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -49,18 +49,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1015,35 +1012,6 @@ public class SelectorTest {
 
         selector.poll(0);
         assertEquals(0, selector.completedReceives().size());
-    }
-
-    /**
-     * Validate that correct subset of io metrics marked deprecated in docs
-     */
-    @Test
-    public void testIoMetricsHaveCorrectDoc() {
-        Predicate<MetricName> docDeprecated =
-                mName -> mName.description().toLowerCase(Locale.ROOT).contains("deprecated");
-
-        List<String> actual = asList("io-ratio", "io-wait-ratio");
-        assertEquals(
-                actual.size(),
-                metrics.metrics().keySet().stream()
-                        .filter(m -> actual.contains(m.name()))
-                        .filter(m -> !docDeprecated.test(m))
-                        .count(),
-                "Metrics " + actual + " should be registered as non-deprecated"
-        );
-
-        List<String> deprecated = asList("iotime-total", "io-waittime-total");
-        assertEquals(
-                deprecated.size(),
-                metrics.metrics().keySet().stream()
-                        .filter(m -> deprecated.contains(m.name()))
-                        .filter(docDeprecated)
-                        .count(),
-                "Metrics " + deprecated + " should be registered as deprecated"
-        );
     }
 
     private String blockingRequest(String node, String s) throws IOException {

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -2344,11 +2344,6 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
-        <td>io-waittime-total</td>
-        <td><b>*Deprecated*</b> The total time the I/O thread spent waiting in nanoseconds. Replacement is <code>io-wait-time-ns-total</code>.</td>
-        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
-      </tr>
-      <tr>
         <td>io-wait-ratio</td>
         <td>The fraction of time the I/O thread spent waiting.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
@@ -2361,11 +2356,6 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
       <tr>
         <td>io-time-ns-total</td>
         <td>The total time the I/O thread spent doing I/O in nanoseconds.</td>
-        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
-      </tr>
-      <tr>
-        <td>iotime-total</td>
-        <td><b>*Deprecated*</b> The total time the I/O thread spent doing I/O in nanoseconds. Replacement is <code>io-time-ns-total</code>.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
@@ -2553,11 +2543,6 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
       <tr>
         <td>bufferpool-wait-ratio</td>
         <td>The fraction of time an appender waits for space allocation.</td>
-        <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
-      </tr>
-      <tr>
-        <td>bufferpool-wait-time-total</td>
-        <td><b>*Deprecated*</b> The total time an appender waits for space allocation in nanoseconds. Replacement is <code>bufferpool-wait-time-ns-total</code></td>
         <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -963,7 +963,7 @@
 <h5><a id="upgrade_310_notable" href="#upgrade_310_notable">Notable changes in 3.1.0</a></h5>
 <ul>
     <li>Apache Kafka supports Java 17.</li>
-    <li>The following metrics have been deprecated: <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>,
+    <li>The following metrics have been deprecated and will be removed in Apache Kafka 4.0: <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>,
         and <code>iotime-total</code>. Please use <code>bufferpool-wait-time-ns-total</code>, <code>io-wait-time-ns-total</code>,
         and <code>io-time-ns-total</code> instead. See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-773%3A+Differentiate+consistently+metric+latency+measured+in+millis+and+nanos">KIP-773</a>
         for more details.</li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -32,6 +32,9 @@
                         <li>The <code>auto.include.jmx.reporter</code> configuration was removed. The <code>metric.reporters</code> configuration
                             is now set to <code>org.apache.kafka.common.metrics.JmxReporter</code> by default.
                         </li>
+                        <li>The <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>, and <code>iotime-total</code> metrics were removed.
+                            Please use <code>bufferpool-wait-time-ns-total</code>, <code>io-wait-time-ns-total</code>, and <code>io-time-ns-total</code> metrics as replacements, respectively.
+                        </li>
                     </ul>
                 </li>
                 <li><b>Broker</b>


### PR DESCRIPTION
In the before-and-after snapshot on JMC, you can see that `bufferpool-wait-time-total`, `io-waittime-total`, and `iotime-total` have been removed.

### Before:
![Screenshot from 2024-11-05 18-20-48](https://github.com/user-attachments/assets/765877b6-a420-425a-a9f6-621fdd295e03)

### After:
![Screenshot from 2024-11-05 21-33-52](https://github.com/user-attachments/assets/4d059f6f-2440-486d-9f60-e821826ee2b8)

JIRA: https://issues.apache.org/jira/browse/KAFKA-17924



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
