### PR TITLE
KAFKA-17993: reassign partition tool stuck with uncaught exception: '…

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -942,6 +942,16 @@ public class MockAdminClient extends AdminClient {
                         case DELETE:
                             newMap.remove(op.configEntry().name());
                             break;
+                        case APPEND:
+                            // should check if entry is splittable but prefer to keep this simple
+                            newMap.compute(op.configEntry().name(), (k, v) -> {
+                                if (v != null) {
+                                    return v + "," + op.configEntry().value();
+                                } else {
+                                    return op.configEntry().value();
+                                }
+                            });
+                            break;
                         default:
                             return new InvalidRequestException(
                                 "Unsupported op type " + op.opType());


### PR DESCRIPTION
…value' field is too long to be serialized

If the incrementalAlterConfig command to set the replication throttling includes values too large to be serialzed (because the number of partitions of a single topic is very large, thousands), split it into succsssive incrementalAlterConfig commands with AlterConfigOp.OpType.APPEND.

JIRA: https://issues.apache.org/jira/browse/KAFKA-17993

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
