### PR TITLE
MINOR: Documentation improvements for dynamic quorums

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -245,13 +245,13 @@
                     See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-956+Tiered+Storage+Quotas">KIP-956</a> for more details.</li>
             </ul>
         </li>
-        <li>KRaft now supports dynamic quorums for new KRaft clusters. See <a href="/{{version}}/documentation.html#kraft_reconfig">here</a> for more details. The below enhancements are added in this release.
+        <li>KRaft now supports dynamic quorums for new KRaft clusters. See <a href="/{{version}}/documentation.html#kraft_reconfig">here</a> for more details. The below enhancements are included in this release.
             <ul>
-                <li>Controllers can be configured for dynamic quorum at creation time by formatting their KRaft controller log directory with the `--standalone` or `--initial-controllers` option.</li>
+                <li>At creation time, controllers can be configured as a dynamic quorum by formatting their KRaft controller log directory with the `--standalone` or `--initial-controllers` option.</li>
                 <li>Controllers can be added in observer mode to an existing dynamic quorum by formatting their KRaft controller log directory with the `--no-initial-controllers` option</li>
                 <li>Observers controllers can be promoted to or removed from the set of voters with the `add-controller` or `remove-controller` subcommands on the `kafka-metadata-quorum` tool</li>
                 <li>Controller listeners can now be included in the `advertised.listeners` property.
-                    This provides KRaft clients (including other controllers) connection information to communicate with dynamically-configured KRaft controllers.</li>
+                    This provides KRaft clients (including other controllers) connection information in order to communicate with dynamically-configured KRaft controllers.</li>
             </ul>
         </li>
     </ul>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -251,7 +251,7 @@
                 <li>Controllers can be added in observer mode to an existing dynamic quorum by formatting their KRaft controller log directory with the `--no-initial-controllers` option</li>
                 <li>Observers controllers can be promoted to or removed from the set of voters with the `add-controller` or `remove-controller` subcommands on the `kafka-metadata-quorum` tool</li>
                 <li>Controller listeners can now be included in the `advertised.listeners` property.
-                    This provides KRaft clients (including other controllers) connection information in order to communicate with dynamically-configured KRaft controllers.</li>
+                    This can help provide KRaft clients (including other controllers) connection information in order to communicate with dynamically-configured KRaft controllers.</li>
             </ul>
         </li>
     </ul>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -245,8 +245,15 @@
                     See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-956+Tiered+Storage+Quotas">KIP-956</a> for more details.</li>
             </ul>
         </li>
-        <li>Controller membership change in KRaft is now supported when formatting with `--standalone` or `--initial-controllers` option.
-            See <a href="/{{version}}/documentation.html#kraft_reconfig">here</a> for more details.</li>
+        <li>KRaft now supports dynamic quorums for new KRaft clusters. See <a href="/{{version}}/documentation.html#kraft_reconfig">here</a> for more details. The below enhancements are added in this release.
+            <ul>
+                <li>Controllers can be configured for dynamic quorum at creation time by formatting their KRaft controller log directory with the `--standalone` or `--initial-controllers` option.</li>
+                <li>Controllers can be added in observer mode to an existing dynamic quorum by formatting their KRaft controller log directory with the `--no-initial-controllers` option</li>
+                <li>Observers controllers can be promoted to or removed from the set of voters with the `add-controller` or `remove-controller` subcommands on the `kafka-metadata-quorum` tool</li>
+                <li>Controller listeners can now be included in the `advertised.listeners` property.
+                    This provides KRaft clients (including other controllers) connection information to communicate with dynamically-configured KRaft controllers.</li>
+            </ul>
+        </li>
     </ul>
 
 <h4><a id="upgrade_3_8_1" href="#upgrade_3_8_1">Upgrading to 3.8.1 from any version 0.8.x through 3.7.x</a></h4>


### PR DESCRIPTION
While testing dynamic quorums, I ran into a few issues that might be mitigated by improved docs, specifically around the semantics of dynamic quorums. This adds a small summary to the new features, where this is added.

The biggest thing I ran into is that 3.8 and below disallowed controller listeners being included in `advertised.listeners`, and 3.9 allows controller listeners in the `advertised.listeners`. Not only that, advertised listeners are effectively *required* to communicate with dynamically-added controllers.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
