### PR TITLE
KAFKA-16460: New consumer times out consuming records in multiple consumer_test.py system tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -851,6 +851,10 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
                 revokedPartitions
         );
 
+        // Mark partitions as pending revocation to stop fetching from the partitions (no new
+        // fetches sent out, and no in-flight fetches responses processed).
+        markPendingRevocationToPauseFetching(revokedPartitions);
+
         // Commit offsets if auto-commit enabled before reconciling a new assignment. Request will
         // be retried until it succeeds, fails with non-retriable error, or timer expires.
         CompletableFuture<Void> commitResult;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -1100,6 +1100,7 @@ public class ShareMembershipManagerTest {
 
         verifyReconciliationNotTriggered(membershipManager);
         membershipManager.poll(time.milliseconds());
+        verify(subscriptionState).markPendingRevocation(Set.of());
 
         // Member should complete reconciliation
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
@@ -1123,6 +1124,7 @@ public class ShareMembershipManagerTest {
         receiveAssignment(topicId, Collections.singletonList(1), membershipManager);
 
         membershipManager.poll(time.milliseconds());
+        verify(subscriptionState, times(2)).markPendingRevocation(Set.of(new TopicPartition(topicName, 0)));
 
         // Revocation should complete without requesting any metadata update given that the topic
         // received in target assignment should exist in local topic name cache.
@@ -1423,7 +1425,6 @@ public class ShareMembershipManagerTest {
         assertEquals(assignmentByTopicId, membershipManager.currentAssignment().partitions);
         assertFalse(membershipManager.reconciliationInProgress());
 
-        verify(subscriptionState).markPendingRevocation(anySet());
         List<TopicPartition> expectedTopicPartitionAssignment =
                 buildTopicPartitions(expectedCurrentAssignment);
         HashSet<TopicPartition> expectedSet = new HashSet<>(expectedTopicPartitionAssignment);


### PR DESCRIPTION
When a consumer receives group heartbeat with revoked partitions. If the consumer enable auto commit, it will send a OffsetCommitRequest before removing revoked partitions from subscription state. There are two potential race conditions in AsyncKafkaConsumer:

* If there is data in FetchBuffer from previous FetchRequest, users can still get data from `poll` function. However, the auto commit function doesn't work for these data, because the consumer mark revoked partitions with `pendingRevocation=true` after we receives OffsetCommitResponse. At that time, there is no further OffsetCommitRequest will be sent by auto commit feature.
* The FetchRequestManager still can send new FetchRequest before the consumer receives OffsetCommitResponse. The reason is same as above.

To fix this, we have to mark `pendingRevocation=true` before the consumer sends last OffsetCommitRequest, so FetchCollector can't get revoked partition data from FetchBuffer and FetchRequestManager doesn't send new FetchReqeust with revoked partitions.

I run `consumer_test.py.test_broker_failure` 10 times without error.

```
> TC_PATHS="tests/kafkatest/tests/client/consumer_test.py::OffsetValidationTest.test_broker_failure" /bin/bash tests/docker/run_tests.sh
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-15--010
run time:         6 minutes 57.245 seconds
tests run:        12
passed:           12
flaky:            0
failed:           0
ignored:          0
================================================================================
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
