### PR TITLE
KAFKA-18004: Use 3.8 to run zk service for e2e

### DIFF
--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -23,7 +23,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.security.security_config import SecurityConfig
-from kafkatest.version import DEV_BRANCH
+from kafkatest.version import LATEST_3_8
 
 
 class ZookeeperService(KafkaPathResolverMixin, Service):
@@ -43,8 +43,9 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
             "collect_default": True}
     }
 
+    # After 4.0, zookeeper service is removed from source code. Using LATEST_3_8 for compatibility test cases.
     def __init__(self, context, num_nodes, zk_sasl = False, zk_client_port = True, zk_client_secure_port = False,
-                 zk_tls_encrypt_only = False, version=DEV_BRANCH):
+                 zk_tls_encrypt_only = False, version=LATEST_3_8):
         """
         :type context
         """
@@ -186,7 +187,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
         chroot_path = ('' if chroot is None else chroot) + path
 
-        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        kafka_run_class = self.path.script("kafka-run-class.sh", LATEST_3_8)
         cmd = "%s %s -server %s %s get %s" % \
               (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
                self.zkTlsConfigFileOption(True),
@@ -211,7 +212,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
         chroot_path = ('' if chroot is None else chroot) + path
 
-        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        kafka_run_class = self.path.script("kafka-run-class.sh", LATEST_3_8)
         cmd = "%s %s -server %s %s ls %s" % \
               (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
                self.zkTlsConfigFileOption(True),
@@ -239,7 +240,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
         chroot_path = ('' if chroot is None else chroot) + path
 
-        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        kafka_run_class = self.path.script("kafka-run-class.sh", LATEST_3_8)
         if recursive:
             op = "deleteall"
         else:
@@ -261,7 +262,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
         chroot_path = ('' if chroot is None else chroot) + path
 
-        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        kafka_run_class = self.path.script("kafka-run-class.sh", LATEST_3_8)
         cmd = "%s %s -server %s %s create %s '%s'" % \
               (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
                self.zkTlsConfigFileOption(True),
@@ -275,7 +276,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         Describe the default user using the ConfigCommand CLI
         """
 
-        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        kafka_run_class = self.path.script("kafka-run-class.sh", LATEST_3_8)
         cmd = "%s kafka.admin.ConfigCommand --zookeeper %s %s --describe --entity-type users --entity-default" % \
               (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
                self.zkTlsConfigFileOption())


### PR DESCRIPTION
We plan to remove all ZooKeeper-related code in version 4.0. However, some old brokers in the end-to-end tests still require ZooKeeper service, so we need to run the ZooKeeper service using the 3.x release instead of the dev branch.

Since version 3.9 is not available in the https://s3-us-west-2.amazonaws.com/kafka-packages repo, we can use version 3.8 for now.

Test with https://github.com/apache/kafka/pull/17768. Failed case with version v2.1.1, v.2.2.2, and v2.3.1 will be fixed in https://issues.apache.org/jira/browse/KAFKA-17888.

```
> git fetch upstream pull/17768/head:PR-17768
> git merge PR-17768
> TC_PATHS="tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py" /bin/bash tests/docker/run_tests.sh

================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-11-12--007
run time:         37 minutes 31.925 seconds
tests run:        18
passed:           15
flaky:            0
failed:           3
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.1.1
status:     FAIL
run time:   1 minute 26.081 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.2.2
status:     FAIL
run time:   1 minute 25.996 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.3.1
status:     FAIL
run time:   1 minute 25.947 seconds


    TimeoutError("Kafka server didn't finish startup in 60 seconds")
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py", line 89, in test_produce_consume
    self.kafka.start()
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 659, in start
    self.wait_for_start(node, monitor, timeout_sec)
  File "/opt/kafka-dev/tests/kafkatest/services/kafka/kafka.py", line 909, in wait_for_start
    err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/cluster/remoteaccount.py", line 754, in wait_until
    allow_fail=True) == 0, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Kafka server didn't finish startup in 60 seconds

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.4.1
status:     PASS
run time:   2 minutes 11.468 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.5.1
status:     PASS
run time:   2 minutes 9.542 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.6.3
status:     PASS
run time:   3 minutes 11.442 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.7.2
status:     PASS
run time:   2 minutes 11.408 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=2.8.2
status:     PASS
run time:   2 minutes 13.602 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.0.2
status:     PASS
run time:   2 minutes 13.112 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.1.2
status:     PASS
run time:   2 minutes 0.379 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.2.3
status:     PASS
run time:   1 minute 53.272 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.3.2
status:     PASS
run time:   1 minute 53.859 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.4.1
status:     PASS
run time:   1 minute 53.557 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.5.2
status:     PASS
run time:   1 minute 53.813 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.6.2
status:     PASS
run time:   1 minute 53.501 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.7.1
status:     PASS
run time:   1 minute 53.747 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=3.8.1
status:     PASS
run time:   2 minutes 53.991 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.client_compatibility_produce_consume_test.ClientCompatibilityProduceConsumeTest.test_produce_consume.broker_version=dev.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   2 minutes 44.947 seconds
--------------------------------------------------------------------------------
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
