### PR TITLE
KAFKA-17983: Configurable JMX Port for Metrics Collection for Kafka MirrorMaker

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -220,6 +220,36 @@ if [  $JMX_PORT ]; then
   fi
 fi
 
+#Kafka MirrorMaker - PORT configurable purpose
+KAFKA_MIRRORMAKER_CONFIGFILE="$base_dir"/config/connect-mirror-maker.properties
+
+# Fetch Kafka Connect JMX port from the configuration file if it exists
+if [ -f "$KAFKA_MIRRORMAKER_CONFIGFILE" ]; then
+        MIRRORMAKER_JMX_PORT=$(grep "^kafka.mirrormaker.jmx.port=" "$KAFKA_MIRRORMAKER_CONFIGFILE" | cut -d'=' -f2)
+fi
+
+# Use the port from the config file if found, otherwise set a default
+if [ -z "$MIRRORMAKER_JMX_PORT" ]; then
+  KAFKA_MIRRORMAKER_JMX_PORT=9998  # Default JMX port
+else
+  KAFKA_MIRRORMAKER_JMX_PORT=$MIRRORMAKER_JMX_PORT
+fi
+
+# Check if the process is for Kafka mm
+IS_KAFKA_MIRRORMAKER=false
+for arg in "$@"; do
+  if [[ "$arg" == "org.apache.kafka.connect.mirror.MirrorMaker" ]]; then
+    IS_KAFKA_MIRRORMAKER=true
+    break
+  fi
+done
+
+# Set JMX options based on whether it's Kafka mm
+if $IS_KAFKA_MIRRORMAKER; then
+  # JMX options for Kafka MIRROR_MAKER
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=$KAFKA_MIRRORMAKER_JMX_PORT"
+fi
+
 # Log directory to use
 if [ "x$LOG_DIR" = "x" ]; then
   LOG_DIR="$base_dir/logs"

--- a/config/connect-mirror-maker.properties
+++ b/config/connect-mirror-maker.properties
@@ -57,3 +57,8 @@ config.storage.replication.factor=1
 # replication.policy.separator = _
 # sync.topic.acls.enabled = false
 # emit.heartbeats.interval.seconds = 5
+
+#Specifies the JMX (Java Management Extensions) port for Kafka MirrorMaker. This port enables remote monitoring and
+# management of MirrorMaker processes through JMX clients, allowing for improved visibility into performance metrics
+# and operational states. Adjusting this port may be necessary for firewall or network configuration requirements.
+kafka.mirrormaker.jmx.port=9998


### PR DESCRIPTION
Apache Jira - [KAFKA-17983](https://issues.apache.org/jira/browse/KAFKA-17983).

Tested locally on multi-node cluster by launching MirrorMaker processes with configurable port for JMX metrix. With this change, it will be able to read JMX metrics on defined port in connect-mirror-maker.properties file



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
