### PR TITLE
KAFKA-17601: Inter-broker connections do not expose their clientSoftwareName and clientSoftwareVersion tags

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -41,7 +41,9 @@ public class RequestContext implements AuthorizableRequestContext {
     public final KafkaPrincipal principal;
     public final ListenerName listenerName;
     public final SecurityProtocol securityProtocol;
-    public final ClientInformation clientInformation;
+    // The client information can be updated if the request is ApiVersionRequest,
+    // so the client information will not be unknown for ApiVersionRequest.
+    public ClientInformation clientInformation;
     public final boolean fromPrivilegedListener;
     public final Optional<KafkaPrincipalSerde> principalSerde;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -42,7 +42,9 @@ public class RequestContext implements AuthorizableRequestContext {
     public final KafkaPrincipal principal;
     public final ListenerName listenerName;
     public final SecurityProtocol securityProtocol;
-    public final ClientInformation clientInformation;
+    // The client information can be updated if the request is ApiVersionRequest,
+    // so the client information will not be unknown for ApiVersionRequest.
+    public ClientInformation clientInformation;
     public final boolean fromPrivilegedListener;
     public final Optional<KafkaPrincipalSerde> principalSerde;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -31,6 +31,7 @@ import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
 
@@ -42,9 +43,8 @@ public class RequestContext implements AuthorizableRequestContext {
     public final KafkaPrincipal principal;
     public final ListenerName listenerName;
     public final SecurityProtocol securityProtocol;
-    // The client information can be updated if the request is ApiVersionRequest,
-    // so the client information will not be unknown for ApiVersionRequest.
-    public ClientInformation clientInformation;
+    private ClientInformation clientInformation;
+    private final AtomicBoolean hasUpdatedClientInformation = new AtomicBoolean(false);
     public final boolean fromPrivilegedListener;
     public final Optional<KafkaPrincipalSerde> principalSerde;
 
@@ -166,6 +166,22 @@ public class RequestContext implements AuthorizableRequestContext {
 
     public String connectionId() {
         return connectionId;
+    }
+
+    public void setClientInformation(ClientInformation clientInformation) {
+        // We only allow updating the client information once, and only if the
+        // current client information is UNKNOWN. This ensures that a malicious
+        // client cannot override a well-known client information with an
+        // arbitrary one.
+        if (hasUpdatedClientInformation.compareAndSet(false, true)) {
+            if (this.clientInformation == ClientInformation.EMPTY) {
+                this.clientInformation = clientInformation;
+            }
+        }
+    }
+
+    public ClientInformation clientInformation() {
+        return clientInformation;
     }
 
     @Override

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1145,6 +1145,7 @@ private[kafka] class Processor(
                     channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
                       apiVersionsRequest.data.clientSoftwareName,
                       apiVersionsRequest.data.clientSoftwareVersion))
+                    context.clientInformation = channel.channelMetadataRegistry.clientInformation
                   }
                 }
                 requestChannel.sendRequest(req)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1035,6 +1035,7 @@ private[kafka] class Processor(
                     channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
                       apiVersionsRequest.data.clientSoftwareName,
                       apiVersionsRequest.data.clientSoftwareVersion))
+                    context.clientInformation = channel.channelMetadataRegistry.clientInformation
                   }
                 }
                 requestChannel.sendRequest(req)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1035,7 +1035,8 @@ private[kafka] class Processor(
                     channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
                       apiVersionsRequest.data.clientSoftwareName,
                       apiVersionsRequest.data.clientSoftwareVersion))
-                    context.clientInformation = channel.channelMetadataRegistry.clientInformation
+                    // Update client information for ApiVersionRequest, so the client information will not be unknown for ApiVersionRequest.
+                    context.setClientInformation(channel.channelMetadataRegistry.clientInformation)
                   }
                 }
                 requestChannel.sendRequest(req)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -274,8 +274,8 @@ class SocketServerTest {
     sendRequest(plainSocket, apiVersionRequestBytes(clientId, version))
     var receivedReq = receiveRequest(server.dataPlaneRequestChannel)
 
-    assertEquals(ClientInformation.UNKNOWN_NAME_OR_VERSION, receivedReq.context.clientInformation.softwareName)
-    assertEquals(ClientInformation.UNKNOWN_NAME_OR_VERSION, receivedReq.context.clientInformation.softwareVersion)
+    assertEquals(expectedClientSoftwareName, receivedReq.context.clientInformation.softwareName)
+    assertEquals(expectedClientSoftwareVersion, receivedReq.context.clientInformation.softwareVersion)
 
     server.dataPlaneRequestChannel.sendNoOpResponse(receivedReq)
 

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -272,7 +272,7 @@ class SocketServerTest {
     val address = plainSocket.getLocalAddress
     val clientId = "clientId"
 
-    // Send ApiVersionsRequest - unknown expected
+    // Send ApiVersionsRequest - if version < 3, unknown expected. Otherwise, client info expected.
     sendRequest(plainSocket, apiVersionRequestBytes(clientId, version))
     var receivedReq = receiveRequest(server.dataPlaneRequestChannel)
 

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -276,8 +276,8 @@ class SocketServerTest {
     sendRequest(plainSocket, apiVersionRequestBytes(clientId, version))
     var receivedReq = receiveRequest(server.dataPlaneRequestChannel)
 
-    assertEquals(ClientInformation.UNKNOWN_NAME_OR_VERSION, receivedReq.context.clientInformation.softwareName)
-    assertEquals(ClientInformation.UNKNOWN_NAME_OR_VERSION, receivedReq.context.clientInformation.softwareVersion)
+    assertEquals(expectedClientSoftwareName, receivedReq.context.clientInformation.softwareName)
+    assertEquals(expectedClientSoftwareVersion, receivedReq.context.clientInformation.softwareVersion)
 
     server.dataPlaneRequestChannel.sendNoOpResponse(receivedReq)
 

--- a/server/src/main/java/org/apache/kafka/network/Request.java
+++ b/server/src/main/java/org/apache/kafka/network/Request.java
@@ -358,7 +358,7 @@ public final class Request implements BaseRequest {
         for (String metricName : overrideMetricNames) {
             RequestMetrics m = metrics.get(metricName);
             m.requestRate(header().apiVersion()).mark();
-            m.deprecatedRequestRate(header().apiKey(), header().apiVersion(), context.clientInformation)
+            m.deprecatedRequestRate(header().apiKey(), header().apiVersion(), context.clientInformation())
                 .ifPresent(Meter::mark);
             m.requestQueueTimeHist.update(Math.round(requestQueueTimeMs));
             m.localTimeHist.update(Math.round(apiLocalTimeMs));

--- a/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
+++ b/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
@@ -805,7 +805,7 @@ public class RequestConvertToJson {
         node.set("securityProtocol", new TextNode(context.securityProtocol.toString()));
         node.set("principal", new TextNode(session.principal.toString()));
         node.set("listener", new TextNode(context.listenerName.value()));
-        node.set("clientInformation", clientInfoNode(context.clientInformation));
+        node.set("clientInformation", clientInfoNode(context.clientInformation()));
         if (temporaryMemoryBytes > 0) {
             node.set("temporaryMemoryBytes", new LongNode(temporaryMemoryBytes));
         }

--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadata.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadata.java
@@ -39,10 +39,10 @@ public class ClientMetricsInstanceMetadata {
 
         attributesMap.put(ClientMetricsConfigs.CLIENT_INSTANCE_ID, clientInstanceId.toString());
         attributesMap.put(ClientMetricsConfigs.CLIENT_ID, requestContext.clientId());
-        attributesMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_NAME, requestContext.clientInformation != null ?
-            requestContext.clientInformation.softwareName() : null);
-        attributesMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION, requestContext.clientInformation != null ?
-            requestContext.clientInformation.softwareVersion() : null);
+        attributesMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_NAME, requestContext.clientInformation() != null ?
+            requestContext.clientInformation().softwareName() : null);
+        attributesMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION, requestContext.clientInformation() != null ?
+            requestContext.clientInformation().softwareVersion() : null);
         attributesMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, requestContext.clientAddress != null ?
             requestContext.clientAddress.getHostAddress() : null);
         attributesMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, requestContext.clientPort.map(String::valueOf).orElse(null));


### PR DESCRIPTION
When Kafka brokers are connecting to other brokers this information is
not properly populated, we see the "unknown" value instead for both
`ClientSoftwareName` and `ClientSoftwareVersion`. The reason is that we
updated `ClientInformation` in `ChannelMetadataRegistry` after we built
`RequestConext`. We should initialize `ClientInformation` before setup
`RequestContext`.

Reviewers: Ismael Juma <ijuma@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>, Kirk True <kirk@kirktrue.pro>
