### PR TITLE
KAFKA-17985: Set share.auto.offset.reset to earliest in ShareRoundTripWorker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2469,10 +2469,15 @@ project(':trogdor') {
     implementation libs.jettyServlet
     implementation libs.jettyServlets
 
+    implementation project(':group-coordinator')
+    implementation project(':group-coordinator:group-coordinator-api')
+
     testImplementation project(':clients')
     testImplementation libs.junitJupiter
     testImplementation project(':clients').sourceSets.test.output
     testImplementation libs.mockitoCore
+
+    testImplementation project(':group-coordinator')
 
     testRuntimeOnly runtimeTestLibs
   }

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -368,6 +368,7 @@
     <allow pkg="org.apache.kafka.common" />
     <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.kafka.trogdor" />
+    <allow pkg="org.apache.kafka.coordinator" />
     <allow pkg="org.eclipse.jetty" />
     <allow pkg="org.glassfish.jersey" />
   </subpackage>

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -333,7 +333,7 @@ public final class WorkerUtils {
         return out;
     }
 
-    private static Admin createAdminClient(
+    public static Admin createAdminClient(
         String bootstrapServers,
         Map<String, String> commonClientConf, Map<String, String> adminClientConf) {
         Properties props = new Properties();

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareRoundTripWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareRoundTripWorker.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupConfig;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareRoundTripWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareRoundTripWorker.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupConfig;
+import org.apache.kafka.trogdor.common.WorkerUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,10 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.kafka.trogdor.common.WorkerUtils.addConfigsToProperties;
-import static org.apache.kafka.trogdor.common.WorkerUtils.createAdminClient;
-
 
 public class ShareRoundTripWorker extends RoundTripWorkerBase {
     private static final Logger log = LoggerFactory.getLogger(ShareRoundTripWorker.class);
@@ -63,12 +60,12 @@ public class ShareRoundTripWorker extends RoundTripWorkerBase {
         props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
         props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 100000);
         // user may over-write the defaults with common client config and consumer config
-        addConfigsToProperties(props, spec.commonClientConf(), spec.consumerConf());
+        WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.consumerConf());
 
         String groupId = "round-trip-share-group-" + id;
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 
-        try (Admin adminClient = createAdminClient(spec.bootstrapServers(), spec.commonClientConf(), spec.adminClientConf())) {
+        try (Admin adminClient = WorkerUtils.createAdminClient(spec.bootstrapServers(), spec.commonClientConf(), spec.adminClientConf())) {
             alterShareAutoOffsetReset(groupId, "earliest", adminClient);
         } catch (Exception e) {
             log.warn("Failed to set share.auto.offset.reset config to 'earliest' mode", e);


### PR DESCRIPTION
*What*
After the `share.auto.offset.reset` dynamic config was added for share groups in this commit - https://github.com/apache/kafka/commit/9db5ed00a8369d5c696e836661230110ea2ea44d, we needed to update this config value to "earliest" in ShareRoundTripWorker when it creates the consumer.