### PR TITLE
KAFKA-17953: Docker image fails when setting env vars

### DIFF
--- a/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
+++ b/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
@@ -118,6 +118,8 @@ class KafkaDockerWrapperTest {
 
     val source = scala.io.Source.fromFile(finalConfigsPath.toString + "/server.properties")
     val actual = try source.mkString finally source.close()
+    // this is a configuration error that will make the image fail, 
+    // so that the user can spot the error and fix it
     val expected = " \n \n "
 
     assertEquals(expected, actual)

--- a/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
+++ b/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
@@ -67,7 +67,7 @@ class KafkaDockerWrapperTest {
 
     val source = scala.io.Source.fromFile(finalConfigsPath.toString + "/server.properties")
     val actual = try source.mkString finally source.close()
-    val expected = "\n" + "env.config=env value"
+    val expected = "default.config=default value" + "\n" + "env.config=env value"
 
     assertEquals(expected, actual)
   }
@@ -98,25 +98,6 @@ class KafkaDockerWrapperTest {
     val envVars = Map.empty[String, String]
 
     Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
-    Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
-
-    KafkaDockerWrapper.prepareServerConfigs(defaultConfigsPath, mountedConfigsPath, finalConfigsPath, envVars)
-
-    val source = scala.io.Source.fromFile(finalConfigsPath.toString + "/server.properties")
-    val actual = try source.mkString finally source.close()
-    val expected = "default.config=default value"
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  def testPrepareServerConfigsWithEmptyMountedFile(): Unit = {
-    val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
-
-    val envVars = Map.empty[String, String]
-
-    Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
-    Files.write(mountedConfigsPath.resolve("server.properties"), " \n \n ".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
 
     KafkaDockerWrapper.prepareServerConfigs(defaultConfigsPath, mountedConfigsPath, finalConfigsPath, envVars)

--- a/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
+++ b/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
@@ -36,11 +36,10 @@ class KafkaDockerWrapperTest {
   }
 
   @Test
-  def testPrepareServerConfigs(): Unit = {
+  def testPrepareServerConfigsWithEnvVarsAndMountedFile(): Unit = {
     val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
 
     val envVars = Map("KAFKA_ENV_CONFIG" -> "env value")
-
     Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(mountedConfigsPath.resolve("server.properties"), "mounted.config=mounted value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
@@ -55,11 +54,10 @@ class KafkaDockerWrapperTest {
   }
 
   @Test
-  def testPrepareServerConfigsWithoutMountedFile(): Unit = {
+  def testPrepareServerConfigsWithEnvVarsAndWithoutMountedFile(): Unit = {
     val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
 
     val envVars = Map("KAFKA_ENV_CONFIG" -> "env value")
-
     Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
 
@@ -73,11 +71,10 @@ class KafkaDockerWrapperTest {
   }
 
   @Test
-  def testPrepareServerConfigsWithoutEnvVariables(): Unit = {
+  def testPrepareServerConfigsWithoutEnvVarsAndWithMountedFile(): Unit = {
     val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
 
     val envVars = Map.empty[String, String]
-
     Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(mountedConfigsPath.resolve("server.properties"), "mounted.config=mounted value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
@@ -92,11 +89,10 @@ class KafkaDockerWrapperTest {
   }
 
   @Test
-  def testPrepareServerConfigsWithoutUserInput(): Unit = {
+  def testPrepareServerConfigsWithoutEnvVarsAndWithoutMountedFile(): Unit = {
     val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
 
     val envVars = Map.empty[String, String]
-
     Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
     Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
 
@@ -105,6 +101,24 @@ class KafkaDockerWrapperTest {
     val source = scala.io.Source.fromFile(finalConfigsPath.toString + "/server.properties")
     val actual = try source.mkString finally source.close()
     val expected = "default.config=default value"
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  def testPrepareServerConfigsWithEmptyMountedFile(): Unit = {
+    val (defaultConfigsPath, mountedConfigsPath, finalConfigsPath) = createDirs()
+
+    val envVars = Map.empty[String, String]
+    Files.write(defaultConfigsPath.resolve("server.properties"), "default.config=default value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
+    Files.write(mountedConfigsPath.resolve("server.properties"), " \n \n ".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
+    Files.write(finalConfigsPath.resolve("server.properties"), "existing.config=existing value".getBytes(StandardCharsets.UTF_8)).toFile.deleteOnExit()
+
+    KafkaDockerWrapper.prepareServerConfigs(defaultConfigsPath, mountedConfigsPath, finalConfigsPath, envVars)
+
+    val source = scala.io.Source.fromFile(finalConfigsPath.toString + "/server.properties")
+    val actual = try source.mkString finally source.close()
+    val expected = " \n \n "
 
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
This patch fixes an issue with the Docker image that fails when setting any env var.

```sh
$ docker run --rm -it -p 9092:9092 \
  -e KAFKA_NUM_NETWORK_THREADS=4 \
  apache/kafka:3.8.1
...
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Missing required configuration `zookeeper.connect` which has no default value. at kafka.server.KafkaConfig.validateValues(KafkaConfig.scala:1232) at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1223) at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:545) at kafka.tools.StorageTool$.$anonfun$execute$1(StorageTool.scala:72) at scala.Option.flatMap(Option.scala:283) at kafka.tools.StorageTool$.execute(StorageTool.scala:72) at kafka.tools.StorageTool$.main(StorageTool.scala:53) at kafka.docker.KafkaDockerWrapper$.main(KafkaDockerWrapper.scala:48) at kafka.docker.KafkaDockerWrapper.main(KafkaDockerWrapper.scala)
```

Basically, the KafkaDockerWrapper does not copy the default KRaft config before appending the user env vars as an override. The result is that you end up with a server.properties that contains only the env vars.

Additionally, if a user sets a custom empty config by mounting the wrong directory, the image silently runs the default configuration. This patch makes the image fail, so that the user can spot the error early on and correct the mount path.
