### PR TITLE
KAFKA-18009: Remove extra public constructor for KafkaShareConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -406,7 +406,7 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
                 keyDeserializer, valueDeserializer);
     }
 
-    public KafkaShareConsumer(ConsumerConfig config,
+    KafkaShareConsumer(ConsumerConfig config,
                               Deserializer<K> keyDeserializer,
                               Deserializer<V> valueDeserializer) {
         delegate = CREATOR.create(config, keyDeserializer, valueDeserializer);


### PR DESCRIPTION
KafkaShareConsumer had a constructor which was marked as public in error and should have been package-private.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
