### PR TITLE
KAFKA-17979: Change [pytest] to [tool:pytest] in setup.cfg file

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ https://cwiki.apache.org/confluence/display/KAFKA/tutorial+-+set+up+and+run+Kafk
         $ cd kafka/tests
         $ virtualenv -p python3 venv
         $ . ./venv/bin/activate
-        $ python3 setup.py develop
+        $ python3 -m pip install --editable .
         $ cd ..  # back to base kafka directory
 
 * Run the bootstrap script to set up Vagrant for testing

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -20,7 +20,7 @@
 #
 # To ease possible confusion, 'check' instead of 'test' as a prefix for unit tests, since
 # many system test files, classes, and methods have 'test' somewhere in the name
-[pytest]
+[tool:pytest]
 testpaths=unit
 python_files=check_*.py
 python_classes=Check

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,27 +15,24 @@
 
 import re
 import sys
-from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
+from setuptools import find_packages, setup, Command
 
 version = ''
 with open('kafkatest/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
 
 
-class PyTest(TestCommand):
+class PyTest(Command):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
     def initialize_options(self):
-        TestCommand.initialize_options(self)
         self.pytest_args = []
 
     def finalize_options(self):
-        TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
 
-    def run_tests(self):
+    def run(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
         print(self.pytest_args)
@@ -51,8 +48,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.12.0", "requests==2.31.0", "psutil==5.7.2"],
-      tests_require=["pytest", "mock"],
+      install_requires=["ducktape==0.12.0", "requests==2.31.0", "psutil==5.7.2", "pytest==8.3.3", "mock==5.1.0"],
       cmdclass={'test': PyTest},
       zip_safe=False
       )

--- a/tests/unit/setup.cfg
+++ b/tests/unit/setup.cfg
@@ -17,7 +17,7 @@
 #
 # To ease possible confusion, prefix muckrake *unit* tests with 'check' instead of 'test', since
 # many muckrake files, classes, and methods have 'test' somewhere in the name
-[pytest]
+[tool:pytest]
 python_files=check_*.py
 python_classes=Check
 python_functions=check_*


### PR DESCRIPTION
* The `[pytest]` is deprecated in `setup.cfg`. Change it to `[tool:pytest]`.
* The `python3 setup.py develop` is deprecated. Change it to `python -m pip install --editable .`. [0]
* The `setuptools.command.test` is deprecated. Change it to `Command`.
```
SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        By 2024-Nov-15, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
```
* The `tests_require` option is deprecated. Move `pytest` and `mock` packages to `install_requires`.
```
from setuptools.command.test import test as TestCommand
apache/kafka/tests/venv/lib/python3.10/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'tests_require'
  warnings.warn(msg)
```

### Test steps to check result:

```
> cd kafka/tests
> virtualenv -p python3 venv
> . ./venv/bin/activate
> python -m pip install --editable .
> python3 setup.py test
running test
[]
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.10.13, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/frankyang/Project/apache/kafka/tests
configfile: setup.cfg
testpaths: unit
plugins: typeguard-4.3.0
collected 6 items

unit/directory_layout/check_project_paths.py .....                                                                                                                                [ 83%]
unit/version/check_version.py .                                                                                                                                                   [100%]

=================================================================================== warnings summary ====================================================================================
kafkatest/version.py:44: 71 warnings
unit/directory_layout/check_project_paths.py: 1 warning
  /home/frankyang/Project/apache/kafka/tests/kafkatest/version.py:44: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    LooseVersion.__init__(self, version_string)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 6 passed, 72 warnings in 0.02s =============================================================================
```

[0] https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-setup-py-deprecated

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
