### PR TITLE
KAFKA-17635: Only purge committed offsets

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1003,10 +1003,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     @Override
     public Map<TopicPartition, Long> purgeableOffsets() {
         final Map<TopicPartition, Long> purgeableConsumedOffsets = new HashMap<>();
-        for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
+        for (final Map.Entry<TopicPartition, Long> entry : committedOffsets.entrySet()) {
             final TopicPartition tp = entry.getKey();
             if (topology.isRepartitionTopic(tp.topic())) {
-                purgeableConsumedOffsets.put(tp, entry.getValue() + 1);
+                // committedOffsets map is initialized at -1 so no purging until there's a committed offset
+                if (entry.getValue() > -1) {
+                    purgeableConsumedOffsets.put(tp, entry.getValue());
+                }
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1752,7 +1752,18 @@ public class StreamTaskTest {
     }
 
     @Test
-    public void shouldReturnOffsetsForRepartitionTopicsForPurging() {
+    public void shouldReturnCommittedOffsetsForRepartitionTopicsForPurging() {
+        final Map<TopicPartition, Long> purgeableOffsets = doReturnPurgeableOffsets(true);
+        assertThat(purgeableOffsets, equalTo(singletonMap(new TopicPartition("repartition", 1), 10L)));
+    }
+
+    @Test
+    public void shouldReturnEmptyMapWhenNoCommitForRepartitionTopicsForPurging() {
+        final Map<TopicPartition, Long> purgeableOffsets = doReturnPurgeableOffsets(false);
+        assertThat(purgeableOffsets, equalTo(Collections.emptyMap()));
+    }
+
+    private Map<TopicPartition, Long> doReturnPurgeableOffsets(final boolean doCommit) {
         final TopicPartition repartition = new TopicPartition("repartition", 1);
 
         final ProcessorTopology topology = withRepartitionTopics(
@@ -1787,7 +1798,7 @@ public class StreamTaskTest {
             context,
             logContext,
             false
-            );
+        );
 
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
@@ -1802,10 +1813,11 @@ public class StreamTaskTest {
         assertTrue(task.process(0L));
 
         task.prepareCommit();
+        if (doCommit) {
+            task.updateCommittedOffsets(repartition, 10L);
+        }
 
-        final Map<TopicPartition, Long> map = task.purgeableOffsets();
-
-        assertThat(map, equalTo(singletonMap(repartition, 11L)));
+        return task.purgeableOffsets();
     }
 
     @Test


### PR DESCRIPTION
This is a backport of #17686 merged to trunk and cherry-picked to 3.9. 
Need to do a standalone PR due to merge conflicts.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
