### PR TITLE
 KAFKA-15995: Adding KIP-877 support to Connect 

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -183,6 +183,9 @@
     <suppress checks="JavaNCSS"
               files="(DistributedHerder|Worker)Test.java"/>
 
+    <suppress checks="ParameterNumber"
+              files="WorkerSinkTaskTest.java"/>
+
     <!-- Raft -->
     <suppress checks="NPathComplexity"
               files="(DynamicVoter|RecordsIterator).java"/>

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectorContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectorContext.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.connect.connector;
 
+import org.apache.kafka.common.metrics.PluginMetrics;
+
 /**
  * ConnectorContext allows {@link Connector}s to proactively interact with the Kafka Connect runtime.
  */
@@ -33,4 +35,26 @@ public interface ConnectorContext {
      * @param e Exception to be raised.
      */
     void raiseError(Exception e);
+
+    /**
+     * Get a {@link PluginMetrics} that can be used to define metrics
+     *
+     * <p>This method was added in Apache Kafka 4.1. Connectors that use this method but want to
+     * maintain backward compatibility so they can also be deployed to older Connect runtimes
+     * should guard the call to this method with a try-catch block, since calling this method will result in a
+     * {@link NoSuchMethodError} or {@link NoClassDefFoundError} when the connector is deployed to
+     * Connect runtimes older than Kafka 4.1. For example:
+     * <pre>
+     *     PluginMetrics pluginMetrics;
+     *     try {
+     *         pluginMetrics = context.pluginMetrics();
+     *     } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *         pluginMetrics = null;
+     *     }
+     * </pre>
+     *
+     * @return the pluginMetrics instance
+     * @since 4.1
+     */
+    PluginMetrics pluginMetrics();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -30,6 +30,11 @@ import java.util.List;
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy}.
+ * <p>
+ * Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the policy to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>config</code> set to
+ * <code>connector.client.config.override.policy</code>, and <code>class</code> set to the
+ * ConnectorClientConfigOverridePolicy class name.
  */
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
@@ -43,6 +43,10 @@ import java.util.Map;
  *
  * <p>When the Connect worker shuts down, it will call the extension's {@link #close} method to allow the implementation to release all of
  * its resources.
+ *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the extension to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>config</code> set to
+ * <code>rest.extension.classes</code>, and <code>class</code> set to the ConnectRestExtension class name.
  */
 public interface ConnectRestExtension extends Configurable, Versioned, Closeable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.sink;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.PluginMetrics;
 
 import java.util.Map;
 import java.util.Set;
@@ -122,5 +123,27 @@ public interface SinkTaskContext {
     default ErrantRecordReporter errantRecordReporter() {
         return null;
     }
+
+    /**
+     * Get a {@link PluginMetrics} that can be used to define metrics
+     *
+     * <p>This method was added in Apache Kafka 4.1. Tasks that use this method but want to
+     * maintain backward compatibility so they can also be deployed to older Connect runtimes
+     * should guard the call to this method with a try-catch block, since calling this method will result in a
+     * {@link NoSuchMethodError} or {@link NoClassDefFoundError} when the connector is deployed to
+     * Connect runtimes older than Kafka 4.1. For example:
+     * <pre>
+     *     PluginMetrics pluginMetrics;
+     *     try {
+     *         pluginMetrics = context.pluginMetrics();
+     *     } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *         pluginMetrics = null;
+     *     }
+     * </pre>
+     *
+     * @return the PluginMetrics instance
+     * @since 4.1
+     */
+    PluginMetrics pluginMetrics();
 
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTaskContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.source;
 
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
 import java.util.Map;
@@ -63,4 +64,26 @@ public interface SourceTaskContext {
     default TransactionContext transactionContext() {
         return null;
     }
+
+    /**
+     * Get a {@link PluginMetrics} that can be used to define metrics
+     *
+     * <p>This method was added in Apache Kafka 4.1. Tasks that use this method but want to
+     * maintain backward compatibility so they can also be deployed to older Connect runtimes
+     * should guard the call to this method with a try-catch block, since calling this method will result in a
+     * {@link NoSuchMethodError} or {@link NoClassDefFoundError} when the connector is deployed to
+     * Connect runtimes older than Kafka 4.1. For example:
+     * <pre>
+     *     PluginMetrics pluginMetrics;
+     *     try {
+     *         pluginMetrics = context.pluginMetrics();
+     *     } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *         pluginMetrics = null;
+     *     }
+     * </pre>
+     *
+     * @return the pluginMetrics instance
+     * @since 4.1
+     */
+    PluginMetrics pluginMetrics();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -30,8 +32,12 @@ import java.util.Map;
  * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.storage.Converter}.
+ *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the converter to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>connector</code> set to connector name,
+ * <code>task</code> set to the task id and <code>converter</code> set to either <code>key</code> or <code>value</code>.
  */
-public interface Converter {
+public interface Converter extends Closeable {
 
     /**
      * Configure this class.
@@ -97,5 +103,10 @@ public interface Converter {
      */
     default ConfigDef config() {
         return new ConfigDef();
+    }
+
+    @Override
+    default void close() throws IOException  {
+        // no op
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
@@ -31,6 +31,10 @@ import java.io.Closeable;
  * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.storage.HeaderConverter}.
+ *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the converter to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>connector</code> set to connector name,
+ * <code>task</code> set to the task id and <code>converter</code> set to <code>header</code>.
  */
 public interface HeaderConverter extends Configurable, Closeable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -30,6 +30,10 @@ import java.io.Closeable;
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.transforms.Transformation}.
  *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the transformation to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>connector</code> set to connector name,
+ * <code>task</code> set to the task id and <code>transformation</code> set to the transformation alias.
+ *
  * @param <R> The type of record (must be an implementation of {@link ConnectRecord})
  */
 public interface Transformation<R extends ConnectRecord<R>> extends Configurable, Closeable {

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -31,6 +31,10 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate}.
  *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the predicate to register metrics.
+ * The following tags are automatically added to all metrics registered: <code>connector</code> set to connector name,
+ * <code>task</code> set to the task id and <code>predicate</code> set to the predicate alias.
+ *
  * @param <R> The type of record.
  */
 public interface Predicate<R extends ConnectRecord<R>> extends Configurable, AutoCloseable {

--- a/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkConnectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkConnectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.sink;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.ConnectorTest;
 import org.apache.kafka.connect.connector.Task;
@@ -50,6 +51,12 @@ public class SinkConnectorTest extends ConnectorTest {
 
         @Override
         public void raiseError(Exception e) {
+            // Unexpected in these tests
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PluginMetrics pluginMetrics() {
             // Unexpected in these tests
             throw new UnsupportedOperationException();
         }

--- a/connect/api/src/test/java/org/apache/kafka/connect/source/SourceConnectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/source/SourceConnectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.source;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.ConnectorTest;
 import org.apache.kafka.connect.connector.Task;
@@ -51,6 +52,12 @@ public class SourceConnectorTest extends ConnectorTest {
 
         @Override
         public void raiseError(Exception e) {
+            // Unexpected in these tests
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PluginMetrics pluginMetrics() {
             // Unexpected in these tests
             throw new UnsupportedOperationException();
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.ConfigDef.ConfigKey;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigTransformer;
 import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
@@ -140,7 +141,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected final StatusBackingStore statusBackingStore;
     protected final ConfigBackingStore configBackingStore;
     private volatile boolean ready = false;
-    private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
+    private final Plugin<ConnectorClientConfigOverridePolicy> connectorClientConfigOverridePolicyPlugin;
     private final ExecutorService connectorExecutor;
     private final Time time;
     protected final Loggers loggers;
@@ -160,7 +161,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.kafkaClusterId = kafkaClusterId;
         this.statusBackingStore = statusBackingStore;
         this.configBackingStore = configBackingStore;
-        this.connectorClientConfigOverridePolicy = connectorClientConfigOverridePolicy;
+        this.connectorClientConfigOverridePolicyPlugin = Plugin.wrapInstance(
+                connectorClientConfigOverridePolicy,
+                worker.metrics().metrics(),
+                WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG);
         this.connectorExecutor = Executors.newCachedThreadPool();
         this.time = time;
         this.loggers = Loggers.newInstance(time);
@@ -185,7 +189,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.configBackingStore.stop();
         this.worker.stop();
         this.connectorExecutor.shutdown();
-        Utils.closeQuietly(this.connectorClientConfigOverridePolicy, "connector client config override policy");
+        Utils.closeQuietly(this.connectorClientConfigOverridePolicyPlugin, "connector client config override policy");
     }
 
     protected void ready() {
@@ -386,6 +390,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
         return new ConnectorStateInfo.TaskState(id.task(), status.state().toString(),
                 status.workerId(), status.trace());
+    }
+
+    @Override
+    public Worker worker() {
+        return worker;
     }
 
     protected Map<String, ConfigValue> validateSinkConnectorConfig(SinkConnector connector, ConfigDef configDef, Map<String, String> config) {
@@ -691,7 +700,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                         connectorClass,
                         connectorType,
                         ConnectorClientConfigRequest.ClientType.PRODUCER,
-                        connectorClientConfigOverridePolicy);
+                        connectorClientConfigOverridePolicyPlugin);
             }
         }
         if (connectorUsesAdmin(connectorType, connectorProps)) {
@@ -705,7 +714,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                         connectorClass,
                         connectorType,
                         ConnectorClientConfigRequest.ClientType.ADMIN,
-                        connectorClientConfigOverridePolicy);
+                        connectorClientConfigOverridePolicyPlugin);
             }
         }
         if (connectorUsesConsumer(connectorType, connectorProps)) {
@@ -719,7 +728,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                         connectorClass,
                         connectorType,
                         ConnectorClientConfigRequest.ClientType.CONSUMER,
-                        connectorClientConfigOverridePolicy);
+                        connectorClientConfigOverridePolicyPlugin);
             }
         }
         return mergeConfigInfos(connType,
@@ -893,7 +902,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                                                       Class<? extends Connector> connectorClass,
                                                       org.apache.kafka.connect.health.ConnectorType connectorType,
                                                       ConnectorClientConfigRequest.ClientType clientType,
-                                                      ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy) {
+                                                      Plugin<ConnectorClientConfigOverridePolicy> connectorClientConfigOverridePolicyPlugin) {
         Map<String, Object> clientConfigs = new HashMap<>();
         for (Map.Entry<String, Object> rawClientConfig : connectorConfig.originalsWithPrefix(prefix).entrySet()) {
             String configName = rawClientConfig.getKey();
@@ -906,7 +915,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         }
         ConnectorClientConfigRequest connectorClientConfigRequest = new ConnectorClientConfigRequest(
             connName, connectorType, connectorClass, clientConfigs, clientType);
-        List<ConfigValue> configValues = connectorClientConfigOverridePolicy.validate(connectorClientConfigRequest);
+        List<ConfigValue> configValues = connectorClientConfigOverridePolicyPlugin.get().validate(connectorClientConfigRequest);
 
         return prefixedConfigInfos(configDef.configKeys(), configValues, prefix);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -393,8 +393,8 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     }
 
     @Override
-    public Worker worker() {
-        return worker;
+    public ConnectMetrics connectMetrics() {
+        return worker.metrics();
     }
 
     protected Map<String, ConfigValue> validateSinkConnectorConfig(SinkConnector connector, ConfigDef configDef, Map<String, String> config) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -27,9 +28,16 @@ import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.internals.MetricsUtils;
+import org.apache.kafka.common.metrics.internals.PluginMetricsImpl;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +53,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * The Connect metrics with configurable {@link MetricsReporter}s.
@@ -164,6 +173,74 @@ public class ConnectMetrics {
         metrics.close();
         LOG.debug("Unregistering Connect metrics with JMX for worker '{}'", workerId);
         AppInfoParser.unregisterAppInfo(JMX_PREFIX, workerId, metrics);
+    }
+
+    PluginMetricsImpl connectorPluginMetrics(String connectorId) {
+        return new PluginMetricsImpl(metrics, connectorPluginTags(connectorId));
+    }
+
+    private static Map<String, String> connectorPluginTags(String connectorId) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("connector", connectorId);
+        return tags;
+    }
+
+    PluginMetricsImpl taskPluginMetrics(ConnectorTaskId connectorTaskId) {
+        return new PluginMetricsImpl(metrics, taskPluginTags(connectorTaskId));
+    }
+
+    private static Map<String, String> taskPluginTags(ConnectorTaskId connectorTaskId) {
+        Map<String, String> tags = connectorPluginTags(connectorTaskId.connector());
+        tags.put("task", String.valueOf(connectorTaskId.task()));
+        return tags;
+    }
+
+    private static Supplier<Map<String, String>> converterPluginTags(ConnectorTaskId connectorTaskId, boolean isKey) {
+        return () -> {
+            Map<String, String> tags = taskPluginTags(connectorTaskId);
+            tags.put("converter", isKey ? "key" : "value");
+            return tags;
+        };
+    }
+
+    private static Supplier<Map<String, String>> headerConverterPluginTags(ConnectorTaskId connectorTaskId) {
+        return () -> {
+            Map<String, String> tags = taskPluginTags(connectorTaskId);
+            tags.put("converter", "header");
+            return tags;
+        };
+    }
+
+    private static Supplier<Map<String, String>> transformationPluginTags(ConnectorTaskId connectorTaskId, String transformationAlias) {
+        return () -> {
+            Map<String, String> tags = taskPluginTags(connectorTaskId);
+            tags.put("transformation", transformationAlias);
+            return tags;
+        };
+    }
+
+    private static Supplier<Map<String, String>> predicatePluginTags(ConnectorTaskId connectorTaskId, String predicateAlias) {
+        return () -> {
+            Map<String, String> tags = taskPluginTags(connectorTaskId);
+            tags.put("predicate", predicateAlias);
+            return tags;
+        };
+    }
+
+    public Plugin<HeaderConverter> wrap(HeaderConverter headerConverter, ConnectorTaskId connectorTaskId) {
+        return Plugin.wrapInstance(headerConverter, metrics, headerConverterPluginTags(connectorTaskId));
+    }
+
+    public Plugin<Converter> wrap(Converter converter, ConnectorTaskId connectorTaskId, boolean isKey) {
+        return Plugin.wrapInstance(converter, metrics, converterPluginTags(connectorTaskId, isKey));
+    }
+
+    public <R extends ConnectRecord<R>> Plugin<Transformation<R>> wrap(Transformation<R> transformation, ConnectorTaskId connectorTaskId, String alias) {
+        return Plugin.wrapInstance(transformation, metrics, transformationPluginTags(connectorTaskId, alias));
+    }
+
+    public <R extends ConnectRecord<R>> Plugin<Predicate<R>> wrap(Predicate<R> predicate, ConnectorTaskId connectorTaskId, String alias) {
+        return Plugin.wrapInstance(predicate, metrics, predicatePluginTags(connectorTaskId, alias));
     }
 
     public static class MetricGroupId {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -175,7 +175,7 @@ public class ConnectMetrics {
         AppInfoParser.unregisterAppInfo(JMX_PREFIX, workerId, metrics);
     }
 
-    PluginMetricsImpl connectorPluginMetrics(String connectorId) {
+    public PluginMetricsImpl connectorPluginMetrics(String connectorId) {
         return new PluginMetricsImpl(metrics, connectorPluginTags(connectorId));
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
@@ -78,9 +79,9 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                                        SourceTask task,
                                        TaskStatus.Listener statusListener,
                                        TargetState initialState,
-                                       Converter keyConverter,
-                                       Converter valueConverter,
-                                       HeaderConverter headerConverter,
+                                       Plugin<Converter> keyConverterPlugin,
+                                       Plugin<Converter> valueConverterPlugin,
+                                       Plugin<HeaderConverter> headerConverterPlugin,
                                        TransformationChain<SourceRecord, SourceRecord> transformationChain,
                                        Producer<byte[], byte[]> producer,
                                        TopicAdmin admin,
@@ -101,8 +102,8 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                                        Runnable preProducerCheck,
                                        Runnable postProducerCheck,
                                        Supplier<List<ErrorReporter<SourceRecord>>> errorReportersSupplier) {
-        super(id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, transformationChain,
-                new WorkerSourceTaskContext(offsetReader, id, configState, buildTransactionContext(sourceConfig)),
+        super(id, task, statusListener, initialState, configState, keyConverterPlugin, valueConverterPlugin, headerConverterPlugin, transformationChain,
+                buildTransactionContext(sourceConfig),
                 producer, admin, topicGroups, offsetReader, offsetWriter, offsetStore, workerConfig, connectMetrics, errorMetrics,
                 loader, time, retryWithToleranceOperator, statusBackingStore, closeExecutor, errorReportersSupplier);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -381,6 +381,12 @@ public interface Herder {
      */
     void setClusterLoggerLevel(String namespace, String level);
 
+    /**
+     * Get the worker for this herder
+     * @return the worker
+     */
+    Worker worker();
+
     enum ConfigReloadAction {
         NONE,
         RESTART

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -382,10 +382,10 @@ public interface Herder {
     void setClusterLoggerLevel(String namespace, String level);
 
     /**
-     * Get the worker for this herder
-     * @return the worker
+     * Get the ConnectMetrics from the worker for this herder
+     * @return the ConnectMetrics
      */
-    Worker worker();
+    ConnectMetrics connectMetrics();
 
     enum ConfigReloadAction {
         NONE,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import org.slf4j.Logger;
@@ -61,6 +62,11 @@ public class HerderConnectorContext implements CloseableConnectorContext {
         }
 
         herder.onFailure(connectorName, e);
+    }
+
+    @Override
+    public PluginMetrics pluginMetrics() {
+        return null;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.common.metrics.internals.PluginMetricsImpl;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import org.slf4j.Logger;
@@ -31,11 +33,13 @@ public class HerderConnectorContext implements CloseableConnectorContext {
 
     private final AbstractHerder herder;
     private final String connectorName;
+    private final PluginMetricsImpl pluginMetrics;
     private volatile boolean closed;
 
-    public HerderConnectorContext(AbstractHerder herder, String connectorName) {
+    public HerderConnectorContext(AbstractHerder herder, String connectorName, PluginMetricsImpl pluginMetrics) {
         this.herder = herder;
         this.connectorName = connectorName;
+        this.pluginMetrics = pluginMetrics;
         this.closed = false;
     }
 
@@ -66,11 +70,12 @@ public class HerderConnectorContext implements CloseableConnectorContext {
 
     @Override
     public PluginMetrics pluginMetrics() {
-        return null;
+        return pluginMetrics;
     }
 
     @Override
     public void close() {
+        Utils.closeQuietly(pluginMetrics, "Plugin metrics for " + connectorName);
         closed = true;
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.metrics.PluginMetrics;
-import org.apache.kafka.common.metrics.internals.PluginMetricsImpl;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
@@ -83,7 +82,6 @@ public class WorkerConnector implements Runnable {
     private State state;
     private final CloseableOffsetStorageReader offsetStorageReader;
     private final ConnectorOffsetBackingStore offsetStore;
-    private final PluginMetricsImpl pluginMetrics;
 
     public WorkerConnector(String connName,
                            Connector connector,
@@ -110,7 +108,6 @@ public class WorkerConnector implements Runnable {
         this.externalFailure = null;
         this.stopping = false;
         this.cancelled = false;
-        this.pluginMetrics = connectMetrics.connectorPluginMetrics(connName);
     }
 
     public ClassLoader loader() {
@@ -195,12 +192,12 @@ public class WorkerConnector implements Runnable {
             log.debug("{} Initializing connector {}", this, connName);
             if (isSinkConnector()) {
                 SinkConnectorConfig.validate(config);
-                connector.initialize(new WorkerSinkConnectorContext(pluginMetrics));
+                connector.initialize(new WorkerSinkConnectorContext());
             } else {
                 Objects.requireNonNull(offsetStore, "Offset store cannot be null for source connectors");
                 Objects.requireNonNull(offsetStorageReader, "Offset reader cannot be null for source connectors");
                 offsetStore.start();
-                connector.initialize(new WorkerSourceConnectorContext(offsetStorageReader, pluginMetrics));
+                connector.initialize(new WorkerSourceConnectorContext(offsetStorageReader));
             }
         } catch (Throwable t) {
             log.error("{} Error initializing connector", this, t);
@@ -328,7 +325,6 @@ public class WorkerConnector implements Runnable {
             if (offsetStore != null) {
                 Utils.closeQuietly(offsetStore::stop, "offset backing store for " + connName);
             }
-            Utils.closeQuietly(pluginMetrics, "plugin metrics");
         }
     }
 
@@ -587,40 +583,27 @@ public class WorkerConnector implements Runnable {
             onFailure(e);
             WorkerConnector.this.ctx.raiseError(e);
         }
-    }
-
-    private class WorkerSinkConnectorContext extends WorkerConnectorContext implements SinkConnectorContext {
-
-        private final PluginMetrics pluginMetrics;
-
-        WorkerSinkConnectorContext(PluginMetrics pluginMetrics) {
-            this.pluginMetrics = pluginMetrics;
-        }
 
         @Override
         public PluginMetrics pluginMetrics() {
-            return pluginMetrics;
+            return WorkerConnector.this.ctx.pluginMetrics();
         }
+    }
+
+    private class WorkerSinkConnectorContext extends WorkerConnectorContext implements SinkConnectorContext {
     }
 
     private class WorkerSourceConnectorContext extends WorkerConnectorContext implements SourceConnectorContext {
 
         private final OffsetStorageReader offsetStorageReader;
-        private final PluginMetrics pluginMetrics;
 
-        WorkerSourceConnectorContext(OffsetStorageReader offsetStorageReader, PluginMetrics pluginMetrics) {
+        WorkerSourceConnectorContext(OffsetStorageReader offsetStorageReader) {
             this.offsetStorageReader = offsetStorageReader;
-            this.pluginMetrics = pluginMetrics;
         }
 
         @Override
         public OffsetStorageReader offsetStorageReader() {
             return offsetStorageReader;
-        }
-
-        @Override
-        public PluginMetrics pluginMetrics() {
-            return pluginMetrics;
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.errors.IllegalWorkerStateException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -163,6 +164,11 @@ public class WorkerSinkTaskContext implements SinkTaskContext {
     @Override
     public ErrantRecordReporter errantRecordReporter() {
         return sinkTask.workerErrantRecordReporter();
+    }
+
+    @Override
+    public PluginMetrics pluginMetrics() {
+        return sinkTask.pluginMetrics();
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.errors.ErrorHandlingMetrics;
@@ -71,10 +72,10 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
                             SourceTask task,
                             TaskStatus.Listener statusListener,
                             TargetState initialState,
-                            Converter keyConverter,
-                            Converter valueConverter,
+                            Plugin<Converter> keyConverterPlugin,
+                            Plugin<Converter> valueConverterPlugin,
                             ErrorHandlingMetrics errorMetrics,
-                            HeaderConverter headerConverter,
+                            Plugin<HeaderConverter> headerConverterPlugin,
                             TransformationChain<SourceRecord, SourceRecord> transformationChain,
                             Producer<byte[], byte[]> producer,
                             TopicAdmin admin,
@@ -92,8 +93,8 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
                             Executor closeExecutor,
                             Supplier<List<ErrorReporter<SourceRecord>>> errorReportersSupplier) {
 
-        super(id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, transformationChain,
-                new WorkerSourceTaskContext(offsetReader, id, configState, null), producer,
+        super(id, task, statusListener, initialState, configState, keyConverterPlugin, valueConverterPlugin, headerConverterPlugin, transformationChain,
+                null, producer,
                 admin, topicGroups, offsetReader, offsetWriter, offsetStore, workerConfig, connectMetrics, errorMetrics, loader,
                 time, retryWithToleranceOperator, statusBackingStore, closeExecutor, errorReportersSupplier);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTaskContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTaskContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.ClusterConfigState;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
@@ -29,15 +30,18 @@ public class WorkerSourceTaskContext implements SourceTaskContext {
     private final ConnectorTaskId id;
     private final ClusterConfigState configState;
     private final WorkerTransactionContext transactionContext;
+    private final PluginMetrics pluginMetrics;
 
     public WorkerSourceTaskContext(OffsetStorageReader reader,
                                    ConnectorTaskId id,
                                    ClusterConfigState configState,
-                                   WorkerTransactionContext transactionContext) {
+                                   WorkerTransactionContext transactionContext,
+                                   PluginMetrics pluginMetrics) {
         this.reader = reader;
         this.id = id;
         this.configState = configState;
         this.transactionContext = transactionContext;
+        this.pluginMetrics = pluginMetrics;
     }
 
     @Override
@@ -53,5 +57,10 @@ public class WorkerSourceTaskContext implements SourceTaskContext {
     @Override
     public WorkerTransactionContext transactionContext() {
         return transactionContext;
+    }
+
+    @Override
+    public PluginMetrics pluginMetrics() {
+        return pluginMetrics;
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -19,7 +19,9 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.internals.PluginMetricsImpl;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Frequencies;
 import org.apache.kafka.common.metrics.stats.Max;
@@ -76,6 +78,7 @@ abstract class WorkerTask<T, R extends ConnectRecord<R>> implements Runnable {
     protected final RetryWithToleranceOperator<T> retryWithToleranceOperator;
     protected final TransformationChain<T, R> transformationChain;
     private final Supplier<List<ErrorReporter<T>>> errorReportersSupplier;
+    protected final PluginMetricsImpl pluginMetrics;
 
     public WorkerTask(ConnectorTaskId id,
                       TaskStatus.Listener statusListener,
@@ -103,6 +106,7 @@ abstract class WorkerTask<T, R extends ConnectRecord<R>> implements Runnable {
         this.errorReportersSupplier = errorReportersSupplier;
         this.time = time;
         this.statusBackingStore = statusBackingStore;
+        this.pluginMetrics = connectMetrics.taskPluginMetrics(id);
     }
 
     public ConnectorTaskId id() {
@@ -111,6 +115,10 @@ abstract class WorkerTask<T, R extends ConnectRecord<R>> implements Runnable {
 
     public ClassLoader loader() {
         return loader;
+    }
+
+    public PluginMetrics pluginMetrics() {
+        return pluginMetrics;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2079,7 +2079,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private void startConnector(String connectorName, Callback<Void> callback) {
         log.info("Starting connector {}", connectorName);
         final Map<String, String> configProps = configState.connectorConfig(connectorName);
-        final CloseableConnectorContext ctx = new HerderConnectorContext(this, connectorName);
+        final CloseableConnectorContext ctx = new HerderConnectorContext(this, connectorName, worker.metrics().connectorPluginMetrics(connectorName));
         final TargetState initialState = configState.targetState(connectorName);
         final Callback<TargetState> onInitialStateChange = (error, newState) -> {
             if (error != null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.runtime.rest;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.health.ConnectClusterDetails;
@@ -96,7 +97,7 @@ public abstract class RestServer {
     private final Server jettyServer;
     private final RequestTimeout requestTimeout;
 
-    private List<ConnectRestExtension> connectRestExtensions = Collections.emptyList();
+    private List<Plugin<ConnectRestExtension>> connectRestExtensionPlugins = Collections.emptyList();
 
     /**
      * Create a REST server for this herder using the specified configs.
@@ -217,10 +218,10 @@ public abstract class RestServer {
             throw new ConnectException("Unable to initialize REST server", e);
         }
 
-        log.info("REST server listening at " + jettyServer.getURI() + ", advertising URL " + advertisedUrl());
+        log.info("REST server listening at {}, advertising URL {}", jettyServer.getURI(), advertisedUrl());
         URI adminUrl = adminUrl();
         if (adminUrl != null)
-            log.info("REST admin endpoints at " + adminUrl);
+            log.info("REST admin endpoints at {}", adminUrl);
     }
 
     protected final void initializeResources() {
@@ -370,11 +371,11 @@ public abstract class RestServer {
                     }
                 }
             }
-            for (ConnectRestExtension connectRestExtension : connectRestExtensions) {
+            for (Plugin<ConnectRestExtension> connectRestExtensionPlugin : connectRestExtensionPlugins) {
                 try {
-                    connectRestExtension.close();
+                    connectRestExtensionPlugin.close();
                 } catch (IOException e) {
-                    log.warn("Error while invoking close on " + connectRestExtension.getClass(), e);
+                    log.warn("Error while invoking close on {}", connectRestExtensionPlugin.get().getClass(), e);
                 }
             }
             jettyServer.stop();
@@ -504,9 +505,14 @@ public abstract class RestServer {
     }
 
     protected final void registerRestExtensions(Herder herder, ResourceConfig resourceConfig) {
-        connectRestExtensions = herder.plugins().newPlugins(
-            config.restExtensions(),
-            config, ConnectRestExtension.class);
+        connectRestExtensionPlugins = Plugin.wrapInstances(
+                herder.plugins().newPlugins(
+                    config.restExtensions(),
+                    config,
+                    ConnectRestExtension.class
+                ),
+                herder.worker().metrics().metrics(),
+                RestServerConfig.REST_EXTENSION_CLASSES_CONFIG);
 
         long herderRequestTimeoutMs = DEFAULT_REST_REQUEST_TIMEOUT_MS;
 
@@ -525,8 +531,8 @@ public abstract class RestServer {
                 new ConnectRestConfigurable(resourceConfig),
                 new ConnectClusterStateImpl(herderRequestTimeoutMs, connectClusterDetails, herder)
             );
-        for (ConnectRestExtension connectRestExtension : connectRestExtensions) {
-            connectRestExtension.register(connectRestExtensionContext);
+        for (Plugin<ConnectRestExtension> connectRestExtensionPlugin : connectRestExtensionPlugins) {
+            connectRestExtensionPlugin.get().register(connectRestExtensionContext);
         }
 
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -511,7 +511,7 @@ public abstract class RestServer {
                     config,
                     ConnectRestExtension.class
                 ),
-                herder.worker().metrics().metrics(),
+                herder.connectMetrics().metrics(),
                 RestServerConfig.REST_EXTENSION_CLASSES_CONFIG);
 
         long herderRequestTimeoutMs = DEFAULT_REST_REQUEST_TIMEOUT_MS;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -463,7 +463,7 @@ public final class StandaloneHerder extends AbstractHerder {
     private void startConnector(String connName, Callback<TargetState> onStart) {
         Map<String, String> connConfigs = configState.connectorConfig(connName);
         TargetState targetState = configState.targetState(connName);
-        worker.startConnector(connName, connConfigs, new HerderConnectorContext(this, connName), this, targetState, onStart);
+        worker.startConnector(connName, connConfigs, new HerderConnectorContext(this, connName, worker.metrics().connectorPluginMetrics(connName)), this, targetState, onStart);
     }
 
     private List<Map<String, String>> recomputeTaskConfigs(String connName) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -323,9 +323,9 @@ public class BlockingConnectorTest {
         normalConnectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, "1");
-        props.put(MonitorableSourceConnector.TOPIC_CONFIG, TEST_TOPIC);
+        props.put(TestableSourceConnector.TOPIC_CONFIG, TEST_TOPIC);
         log.info("Creating normal connector");
         try {
             connect.configureConnector(NORMAL_CONNECTOR_NAME, props);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -79,7 +79,7 @@ import static org.apache.kafka.common.config.AbstractConfig.CONFIG_PROVIDERS_CON
 import static org.apache.kafka.common.config.TopicConfig.DELETE_RETENTION_MS_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_MS_CONFIG;
 import static org.apache.kafka.connect.integration.BlockingConnectorTest.TASK_STOP;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_PRODUCER_OVERRIDES_PREFIX;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG;
@@ -326,7 +326,7 @@ public class ConnectWorkerIntegrationTest {
 
         // base connector props
         Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
 
         // start the connector with only one task
         int initialNumTasks = 1;
@@ -792,7 +792,7 @@ public class ConnectWorkerIntegrationTest {
     private Map<String, String> defaultSinkConnectorProps(String topics) {
         // setup props for the sink connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, topics);
 
@@ -987,7 +987,7 @@ public class ConnectWorkerIntegrationTest {
         int maxTasks = 1;
         connectorProps.put(TASKS_MAX_CONFIG, Integer.toString(maxTasks));
         int numTasks = 2;
-        connectorProps.put(MonitorableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
+        connectorProps.put(TestableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
         connect.configureConnector(CONNECTOR_NAME, connectorProps);
 
         // A connector that generates excessive tasks will be failed with an expected error message
@@ -1019,7 +1019,7 @@ public class ConnectWorkerIntegrationTest {
             );
 
             for (int i = 0; i < numTasks; i++) {
-                Map<String, String> taskConfig = MonitorableSourceConnector.taskConfig(
+                Map<String, String> taskConfig = TestableSourceConnector.taskConfig(
                         connectorProps,
                         CONNECTOR_NAME,
                         i
@@ -1070,7 +1070,7 @@ public class ConnectWorkerIntegrationTest {
         );
 
         numTasks++;
-        connectorProps.put(MonitorableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
+        connectorProps.put(TestableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
         connect.configureConnector(CONNECTOR_NAME, connectorProps);
 
         // A connector will be allowed to generate excessive tasks when tasks.max.enforce is set to false
@@ -1081,7 +1081,7 @@ public class ConnectWorkerIntegrationTest {
         );
 
         numTasks = maxTasks;
-        connectorProps.put(MonitorableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
+        connectorProps.put(TestableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
         connectorProps.put(TASKS_MAX_ENFORCE_CONFIG, "true");
         connect.configureConnector(CONNECTOR_NAME, connectorProps);
 
@@ -1092,7 +1092,7 @@ public class ConnectWorkerIntegrationTest {
         );
 
         numTasks = maxTasks + 1;
-        connectorProps.put(MonitorableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
+        connectorProps.put(TestableSourceConnector.NUM_TASKS, Integer.toString(numTasks));
         connect.configureConnector(CONNECTOR_NAME, connectorProps);
 
         // A connector that generates excessive tasks after being reconfigured will be failed, but its existing tasks will continue running
@@ -1386,7 +1386,7 @@ public class ConnectWorkerIntegrationTest {
         final String sourceConnectorName = "plugins-alias-test-source";
         Map<String, String> sourceConnectorConfig = new HashMap<>(baseConnectorConfig);
         // Aliased source connector class
-        sourceConnectorConfig.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        sourceConnectorConfig.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         // Connector-specific properties
         sourceConnectorConfig.put(TOPIC_CONFIG, topic);
         sourceConnectorConfig.put("throughput", "10");
@@ -1400,7 +1400,7 @@ public class ConnectWorkerIntegrationTest {
         final String sinkConnectorName = "plugins-alias-test-sink";
         Map<String, String> sinkConnectorConfig = new HashMap<>(baseConnectorConfig);
         // Aliased sink connector class
-        sinkConnectorConfig.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        sinkConnectorConfig.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         // Connector-specific properties
         sinkConnectorConfig.put(TOPICS_CONFIG, topic);
         // Create the connector and ensure it and its tasks can start
@@ -1412,7 +1412,7 @@ public class ConnectWorkerIntegrationTest {
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup props for the source connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put("throughput", "10");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
@@ -148,7 +148,7 @@ public class ConnectorClientPolicyIntegrationTest {
 
     public Map<String, String> basicConnectorConfig() {
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, "test-topic");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Response;
 
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
@@ -415,7 +415,7 @@ public class ConnectorRestartApiIntegrationTest {
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup up props for the source connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put("throughput", "10");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
@@ -296,7 +296,7 @@ public class ConnectorTopicsIntegrationTest {
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup up props for the source connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put("throughput", String.valueOf(10));
@@ -311,7 +311,7 @@ public class ConnectorTopicsIntegrationTest {
     private Map<String, String> defaultSinkConnectorProps(String... topics) {
         // setup up props for the sink connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, String.join(",", topics));
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -39,7 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG;
@@ -228,7 +228,7 @@ public class ConnectorValidationIntegrationTest {
         Map<String, String> config = defaultSinkConnectorProps();
         String transformName = "t";
         config.put(TRANSFORMS_CONFIG, transformName);
-        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", MonitorableSinkConnector.class.getName());
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", TestableSinkConnector.class.getName());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -289,7 +289,7 @@ public class ConnectorValidationIntegrationTest {
         Map<String, String> config = defaultSinkConnectorProps();
         String predicateName = "p";
         config.put(PREDICATES_CONFIG, predicateName);
-        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", MonitorableSinkConnector.class.getName());
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", TestableSinkConnector.class.getName());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -315,7 +315,7 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testConnectorHasInvalidConverterClassType() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
-        config.put(KEY_CONVERTER_CLASS_CONFIG, MonitorableSinkConnector.class.getName());
+        config.put(KEY_CONVERTER_CLASS_CONFIG, TestableSinkConnector.class.getName());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -413,7 +413,7 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testConnectorHasInvalidHeaderConverterClassType() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
-        config.put(HEADER_CONVERTER_CLASS_CONFIG, MonitorableSinkConnector.class.getName());
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestableSinkConnector.class.getName());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -560,7 +560,7 @@ public class ConnectorValidationIntegrationTest {
         // setup up props for the source connector
         Map<String, String> props = new HashMap<>();
         props.put(NAME_CONFIG, "source-connector");
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, "1");
         props.put(TOPIC_CONFIG, "t1");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -572,7 +572,7 @@ public class ConnectorValidationIntegrationTest {
         // setup up props for the sink connector
         Map<String, String> props = new HashMap<>();
         props.put(NAME_CONFIG, "sink-connector");
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, "1");
         props.put(TOPICS_CONFIG, "t1");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
@@ -30,14 +30,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-public class ErrantRecordSinkConnector extends MonitorableSinkConnector {
+public class ErrantRecordSinkConnector extends TestableSinkConnector {
 
     @Override
     public Class<? extends Task> taskClass() {
         return ErrantRecordSinkTask.class;
     }
 
-    public static class ErrantRecordSinkTask extends MonitorableSinkTask {
+    public static class ErrantRecordSinkTask extends TestableSinkTask {
         private ErrantRecordReporter reporter;
         private ExecutorService executorService;
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -110,7 +110,7 @@ public class ErrorHandlingIntegrationTest {
 
         // setup connector config
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, "test-topic");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -84,11 +84,11 @@ import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.CUSTOM_TRANSACTION_BOUNDARIES_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.MAX_MESSAGES_PER_SECOND_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.MESSAGES_PER_POLL_CONFIG;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.CUSTOM_TRANSACTION_BOUNDARIES_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.MAX_MESSAGES_PER_SECOND_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.MESSAGES_PER_POLL_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
@@ -183,7 +183,7 @@ public class ExactlyOnceSourceIntegrationTest {
         startConnect();
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, "1");
         props.put(TOPIC_CONFIG, "topic");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -194,8 +194,8 @@ public class ExactlyOnceSourceIntegrationTest {
         props.put(EXACTLY_ONCE_SUPPORT_CONFIG, "required");
 
         // Connector will return null from SourceConnector::exactlyOnceSupport
-        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, MonitorableSourceConnector.EXACTLY_ONCE_NULL);
-        ConfigInfos validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, TestableSourceConnector.EXACTLY_ONCE_NULL);
+        ConfigInfos validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(),
                 "Preflight validation should have exactly one error");
         ConfigInfo propertyValidation = findConfigInfo(EXACTLY_ONCE_SUPPORT_CONFIG, validation);
@@ -203,56 +203,56 @@ public class ExactlyOnceSourceIntegrationTest {
                 "Preflight validation for exactly-once support property should have at least one error message");
 
         // Connector will return UNSUPPORTED from SourceConnector::exactlyOnceSupport
-        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, MonitorableSourceConnector.EXACTLY_ONCE_UNSUPPORTED);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, TestableSourceConnector.EXACTLY_ONCE_UNSUPPORTED);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(), "Preflight validation should have exactly one error");
         propertyValidation = findConfigInfo(EXACTLY_ONCE_SUPPORT_CONFIG, validation);
         assertFalse(propertyValidation.configValue().errors().isEmpty(), 
                 "Preflight validation for exactly-once support property should have at least one error message");
 
         // Connector will throw an exception from SourceConnector::exactlyOnceSupport
-        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, MonitorableSourceConnector.EXACTLY_ONCE_FAIL);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, TestableSourceConnector.EXACTLY_ONCE_FAIL);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(), "Preflight validation should have exactly one error");
         propertyValidation = findConfigInfo(EXACTLY_ONCE_SUPPORT_CONFIG, validation);
         assertFalse(propertyValidation.configValue().errors().isEmpty(),
                 "Preflight validation for exactly-once support property should have at least one error message");
 
         // Connector will return SUPPORTED from SourceConnector::exactlyOnceSupport
-        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, MonitorableSourceConnector.EXACTLY_ONCE_SUPPORTED);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, TestableSourceConnector.EXACTLY_ONCE_SUPPORTED);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(0, validation.errorCount(), "Preflight validation should have zero errors");
 
         // Test out the transaction boundary definition property
         props.put(TRANSACTION_BOUNDARY_CONFIG, CONNECTOR.toString());
 
         // Connector will return null from SourceConnector::canDefineTransactionBoundaries
-        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, MonitorableSourceConnector.TRANSACTION_BOUNDARIES_NULL);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TestableSourceConnector.TRANSACTION_BOUNDARIES_NULL);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(), "Preflight validation should have exactly one error");
         propertyValidation = findConfigInfo(TRANSACTION_BOUNDARY_CONFIG, validation);
         assertFalse(propertyValidation.configValue().errors().isEmpty(),
                 "Preflight validation for transaction boundary property should have at least one error message");
 
         // Connector will return UNSUPPORTED from SourceConnector::canDefineTransactionBoundaries
-        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, MonitorableSourceConnector.TRANSACTION_BOUNDARIES_UNSUPPORTED);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TestableSourceConnector.TRANSACTION_BOUNDARIES_UNSUPPORTED);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(), "Preflight validation should have exactly one error");
         propertyValidation = findConfigInfo(TRANSACTION_BOUNDARY_CONFIG, validation);
         assertFalse(propertyValidation.configValue().errors().isEmpty(),
                 "Preflight validation for transaction boundary property should have at least one error message");
 
         // Connector will throw an exception from SourceConnector::canDefineTransactionBoundaries
-        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, MonitorableSourceConnector.TRANSACTION_BOUNDARIES_FAIL);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TestableSourceConnector.TRANSACTION_BOUNDARIES_FAIL);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(1, validation.errorCount(), "Preflight validation should have exactly one error");
         propertyValidation = findConfigInfo(TRANSACTION_BOUNDARY_CONFIG, validation);
         assertFalse(propertyValidation.configValue().errors().isEmpty(), 
                 "Preflight validation for transaction boundary property should have at least one error message");
 
         // Connector will return SUPPORTED from SourceConnector::canDefineTransactionBoundaries
-        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, MonitorableSourceConnector.TRANSACTION_BOUNDARIES_SUPPORTED);
-        validation = connect.validateConnectorConfig(MonitorableSourceConnector.class.getSimpleName(), props);
+        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TestableSourceConnector.TRANSACTION_BOUNDARIES_SUPPORTED);
+        validation = connect.validateConnectorConfig(TestableSourceConnector.class.getSimpleName(), props);
         assertEquals(0, validation.errorCount(), "Preflight validation should have zero errors");
     }
 
@@ -274,7 +274,7 @@ public class ExactlyOnceSourceIntegrationTest {
         int numTasks = 1;
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, Integer.toString(numTasks));
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -333,7 +333,7 @@ public class ExactlyOnceSourceIntegrationTest {
         int numTasks = 1;
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, Integer.toString(numTasks));
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -393,14 +393,14 @@ public class ExactlyOnceSourceIntegrationTest {
         connect.kafka().createTopic(topic, 3);
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, "1");
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(NAME_CONFIG, CONNECTOR_NAME);
         props.put(TRANSACTION_BOUNDARY_CONFIG, CONNECTOR.toString());
-        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, MonitorableSourceConnector.TRANSACTION_BOUNDARIES_SUPPORTED);
+        props.put(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TestableSourceConnector.TRANSACTION_BOUNDARIES_SUPPORTED);
         props.put(MESSAGES_PER_POLL_CONFIG, MESSAGES_PER_POLL);
         props.put(MAX_MESSAGES_PER_SECOND_CONFIG, MESSAGES_PER_SECOND);
 
@@ -495,7 +495,7 @@ public class ExactlyOnceSourceIntegrationTest {
         int numTasks = 1;
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TASKS_MAX_CONFIG, Integer.toString(numTasks));
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -562,7 +562,7 @@ public class ExactlyOnceSourceIntegrationTest {
         connect.kafka().createTopic(topic, 3);
 
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -669,7 +669,7 @@ public class ExactlyOnceSourceIntegrationTest {
 
         Map<String, String> props = new HashMap<>();
         int tasksMax = 2; // Use two tasks since single-task connectors don't require zombie fencing
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -824,7 +824,7 @@ public class ExactlyOnceSourceIntegrationTest {
             int numTasks = 1;
 
             Map<String, String> props = new HashMap<>();
-            props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getName());
+            props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getName());
             props.put(TASKS_MAX_CONFIG, Integer.toString(numTasks));
             props.put(TOPIC_CONFIG, topic);
             props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -1123,7 +1123,7 @@ public class ExactlyOnceSourceIntegrationTest {
             @SuppressWarnings("unchecked")
             Map<String, Object> partition = assertAndCast(key.get(1), Map.class, "Key[1]");
             Object taskIdObject = partition.get("task.id");
-            assertNotNull(taskIdObject, "Serialized source partition should contain 'task.id' field from MonitorableSourceConnector");
+            assertNotNull(taskIdObject, "Serialized source partition should contain 'task.id' field from TestableSourceConnector");
             String taskId = assertAndCast(taskIdObject, String.class, "task ID");
             assertTrue(taskId.startsWith(CONNECTOR_NAME + "-"), "task ID should match pattern '<connectorName>-<taskId>");
             String taskIdRemainder = taskId.substring(CONNECTOR_NAME.length() + 1);
@@ -1138,7 +1138,7 @@ public class ExactlyOnceSourceIntegrationTest {
             Map<String, Object> value = assertAndCast(valueObject, Map.class, "Value");
 
             Object seqnoObject = value.get("saved");
-            assertNotNull(seqnoObject, "Serialized source offset should contain 'seqno' field from MonitorableSourceConnector");
+            assertNotNull(seqnoObject, "Serialized source offset should contain 'seqno' field from TestableSourceConnector");
             long seqno = assertAndCast(seqnoObject, Long.class, "Seqno offset field");
 
             result.computeIfAbsent(taskNum, t -> new ArrayList<>()).add(seqno);
@@ -1163,7 +1163,7 @@ public class ExactlyOnceSourceIntegrationTest {
     private StartAndStopLatch connectorAndTaskStart(int numTasks) {
         connectorHandle.clearTasks();
         IntStream.range(0, numTasks)
-                .mapToObj(i -> MonitorableSourceConnector.taskId(CONNECTOR_NAME, i))
+                .mapToObj(i -> TestableSourceConnector.taskId(CONNECTOR_NAME, i))
                 .forEach(connectorHandle::taskHandle);
         return connectorHandle.expectedStarts(1, true);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -63,8 +63,8 @@ public class ExampleConnectIntegrationTest {
     private static final int NUM_TASKS = 3;
     private static final int NUM_WORKERS = 3;
     private static final String CONNECTOR_NAME = "simple-conn";
-    private static final String SINK_CONNECTOR_CLASS_NAME = MonitorableSinkConnector.class.getSimpleName();
-    private static final String SOURCE_CONNECTOR_CLASS_NAME = MonitorableSourceConnector.class.getSimpleName();
+    private static final String SINK_CONNECTOR_CLASS_NAME = TestableSinkConnector.class.getSimpleName();
+    private static final String SOURCE_CONNECTOR_CLASS_NAME = TestableSourceConnector.class.getSimpleName();
 
     private EmbeddedConnectCluster connect;
     private ConnectorHandle connectorHandle;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -28,8 +28,8 @@ import java.util.Map;
 
 public class MonitorableSinkConnector extends TestableSinkConnector {
 
-    public static MetricName metricsName = null;
     public static final String VALUE = "started";
+    public static MetricName metricsName = null;
 
     @Override
     public void start(Map<String, String> props) {
@@ -59,8 +59,8 @@ public class MonitorableSinkConnector extends TestableSinkConnector {
 
         @Override
         public void put(Collection<SinkRecord> records) {
+            super.put(records);
             for (SinkRecord ignore : records) {
-                taskHandle.record();
                 count++;
             }
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -16,48 +16,27 @@
  */
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.runtime.SampleSinkConnector;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTask;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-/**
- * A sink connector that is used in Apache Kafka integration tests to verify the behavior of the
- * Connect framework, but that can be used in other integration tests as a simple connector that
- * consumes and counts records. This class provides methods to find task instances
- * which are initiated by the embedded connector, and wait for them to consume a desired number of
- * messages.
- */
-public class MonitorableSinkConnector extends SampleSinkConnector {
+public class MonitorableSinkConnector extends TestableSinkConnector {
 
-    private static final Logger log = LoggerFactory.getLogger(MonitorableSinkConnector.class);
-
-    // Boolean valued configuration that determines whether MonitorableSinkConnector::alterOffsets should return true or false
-    public static final String ALTER_OFFSETS_RESULT = "alter.offsets.result";
-
-    private String connectorName;
-    private Map<String, String> commonConfigs;
-    private ConnectorHandle connectorHandle;
+    public static MetricName metricsName = null;
+    public static final String VALUE = "started";
 
     @Override
     public void start(Map<String, String> props) {
-        connectorHandle = RuntimeHandles.get().connectorHandle(props.get("name"));
-        connectorName = props.get("name");
-        commonConfigs = props;
-        log.info("Starting connector {}", props.get("name"));
-        connectorHandle.recordConnectorStart();
+        super.start(props);
+        PluginMetrics pluginMetrics = context.pluginMetrics();
+        metricsName = pluginMetrics.metricName("start", "description", Map.of());
+        pluginMetrics.addMetric(metricsName, (Gauge<Object>) (config, now) -> VALUE);
     }
 
     @Override
@@ -65,103 +44,26 @@ public class MonitorableSinkConnector extends SampleSinkConnector {
         return MonitorableSinkTask.class;
     }
 
-    @Override
-    public List<Map<String, String>> taskConfigs(int maxTasks) {
-        List<Map<String, String>> configs = new ArrayList<>();
-        for (int i = 0; i < maxTasks; i++) {
-            Map<String, String> config = new HashMap<>(commonConfigs);
-            config.put("connector.name", connectorName);
-            config.put("task.id", connectorName + "-" + i);
-            configs.add(config);
-        }
-        return configs;
-    }
+    public static class MonitorableSinkTask extends TestableSinkTask {
 
-    @Override
-    public void stop() {
-        log.info("Stopped {} connector {}", this.getClass().getSimpleName(), connectorName);
-        connectorHandle.recordConnectorStop();
-    }
-
-    @Override
-    public ConfigDef config() {
-        return new ConfigDef();
-    }
-
-    @Override
-    public boolean alterOffsets(Map<String, String> connectorConfig, Map<TopicPartition, Long> offsets) {
-        return Boolean.parseBoolean(connectorConfig.get(ALTER_OFFSETS_RESULT));
-    }
-
-    public static class MonitorableSinkTask extends SinkTask {
-
-        private String taskId;
-        TaskHandle taskHandle;
-        Map<TopicPartition, Integer> committedOffsets;
-        Map<String, Map<Integer, TopicPartition>> cachedTopicPartitions;
-
-        public MonitorableSinkTask() {
-            this.committedOffsets = new HashMap<>();
-            this.cachedTopicPartitions = new HashMap<>();
-        }
-
-        @Override
-        public String version() {
-            return "unknown";
-        }
+        public static MetricName metricsName = null;
+        private int count = 0;
 
         @Override
         public void start(Map<String, String> props) {
-            taskId = props.get("task.id");
-            String connectorName = props.get("connector.name");
-            taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
-            log.debug("Starting task {}", taskId);
-            taskHandle.recordTaskStart();
-        }
-
-        @Override
-        public void open(Collection<TopicPartition> partitions) {
-            log.debug("Opening partitions {}", partitions);
-            taskHandle.partitionsAssigned(partitions);
-        }
-
-        @Override
-        public void close(Collection<TopicPartition> partitions) {
-            log.debug("Closing partitions {}", partitions);
-            taskHandle.partitionsRevoked(partitions);
-            partitions.forEach(committedOffsets::remove);
+            super.start(props);
+            PluginMetrics pluginMetrics = context.pluginMetrics();
+            metricsName = pluginMetrics.metricName("put", "description", Map.of());
+            pluginMetrics.addMetric(metricsName, (Measurable) (config, now) -> count);
         }
 
         @Override
         public void put(Collection<SinkRecord> records) {
-            for (SinkRecord rec : records) {
-                taskHandle.record(rec);
-                TopicPartition tp = cachedTopicPartitions
-                        .computeIfAbsent(rec.topic(), v -> new HashMap<>())
-                        .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));
-                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0) + 1);
-                log.trace("Task {} obtained record (key='{}' value='{}')", taskId, rec.key(), rec.value());
+            for (SinkRecord ignore : records) {
+                taskHandle.record();
+                count++;
             }
         }
 
-        @Override
-        public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
-            taskHandle.partitionsCommitted(offsets.keySet());
-            offsets.forEach((tp, offset) -> {
-                int recordsSinceLastCommit = committedOffsets.getOrDefault(tp, 0);
-                if (recordsSinceLastCommit != 0) {
-                    taskHandle.commit(recordsSinceLastCommit);
-                    log.debug("Forwarding to framework request to commit {} records for {}", recordsSinceLastCommit, tp);
-                    committedOffsets.put(tp, 0);
-                }
-            });
-            return offsets;
-        }
-
-        @Override
-        public void stop() {
-            log.info("Stopped {} task {}", this.getClass().getSimpleName(), taskId);
-            taskHandle.recordTaskStop();
-        }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectStandalone;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for a sink connector defining metrics via the PluginMetrics API
+ */
+@Tag("integration")
+@Timeout(value = 600)
+public class MonitorableSinkIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MonitorableSinkIntegrationTest.class);
+
+    private static final String CONNECTOR_NAME = "monitorable-sink";
+    private static final String TASK_ID = CONNECTOR_NAME + "-0";
+    private static final int NUM_RECORDS_PRODUCED = 1000;
+    private static final int NUM_TASKS = 1;
+    private static final long CONNECTOR_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+    private static final long CONSUME_MAX_DURATION_MS = TimeUnit.SECONDS.toMillis(30);
+
+    private EmbeddedConnectStandalone connect;
+    private ConnectorHandle connectorHandle;
+
+    @BeforeEach
+    public void setup() throws InterruptedException {
+        // setup Connect cluster with defaults
+        connect = new EmbeddedConnectStandalone.Builder().build();
+
+        // start Connect cluster
+        connect.start();
+
+        // get connector handles before starting test.
+        connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+    }
+
+    @AfterEach
+    public void close() {
+        connect.stop();
+    }
+
+    @Test
+    public void testMonitorableSinkConnectorAndTask() throws Exception {
+        connect.kafka().createTopic("test-topic");
+
+        Map<String, String> props = Map.of(
+            CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName(),
+            TASKS_MAX_CONFIG, "1",
+            TOPICS_CONFIG, "test-topic",
+            KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName(),
+            VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+
+        // set expected records to successfully reach the task
+        connectorHandle.taskHandle(TASK_ID).expectedRecords(NUM_RECORDS_PRODUCED);
+
+        connect.configureConnector(CONNECTOR_NAME, props);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
+                "Connector tasks did not start in time.");
+
+        waitForCondition(this::checkForPartitionAssignment,
+                CONNECTOR_SETUP_DURATION_MS,
+                "Connector task was not assigned a partition.");
+
+        // check connector metric
+        Map<MetricName, KafkaMetric> metrics = connect.herder().worker().metrics().metrics().metrics();
+        MetricName connectorMetric = MonitorableSinkConnector.metricsName;
+        assertTrue(metrics.containsKey(connectorMetric));
+        assertEquals(CONNECTOR_NAME, connectorMetric.tags().get("connector"));
+        KafkaMetric kafkaMetric = metrics.get(connectorMetric);
+        assertEquals(MonitorableSinkConnector.VALUE, kafkaMetric.metricValue());
+
+        // produce some records
+        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+            connect.kafka().produce("test-topic", "key-" + i, "value-" + i);
+        }
+
+        // wait for records to reach the task
+        connectorHandle.taskHandle(TASK_ID).awaitRecords(CONSUME_MAX_DURATION_MS);
+
+        // check task metric
+        metrics = connect.herder().worker().metrics().metrics().metrics();
+        MetricName taskMetric = MonitorableSinkConnector.MonitorableSinkTask.metricsName;
+        assertTrue(metrics.containsKey(taskMetric));
+        assertEquals(CONNECTOR_NAME, taskMetric.tags().get("connector"));
+        assertEquals("0", taskMetric.tags().get("task"));
+        assertEquals((double) NUM_RECORDS_PRODUCED, metrics.get(taskMetric).metricValue());
+
+        connect.deleteConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorDoesNotExist(CONNECTOR_NAME,
+                "Connector wasn't deleted in time.");
+
+        // verify connector and task metrics have been deleted
+        metrics = connect.herder().worker().metrics().metrics().metrics();
+        assertFalse(metrics.containsKey(connectorMetric));
+        assertFalse(metrics.containsKey(taskMetric));
+    }
+
+    /**
+     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from a
+     * {@link org.apache.kafka.test.TestUtils#waitForCondition} that will throw an error if this method continued
+     * to return false after the specified duration has elapsed.
+     *
+     * @return true if each task was assigned a partition each, false if this was not true or an error occurred when
+     * executing this operation.
+     */
+    private boolean checkForPartitionAssignment() {
+        try {
+            ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
+            return info != null && info.tasks().size() == NUM_TASKS
+                    && connectorHandle.taskHandle(TASK_ID).numPartitionsAssigned() == 1;
+        }  catch (Exception e) {
+            // Log the exception and return that the partitions were not assigned
+            log.error("Could not check connector state info.", e);
+            return false;
+        }
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
@@ -102,7 +102,7 @@ public class MonitorableSinkIntegrationTest {
                 "Connector task was not assigned a partition.");
 
         // check connector metric
-        Map<MetricName, KafkaMetric> metrics = connect.herder().worker().metrics().metrics().metrics();
+        Map<MetricName, KafkaMetric> metrics = connect.connectMetrics().metrics().metrics();
         MetricName connectorMetric = MonitorableSinkConnector.metricsName;
         assertTrue(metrics.containsKey(connectorMetric));
         assertEquals(CONNECTOR_NAME, connectorMetric.tags().get("connector"));
@@ -118,7 +118,7 @@ public class MonitorableSinkIntegrationTest {
         connectorHandle.taskHandle(TASK_ID).awaitRecords(CONSUME_MAX_DURATION_MS);
 
         // check task metric
-        metrics = connect.herder().worker().metrics().metrics().metrics();
+        metrics = connect.connectMetrics().metrics().metrics();
         MetricName taskMetric = MonitorableSinkConnector.MonitorableSinkTask.metricsName;
         assertTrue(metrics.containsKey(taskMetric));
         assertEquals(CONNECTOR_NAME, taskMetric.tags().get("connector"));
@@ -130,7 +130,7 @@ public class MonitorableSinkIntegrationTest {
                 "Connector wasn't deleted in time.");
 
         // verify connector and task metrics have been deleted
-        metrics = connect.herder().worker().metrics().metrics().metrics();
+        metrics = connect.connectMetrics().metrics().metrics();
         assertFalse(metrics.containsKey(connectorMetric));
         assertFalse(metrics.containsKey(taskMetric));
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -16,76 +16,27 @@
  */
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.runtime.SampleSourceConnector;
-import org.apache.kafka.connect.source.ConnectorTransactionBoundaries;
-import org.apache.kafka.connect.source.ExactlyOnceSupport;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.source.SourceTask;
-import org.apache.kafka.server.util.ThroughputThrottler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 
-/**
- * A source connector that is used in Apache Kafka integration tests to verify the behavior of
- * the Connect framework, but that can be used in other integration tests as a simple connector
- * that generates records of a fixed structure. The rate of record production can be adjusted
- * through the configs 'throughput' and 'messages.per.poll'
- */
-public class MonitorableSourceConnector extends SampleSourceConnector {
-    private static final Logger log = LoggerFactory.getLogger(MonitorableSourceConnector.class);
+public class MonitorableSourceConnector extends TestableSourceConnector {
 
-    public static final String TOPIC_CONFIG = "topic";
-    public static final String NUM_TASKS = "num.tasks";
-    public static final String MESSAGES_PER_POLL_CONFIG = "messages.per.poll";
-    public static final String MAX_MESSAGES_PER_SECOND_CONFIG = "throughput";
-    public static final String MAX_MESSAGES_PRODUCED_CONFIG = "max.messages";
-
-    public static final String CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG = "custom.exactly.once.support";
-    public static final String EXACTLY_ONCE_SUPPORTED = "supported";
-    public static final String EXACTLY_ONCE_UNSUPPORTED = "unsupported";
-    public static final String EXACTLY_ONCE_NULL = "null";
-    public static final String EXACTLY_ONCE_FAIL = "fail";
-
-    public static final String CUSTOM_TRANSACTION_BOUNDARIES_CONFIG = "custom.transaction.boundaries";
-    public static final String TRANSACTION_BOUNDARIES_SUPPORTED = "supported";
-    public static final String TRANSACTION_BOUNDARIES_UNSUPPORTED = "unsupported";
-    public static final String TRANSACTION_BOUNDARIES_NULL = "null";
-    public static final String TRANSACTION_BOUNDARIES_FAIL = "fail";
-
-    // Boolean valued configuration that determines whether MonitorableSourceConnector::alterOffsets should return true or false
-    public static final String ALTER_OFFSETS_RESULT = "alter.offsets.result";
-
-    private String connectorName;
-    private ConnectorHandle connectorHandle;
-    private Map<String, String> commonConfigs;
+    public static MetricName metricsName = null;
+    public static final String VALUE = "started";
 
     @Override
     public void start(Map<String, String> props) {
-        connectorHandle = RuntimeHandles.get().connectorHandle(props.get("name"));
-        connectorName = connectorHandle.name();
-        commonConfigs = props;
-        log.info("Started {} connector {}", this.getClass().getSimpleName(), connectorName);
-        connectorHandle.recordConnectorStart();
-        if (Boolean.parseBoolean(props.getOrDefault("connector.start.inject.error", "false"))) {
-            throw new RuntimeException("Injecting errors during connector start");
-        }
+        super.start(props);
+        PluginMetrics pluginMetrics = context.pluginMetrics();
+        metricsName = pluginMetrics.metricName("start", "description", Map.of());
+        pluginMetrics.addMetric(metricsName, (Gauge<Object>) (config, now) -> VALUE);
     }
 
     @Override
@@ -93,222 +44,27 @@ public class MonitorableSourceConnector extends SampleSourceConnector {
         return MonitorableSourceTask.class;
     }
 
-    @Override
-    public List<Map<String, String>> taskConfigs(int maxTasks) {
-        String numTasksProp = commonConfigs.get(NUM_TASKS);
-        int numTasks = numTasksProp != null ? Integer.parseInt(numTasksProp) : maxTasks;
-        List<Map<String, String>> configs = new ArrayList<>();
-        for (int i = 0; i < numTasks; i++) {
-            Map<String, String> config = taskConfig(commonConfigs, connectorName, i);
-            configs.add(config);
-        }
-        return configs;
-    }
+    public static class MonitorableSourceTask extends TestableSourceTask {
 
-    public static Map<String, String> taskConfig(
-            Map<String, String> connectorProps,
-            String connectorName,
-            int taskNum
-    ) {
-        Map<String, String> result = new HashMap<>(connectorProps);
-        result.put("connector.name", connectorName);
-        result.put("task.id", taskId(connectorName, taskNum));
-        return result;
-    }
-
-    @Override
-    public void stop() {
-        log.info("Stopped {} connector {}", this.getClass().getSimpleName(), connectorName);
-        connectorHandle.recordConnectorStop();
-        if (Boolean.parseBoolean(commonConfigs.getOrDefault("connector.stop.inject.error", "false"))) {
-            throw new RuntimeException("Injecting errors during connector stop");
-        }
-    }
-
-    @Override
-    public ConfigDef config() {
-        log.info("Configured {} connector {}", this.getClass().getSimpleName(), connectorName);
-        return new ConfigDef();
-    }
-
-    @Override
-    public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> connectorConfig) {
-        String supportLevel = connectorConfig.getOrDefault(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, "null").toLowerCase(Locale.ROOT);
-        switch (supportLevel) {
-            case EXACTLY_ONCE_SUPPORTED:
-                return ExactlyOnceSupport.SUPPORTED;
-            case EXACTLY_ONCE_UNSUPPORTED:
-                return ExactlyOnceSupport.UNSUPPORTED;
-            case EXACTLY_ONCE_FAIL:
-                throw new ConnectException("oops");
-            default:
-            case EXACTLY_ONCE_NULL:
-                return null;
-        }
-    }
-
-    @Override
-    public ConnectorTransactionBoundaries canDefineTransactionBoundaries(Map<String, String> connectorConfig) {
-        String supportLevel = connectorConfig.getOrDefault(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TRANSACTION_BOUNDARIES_UNSUPPORTED).toLowerCase(Locale.ROOT);
-        switch (supportLevel) {
-            case TRANSACTION_BOUNDARIES_SUPPORTED:
-                return ConnectorTransactionBoundaries.SUPPORTED;
-            case TRANSACTION_BOUNDARIES_FAIL:
-                throw new ConnectException("oh no :(");
-            case TRANSACTION_BOUNDARIES_NULL:
-                return null;
-            default:
-            case TRANSACTION_BOUNDARIES_UNSUPPORTED:
-                return ConnectorTransactionBoundaries.UNSUPPORTED;
-        }
-    }
-
-    @Override
-    public boolean alterOffsets(Map<String, String> connectorConfig, Map<Map<String, ?>, Map<String, ?>> offsets) {
-        return Boolean.parseBoolean(connectorConfig.get(ALTER_OFFSETS_RESULT));
-    }
-
-    public static String taskId(String connectorName, int taskId) {
-        return connectorName + "-" + taskId;
-    }
-
-    public static class MonitorableSourceTask extends SourceTask {
-        private String taskId;
-        private String topicName;
-        private TaskHandle taskHandle;
-        private volatile boolean stopped;
-        private long startingSeqno;
-        private long seqno;
-        private int batchSize;
-        private ThroughputThrottler throttler;
-        private long maxMessages;
-
-        private long priorTransactionBoundary;
-        private long nextTransactionBoundary;
-
-        @Override
-        public String version() {
-            return "unknown";
-        }
+        public static MetricName metricsName = null;
+        private int count = 0;
 
         @Override
         public void start(Map<String, String> props) {
-            taskId = props.get("task.id");
-            String connectorName = props.get("connector.name");
-            topicName = props.getOrDefault(TOPIC_CONFIG, "sequential-topic");
-            batchSize = Integer.parseInt(props.getOrDefault(MESSAGES_PER_POLL_CONFIG, "1"));
-            taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
-            Map<String, Object> offset = Optional.ofNullable(
-                    context.offsetStorageReader().offset(sourcePartition(taskId)))
-                    .orElse(Collections.emptyMap());
-            startingSeqno = Optional.ofNullable((Long) offset.get("saved")).orElse(0L);
-            seqno = startingSeqno;
-            log.info("Started {} task {} with properties {}", this.getClass().getSimpleName(), taskId, props);
-            throttler = new ThroughputThrottler(Long.parseLong(props.getOrDefault(MAX_MESSAGES_PER_SECOND_CONFIG, "-1")), System.currentTimeMillis());
-            maxMessages = Long.parseLong(props.getOrDefault(MAX_MESSAGES_PRODUCED_CONFIG, String.valueOf(Long.MAX_VALUE)));
-            taskHandle.recordTaskStart();
-            priorTransactionBoundary = 0;
-            nextTransactionBoundary = 1;
-            if (Boolean.parseBoolean(props.getOrDefault("task-" + taskId + ".start.inject.error", "false"))) {
-                throw new RuntimeException("Injecting errors during task start");
-            }
-            calculateNextBoundary();
+            super.start(props);
+            PluginMetrics pluginMetrics = context.pluginMetrics();
+            metricsName = pluginMetrics.metricName("poll", "description", Map.of());
+            pluginMetrics.addMetric(metricsName, (Measurable) (config, now) -> count);
         }
 
         @Override
         public List<SourceRecord> poll() {
-            if (!stopped) {
-                // Don't return any more records since we've already produced the configured maximum number.
-                if (seqno >= maxMessages) {
-                    return null;
-                }
-                if (throttler.shouldThrottle(seqno - startingSeqno, System.currentTimeMillis())) {
-                    throttler.throttle();
-                }
-                int currentBatchSize = (int) Math.min(maxMessages - seqno, batchSize);
-                taskHandle.record(currentBatchSize);
-                log.trace("Returning batch of {} records", currentBatchSize);
-                return LongStream.range(0, currentBatchSize)
-                        .mapToObj(i -> {
-                            seqno++;
-                            SourceRecord record = new SourceRecord(
-                                    sourcePartition(taskId),
-                                    sourceOffset(seqno),
-                                    topicName,
-                                    null,
-                                    Schema.STRING_SCHEMA,
-                                    "key-" + taskId + "-" + seqno,
-                                    Schema.STRING_SCHEMA,
-                                    "value-" + taskId + "-" + seqno,
-                                    null,
-                                    new ConnectHeaders().addLong("header-" + seqno, seqno));
-                            maybeDefineTransactionBoundary(record);
-                            return record;
-                        })
-                        .collect(Collectors.toList());
+            List<SourceRecord> records = super.poll();
+            if (records != null) {
+                count += records.size();
             }
-            return null;
+            return records;
         }
 
-        @Override
-        public void commit() {
-            log.info("Task {} committing offsets", taskId);
-            //TODO: save progress outside the offset topic, potentially in the task handle
-        }
-
-        @Override
-        public void commitRecord(SourceRecord record, RecordMetadata metadata) {
-            log.trace("Committing record: {}", record);
-            taskHandle.commit();
-        }
-
-        @Override
-        public void stop() {
-            log.info("Stopped {} task {}", this.getClass().getSimpleName(), taskId);
-            stopped = true;
-            taskHandle.recordTaskStop();
-        }
-
-        /**
-         * Calculate the next transaction boundary, i.e., the seqno whose corresponding source record should be used to
-         * either {@link org.apache.kafka.connect.source.TransactionContext#commitTransaction(SourceRecord) commit}
-         * or {@link org.apache.kafka.connect.source.TransactionContext#abortTransaction(SourceRecord) abort} the next transaction.
-         * <p>
-         * This connector defines transactions whose size correspond to successive elements of the Fibonacci sequence,
-         * where transactions with an even number of records are aborted, and those with an odd number of records are committed.
-         */
-        private void calculateNextBoundary() {
-            while (nextTransactionBoundary <= seqno) {
-                nextTransactionBoundary += priorTransactionBoundary;
-                priorTransactionBoundary = nextTransactionBoundary - priorTransactionBoundary;
-            }
-        }
-
-        private void maybeDefineTransactionBoundary(SourceRecord record) {
-            if (context.transactionContext() == null || seqno != nextTransactionBoundary) {
-                return;
-            }
-            long transactionSize = nextTransactionBoundary - priorTransactionBoundary;
-
-            // If the transaction boundary ends on an even-numbered offset, abort it
-            // Otherwise, commit
-            boolean abort = nextTransactionBoundary % 2 == 0;
-            calculateNextBoundary();
-            if (abort) {
-                log.info("Aborting transaction of {} records", transactionSize);
-                context.transactionContext().abortTransaction(record);
-            } else {
-                log.info("Committing transaction of {} records", transactionSize);
-                context.transactionContext().commitTransaction(record);
-            }
-        }
-    }
-
-    public static Map<String, Object> sourcePartition(String taskId) {
-        return Collections.singletonMap("task.id", taskId);
-    }
-
-    public static Map<String, Object> sourceOffset(long seqno) {
-        return Collections.singletonMap("saved", seqno);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceIntegrationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectStandalone;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.connect.integration.TestableSourceConnector.MAX_MESSAGES_PER_SECOND_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.MESSAGES_PER_POLL_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for a source connector defining metrics via the PluginMetrics API
+ */
+@Tag("integration")
+@Timeout(value = 600)
+public class MonitorableSourceIntegrationTest {
+
+    private static final String CONNECTOR_NAME = "monitorable-source";
+    private static final String TASK_ID = CONNECTOR_NAME + "-0";
+
+    private static final int NUM_TASKS = 1;
+    private static final long SOURCE_TASK_PRODUCE_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+    private static final int MINIMUM_MESSAGES = 100;
+    private static final String MESSAGES_PER_POLL = Integer.toString(MINIMUM_MESSAGES);
+    private static final String MESSAGES_PER_SECOND = Long.toString(MINIMUM_MESSAGES / 2);
+
+    private EmbeddedConnectStandalone connect;
+    private ConnectorHandle connectorHandle;
+
+    @BeforeEach
+    public void setup() throws InterruptedException {
+        // setup Connect cluster with defaults
+        connect = new EmbeddedConnectStandalone.Builder().build();
+
+        // start Connect cluster
+        connect.start();
+
+        // get connector handles before starting test.
+        connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+    }
+
+    @AfterEach
+    public void close() {
+        connect.stop();
+    }
+
+    @Test
+    public void testMonitorableSourceConnectorAndTask() throws Exception {
+        connect.kafka().createTopic("test-topic");
+
+        Map<String, String> props = Map.of(
+            CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName(),
+            TASKS_MAX_CONFIG, "1",
+            TOPIC_CONFIG, "test-topic",
+            KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName(),
+            VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName(),
+            MESSAGES_PER_POLL_CONFIG, MESSAGES_PER_POLL,
+            MAX_MESSAGES_PER_SECOND_CONFIG, MESSAGES_PER_SECOND);
+
+        // set expected records to successfully reach the task
+        // expect all records to be consumed and committed by the task
+        connectorHandle.taskHandle(TASK_ID).expectedRecords(MINIMUM_MESSAGES);
+        connectorHandle.taskHandle(TASK_ID).expectedCommits(MINIMUM_MESSAGES);
+
+        connect.configureConnector(CONNECTOR_NAME, props);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
+                "Connector tasks did not start in time.");
+
+        // wait for the connector tasks to produce enough records
+        connectorHandle.taskHandle(TASK_ID).awaitRecords(SOURCE_TASK_PRODUCE_TIMEOUT_MS);
+        connectorHandle.taskHandle(TASK_ID).awaitCommits(TimeUnit.MINUTES.toMillis(1));
+
+        // check connector metric
+        Map<MetricName, KafkaMetric> metrics = connect.herder().worker().metrics().metrics().metrics();
+        MetricName connectorMetric = MonitorableSourceConnector.metricsName;
+        assertTrue(metrics.containsKey(connectorMetric));
+        assertEquals(CONNECTOR_NAME, connectorMetric.tags().get("connector"));
+        assertEquals(MonitorableSourceConnector.VALUE, metrics.get(connectorMetric).metricValue());
+
+        // check task metric
+        metrics = connect.herder().worker().metrics().metrics().metrics();
+        MetricName taskMetric = MonitorableSourceConnector.MonitorableSourceTask.metricsName;
+        assertTrue(metrics.containsKey(taskMetric));
+        assertEquals(CONNECTOR_NAME, taskMetric.tags().get("connector"));
+        assertEquals("0", taskMetric.tags().get("task"));
+        assertTrue(MINIMUM_MESSAGES <= (double) metrics.get(taskMetric).metricValue());
+
+        connect.deleteConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorDoesNotExist(CONNECTOR_NAME,
+                "Connector wasn't deleted in time.");
+
+        // verify the connector and task metrics have been deleted
+        metrics = connect.herder().worker().metrics().metrics().metrics();
+        assertFalse(metrics.containsKey(connectorMetric));
+        assertFalse(metrics.containsKey(taskMetric));
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceIntegrationTest.java
@@ -104,14 +104,14 @@ public class MonitorableSourceIntegrationTest {
         connectorHandle.taskHandle(TASK_ID).awaitCommits(TimeUnit.MINUTES.toMillis(1));
 
         // check connector metric
-        Map<MetricName, KafkaMetric> metrics = connect.herder().worker().metrics().metrics().metrics();
+        Map<MetricName, KafkaMetric> metrics = connect.connectMetrics().metrics().metrics();
         MetricName connectorMetric = MonitorableSourceConnector.metricsName;
         assertTrue(metrics.containsKey(connectorMetric));
         assertEquals(CONNECTOR_NAME, connectorMetric.tags().get("connector"));
         assertEquals(MonitorableSourceConnector.VALUE, metrics.get(connectorMetric).metricValue());
 
         // check task metric
-        metrics = connect.herder().worker().metrics().metrics().metrics();
+        metrics = connect.connectMetrics().metrics().metrics();
         MetricName taskMetric = MonitorableSourceConnector.MonitorableSourceTask.metricsName;
         assertTrue(metrics.containsKey(taskMetric));
         assertEquals(CONNECTOR_NAME, taskMetric.tags().get("connector"));
@@ -123,7 +123,7 @@ public class MonitorableSourceIntegrationTest {
                 "Connector wasn't deleted in time.");
 
         // verify the connector and task metrics have been deleted
-        metrics = connect.herder().worker().metrics().metrics().metrics();
+        metrics = connect.connectMetrics().metrics().metrics();
         assertFalse(metrics.containsKey(connectorMetric));
         assertFalse(metrics.containsKey(taskMetric));
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
@@ -298,7 +298,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup up props for the source connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put("throughput", String.valueOf(10));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
@@ -92,7 +92,7 @@ public class RestExtensionIntegrationTest {
         try {
             // setup up props for the connector
             Map<String, String> connectorProps = new HashMap<>();
-            connectorProps.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+            connectorProps.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
             connectorProps.put(TASKS_MAX_CONFIG, String.valueOf(1));
             connectorProps.put(TOPICS_CONFIG, "test-topic");
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.ConnectionMode;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.MockConnectMetrics;
+import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
@@ -75,6 +77,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,6 +95,8 @@ public class RestForwardingIntegrationTest {
     private ConnectRestServer leaderServer;
     @Mock
     private Herder leaderHerder;
+    @Mock
+    private Worker worker;
 
     private SslContextFactory.Client factory;
     private CloseableHttpClient httpClient;
@@ -167,6 +172,8 @@ public class RestForwardingIntegrationTest {
         followerServer = new ConnectRestServer(null, followerClient, followerConfig.originals());
         followerServer.initializeServer();
         when(followerHerder.plugins()).thenReturn(plugins);
+        doReturn(new MockConnectMetrics()).when(worker).metrics();
+        doReturn(worker).when(followerHerder).worker();
         followerServer.initializeResources(followerHerder);
 
         // Leader worker setup
@@ -174,6 +181,8 @@ public class RestForwardingIntegrationTest {
         leaderServer = new ConnectRestServer(null, leaderClient, leaderConfig.originals());
         leaderServer.initializeServer();
         when(leaderHerder.plugins()).thenReturn(plugins);
+        doReturn(new MockConnectMetrics()).when(worker).metrics();
+        doReturn(worker).when(leaderHerder).worker();
         leaderServer.initializeResources(leaderHerder);
 
         // External client setup

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.network.ConnectionMode;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.MockConnectMetrics;
-import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
@@ -95,8 +94,6 @@ public class RestForwardingIntegrationTest {
     private ConnectRestServer leaderServer;
     @Mock
     private Herder leaderHerder;
-    @Mock
-    private Worker worker;
 
     private SslContextFactory.Client factory;
     private CloseableHttpClient httpClient;
@@ -172,8 +169,7 @@ public class RestForwardingIntegrationTest {
         followerServer = new ConnectRestServer(null, followerClient, followerConfig.originals());
         followerServer.initializeServer();
         when(followerHerder.plugins()).thenReturn(plugins);
-        doReturn(new MockConnectMetrics()).when(worker).metrics();
-        doReturn(worker).when(followerHerder).worker();
+        doReturn(new MockConnectMetrics()).when(followerHerder).connectMetrics();
         followerServer.initializeResources(followerHerder);
 
         // Leader worker setup
@@ -181,8 +177,7 @@ public class RestForwardingIntegrationTest {
         leaderServer = new ConnectRestServer(null, leaderClient, leaderConfig.originals());
         leaderServer.initializeServer();
         when(leaderHerder.plugins()).thenReturn(plugins);
-        doReturn(new MockConnectMetrics()).when(worker).metrics();
-        doReturn(worker).when(leaderHerder).worker();
+        doReturn(new MockConnectMetrics()).when(leaderHerder).connectMetrics();
         leaderServer.initializeResources(leaderHerder);
 
         // External client setup

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
@@ -122,7 +122,7 @@ public class SessionedProtocolIntegrationTest {
         // Create the connector now
         // setup up props for the sink connector
         Map<String, String> connectorProps = new HashMap<>();
-        connectorProps.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        connectorProps.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         connectorProps.put(TASKS_MAX_CONFIG, String.valueOf(1));
         connectorProps.put(TOPICS_CONFIG, "test-topic");
         connectorProps.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
@@ -309,7 +309,7 @@ public class SinkConnectorsIntegrationTest {
 
     private Map<String, String> baseSinkConnectorProps(String topics) {
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSinkConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, topics);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
@@ -208,7 +208,7 @@ public class SourceConnectorsIntegrationTest {
     private Map<String, String> defaultSourceConnectorProps(String topic) {
         // setup up props for the source connector
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put("throughput", String.valueOf(10));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StandaloneWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StandaloneWorkerIntegrationTest.java
@@ -45,7 +45,7 @@ import jakarta.ws.rs.core.Response;
 import static org.apache.kafka.connect.integration.BlockingConnectorTest.Block.BLOCK_CONFIG;
 import static org.apache.kafka.connect.integration.BlockingConnectorTest.CONNECTOR_START;
 import static org.apache.kafka.connect.integration.BlockingConnectorTest.CONNECTOR_TASK_CONFIGS;
-import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
@@ -370,7 +370,7 @@ public class StandaloneWorkerIntegrationTest {
         // setup props for the source connector
         Map<String, String> props = new HashMap<>();
         props.put(NAME_CONFIG, CONNECTOR_NAME);
-        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(CONNECTOR_CLASS_CONFIG, TestableSourceConnector.class.getSimpleName());
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, topic);
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSinkConnector.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.runtime.SampleSinkConnector;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A sink connector that is used in Apache Kafka integration tests to verify the behavior of the
+ * Connect framework, but that can be used in other integration tests as a simple connector that
+ * consumes and counts records. This class provides methods to find task instances
+ * which are initiated by the embedded connector, and wait for them to consume a desired number of
+ * messages.
+ */
+public class TestableSinkConnector extends SampleSinkConnector {
+
+    private static final Logger log = LoggerFactory.getLogger(TestableSinkConnector.class);
+
+    // Boolean valued configuration that determines whether TestableSinkConnector::alterOffsets should return true or false
+    public static final String ALTER_OFFSETS_RESULT = "alter.offsets.result";
+
+    private String connectorName;
+    private Map<String, String> commonConfigs;
+    private ConnectorHandle connectorHandle;
+
+    @Override
+    public void start(Map<String, String> props) {
+        connectorHandle = RuntimeHandles.get().connectorHandle(props.get("name"));
+        connectorName = props.get("name");
+        commonConfigs = props;
+        log.info("Starting connector {}", props.get("name"));
+        connectorHandle.recordConnectorStart();
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return TestableSinkTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        List<Map<String, String>> configs = new ArrayList<>();
+        for (int i = 0; i < maxTasks; i++) {
+            Map<String, String> config = new HashMap<>(commonConfigs);
+            config.put("connector.name", connectorName);
+            config.put("task.id", connectorName + "-" + i);
+            configs.add(config);
+        }
+        return configs;
+    }
+
+    @Override
+    public void stop() {
+        log.info("Stopped {} connector {}", this.getClass().getSimpleName(), connectorName);
+        connectorHandle.recordConnectorStop();
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public boolean alterOffsets(Map<String, String> connectorConfig, Map<TopicPartition, Long> offsets) {
+        return Boolean.parseBoolean(connectorConfig.get(ALTER_OFFSETS_RESULT));
+    }
+
+    public static class TestableSinkTask extends SinkTask {
+
+        private String taskId;
+        TaskHandle taskHandle;
+        Map<TopicPartition, Integer> committedOffsets;
+        Map<String, Map<Integer, TopicPartition>> cachedTopicPartitions;
+
+        public TestableSinkTask() {
+            this.committedOffsets = new HashMap<>();
+            this.cachedTopicPartitions = new HashMap<>();
+        }
+
+        @Override
+        public String version() {
+            return "unknown";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            taskId = props.get("task.id");
+            String connectorName = props.get("connector.name");
+            taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
+            log.debug("Starting task {}", taskId);
+            taskHandle.recordTaskStart();
+        }
+
+        @Override
+        public void open(Collection<TopicPartition> partitions) {
+            log.debug("Opening partitions {}", partitions);
+            taskHandle.partitionsAssigned(partitions);
+        }
+
+        @Override
+        public void close(Collection<TopicPartition> partitions) {
+            log.debug("Closing partitions {}", partitions);
+            taskHandle.partitionsRevoked(partitions);
+            partitions.forEach(committedOffsets::remove);
+        }
+
+        @Override
+        public void put(Collection<SinkRecord> records) {
+            for (SinkRecord rec : records) {
+                taskHandle.record(rec);
+                TopicPartition tp = cachedTopicPartitions
+                        .computeIfAbsent(rec.topic(), v -> new HashMap<>())
+                        .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));
+                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0) + 1);
+                log.trace("Task {} obtained record (key='{}' value='{}')", taskId, rec.key(), rec.value());
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
+            taskHandle.partitionsCommitted(offsets.keySet());
+            offsets.forEach((tp, offset) -> {
+                int recordsSinceLastCommit = committedOffsets.getOrDefault(tp, 0);
+                if (recordsSinceLastCommit != 0) {
+                    taskHandle.commit(recordsSinceLastCommit);
+                    log.debug("Forwarding to framework request to commit {} records for {}", recordsSinceLastCommit, tp);
+                    committedOffsets.put(tp, 0);
+                }
+            });
+            return offsets;
+        }
+
+        @Override
+        public void stop() {
+            log.info("Stopped {} task {}", this.getClass().getSimpleName(), taskId);
+            taskHandle.recordTaskStop();
+        }
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSourceConnector.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.runtime.SampleSourceConnector;
+import org.apache.kafka.connect.source.ConnectorTransactionBoundaries;
+import org.apache.kafka.connect.source.ExactlyOnceSupport;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.server.util.ThroughputThrottler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+/**
+ * A source connector that is used in Apache Kafka integration tests to verify the behavior of
+ * the Connect framework, but that can be used in other integration tests as a simple connector
+ * that generates records of a fixed structure. The rate of record production can be adjusted
+ * through the configs 'throughput' and 'messages.per.poll'
+ */
+public class TestableSourceConnector extends SampleSourceConnector {
+    private static final Logger log = LoggerFactory.getLogger(TestableSourceConnector.class);
+
+    public static final String TOPIC_CONFIG = "topic";
+    public static final String NUM_TASKS = "num.tasks";
+    public static final String MESSAGES_PER_POLL_CONFIG = "messages.per.poll";
+    public static final String MAX_MESSAGES_PER_SECOND_CONFIG = "throughput";
+    public static final String MAX_MESSAGES_PRODUCED_CONFIG = "max.messages";
+
+    public static final String CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG = "custom.exactly.once.support";
+    public static final String EXACTLY_ONCE_SUPPORTED = "supported";
+    public static final String EXACTLY_ONCE_UNSUPPORTED = "unsupported";
+    public static final String EXACTLY_ONCE_NULL = "null";
+    public static final String EXACTLY_ONCE_FAIL = "fail";
+
+    public static final String CUSTOM_TRANSACTION_BOUNDARIES_CONFIG = "custom.transaction.boundaries";
+    public static final String TRANSACTION_BOUNDARIES_SUPPORTED = "supported";
+    public static final String TRANSACTION_BOUNDARIES_UNSUPPORTED = "unsupported";
+    public static final String TRANSACTION_BOUNDARIES_NULL = "null";
+    public static final String TRANSACTION_BOUNDARIES_FAIL = "fail";
+
+    // Boolean valued configuration that determines whether TestableSourceConnector::alterOffsets should return true or false
+    public static final String ALTER_OFFSETS_RESULT = "alter.offsets.result";
+
+    private String connectorName;
+    private ConnectorHandle connectorHandle;
+    private Map<String, String> commonConfigs;
+
+    @Override
+    public void start(Map<String, String> props) {
+        connectorHandle = RuntimeHandles.get().connectorHandle(props.get("name"));
+        connectorName = connectorHandle.name();
+        commonConfigs = props;
+        log.info("Started {} connector {}", this.getClass().getSimpleName(), connectorName);
+        connectorHandle.recordConnectorStart();
+        if (Boolean.parseBoolean(props.getOrDefault("connector.start.inject.error", "false"))) {
+            throw new RuntimeException("Injecting errors during connector start");
+        }
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return TestableSourceTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        String numTasksProp = commonConfigs.get(NUM_TASKS);
+        int numTasks = numTasksProp != null ? Integer.parseInt(numTasksProp) : maxTasks;
+        List<Map<String, String>> configs = new ArrayList<>();
+        for (int i = 0; i < numTasks; i++) {
+            Map<String, String> config = taskConfig(commonConfigs, connectorName, i);
+            configs.add(config);
+        }
+        return configs;
+    }
+
+    public static Map<String, String> taskConfig(
+            Map<String, String> connectorProps,
+            String connectorName,
+            int taskNum
+    ) {
+        Map<String, String> result = new HashMap<>(connectorProps);
+        result.put("connector.name", connectorName);
+        result.put("task.id", taskId(connectorName, taskNum));
+        return result;
+    }
+
+    @Override
+    public void stop() {
+        log.info("Stopped {} connector {}", this.getClass().getSimpleName(), connectorName);
+        connectorHandle.recordConnectorStop();
+        if (Boolean.parseBoolean(commonConfigs.getOrDefault("connector.stop.inject.error", "false"))) {
+            throw new RuntimeException("Injecting errors during connector stop");
+        }
+    }
+
+    @Override
+    public ConfigDef config() {
+        log.info("Configured {} connector {}", this.getClass().getSimpleName(), connectorName);
+        return new ConfigDef();
+    }
+
+    @Override
+    public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> connectorConfig) {
+        String supportLevel = connectorConfig.getOrDefault(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, "null").toLowerCase(Locale.ROOT);
+        switch (supportLevel) {
+            case EXACTLY_ONCE_SUPPORTED:
+                return ExactlyOnceSupport.SUPPORTED;
+            case EXACTLY_ONCE_UNSUPPORTED:
+                return ExactlyOnceSupport.UNSUPPORTED;
+            case EXACTLY_ONCE_FAIL:
+                throw new ConnectException("oops");
+            default:
+            case EXACTLY_ONCE_NULL:
+                return null;
+        }
+    }
+
+    @Override
+    public ConnectorTransactionBoundaries canDefineTransactionBoundaries(Map<String, String> connectorConfig) {
+        String supportLevel = connectorConfig.getOrDefault(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TRANSACTION_BOUNDARIES_UNSUPPORTED).toLowerCase(Locale.ROOT);
+        switch (supportLevel) {
+            case TRANSACTION_BOUNDARIES_SUPPORTED:
+                return ConnectorTransactionBoundaries.SUPPORTED;
+            case TRANSACTION_BOUNDARIES_FAIL:
+                throw new ConnectException("oh no :(");
+            case TRANSACTION_BOUNDARIES_NULL:
+                return null;
+            default:
+            case TRANSACTION_BOUNDARIES_UNSUPPORTED:
+                return ConnectorTransactionBoundaries.UNSUPPORTED;
+        }
+    }
+
+    @Override
+    public boolean alterOffsets(Map<String, String> connectorConfig, Map<Map<String, ?>, Map<String, ?>> offsets) {
+        return Boolean.parseBoolean(connectorConfig.get(ALTER_OFFSETS_RESULT));
+    }
+
+    public static String taskId(String connectorName, int taskId) {
+        return connectorName + "-" + taskId;
+    }
+
+    public static class TestableSourceTask extends SourceTask {
+        private String taskId;
+        private String topicName;
+        private TaskHandle taskHandle;
+        private volatile boolean stopped;
+        private long startingSeqno;
+        private long seqno;
+        private int batchSize;
+        private ThroughputThrottler throttler;
+        private long maxMessages;
+
+        private long priorTransactionBoundary;
+        private long nextTransactionBoundary;
+
+        @Override
+        public String version() {
+            return "unknown";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            taskId = props.get("task.id");
+            String connectorName = props.get("connector.name");
+            topicName = props.getOrDefault(TOPIC_CONFIG, "sequential-topic");
+            batchSize = Integer.parseInt(props.getOrDefault(MESSAGES_PER_POLL_CONFIG, "1"));
+            taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
+            Map<String, Object> offset = Optional.ofNullable(
+                    context.offsetStorageReader().offset(sourcePartition(taskId)))
+                    .orElse(Collections.emptyMap());
+            startingSeqno = Optional.ofNullable((Long) offset.get("saved")).orElse(0L);
+            seqno = startingSeqno;
+            log.info("Started {} task {} with properties {}", this.getClass().getSimpleName(), taskId, props);
+            throttler = new ThroughputThrottler(Long.parseLong(props.getOrDefault(MAX_MESSAGES_PER_SECOND_CONFIG, "-1")), System.currentTimeMillis());
+            maxMessages = Long.parseLong(props.getOrDefault(MAX_MESSAGES_PRODUCED_CONFIG, String.valueOf(Long.MAX_VALUE)));
+            taskHandle.recordTaskStart();
+            priorTransactionBoundary = 0;
+            nextTransactionBoundary = 1;
+            if (Boolean.parseBoolean(props.getOrDefault("task-" + taskId + ".start.inject.error", "false"))) {
+                throw new RuntimeException("Injecting errors during task start");
+            }
+            calculateNextBoundary();
+        }
+
+        @Override
+        public List<SourceRecord> poll() {
+            if (!stopped) {
+                // Don't return any more records since we've already produced the configured maximum number.
+                if (seqno >= maxMessages) {
+                    return null;
+                }
+                if (throttler.shouldThrottle(seqno - startingSeqno, System.currentTimeMillis())) {
+                    throttler.throttle();
+                }
+                int currentBatchSize = (int) Math.min(maxMessages - seqno, batchSize);
+                taskHandle.record(currentBatchSize);
+                log.trace("Returning batch of {} records", currentBatchSize);
+                return LongStream.range(0, currentBatchSize)
+                        .mapToObj(i -> {
+                            seqno++;
+                            SourceRecord record = new SourceRecord(
+                                    sourcePartition(taskId),
+                                    sourceOffset(seqno),
+                                    topicName,
+                                    null,
+                                    Schema.STRING_SCHEMA,
+                                    "key-" + taskId + "-" + seqno,
+                                    Schema.STRING_SCHEMA,
+                                    "value-" + taskId + "-" + seqno,
+                                    null,
+                                    new ConnectHeaders().addLong("header-" + seqno, seqno));
+                            maybeDefineTransactionBoundary(record);
+                            return record;
+                        })
+                        .collect(Collectors.toList());
+            }
+            return null;
+        }
+
+        @Override
+        public void commit() {
+            log.info("Task {} committing offsets", taskId);
+            //TODO: save progress outside the offset topic, potentially in the task handle
+        }
+
+        @Override
+        public void commitRecord(SourceRecord record, RecordMetadata metadata) {
+            log.trace("Committing record: {}", record);
+            taskHandle.commit();
+        }
+
+        @Override
+        public void stop() {
+            log.info("Stopped {} task {}", this.getClass().getSimpleName(), taskId);
+            stopped = true;
+            taskHandle.recordTaskStop();
+        }
+
+        /**
+         * Calculate the next transaction boundary, i.e., the seqno whose corresponding source record should be used to
+         * either {@link org.apache.kafka.connect.source.TransactionContext#commitTransaction(SourceRecord) commit}
+         * or {@link org.apache.kafka.connect.source.TransactionContext#abortTransaction(SourceRecord) abort} the next transaction.
+         * <p>
+         * This connector defines transactions whose size correspond to successive elements of the Fibonacci sequence,
+         * where transactions with an even number of records are aborted, and those with an odd number of records are committed.
+         */
+        private void calculateNextBoundary() {
+            while (nextTransactionBoundary <= seqno) {
+                nextTransactionBoundary += priorTransactionBoundary;
+                priorTransactionBoundary = nextTransactionBoundary - priorTransactionBoundary;
+            }
+        }
+
+        private void maybeDefineTransactionBoundary(SourceRecord record) {
+            if (context.transactionContext() == null || seqno != nextTransactionBoundary) {
+                return;
+            }
+            long transactionSize = nextTransactionBoundary - priorTransactionBoundary;
+
+            // If the transaction boundary ends on an even-numbered offset, abort it
+            // Otherwise, commit
+            boolean abort = nextTransactionBoundary % 2 == 0;
+            calculateNextBoundary();
+            if (abort) {
+                log.info("Aborting transaction of {} records", transactionSize);
+                context.transactionContext().abortTransaction(record);
+            } else {
+                log.info("Committing transaction of {} records", transactionSize);
+                context.transactionContext().commitTransaction(record);
+            }
+        }
+    }
+
+    public static Map<String, Object> sourcePartition(String taskId) {
+        return Collections.singletonMap("task.id", taskId);
+    }
+
+    public static Map<String, Object> sourceOffset(long seqno) {
+        return Collections.singletonMap("saved", seqno);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -63,8 +63,8 @@ public class TransformationIntegrationTest {
     private static final int NUM_TASKS = 1;
     private static final int NUM_WORKERS = 3;
     private static final String CONNECTOR_NAME = "simple-conn";
-    private static final String SINK_CONNECTOR_CLASS_NAME = MonitorableSinkConnector.class.getSimpleName();
-    private static final String SOURCE_CONNECTOR_CLASS_NAME = MonitorableSourceConnector.class.getSimpleName();
+    private static final String SINK_CONNECTOR_CLASS_NAME = TestableSinkConnector.class.getSimpleName();
+    private static final String SOURCE_CONNECTOR_CLASS_NAME = TestableSourceConnector.class.getSimpleName();
 
     private EmbeddedConnectCluster connect;
     private ConnectorHandle connectorHandle;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -18,19 +18,36 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Monitorable;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.internals.PluginMetricsImpl;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroupId;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Collections;
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,12 +60,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConnectMetricsTest {
 
-    private static final Map<String, String> DEFAULT_WORKER_CONFIG = new HashMap<>();
-
-    static {
-        DEFAULT_WORKER_CONFIG.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULT_WORKER_CONFIG.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-    }
+    private static final Map<String, String> DEFAULT_WORKER_CONFIG = Map.of(
+        WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter",
+        WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+    private static final ConnectorTaskId CONNECTOR_TASK_ID = new ConnectorTaskId("connector", 0);
+    private static final Map<String, String> TAGS = Map.of("t1", "v1");
 
     private ConnectMetrics metrics;
 
@@ -171,6 +187,221 @@ public class ConnectMetricsTest {
         cm.stop();
     }
 
+    @Test
+    public void testConnectorPluginMetrics() throws Exception {
+        try (PluginMetricsImpl pluginMetrics = metrics.connectorPluginMetrics(CONNECTOR_TASK_ID.connector())) {
+            MetricName metricName = pluginMetrics.metricName("name", "description", TAGS);
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+        }
+    }
+
+    @Test
+    public void testTaskPluginMetrics() throws Exception {
+        try (PluginMetricsImpl pluginMetrics = metrics.taskPluginMetrics(CONNECTOR_TASK_ID)) {
+            MetricName metricName = pluginMetrics.metricName("name", "description", TAGS);
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.put("task", String.valueOf(CONNECTOR_TASK_ID.task()));
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+        }
+    }
+
+    static final class MonitorableConverter implements Converter, HeaderConverter, Monitorable {
+
+        private int calls = 0;
+        private PluginMetrics pluginMetrics = null;
+        private MetricName metricName = null;
+
+        @Override
+        public void withPluginMetrics(PluginMetrics pluginMetrics) {
+            this.pluginMetrics = pluginMetrics;
+            metricName = pluginMetrics.metricName("name", "description", TAGS);
+            pluginMetrics.addMetric(metricName, (Measurable) (config, now) -> calls);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) { }
+
+        @Override
+        public byte[] fromConnectData(String topic, Schema schema, Object value) {
+            calls++;
+            return new byte[0];
+        }
+
+        @Override
+        public SchemaAndValue toConnectData(String topic, byte[] value) {
+            calls++;
+            return null;
+        }
+
+        @Override
+        public ConfigDef config() {
+            return Converter.super.config();
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) { }
+
+        @Override
+        public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+            calls++;
+            return null;
+        }
+
+        @Override
+        public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+            calls++;
+            return new byte[0];
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testWrapConverter(boolean isKey) throws IOException {
+        try (MonitorableConverter converter = new MonitorableConverter()) {
+            metrics.wrap(converter, CONNECTOR_TASK_ID, isKey);
+            assertNotNull(converter.pluginMetrics);
+            MetricName metricName = converter.metricName;
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.put("task", String.valueOf(CONNECTOR_TASK_ID.task()));
+            expectedTags.put("converter", isKey ? "key" : "value");
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+            KafkaMetric metric = metrics.metrics().metrics().get(metricName);
+            assertEquals(0.0, (double) metric.metricValue());
+            converter.toConnectData("topic", new byte[]{});
+            assertEquals(1.0, (double) metric.metricValue());
+            converter.fromConnectData("topic", null, null);
+            assertEquals(2.0, (double) metric.metricValue());
+        }
+    }
+
+    @Test
+    public void testWrapHeaderConverter() throws IOException {
+        try (MonitorableConverter converter = new MonitorableConverter()) {
+            metrics.wrap(converter, CONNECTOR_TASK_ID);
+            assertNotNull(converter.pluginMetrics);
+            MetricName metricName = converter.metricName;
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.put("task", String.valueOf(CONNECTOR_TASK_ID.task()));
+            expectedTags.put("converter", "header");
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+            KafkaMetric metric = metrics.metrics().metrics().get(metricName);
+            assertEquals(0.0, (double) metric.metricValue());
+            converter.toConnectHeader("topic", "header", new byte[]{});
+            assertEquals(1.0, (double) metric.metricValue());
+            converter.fromConnectHeader("topic", "header", null, null);
+            assertEquals(2.0, (double) metric.metricValue());
+        }
+    }
+
+    static final class MonitorableTransformation implements Transformation<SourceRecord>, Monitorable {
+
+        private int calls = 0;
+        private PluginMetrics pluginMetrics = null;
+        private MetricName metricName = null;
+
+        @Override
+        public void withPluginMetrics(PluginMetrics pluginMetrics) {
+            this.pluginMetrics = pluginMetrics;
+            metricName = pluginMetrics.metricName("name", "description", TAGS);
+            pluginMetrics.addMetric(metricName, (Measurable) (config, now) -> calls);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) { }
+
+        @Override
+        public SourceRecord apply(SourceRecord record) {
+            calls++;
+            return null;
+        }
+
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+
+        @Override
+        public void close() { }
+    }
+
+    @Test
+    public void testWrapTransformation() {
+        try (MonitorableTransformation transformation = new MonitorableTransformation()) {
+            metrics.wrap(transformation, CONNECTOR_TASK_ID, "alias");
+            assertNotNull(transformation.pluginMetrics);
+            MetricName metricName = transformation.metricName;
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.put("task", String.valueOf(CONNECTOR_TASK_ID.task()));
+            expectedTags.put("transformation", "alias");
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+            KafkaMetric metric = metrics.metrics().metrics().get(metricName);
+            assertEquals(0.0, (double) metric.metricValue());
+            transformation.apply(null);
+            assertEquals(1.0, (double) metric.metricValue());
+        }
+    }
+
+    static final class MonitorablePredicate implements Predicate<SourceRecord>, Monitorable {
+
+        private int calls = 0;
+        private PluginMetrics pluginMetrics = null;
+        private MetricName metricName = null;
+
+        @Override
+        public void withPluginMetrics(PluginMetrics pluginMetrics) {
+            this.pluginMetrics = pluginMetrics;
+            metricName = pluginMetrics.metricName("name", "description", TAGS);
+            pluginMetrics.addMetric(metricName, (Measurable) (config, now) -> calls);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) { }
+
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+
+        @Override
+        public boolean test(SourceRecord record) {
+            calls++;
+            return false;
+        }
+
+        @Override
+        public void close() { }
+    }
+
+    @Test
+    public void testWrapPredicate() {
+        try (MonitorablePredicate predicate = new MonitorablePredicate()) {
+            metrics.wrap(predicate, CONNECTOR_TASK_ID, "alias");
+            assertNotNull(predicate.pluginMetrics);
+            MetricName metricName = predicate.metricName;
+            Map<String, String> expectedTags = new LinkedHashMap<>();
+            expectedTags.put("connector", CONNECTOR_TASK_ID.connector());
+            expectedTags.put("task", String.valueOf(CONNECTOR_TASK_ID.task()));
+            expectedTags.put("predicate", "alias");
+            expectedTags.putAll(TAGS);
+            assertEquals(expectedTags, metricName.tags());
+            KafkaMetric metric = metrics.metrics().metrics().get(metricName);
+            assertEquals(0.0, (double) metric.metricValue());
+            predicate.test(null);
+            assertEquals(1.0, (double) metric.metricValue());
+        }
+    }
+
     private Sensor addToGroup(ConnectMetrics connectMetrics, boolean shouldClose) {
         ConnectMetricsRegistry registry = connectMetrics.registry();
         ConnectMetrics.MetricGroup metricGroup = connectMetrics.group(registry.taskGroupName(),
@@ -188,6 +419,6 @@ public class ConnectMetricsTest {
     }
 
     static MetricName metricName(String name) {
-        return new MetricName(name, "test_group", "metrics for testing", Collections.emptyMap());
+        return new MetricName(name, "test_group", "metrics for testing", Map.of());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationStageTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationStageTest.java
@@ -54,10 +54,8 @@ public class TransformationStageTest {
         when(predicatePlugin.get()).thenReturn(predicate);
         Plugin<Transformation<SourceRecord>> transformationPlugin = mock(Plugin.class);
         Transformation<SourceRecord> transformation = mock(Transformation.class);
-        if ((predicateResult && !negate) || (!predicateResult && negate)) {
-            when(transformationPlugin.get()).thenReturn(transformation);
-        }
         if (expectedResult == transformed) {
+            when(transformationPlugin.get()).thenReturn(transformation);
             when(transformation.apply(any())).thenReturn(transformed);
         }
         TransformationStage<SourceRecord> stage = new TransformationStage<>(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationStageTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationStageTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
@@ -38,33 +39,36 @@ public class TransformationStageTest {
     private final SourceRecord transformed = new SourceRecord(singletonMap("transformed", 2), null, null, null, null);
 
     @Test
-    public void apply() {
+    public void apply() throws Exception {
         applyAndAssert(true, false, transformed);
         applyAndAssert(true, true, initial);
         applyAndAssert(false, false, initial);
         applyAndAssert(false, true, transformed);
     }
 
-    private void applyAndAssert(boolean predicateResult, boolean negate,
-                                SourceRecord expectedResult) {
-
-        @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
+    private void applyAndAssert(boolean predicateResult, boolean negate, SourceRecord expectedResult) throws Exception {
+        Plugin<Predicate<SourceRecord>> predicatePlugin = mock(Plugin.class);
         Predicate<SourceRecord> predicate = mock(Predicate.class);
         when(predicate.test(any())).thenReturn(predicateResult);
-        @SuppressWarnings("unchecked")
+        when(predicatePlugin.get()).thenReturn(predicate);
+        Plugin<Transformation<SourceRecord>> transformationPlugin = mock(Plugin.class);
         Transformation<SourceRecord> transformation = mock(Transformation.class);
+        if ((predicateResult && !negate) || (!predicateResult && negate)) {
+            when(transformationPlugin.get()).thenReturn(transformation);
+        }
         if (expectedResult == transformed) {
             when(transformation.apply(any())).thenReturn(transformed);
         }
         TransformationStage<SourceRecord> stage = new TransformationStage<>(
-                predicate,
+                predicatePlugin,
                 negate,
-                transformation);
+                transformationPlugin);
 
         assertEquals(expectedResult, stage.apply(initial));
 
         stage.close();
-        verify(predicate).close();
-        verify(transformation).close();
+        verify(predicatePlugin).close();
+        verify(transformationPlugin).close();
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -174,9 +175,12 @@ public class WorkerSinkTaskThreadedTest {
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
+        Plugin<Converter> keyConverterPlugin = metrics.wrap(keyConverter, taskId,  true);
+        Plugin<Converter> valueConverterPlugin = metrics.wrap(valueConverter, taskId,  false);
+        Plugin<HeaderConverter> headerConverterPlugin = metrics.wrap(headerConverter, taskId);
         workerTask = new WorkerSinkTask(
-                taskId, sinkTask, statusListener, initialState, workerConfig, ClusterConfigState.EMPTY, metrics, keyConverter,
-                valueConverter, errorHandlingMetrics, headerConverter, transformationChain,
+                taskId, sinkTask, statusListener, initialState, workerConfig, ClusterConfigState.EMPTY, metrics, keyConverterPlugin,
+                valueConverterPlugin, errorHandlingMetrics, headerConverterPlugin, transformationChain,
                 consumer, pluginLoader, time, RetryWithToleranceOperatorTest.noneOperator(), null, statusBackingStore,
                 Collections::emptyList);
         recordsReturned = 0;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -312,6 +312,7 @@ public class DistributedHerderTest {
     public void setUp() throws Exception {
         time = new MockTime();
         metrics = new MockConnectMetrics(time);
+        when(worker.metrics()).thenReturn(metrics);
         AutoCloseable uponShutdown = shutdownCalled::countDown;
 
         // Default to the old protocol unless specified otherwise

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
@@ -23,12 +23,10 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Monitorable;
 import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.common.utils.LogCaptureAppender;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.MockConnectMetrics;
-import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.isolation.PluginsTest;
 import org.apache.kafka.connect.runtime.rest.entities.LoggerLevel;
@@ -66,6 +64,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.ws.rs.core.MediaType;
@@ -75,7 +74,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -89,7 +87,6 @@ public class ConnectRestServerTest {
     @Mock private RestClient restClient;
     @Mock private Herder herder;
     @Mock private Plugins plugins;
-    @Mock private Worker worker;
     private ConnectRestServer server;
     private CloseableHttpClient httpClient;
     private final Collection<CloseableHttpResponse> responses = new ArrayList<>();
@@ -99,8 +96,7 @@ public class ConnectRestServerTest {
     @BeforeEach
     public void setUp() {
         httpClient = HttpClients.createMinimal();
-        doReturn(new MockConnectMetrics()).when(worker).metrics();
-        doReturn(worker).when(herder).worker();
+        doReturn(new MockConnectMetrics()).when(herder).connectMetrics();
     }
 
     @AfterEach
@@ -136,7 +132,6 @@ public class ConnectRestServerTest {
     public void testAdvertisedUri() {
         // Clear stubs not needed by this test
         reset(herder);
-        reset(worker);
 
         // Advertised URI from listeners without protocol
         Map<String, String> configMap = new HashMap<>(baseServerProps());
@@ -418,18 +413,18 @@ public class ConnectRestServerTest {
         configMap.put(RestServerConfig.REST_EXTENSION_CLASSES_CONFIG, MonitorableConnectRestExtension.class.getName());
 
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.singletonList(new MonitorableConnectRestExtension())).when(plugins).newPlugins(any(), any(), any());
+        doReturn(List.of(new MonitorableConnectRestExtension())).when(plugins).newPlugins(any(), any(), eq(ConnectRestExtension.class));
+
         server = new ConnectRestServer(null, restClient, configMap);
+        server.initializeServer();
+        server.initializeResources(herder);
 
-        // the call throws because of mocks but the ConnectRestExtension should have been initialized
-        assertThrows(ConnectException.class, () -> server.initializeResources(herder));
-
-        Map<MetricName, KafkaMetric> metrics = herder.worker().metrics().metrics().metrics();
+        Map<MetricName, KafkaMetric> metrics = herder.connectMetrics().metrics().metrics();
         assertTrue(metrics.containsKey(MonitorableConnectRestExtension.metricName));
         assertTrue((boolean) metrics.get(MonitorableConnectRestExtension.metricName).metricValue());
 
         server.stop();
-        metrics = herder.worker().metrics().metrics().metrics();
+        metrics = herder.connectMetrics().metrics().metrics();
         assertFalse(metrics.containsKey(MonitorableConnectRestExtension.metricName));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
@@ -16,11 +16,21 @@
  */
 package org.apache.kafka.connect.runtime.rest;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Monitorable;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.common.utils.LogCaptureAppender;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
+import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.MockConnectMetrics;
+import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.isolation.PluginsTest;
 import org.apache.kafka.connect.runtime.rest.entities.LoggerLevel;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -62,12 +72,15 @@ import jakarta.ws.rs.core.MediaType;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -76,6 +89,7 @@ public class ConnectRestServerTest {
     @Mock private RestClient restClient;
     @Mock private Herder herder;
     @Mock private Plugins plugins;
+    @Mock private Worker worker;
     private ConnectRestServer server;
     private CloseableHttpClient httpClient;
     private final Collection<CloseableHttpResponse> responses = new ArrayList<>();
@@ -85,6 +99,8 @@ public class ConnectRestServerTest {
     @BeforeEach
     public void setUp() {
         httpClient = HttpClients.createMinimal();
+        doReturn(new MockConnectMetrics()).when(worker).metrics();
+        doReturn(worker).when(herder).worker();
     }
 
     @AfterEach
@@ -118,6 +134,10 @@ public class ConnectRestServerTest {
 
     @Test
     public void testAdvertisedUri() {
+        // Clear stubs not needed by this test
+        reset(herder);
+        reset(worker);
+
         // Advertised URI from listeners without protocol
         Map<String, String> configMap = new HashMap<>(baseServerProps());
         configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
@@ -373,6 +393,44 @@ public class ConnectRestServerTest {
         String headerConfig = "";
         Map<String, String> expectedHeaders = new HashMap<>();
         checkCustomizedHttpResponseHeaders(headerConfig, expectedHeaders);
+    }
+
+    static final class MonitorableConnectRestExtension extends PluginsTest.TestConnectRestExtension implements Monitorable {
+
+        private boolean called = false;
+        private static MetricName metricName;
+
+        @Override
+        public void register(ConnectRestExtensionContext restPluginContext) {
+            called = true;
+        }
+
+        @Override
+        public void withPluginMetrics(PluginMetrics metrics) {
+            metricName = metrics.metricName("name", "description", Map.of());
+            metrics.addMetric(metricName, (Gauge<Boolean>) (config, now) -> called);
+        }
+    }
+
+    @Test
+    public void testMonitorableConnectRestExtension() {
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.REST_EXTENSION_CLASSES_CONFIG, MonitorableConnectRestExtension.class.getName());
+
+        doReturn(plugins).when(herder).plugins();
+        doReturn(Collections.singletonList(new MonitorableConnectRestExtension())).when(plugins).newPlugins(any(), any(), any());
+        server = new ConnectRestServer(null, restClient, configMap);
+
+        // the call throws because of mocks but the ConnectRestExtension should have been initialized
+        assertThrows(ConnectException.class, () -> server.initializeResources(herder));
+
+        Map<MetricName, KafkaMetric> metrics = herder.worker().metrics().metrics().metrics();
+        assertTrue(metrics.containsKey(MonitorableConnectRestExtension.metricName));
+        assertTrue((boolean) metrics.get(MonitorableConnectRestExtension.metricName).metricValue());
+
+        server.stop();
+        metrics = herder.worker().metrics().metrics().metrics();
+        assertFalse(metrics.containsKey(MonitorableConnectRestExtension.metricName));
     }
 
     private void checkCustomizedHttpResponseHeaders(String headerConfig, Map<String, String> expectedHeaders)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
+import org.apache.kafka.connect.runtime.MockConnectMetrics;
 import org.apache.kafka.connect.runtime.RestartPlan;
 import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
@@ -149,6 +150,7 @@ public class StandaloneHerderTest {
 
     public void initialize(boolean mockTransform) {
         when(worker.getPlugins()).thenReturn(plugins);
+        when(worker.metrics()).thenReturn(new MockConnectMetrics());
         herder = mock(StandaloneHerder.class, withSettings()
             .useConstructor(worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy, new MockTime())
             .defaultAnswer(CALLS_REAL_METHODS));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicCreationTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.runtime.ConnectMetrics;
+import org.apache.kafka.connect.runtime.MockConnectMetrics;
 import org.apache.kafka.connect.runtime.SourceConnectorConfig;
 import org.apache.kafka.connect.runtime.TransformationStage;
 import org.apache.kafka.connect.runtime.WorkerConfig;
@@ -80,6 +82,8 @@ public class TopicCreationTest {
 
     private static final short DEFAULT_REPLICATION_FACTOR = -1;
     private static final int DEFAULT_PARTITIONS = -1;
+    private static final ConnectMetrics METRICS = new MockConnectMetrics();
+    private static final ConnectorTaskId CONNECTOR_TASK_ID = new ConnectorTaskId("test", 0);
 
     Map<String, String> workerProps;
     WorkerConfig workerConfig;
@@ -515,7 +519,7 @@ public class TopicCreationTest {
         topicCreation.addTopic(FOO_TOPIC);
         assertFalse(topicCreation.isTopicCreationRequired(FOO_TOPIC));
 
-        List<TransformationStage<SourceRecord>> transformationStages = sourceConfig.transformationStages();
+        List<TransformationStage<SourceRecord>> transformationStages = sourceConfig.transformationStages(CONNECTOR_TASK_ID, METRICS);
         assertEquals(1, transformationStages.size());
         TransformationStage<SourceRecord> xform = transformationStages.get(0);
         SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0, null, null, Schema.INT8_SCHEMA, 42));
@@ -622,7 +626,7 @@ public class TopicCreationTest {
         assertEquals(barPartitions, barTopicSpec.numPartitions());
         assertEquals(barTopicProps, barTopicSpec.configs());
 
-        List<TransformationStage<SourceRecord>> transformationStages = sourceConfig.transformationStages();
+        List<TransformationStage<SourceRecord>> transformationStages = sourceConfig.transformationStages(CONNECTOR_TASK_ID, METRICS);
         assertEquals(2, transformationStages.size());
 
         TransformationStage<SourceRecord> castXForm = transformationStages.get(0);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectStandalone.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectStandalone.java
@@ -62,6 +62,7 @@ public class EmbeddedConnectStandalone extends EmbeddedConnect {
     private final String offsetsFile;
 
     private volatile WorkerHandle connectWorker;
+    private Connect<StandaloneHerder> connect;
 
     private EmbeddedConnectStandalone(
             int numBrokers,
@@ -92,7 +93,7 @@ public class EmbeddedConnectStandalone extends EmbeddedConnect {
         workerProps.putIfAbsent(PLUGIN_DISCOVERY_CONFIG, "hybrid_fail");
 
         ConnectStandalone cli = new ConnectStandalone();
-        Connect<StandaloneHerder> connect = cli.startConnect(workerProps);
+        connect = cli.startConnect(workerProps);
         connectWorker = new WorkerHandle("standalone", connect);
         cli.processExtraArgs(connect, connectorConfigFiles());
     }
@@ -135,6 +136,10 @@ public class EmbeddedConnectStandalone extends EmbeddedConnect {
         }
 
         return result;
+    }
+
+    public StandaloneHerder herder() {
+        return connect.herder();
     }
 
     public static class Builder extends EmbeddedConnectBuilder<EmbeddedConnectStandalone, Builder> {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectStandalone.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectStandalone.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.util.clusters;
 
 import org.apache.kafka.connect.cli.ConnectStandalone;
 import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.ConnectMetrics;
 import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
 import org.apache.kafka.test.TestUtils;
 
@@ -138,8 +139,8 @@ public class EmbeddedConnectStandalone extends EmbeddedConnect {
         return result;
     }
 
-    public StandaloneHerder herder() {
-        return connect.herder();
+    public ConnectMetrics connectMetrics() {
+        return connect.herder().connectMetrics();
     }
 
     public static class Builder extends EmbeddedConnectBuilder<EmbeddedConnectStandalone, Builder> {

--- a/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -17,5 +17,6 @@ org.apache.kafka.connect.integration.BlockingConnectorTest$BlockingSinkConnector
 org.apache.kafka.connect.integration.BlockingConnectorTest$TaskInitializeBlockingSinkConnector
 org.apache.kafka.connect.integration.ErrantRecordSinkConnector
 org.apache.kafka.connect.integration.MonitorableSinkConnector
+org.apache.kafka.connect.integration.TestableSinkConnector
 org.apache.kafka.connect.runtime.SampleSinkConnector
 org.apache.kafka.connect.integration.ConnectWorkerIntegrationTest$EmptyTaskConfigsConnector

--- a/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/runtime/src/test/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -21,5 +21,6 @@ org.apache.kafka.connect.integration.BlockingConnectorTest$BlockingSourceConnect
 org.apache.kafka.connect.integration.BlockingConnectorTest$TaskInitializeBlockingSourceConnector
 org.apache.kafka.connect.integration.ExactlyOnceSourceIntegrationTest$NaughtyConnector
 org.apache.kafka.connect.integration.MonitorableSourceConnector
+org.apache.kafka.connect.integration.TestableSourceConnector
 org.apache.kafka.connect.runtime.SampleSourceConnector
 org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResourceTest$ConnectorPluginsResourceTestConnector


### PR DESCRIPTION
Built on top of #17511, this adds [KIP-877](https://cwiki.apache.org/confluence/display/KAFKA/KIP-877%3A+Mechanism+for+plugins+and+connectors+to+register+metrics) support to Connect

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
