### PR TITLE
KAFKA-17910: Create integration tests for Admin.listGroups and Admin.describeClassicGroups

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
@@ -17,27 +17,52 @@
 package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AdminClientTestUtils;
+import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.GroupListing;
 import org.apache.kafka.clients.admin.ListGroupsResult;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.GroupProtocol;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.KafkaShareConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.test.api.ClusterConfigProperty;
+import org.apache.kafka.common.test.api.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestExtensions;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Timeout(value = 60)
+@ExtendWith(ClusterTestExtensions.class)
 public class GroupsCommandTest {
 
     private final String bootstrapServer = "localhost:9092";
@@ -357,6 +382,122 @@ public class GroupsCommandTest {
         )));
     }
 
+    @SuppressWarnings("NPathComplexity")
+    @ClusterTest(
+        serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,share"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
+        }
+    )
+    public void testGroupCommand(ClusterInstance clusterInstance) throws Exception {
+        String topic = "topic";
+        String classicGroupId = "classic_group";
+        String consumerGroupId = "consumer_group";
+        String shareGroupId = "share_group";
+        String simpleGroupId = "simple_group";
+        clusterInstance.createTopic("topic", 1, (short) 1);
+        TopicPartition topicPartition = new TopicPartition(topic, 0);
+
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+
+        try (KafkaConsumer<String, String> classicGroup = createKafkaConsumer(clusterInstance, classicGroupId, GroupProtocol.CLASSIC);
+             KafkaConsumer<String, String> consumerGroup = createKafkaConsumer(clusterInstance, consumerGroupId, GroupProtocol.CONSUMER);
+             KafkaShareConsumer<String, String> shareGroup = createKafkaShareConsumer(clusterInstance, shareGroupId);
+             Admin admin = clusterInstance.admin();
+             GroupsCommand.GroupsService groupsCommand = new GroupsCommand.GroupsService(props)
+        ) {
+            classicGroup.subscribe(List.of(topic));
+            classicGroup.poll(Duration.ofMillis(1000));
+            consumerGroup.subscribe(List.of(topic));
+            consumerGroup.poll(Duration.ofMillis(1000));
+            shareGroup.subscribe(List.of(topic));
+            shareGroup.poll(Duration.ofMillis(1000));
+
+            AlterConsumerGroupOffsetsResult result = admin.alterConsumerGroupOffsets(simpleGroupId, Map.of(topicPartition, new OffsetAndMetadata(0L)));
+            assertNull(result.all().get());
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 5 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{classicGroupId, "Classic", "consumer"},
+                        new String[]{consumerGroupId, "Consumer", "consumer"},
+                        new String[]{simpleGroupId, "Classic"},
+                        new String[]{shareGroupId, "Share", "share"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return all groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--consumer").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 4 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{classicGroupId, "Classic", "consumer"},
+                        new String[]{consumerGroupId, "Consumer", "consumer"},
+                        new String[]{simpleGroupId, "Classic"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return consumer protocol groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--group-type", "classic").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 3 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{classicGroupId, "Classic", "consumer"},
+                        new String[]{simpleGroupId, "Classic"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return classic type groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--group-type", "consumer").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{consumerGroupId, "Consumer", "consumer"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return consumer type groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--group-type", "share").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{shareGroupId, "Share", "share"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return share type groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--share").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{shareGroupId, "Share", "share"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return share type groups");
+        }
+    }
+
     private void assertInitializeInvalidOptionsExitCode(int expected, String[] options) {
         Exit.setExitProcedure((exitCode, message) -> {
             assertEquals(expected, exitCode);
@@ -377,5 +518,22 @@ public class GroupsCommandTest {
         for (String[] line : expectedLines) {
             assertEquals(String.join(",", line), String.join(",", capturedLines[i++].split(" +")));
         }
+    }
+
+    private KafkaConsumer<String, String> createKafkaConsumer(ClusterInstance clusterInstance, String groupId, GroupProtocol groupProtocol) {
+        return new KafkaConsumer<>(Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers(),
+            ConsumerConfig.GROUP_ID_CONFIG, groupId,
+            ConsumerConfig.GROUP_PROTOCOL_CONFIG, groupProtocol.name,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()));
+    }
+
+    private KafkaShareConsumer<String, String> createKafkaShareConsumer(ClusterInstance clusterInstance, String groupId) {
+        return new KafkaShareConsumer<>(Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers(),
+            ConsumerConfig.GROUP_ID_CONFIG, groupId,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()));
     }
 }


### PR DESCRIPTION
Followup: https://github.com/apache/kafka/pull/17626#discussion_r1824798591

Add integration test for `GroupsCommand`, `Admin.listGroups`, and `Admin.describeClassicGroups`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
