### PR TITLE
KAFKA-17904: Flaky testMultiConsumerSessionTimeoutOnClose

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
@@ -36,8 +36,8 @@ class PlaintextConsumerPollTest extends AbstractConsumerTest {
 
   override protected def brokerPropertyOverrides(properties: Properties): Unit = {
     super.brokerPropertyOverrides(properties)
-    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
-    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
+    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, 500.toString)
+    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, 500.toString)
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
@@ -16,6 +16,7 @@ import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.{MetricName, TopicPartition}
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -23,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource
 
 import java.time.Duration
 import java.util
+import java.util.Properties
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
@@ -32,6 +32,12 @@ import scala.jdk.CollectionConverters._
 @Timeout(600)
 class PlaintextConsumerPollTest extends AbstractConsumerTest {
 
+  override protected def brokerPropertyOverrides(properties: Properties): Unit = {
+    super.brokerPropertyOverrides(properties)
+    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
+    properties.setProperty(GroupCoordinatorConfig.CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
+  }
+
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testMaxPollRecords(quorum: String, groupProtocol: String): Unit = {


### PR DESCRIPTION
Here are some of my conclusions about this flaky test.

First of all, the reason for the failure of this test is due to TIMEOUT, the method `AbstractConsumerTest#validateGroupAssignment` timeout after waiting for 10 seconds. And it reproduced on my computer.

`AbstractConsumerTest#validateGroupAssignment` is used to check all the consumer's assignments meet expectations, the exception as below:  

```
org.opentest4j.AssertionFailedError: Did not get valid assignment for partitions HashSet(topic1-2, topic1-4, topic-1, topic-0, topic1-5, topic1-1, topic1-0, topic1-3). Instead, got ArrayBuffer(Set(topic1-1, topic1-0, topic1-2), Set(topic1-5, topic1-4), Set())
```

I ran this junit test many times on my local computer after I added some logs. Then I found the timeout case is the GroupProtocol.CONSUMER mode. The CONSUMER mode maybe interact with the GroupCoordinator multiple times before reconciliation completed
![image](https://github.com/user-attachments/assets/f7b901cb-f915-41d5-8250-4a2b997a4596)


The frequency of interaction is controlled by configuration `group.consumer.heartbeat.interval.ms` which default value is 5000ms. Those successful unit tests take at least 5 seconds to complete, so maybe we can reduce heartbeat interval.

After I set `group.consumer.heartbeat.interval.ms` to 1000ms, this problem has not occurred again on my computer. And running this unit test has become more faster.

![image](https://github.com/user-attachments/assets/e3212128-99ea-4dee-b982-97c379d9fd81)

