### PR TITLE
MINOR: doc link fix for producer design

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -160,7 +160,7 @@
     to accumulate no more than a fixed number of messages and to wait no longer than some fixed latency bound (say 64k or 10 ms). This allows the accumulation of more bytes to send, and few larger I/O operations on the
     servers. This buffering is configurable and gives a mechanism to trade off a small amount of additional latency for better throughput.
     <p>
-    Details on <a href="#producerconfigs">configuration</a> and the <a href="https://kafka.apache.org/{{version}}/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html">api</a> for the producer can be found
+    Details on <a href="#producerconfigs">configuration</a> and the <a href="#producerapi">api</a> for the producer can be found
     elsewhere in the documentation.
 
     <h3 class="anchor-heading"><a id="theconsumer" class="anchor-link"></a><a href="#theconsumer">4.5 The Consumer</a></h3>


### PR DESCRIPTION
This is from [the Producer ](https://kafka.apache.org/documentation/#theproducer) in the docs. 
There is a spot there to link to the producer API section.
This link was not working for me, looks either blocked or inaccessible. 
Assume we wanted to anchor here to [2.1 Producer API](https://kafka.apache.org/documentation/#producerapi).