### PR TITLE
KAFKA-15549: Bump swagger dependency version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -260,7 +260,7 @@ scala-library-2.13.15
 scala-logging_2.13-3.9.5
 scala-reflect-2.13.15
 snappy-java-1.1.10.5
-swagger-annotations-2.2.8
+swagger-annotations-2.2.25
 zookeeper-3.8.4
 zookeeper-jute-3.8.4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,7 @@ group=org.apache.kafka
 version=4.0.0-SNAPSHOT
 scalaVersion=2.13.15
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-# New version of Swagger 2.2.14 requires minimum JDK 11.
-swaggerVersion=2.2.8
+swaggerVersion=2.2.25
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
Now, we can use swagger 2.2.25, as we're using JDK 11 as the minimum version.

JIRA: https://issues.apache.org/jira/browse/KAFKA-15549

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
