### PR TITLE
KAFKA-17200: Allow the replication of user internal topics

### DIFF
--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.java
@@ -115,6 +115,6 @@ public class DefaultReplicationPolicy implements ReplicationPolicy, Configurable
 
     @Override
     public boolean isMM2InternalTopic(String topic) {
-        return  topic.endsWith(internalSuffix());
+        return  topic.startsWith("mm2") && topic.endsWith(internalSuffix()) || isCheckpointsTopic(topic);
     }
 }

--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/ReplicationPolicy.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/ReplicationPolicy.java
@@ -98,7 +98,7 @@ public interface ReplicationPolicy {
      * This is used to make sure the topic doesn't need to be replicated.
      */
     default boolean isMM2InternalTopic(String topic) {
-        return  topic.endsWith(".internal");
+        return  topic.startsWith("mm2") && topic.endsWith(".internal") || isCheckpointsTopic(topic);
     }
 
     /**
@@ -106,7 +106,6 @@ public interface ReplicationPolicy {
      */
     default boolean isInternalTopic(String topic) {
         boolean isKafkaInternalTopic = topic.startsWith("__") || topic.startsWith(".");
-        boolean isDefaultConnectTopic =  topic.endsWith("-internal") ||  topic.endsWith(".internal");
-        return isMM2InternalTopic(topic) || isKafkaInternalTopic || isDefaultConnectTopic;
+        return isMM2InternalTopic(topic) || isKafkaInternalTopic;
     }
 }

--- a/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/ReplicationPolicyTest.java
+++ b/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/ReplicationPolicyTest.java
@@ -49,8 +49,6 @@ public class ReplicationPolicyTest {
 
         // starts with 'mm2' and ends with '.internal': default DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG in standalone mode.
         assertTrue(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets.CLUSTER.internal"));
-        // starts with 'mm2' and ends with '-internal'
-        assertFalse(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets-CLUSTER-internal"));
         // non-internal topic.
         assertFalse(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets_CLUSTER_internal"));
     }

--- a/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/ReplicationPolicyTest.java
+++ b/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/ReplicationPolicyTest.java
@@ -38,15 +38,19 @@ public class ReplicationPolicyTest {
 
     @Test
     public void testInternalTopic() {
+        Map<String, Object> config =  new HashMap<>();
+        config.put(MirrorClientConfig.REPLICATION_POLICY_SEPARATOR, ".");
+        DEFAULT_REPLICATION_POLICY.configure(config);
+
         // starts with '__'
         assertTrue(DEFAULT_REPLICATION_POLICY.isInternalTopic("__consumer_offsets"));
         // starts with '.'
         assertTrue(DEFAULT_REPLICATION_POLICY.isInternalTopic(".hiddentopic"));
 
-        // ends with '.internal': default DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG in standalone mode.
+        // starts with 'mm2' and ends with '.internal': default DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG in standalone mode.
         assertTrue(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets.CLUSTER.internal"));
-        // ends with '-internal'
-        assertTrue(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets-CLUSTER-internal"));
+        // starts with 'mm2' and ends with '-internal'
+        assertFalse(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets-CLUSTER-internal"));
         // non-internal topic.
         assertFalse(DEFAULT_REPLICATION_POLICY.isInternalTopic("mm2-offsets_CLUSTER_internal"));
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicFilter.java
@@ -33,7 +33,7 @@ public class DefaultTopicFilter implements TopicFilter {
 
     public static final String TOPICS_EXCLUDE_CONFIG = "topics.exclude";
     private static final String TOPICS_EXCLUDE_DOC = "List of topics and/or regexes that should not be replicated.";
-    public static final String TOPICS_EXCLUDE_DEFAULT = ".*[\\-\\.]internal, .*\\.replica, __.*";
+    public static final String TOPICS_EXCLUDE_DEFAULT = "mm2.*\\.internal, .*\\.replica, __.*";
 
     private Pattern includePattern;
     private Pattern excludePattern;

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -157,6 +157,11 @@
                     index. This API is used when the consumers are enabled with isolation level as READ_COMMITTED.
                     See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-1058:+Txn+consumer+exerts+pressure+on+remote+storage+when+collecting+aborted+transactions">KIP-1058</a> for more details.
                 </li>
+                <li>
+                    The criteria for identifying internal topics in ReplicationPolicy and DefaultReplicationPolicy have
+                    been updated to enable the replication of topics that appear to be internal but aren't truly internal to Kafka and Mirror Maker 2.
+                    See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-1074%3A+Allow+the+replication+of+user+internal+topics">KIP-1074</a> for more details.
+                </li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
This change refines the condition for identifying internal topics in the ReplicationPolicy, allowing replication of topics that appear internal but are not.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
