### PR TITLE
KAFKA-17992: Remove `getUnderlying` and `isKRaftTest` from ClusterInstance

### DIFF
--- a/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
+++ b/core/src/test/java/kafka/admin/ConfigCommandIntegrationTest.java
@@ -87,7 +87,7 @@ public class ConfigCommandIntegrationTest {
     @ClusterTest
     public void testExitWithNonZeroStatusOnUpdatingUnallowedConfig() {
         assertNonZeroStatusExit(Stream.concat(quorumArgs(), Stream.of(
-            "--entity-name", cluster.isKRaftTest() ? "0" : "1",
+            "--entity-name", "0",
             "--entity-type", "brokers",
             "--alter",
             "--add-config", "security.inter.broker.protocol=PLAINTEXT")),

--- a/core/src/test/java/kafka/server/LogManagerIntegrationTest.java
+++ b/core/src/test/java/kafka/server/LogManagerIntegrationTest.java
@@ -76,12 +76,12 @@ public class LogManagerIntegrationTest {
         cluster.waitForTopic("foo", 1);
 
         Optional<PartitionMetadataFile> partitionMetadataFile = Optional.ofNullable(
-                raftInstance.getUnderlying().brokers().get(0).logManager()
+                raftInstance.brokers().get(0).logManager()
                         .getLog(new TopicPartition("foo", 0), false).get()
                         .partitionMetadataFile().getOrElse(null));
         assertTrue(partitionMetadataFile.isPresent());
 
-        raftInstance.getUnderlying().brokers().get(0).shutdown();
+        raftInstance.brokers().get(0).shutdown();
         try (Admin admin = cluster.admin()) {
             TestUtils.waitForCondition(() -> {
                 List<TopicPartitionInfo> partitionInfos = admin.describeTopics(Collections.singletonList("foo"))
@@ -93,7 +93,7 @@ public class LogManagerIntegrationTest {
         // delete partition.metadata file here to simulate the scenario that partition.metadata not flush to disk yet
         partitionMetadataFile.get().delete();
         assertFalse(partitionMetadataFile.get().exists());
-        raftInstance.getUnderlying().brokers().get(0).startup();
+        raftInstance.brokers().get(0).startup();
         // make sure there is no error during load logs
         assertDoesNotThrow(() -> raftInstance.getUnderlying().fatalFaultHandler().maybeRethrowFirstException());
         try (Admin admin = cluster.admin()) {

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -64,7 +64,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
     clientTelemetryEnabled: Boolean = false,
     apiVersion: Short = ApiKeys.API_VERSIONS.latestVersion
   ): Unit = {
-    if (cluster.isKRaftTest && apiVersion >= 3) {
+    if (apiVersion >= 3) {
       assertEquals(3, apiVersionsResponse.data().finalizedFeatures().size())
       assertEquals(MetadataVersion.latestTesting().featureLevel(), apiVersionsResponse.data().finalizedFeatures().find(MetadataVersion.FEATURE_NAME).minVersionLevel())
       assertEquals(MetadataVersion.latestTesting().featureLevel(), apiVersionsResponse.data().finalizedFeatures().find(MetadataVersion.FEATURE_NAME).maxVersionLevel())
@@ -84,12 +84,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).minVersion())
       assertEquals(GroupVersion.GV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).maxVersion())
     }
-    val expectedApis = if (!cluster.isKRaftTest) {
-      ApiVersionsResponse.collectApis(
-        ApiKeys.apisForListener(ApiMessageType.ListenerType.ZK_BROKER),
-        enableUnstableLastVersion
-      )
-    } else if (cluster.controllerListenerName().toScala.contains(listenerName)) {
+    val expectedApis = if (cluster.controllerListenerName().toScala.contains(listenerName)) {
       ApiVersionsResponse.collectApis(
         ApiKeys.apisForListener(ApiMessageType.ListenerType.CONTROLLER),
         enableUnstableLastVersion
@@ -107,9 +102,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
     assertEquals(expectedApis.size, apiVersionsResponse.data.apiKeys.size,
       "API keys in ApiVersionsResponse must match API keys supported by broker.")
 
-    val defaultApiVersionsResponse = if (!cluster.isKRaftTest) {
-      TestUtils.defaultApiVersionsResponse(0, ListenerType.ZK_BROKER, enableUnstableLastVersion)
-    } else if (cluster.controllerListenerName().toScala.contains(listenerName)) {
+    val defaultApiVersionsResponse = if (cluster.controllerListenerName().toScala.contains(listenerName)) {
       TestUtils.defaultApiVersionsResponse(0, ListenerType.CONTROLLER, enableUnstableLastVersion)
     } else {
       TestUtils.createApiVersionsResponse(0, expectedApis)

--- a/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
@@ -57,7 +57,7 @@ class BrokerRegistrationRequestTest {
 
         val saslMechanism: String = ""
 
-        def isZkController: Boolean = !clusterInstance.isKRaftTest
+        def isZkController: Boolean = false
 
         override def getControllerInfo(): ControllerInformation =
           ControllerInformation(node, listenerName, securityProtocol, saslMechanism, isZkController)

--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java
@@ -70,10 +70,6 @@ public interface ClusterInstance {
 
     Type type();
 
-    default boolean isKRaftTest() {
-        return type() == Type.KRAFT || type() == Type.CO_KRAFT;
-    }
-
     Map<Integer, KafkaBroker> brokers();
 
     default Map<Integer, KafkaBroker> aliveBrokers() {
@@ -158,15 +154,6 @@ public interface ClusterInstance {
 
     String clusterId();
 
-    /**
-     * The underlying object which is responsible for setting up and tearing down the cluster.
-     */
-    Object getUnderlying();
-
-    default <T> T getUnderlying(Class<T> asClass) {
-        return asClass.cast(getUnderlying());
-    }
-
     //---------------------------[producer/consumer/admin]---------------------------//
 
     default <K, V> Producer<K, V> producer(Map<String, Object> configs) {
@@ -216,7 +203,7 @@ public interface ClusterInstance {
     }
 
     default Set<GroupProtocol> supportedGroupProtocols() {
-        if (isKRaftTest() && brokers().values().stream().allMatch(b -> b.dataPlaneRequestProcessor().isConsumerGroupProtocolEnabled())) {
+        if (brokers().values().stream().allMatch(b -> b.dataPlaneRequestProcessor().isConsumerGroupProtocolEnabled())) {
             return Set.of(CLASSIC, CONSUMER);
         } else {
             return Collections.singleton(CLASSIC);

--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/RaftClusterInvocationContext.java
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/RaftClusterInvocationContext.java
@@ -165,7 +165,6 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
             return controllers().keySet();
         }
 
-        @Override
         public KafkaClusterTestKit getUnderlying() {
             return clusterTestKit;
         }

--- a/tools/src/test/java/org/apache/kafka/tools/BrokerApiVersionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/BrokerApiVersionsCommandTest.java
@@ -56,8 +56,7 @@ public class BrokerApiVersionsCommandTest {
         assertTrue(lineIter.hasNext());
         assertEquals(clusterInstance.bootstrapServers() + " (id: 0 rack: null) -> (", lineIter.next());
 
-        ApiMessageType.ListenerType listenerType = clusterInstance.isKRaftTest() ?
-                ApiMessageType.ListenerType.BROKER : ApiMessageType.ListenerType.ZK_BROKER;
+        ApiMessageType.ListenerType listenerType = ApiMessageType.ListenerType.BROKER;
 
         NodeApiVersions nodeApiVersions = new NodeApiVersions(
                 ApiVersionsResponse.collectApis(ApiKeys.clientApis(), true),

--- a/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
@@ -51,22 +51,14 @@ public class ClusterToolTest {
     @ClusterTest(brokers = 3)
     public void testUnregister(ClusterInstance clusterInstance) {
         int brokerId;
-        if (!clusterInstance.isKRaftTest()) {
-            brokerId = assertDoesNotThrow(() -> clusterInstance.brokerIds().stream().findFirst().get());
-        } else {
-            Set<Integer> brokerIds = clusterInstance.brokerIds();
-            brokerIds.removeAll(clusterInstance.controllerIds());
-            brokerId = assertDoesNotThrow(() -> brokerIds.stream().findFirst().get());
-        }
+        Set<Integer> brokerIds = clusterInstance.brokerIds();
+        brokerIds.removeAll(clusterInstance.controllerIds());
+        brokerId = assertDoesNotThrow(() -> brokerIds.stream().findFirst().get());
         clusterInstance.shutdownBroker(brokerId);
         String output = ToolsTestUtils.captureStandardOut(() ->
                 assertDoesNotThrow(() -> ClusterTool.execute("unregister", "--bootstrap-server", clusterInstance.bootstrapServers(), "--id", String.valueOf(brokerId))));
 
-        if (clusterInstance.isKRaftTest()) {
-            assertTrue(output.contains("Broker " + brokerId + " is no longer registered."));
-        } else {
-            assertTrue(output.contains("The target cluster does not support the broker unregistration API."));
-        }
+        assertTrue(output.contains("Broker " + brokerId + " is no longer registered."));
     }
 
     @ClusterTest(types = {Type.KRAFT, Type.CO_KRAFT})

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -205,11 +205,7 @@ public class GetOffsetShellTest {
         setUp();
 
         List<Row> output = executeAndParse();
-        if (!cluster.isKRaftTest()) {
-            assertEquals(expectedOffsetsWithInternal(), output);
-        } else {
-            assertEquals(expectedTestTopicOffsets(), output);
-        }
+        assertEquals(expectedTestTopicOffsets(), output);
     }
 
     @ClusterTest
@@ -247,11 +243,7 @@ public class GetOffsetShellTest {
         setUp();
 
         List<Row> offsets = executeAndParse("--partitions", "0,1");
-        if (!cluster.isKRaftTest()) {
-            assertEquals(expectedOffsetsWithInternal().stream().filter(r -> r.partition <= 1).collect(Collectors.toList()), offsets);
-        } else {
-            assertEquals(expectedTestTopicOffsets().stream().filter(r -> r.partition <= 1).collect(Collectors.toList()), offsets);
-        }
+        assertEquals(expectedTestTopicOffsets().stream().filter(r -> r.partition <= 1).collect(Collectors.toList()), offsets);
     }
 
     @ClusterTest

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -908,11 +908,8 @@ public class TopicCommandTest {
              TopicCommand.TopicService topicService = new TopicCommand.TopicService(adminClient)) {
 
             // create the offset topic
-            // In ZK mode, Topic.GROUP_METADATA_TOPIC_NAME exist when cluster is created.
-            if (clusterInstance.isKRaftTest()) {
-                adminClient.createTopics(Collections.singletonList(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, defaultNumPartitions, defaultReplicationFactor)));
-                clusterInstance.waitForTopic(Topic.GROUP_METADATA_TOPIC_NAME, defaultNumPartitions);
-            }
+            adminClient.createTopics(Collections.singletonList(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, defaultNumPartitions, defaultReplicationFactor)));
+            clusterInstance.waitForTopic(Topic.GROUP_METADATA_TOPIC_NAME, defaultNumPartitions);
 
             // Try to delete the Topic.GROUP_METADATA_TOPIC_NAME which is allowed by default.
             // This is a difference between the new and the old command as the old one didn't allow internal topic deletion.

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
@@ -396,42 +396,22 @@ public class ConsoleConsumerTest {
 
                 JsonNode jsonNode = objectMapper.reader().readTree(out.toByteArray());
 
-                // The new group coordinator writes an empty group metadata record when the group is created for
-                // the first time whereas the old group coordinator only writes a group metadata record when
-                // the first rebalance completes.
-                if (cluster.isKRaftTest()) {
-                    JsonNode keyNode = jsonNode.get("key");
-                    GroupMetadataKey groupMetadataKey =
-                        GroupMetadataKeyJsonConverter.read(keyNode.get("data"), GroupMetadataKey.HIGHEST_SUPPORTED_VERSION);
-                    assertNotNull(groupMetadataKey);
-                    assertEquals(groupId, groupMetadataKey.group());
+                // The group coordinator writes an empty group metadata record when the group is created for the first time
+                JsonNode keyNode = jsonNode.get("key");
+                GroupMetadataKey groupMetadataKey =
+                    GroupMetadataKeyJsonConverter.read(keyNode.get("data"), GroupMetadataKey.HIGHEST_SUPPORTED_VERSION);
+                assertNotNull(groupMetadataKey);
+                assertEquals(groupId, groupMetadataKey.group());
 
-                    JsonNode valueNode = jsonNode.get("value");
-                    GroupMetadataValue groupMetadataValue =
-                        GroupMetadataValueJsonConverter.read(valueNode.get("data"), GroupMetadataValue.HIGHEST_SUPPORTED_VERSION);
-                    assertNotNull(groupMetadataValue);
-                    assertEquals("", groupMetadataValue.protocolType());
-                    assertEquals(0, groupMetadataValue.generation());
-                    assertNull(groupMetadataValue.protocol());
-                    assertNull(groupMetadataValue.leader());
-                    assertEquals(0, groupMetadataValue.members().size());
-                } else {
-                    JsonNode keyNode = jsonNode.get("key");
-                    GroupMetadataKey groupMetadataKey =
-                        GroupMetadataKeyJsonConverter.read(keyNode.get("data"), GroupMetadataKey.HIGHEST_SUPPORTED_VERSION);
-                    assertNotNull(groupMetadataKey);
-                    assertEquals(groupId, groupMetadataKey.group());
-
-                    JsonNode valueNode = jsonNode.get("value");
-                    GroupMetadataValue groupMetadataValue =
-                        GroupMetadataValueJsonConverter.read(valueNode.get("data"), GroupMetadataValue.HIGHEST_SUPPORTED_VERSION);
-                    assertNotNull(groupMetadataValue);
-                    assertEquals("consumer", groupMetadataValue.protocolType());
-                    assertEquals(1, groupMetadataValue.generation());
-                    assertEquals("range", groupMetadataValue.protocol());
-                    assertNotNull(groupMetadataValue.leader());
-                    assertEquals(1, groupMetadataValue.members().size());
-                }
+                JsonNode valueNode = jsonNode.get("value");
+                GroupMetadataValue groupMetadataValue =
+                    GroupMetadataValueJsonConverter.read(valueNode.get("data"), GroupMetadataValue.HIGHEST_SUPPORTED_VERSION);
+                assertNotNull(groupMetadataValue);
+                assertEquals("", groupMetadataValue.protocolType());
+                assertEquals(0, groupMetadataValue.generation());
+                assertNull(groupMetadataValue.protocol());
+                assertNull(groupMetadataValue.leader());
+                assertEquals(0, groupMetadataValue.members().size());
             } finally {
                 consumerWrapper.cleanup();
             }


### PR DESCRIPTION
As title,

- Since ZK will be removed in Kafka 4.0, `isKRaftTest` is no longer required.

- To avoid directly exposing or returning the underlying object through interface `getUnderlying`, which is responsible for setting up and tearing down the cluster, we plan to remove `getUnderlying`. We plan to design and implement a better interface in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
