### PR TITLE
KAFKA-17850: fix leaking internal exception in state manager

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -144,7 +144,7 @@ public class ProcessingExceptionHandlerIntegrationTest {
             final StreamsException exception = assertThrows(StreamsException.class,
                 () -> inputTopic.pipeKeyValueList(events, TIMESTAMP, Duration.ZERO));
 
-            assertTrue(exception.getMessage().contains("java.lang.RuntimeException: Exception should be handled by processing exception handler"));
+            assertTrue(exception.getMessage().contains("Failed to flush cache of store KSTREAM-AGGREGATE-STATE-STORE-0000000001"));
             assertEquals(expectedProcessedRecords.size(), processor.theCapturedProcessor().processed().size());
             assertIterableEquals(expectedProcessedRecords, processor.theCapturedProcessor().processed());
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.LogAndContinueProcessingExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndFailProcessingExceptionHandler;
 import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -109,6 +111,52 @@ public class ProcessingExceptionHandlerIntegrationTest {
     }
 
     @Test
+    public void shouldFailWhenProcessingExceptionOccursFromFlushingCacheIfExceptionHandlerReturnsFail() {
+        final List<KeyValue<String, String>> events = Arrays.asList(
+            new KeyValue<>("ID123-1", "ID123-A1"),
+            new KeyValue<>("ID123-1", "ID123-A2"),
+            new KeyValue<>("ID123-1", "ID123-A3"),
+            new KeyValue<>("ID123-1", "ID123-A4")
+        );
+
+        final List<KeyValueTimestamp<String, String>> expectedProcessedRecords = Arrays.asList(
+            new KeyValueTimestamp<>("ID123-1", "1", TIMESTAMP.toEpochMilli()),
+            new KeyValueTimestamp<>("ID123-1", "2", TIMESTAMP.toEpochMilli())
+        );
+
+        final MockProcessorSupplier<String, String, Void, Void> processor = new MockProcessorSupplier<>();
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .stream("TOPIC_NAME", Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .count()
+            .toStream()
+            .mapValues(value -> value.toString())
+            .process(runtimeErrorProcessorSupplierMock())
+            .process(processor);
+
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndFailProcessingExceptionHandler.class);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), properties, Instant.ofEpochMilli(0L))) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic("TOPIC_NAME", new StringSerializer(), new StringSerializer());
+
+            final StreamsException exception = assertThrows(StreamsException.class,
+                () -> inputTopic.pipeKeyValueList(events, TIMESTAMP, Duration.ZERO));
+
+            assertTrue(exception.getMessage().contains("java.lang.RuntimeException: Exception should be handled by processing exception handler"));
+            assertEquals(expectedProcessedRecords.size(), processor.theCapturedProcessor().processed().size());
+            assertIterableEquals(expectedProcessedRecords, processor.theCapturedProcessor().processed());
+
+            final MetricName dropTotal = droppedRecordsTotalMetric();
+            final MetricName dropRate = droppedRecordsRateMetric();
+
+            assertEquals(0.0, driver.metrics().get(dropTotal).metricValue());
+            assertEquals(0.0, driver.metrics().get(dropRate).metricValue());
+        }
+    }
+
+    @Test
     public void shouldContinueWhenProcessingExceptionOccursIfExceptionHandlerReturnsContinue() {
         final List<KeyValue<String, String>> events = Arrays.asList(
             new KeyValue<>("ID123-1", "ID123-A1"),
@@ -149,6 +197,50 @@ public class ProcessingExceptionHandlerIntegrationTest {
             final MetricName dropRate = droppedRecordsRateMetric();
 
             assertEquals(2.0, driver.metrics().get(dropTotal).metricValue());
+            assertTrue((Double) driver.metrics().get(dropRate).metricValue() > 0.0);
+        }
+    }
+
+    @Test
+    public void shouldContinueWhenProcessingExceptionOccursFromFlushingCacheIfExceptionHandlerReturnsContinue() {
+        final List<KeyValue<String, String>> events = Arrays.asList(
+            new KeyValue<>("ID123-1", "ID123-A1"),
+            new KeyValue<>("ID123-1", "ID123-A2"),
+            new KeyValue<>("ID123-1", "ID123-A3"),
+            new KeyValue<>("ID123-1", "ID123-A4")
+        );
+
+        final List<KeyValueTimestamp<String, String>> expectedProcessedRecords = Arrays.asList(
+            new KeyValueTimestamp<>("ID123-1", "1", TIMESTAMP.toEpochMilli()),
+            new KeyValueTimestamp<>("ID123-1", "2", TIMESTAMP.toEpochMilli()),
+            new KeyValueTimestamp<>("ID123-1", "4", TIMESTAMP.toEpochMilli())
+        );
+
+        final MockProcessorSupplier<String, String, Void, Void> processor = new MockProcessorSupplier<>();
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .stream("TOPIC_NAME", Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .count()
+            .toStream()
+            .mapValues(value -> value.toString())
+            .process(runtimeErrorProcessorSupplierMock())
+            .process(processor);
+
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndContinueProcessingExceptionHandler.class);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), properties, Instant.ofEpochMilli(0L))) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic("TOPIC_NAME", new StringSerializer(), new StringSerializer());
+            inputTopic.pipeKeyValueList(events, TIMESTAMP, Duration.ZERO);
+
+            assertEquals(expectedProcessedRecords.size(), processor.theCapturedProcessor().processed().size());
+            assertIterableEquals(expectedProcessedRecords, processor.theCapturedProcessor().processed());
+
+            final MetricName dropTotal = droppedRecordsTotalMetric();
+            final MetricName dropRate = droppedRecordsRateMetric();
+
+            assertEquals(1.0, driver.metrics().get(dropTotal).metricValue());
             assertTrue((Double) driver.metrics().get(dropRate).metricValue() > 0.0);
         }
     }
@@ -377,7 +469,7 @@ public class ProcessingExceptionHandlerIntegrationTest {
         return () -> new ContextualProcessor<String, String, String, String>() {
             @Override
             public void process(final Record<String, String> record) {
-                if (record.key().contains("ERR")) {
+                if (record.key().contains("ERR") || record.value().equals("3")) {
                     throw new RuntimeException("Exception should be handled by processing exception handler");
                 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -549,9 +549,9 @@ public class ProcessorStateManager implements StateManager {
                         else
                             firstException = new ProcessorStateException(
                                 format("%sFailed to flush state store %s", logPrefix, store.name()), exception);
-                        log.error("Failed to flush cache of store {}: ", store.name(), firstException);
+                        log.error("Failed to flush state store {}: ", store.name(), firstException);
                     } else {
-                        log.error("Failed to flush cache of store {}: ", store.name(), exception);
+                        log.error("Failed to flush state store {}: ", store.name(), exception);
                     }
                 }
             }
@@ -584,7 +584,7 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException) {
                             firstException = new ProcessorStateException(
-                                format("%sFailed to flush state store %s", logPrefix, store.name()),
+                                format("%sFailed to flush cache of store %s", logPrefix, store.name()),
                                 exception.getCause());
                         } else if (exception instanceof StreamsException) {
                             firstException = exception;
@@ -636,16 +636,16 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
                             firstException = new ProcessorStateException(
-                                format("%sFailed to flush state store %s", logPrefix, store.name()),
+                                format("%sFailed to close state store %s", logPrefix, store.name()),
                                 exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
                             firstException = new ProcessorStateException(
                                 format("%sFailed to close state store %s", logPrefix, store.name()), exception);
-                        log.error("Failed to flush cache of store {}: ", store.name(), firstException);
+                        log.error("Failed to close state store {}: ", store.name(), firstException);
                     } else {
-                        log.error("Failed to flush cache of store {}: ", store.name(), exception);
+                        log.error("Failed to close state store {}: ", store.name(), exception);
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -541,7 +541,9 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
-                            firstException = new ProcessorStateException(exception.getCause());
+                            firstException = new ProcessorStateException(
+                                format("%sFailed to flush state store %s", logPrefix, store.name()),
+                                exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
@@ -581,7 +583,9 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException) {
-                            firstException = new ProcessorStateException(exception.getCause());
+                            firstException = new ProcessorStateException(
+                                format("%sFailed to flush state store %s", logPrefix, store.name()),
+                                exception.getCause());
                         } else if (exception instanceof StreamsException) {
                             firstException = exception;
                         } else {
@@ -631,7 +635,9 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
-                            firstException = new ProcessorStateException(exception.getCause());
+                            firstException = new ProcessorStateException(
+                                format("%sFailed to flush state store %s", logPrefix, store.name()),
+                                exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -541,14 +541,16 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
-                            firstException = new StreamsException(exception.getCause());
+                            firstException = new ProcessorStateException(exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
                             firstException = new ProcessorStateException(
                                 format("%sFailed to flush state store %s", logPrefix, store.name()), exception);
+                        log.error("Failed to flush cache of store {}: ", store.name(), firstException);
+                    } else {
+                        log.error("Failed to flush cache of store {}: ", store.name(), exception);
                     }
-                    log.error("Failed to flush state store {}: ", store.name(), exception.getCause());
                 }
             }
         }
@@ -579,7 +581,7 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException) {
-                            firstException = new StreamsException(exception.getCause());
+                            firstException = new ProcessorStateException(exception.getCause());
                         } else if (exception instanceof StreamsException) {
                             firstException = exception;
                         } else {
@@ -588,8 +590,10 @@ public class ProcessorStateManager implements StateManager {
                                 exception
                             );
                         }
+                        log.error("Failed to flush cache of store {}: ", store.name(), firstException);
+                    } else {
+                        log.error("Failed to flush cache of store {}: ", store.name(), exception);
                     }
-                    log.error("Failed to flush cache of store {}: ", store.name(), exception.getCause());
                 }
             }
         }
@@ -627,14 +631,16 @@ public class ProcessorStateManager implements StateManager {
                         // do NOT wrap the error if it is actually caused by Streams itself
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
-                            firstException = new StreamsException(exception.getCause());
+                            firstException = new ProcessorStateException(exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
                             firstException = new ProcessorStateException(
                                 format("%sFailed to close state store %s", logPrefix, store.name()), exception);
+                        log.error("Failed to flush cache of store {}: ", store.name(), firstException);
+                    } else {
+                        log.error("Failed to flush cache of store {}: ", store.name(), exception);
                     }
-                    log.error("Failed to close state store {}: ", store.name(), exception.getCause());
                 }
             }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockCacheKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockCacheKeyValueStore.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.streams.state.internals.CacheFlushListener;
+import org.apache.kafka.streams.state.internals.CachedStateStore;
+
+public class MockCacheKeyValueStore extends MockKeyValueStore implements CachedStateStore<Object, Object> {
+
+    public MockCacheKeyValueStore(String name, boolean persistent) {
+        super(name, persistent);
+    }
+
+    @Override
+    public boolean setFlushListener(CacheFlushListener<Object, Object> listener, boolean sendOldValues) {
+        return false;
+    }
+
+    @Override
+    public void flushCache() {
+
+    }
+
+    @Override
+    public void clearCache() {
+
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/test/MockCachedKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockCachedKeyValueStore.java
@@ -19,9 +19,9 @@ package org.apache.kafka.test;
 import org.apache.kafka.streams.state.internals.CacheFlushListener;
 import org.apache.kafka.streams.state.internals.CachedStateStore;
 
-public class MockCacheKeyValueStore extends MockKeyValueStore implements CachedStateStore<Object, Object> {
+public class MockCachedKeyValueStore extends MockKeyValueStore implements CachedStateStore<Object, Object> {
 
-    public MockCacheKeyValueStore(String name, boolean persistent) {
+    public MockCachedKeyValueStore(String name, boolean persistent) {
         super(name, persistent);
     }
 


### PR DESCRIPTION
Following the [KIP-1033](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1033%3A+Add+Kafka+Streams+exception+handler+for+exceptions+occurring+during+processing) a FailedProcessingException is passed to the Streams-specific uncaught exception handler.

The goal of the PR is to unwrap a FailedProcessingException into a StreamsException when an exception occurs during the flushing or closing of a store
