### PR TITLE
KAFKA-17982: Configurable JMX Port for Metrics Collection for Kafka Connect

### DIFF
--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -87,3 +87,7 @@ offset.flush.interval.ms=10000
 # Examples: 
 # plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors,
 #plugin.path=
+
+
+#kafka connect configurable jmx port for connect obeservability.
+kafka.connect.jmx.port=9994


### PR DESCRIPTION
Apache Jira - [KAFKA-17982](https://issues.apache.org/jira/browse/KAFKA-17982)

Tested locally on multi-node cluster by launching multiple connect processes with configurable port for JMX metrix configuration.  With this change, it will be able to read JMX metrics on defined port in `connect-distributed.properties` file


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
