### PR TITLE
KAFKA-17991: Added timed calls for future.get in persister.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -340,6 +340,10 @@
     <suppress checks="CyclomaticComplexity"
               files="ShareCoordinatorShard.java"/>
 
+    <!-- share -->
+    <suppress checks="ClassDataAbstractionCoupling"
+              files="DefaultStatePersisterTest.java"/>
+
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"
               files="(LogLoader|LogValidator|RemoteLogManagerConfig|RemoteLogManager).java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -340,10 +340,6 @@
     <suppress checks="CyclomaticComplexity"
               files="ShareCoordinatorShard.java"/>
 
-    <!-- share -->
-    <suppress checks="ClassDataAbstractionCoupling"
-              files="DefaultStatePersisterTest.java"/>
-
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"
               files="(LogLoader|LogValidator|RemoteLogManagerConfig|RemoteLogManager).java"/>

--- a/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -119,7 +121,14 @@ public class DefaultStatePersister implements Persister {
         return combinedFuture.thenApply(v -> writeResponsesToResult(futureMap));
     }
 
-    private WriteShareGroupStateResult writeResponsesToResult(
+    /**
+     * Takes in a list of COMPLETED futures and combines the results,
+     * taking care of errors if any, into a single WriteShareGroupStateResult
+     * @param futureMap - HashMap of {topic -> {part -> future}}
+     * @return Object representing combined result of type WriteShareGroupStateResult
+     */
+    // visible for testing
+    WriteShareGroupStateResult writeResponsesToResult(
         Map<Uuid, Map<Integer, CompletableFuture<WriteShareGroupStateResponse>>> futureMap
     ) {
         List<TopicData<PartitionErrorData>> topicsData = futureMap.keySet().stream()
@@ -129,14 +138,15 @@ public class DefaultStatePersister implements Persister {
                         int partition = partitionFuture.getKey();
                         CompletableFuture<WriteShareGroupStateResponse> future = partitionFuture.getValue();
                         try {
-                            WriteShareGroupStateResponse partitionResponse = future.get();
+                            // already completed because of allOf application in the caller
+                            WriteShareGroupStateResponse partitionResponse = future.get(0, TimeUnit.MILLISECONDS);
                             return partitionResponse.data().results().get(0).partitions().stream()
                                 .map(partitionResult -> PartitionFactory.newPartitionErrorData(
                                     partitionResult.partition(),
                                     partitionResult.errorCode(),
                                     partitionResult.errorMessage()))
                                 .collect(Collectors.toList());
-                        } catch (InterruptedException | ExecutionException e) {
+                        } catch (InterruptedException | ExecutionException | TimeoutException e) {
                             log.error("Unexpected exception while writing data to share coordinator", e);
                             return Collections.singletonList(PartitionFactory.newPartitionErrorData(
                                 partition,
@@ -201,7 +211,14 @@ public class DefaultStatePersister implements Persister {
         return combinedFuture.thenApply(v -> readResponsesToResult(futureMap));
     }
 
-    private ReadShareGroupStateResult readResponsesToResult(
+    /**
+     * Takes in a list of COMPLETED futures and combines the results,
+     * taking care of errors if any, into a single ReadShareGroupStateResult
+     * @param futureMap - HashMap of {topic -> {part -> future}}
+     * @return Object representing combined result of type ReadShareGroupStateResult
+     */
+    // visible for testing
+    ReadShareGroupStateResult readResponsesToResult(
         Map<Uuid, Map<Integer, CompletableFuture<ReadShareGroupStateResponse>>> futureMap
     ) {
         List<TopicData<PartitionAllData>> topicsData = futureMap.keySet().stream()
@@ -211,7 +228,8 @@ public class DefaultStatePersister implements Persister {
                         int partition = partitionFuture.getKey();
                         CompletableFuture<ReadShareGroupStateResponse> future = partitionFuture.getValue();
                         try {
-                            ReadShareGroupStateResponse partitionResponse = future.get();
+                            // already completed because of allOf call in the caller
+                            ReadShareGroupStateResponse partitionResponse = future.get(0, TimeUnit.MILLISECONDS);
                             return partitionResponse.data().results().get(0).partitions().stream()
                                 .map(partitionResult -> PartitionFactory.newPartitionAllData(
                                     partitionResult.partition(),
@@ -222,7 +240,7 @@ public class DefaultStatePersister implements Persister {
                                     partitionResult.stateBatches().stream().map(PersisterStateBatch::from).collect(Collectors.toList())
                                 ))
                                 .collect(Collectors.toList());
-                        } catch (InterruptedException | ExecutionException e) {
+                        } catch (InterruptedException | ExecutionException | TimeoutException e) {
                             log.error("Unexpected exception while getting data from share coordinator", e);
                             return Collections.singletonList(PartitionFactory.newPartitionAllData(
                                 partition,

--- a/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -656,7 +656,7 @@ class DefaultStatePersisterTest {
         futureMap.computeIfAbsent(tp3.topicId(), k -> new HashMap<>())
             .put(tp3.partition(), CompletableFuture.failedFuture(new ExecutionException(new Exception("some execution problem"))));
 
-        // one entry has execution failure future
+        // one entry has timeout
         futureMap.computeIfAbsent(tp4.topicId(), k -> new HashMap<>())
             .put(tp4.partition(), CompletableFuture.failedFuture(new TimeoutException("timeout happened")));
 
@@ -792,7 +792,7 @@ class DefaultStatePersisterTest {
         futureMap.computeIfAbsent(tp3.topicId(), k -> new HashMap<>())
             .put(tp3.partition(), CompletableFuture.failedFuture(new ExecutionException(new Exception("some execution problem"))));
 
-        // one entry has timeout exception
+        // one entry has timeout
         futureMap.computeIfAbsent(tp4.topicId(), k -> new HashMap<>())
             .put(tp4.partition(), CompletableFuture.failedFuture(new TimeoutException("timeout happened")));
 

--- a/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -396,7 +396,8 @@ class DefaultStatePersisterTest {
 
         WriteShareGroupStateResult result = null;
         try {
-            result = resultFuture.get(100L, TimeUnit.MILLISECONDS);
+            // adding long delay to allow for environment/GC issues
+            result = resultFuture.get(10L, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("Unexpected exception", e);
         }
@@ -540,7 +541,8 @@ class DefaultStatePersisterTest {
 
         ReadShareGroupStateResult result = null;
         try {
-            result = resultFuture.get(100L, TimeUnit.MILLISECONDS);
+            // adding long delay to allow for environment/GC issues
+            result = resultFuture.get(10L, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("Unexpected exception", e);
         }


### PR DESCRIPTION
 * Currently, we are fetching results from futures using `future.get()` calls in `DefaultStatePersisterTest`. This may cause subtle issues resulting in hanging tests.
* In this PR, the issue is resolved by replacing `get()` calls with `get(timeout)`.
* Also, in the  `DefaultStatePersister` class, calls to `future.get` were replaced with `future.join` since in the concerned code, the futures are already completed when this call is made as the futures are combined using `allOf` and then passed to `thenApply`.
* Few new tests have been added to `DefaultStatePersisterTest` to test various cases of extracting results from the futures - taking care of exceptional cases.