### PR TITLE
KAFKA-17969: Fix StorageToolTest for 3.9

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -325,7 +325,7 @@ Found problem:
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream = new ByteArrayOutputStream()
     assertEquals(0, runFormatCommand(stream, properties, Seq("--feature", "metadata.version=20")))
-    assertTrue(stream.toString().contains("3.9-IV0"),
+    assertTrue(stream.toString().contains("3.8-IV0"),
       "Failed to find content in output: " + stream.toString())
   }
 
@@ -336,7 +336,7 @@ Found problem:
     properties.putAll(defaultStaticQuorumProperties)
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     assertEquals("Unsupported feature: non.existent.feature. Supported features are: " +
-      "group.version, kraft.version, transaction.version",
+      "kraft.version, transaction.version",
         assertThrows(classOf[FormatterException], () =>
           runFormatCommand(new ByteArrayOutputStream(), properties,
             Seq("--feature", "non.existent.feature=20"))).getMessage)


### PR DESCRIPTION
Fix StorageToolTest#testFormatWithReleaseVersionAsFeature and StorageToolTest#testFormatWithInvalidFeature for 3.9

The command passes on my end after the fix.
`./gradlew core:test --tests StorageToolTest`

JIRA: https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-17969

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
