### PR TITLE
KAFKA-17994: Checked exceptions are not handled

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -320,8 +320,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                             restoreCount++;
                         }
                     } catch (final Exception deserializationException) {
-                        // while Java distinguishes checked vs unchecked exceptions, other languages like
-                        // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+                        // while Java distinguishes checked vs unchecked exceptions, other languages
+                        // like Scala or Kotlin do not, and thus we need to catch `Exception`
+                        // (instead of `RuntimeException`) to work well with those languages
                         handleDeserializationFailure(
                             deserializationExceptionHandler,
                             globalProcessorContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -319,7 +319,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                                 record.headers()));
                             restoreCount++;
                         }
-                    } catch (final RuntimeException deserializationException) {
+                    } catch (final Exception deserializationException) {
+                        // while Java distinguishes checked vs unchecked exceptions, other languages like
+                        // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
                         handleDeserializationFailure(
                             deserializationExceptionHandler,
                             globalProcessorContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -203,7 +203,9 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
         } catch (final FailedProcessingException | TaskCorruptedException | TaskMigratedException e) {
             // Rethrow exceptions that should not be handled here
             throw e;
-        } catch (final RuntimeException processingException) {
+        } catch (final Exception processingException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null, // only required to pass for DeserializationExceptionHandler
                 internalProcessorContext.topic(),
@@ -220,7 +222,9 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                     processingExceptionHandler.handle(errorHandlerContext, record, processingException),
                     "Invalid ProductionExceptionHandler response."
                 );
-            } catch (final RuntimeException fatalUserException) {
+            } catch (final Exception fatalUserException) {
+                // while Java distinguishes checked vs unchecked exceptions, other languages like
+                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
                 log.error(
                     "Processing error callback failed after processing error for record: {}",
                     errorHandlerContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -204,8 +204,9 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
             // Rethrow exceptions that should not be handled here
             throw e;
         } catch (final Exception processingException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null, // only required to pass for DeserializationExceptionHandler
                 internalProcessorContext.topic(),
@@ -223,8 +224,9 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                     "Invalid ProductionExceptionHandler response."
                 );
             } catch (final Exception fatalUserException) {
-                // while Java distinguishes checked vs unchecked exceptions, other languages like
-                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+                // while Java distinguishes checked vs unchecked exceptions, other languages
+                // like Scala or Kotlin do not, and thus we need to catch `Exception`
+                // (instead of `RuntimeException`) to work well with those languages
                 log.error(
                     "Processing error callback failed after processing error for record: {}",
                     errorHandlerContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -210,7 +210,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 key,
                 keySerializer,
                 exception);
-        } catch (final RuntimeException serializationException) {
+        } catch (final Exception serializationException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             handleException(
                 ProductionExceptionHandler.SerializationExceptionOrigin.KEY,
                 topic,
@@ -221,7 +223,8 @@ public class RecordCollectorImpl implements RecordCollector {
                 timestamp,
                 processorNodeId,
                 context,
-                serializationException);
+                serializationException
+            );
             return;
         }
 
@@ -234,7 +237,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 value,
                 valueSerializer,
                 exception);
-        } catch (final RuntimeException serializationException) {
+        } catch (final Exception serializationException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             handleException(
                 ProductionExceptionHandler.SerializationExceptionOrigin.VALUE,
                 topic,
@@ -312,7 +317,7 @@ public class RecordCollectorImpl implements RecordCollector {
                                         final Long timestamp,
                                         final String processorNodeId,
                                         final InternalProcessorContext<Void, Void> context,
-                                        final RuntimeException serializationException) {
+                                        final Exception serializationException) {
         log.debug(String.format("Error serializing record for topic %s", topic), serializationException);
 
         final ProducerRecord<K, V> record = new ProducerRecord<>(topic, partition, timestamp, key, value, headers);
@@ -328,7 +333,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 ),
                 "Invalid ProductionExceptionHandler response."
             );
-        } catch (final RuntimeException fatalUserException) {
+        } catch (final Exception fatalUserException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             log.error(
                 String.format(
                     "Production error callback failed after serialization error for record %s: %s",
@@ -442,7 +449,9 @@ public class RecordCollectorImpl implements RecordCollector {
                     ),
                     "Invalid ProductionExceptionHandler response."
                 );
-            } catch (final RuntimeException fatalUserException) {
+            } catch (final Exception fatalUserException) {
+                // while Java distinguishes checked vs unchecked exceptions, other languages like
+                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
                 log.error(
                     "Production error callback failed after production error for record {}",
                     serializedRecord,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -211,8 +211,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 keySerializer,
                 exception);
         } catch (final Exception serializationException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             handleException(
                 ProductionExceptionHandler.SerializationExceptionOrigin.KEY,
                 topic,
@@ -238,8 +239,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 valueSerializer,
                 exception);
         } catch (final Exception serializationException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             handleException(
                 ProductionExceptionHandler.SerializationExceptionOrigin.VALUE,
                 topic,
@@ -334,8 +336,9 @@ public class RecordCollectorImpl implements RecordCollector {
                 "Invalid ProductionExceptionHandler response."
             );
         } catch (final Exception fatalUserException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             log.error(
                 String.format(
                     "Production error callback failed after serialization error for record %s: %s",
@@ -450,8 +453,9 @@ public class RecordCollectorImpl implements RecordCollector {
                     "Invalid ProductionExceptionHandler response."
                 );
             } catch (final Exception fatalUserException) {
-                // while Java distinguishes checked vs unchecked exceptions, other languages like
-                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+                // while Java distinguishes checked vs unchecked exceptions, other languages
+                // like Scala or Kotlin do not, and thus we need to catch `Exception`
+                // (instead of `RuntimeException`) to work well with those languages
                 log.error(
                     "Production error callback failed after production error for record {}",
                     serializedRecord,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -71,8 +71,9 @@ public class RecordDeserializer {
                 rawRecord.leaderEpoch()
             );
         } catch (final Exception deserializationException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor, sourceNode().name());
             return null; //  'handleDeserializationFailure' would either throw or swallow -- if we swallow we need to skip the record by returning 'null'
         }
@@ -103,8 +104,9 @@ public class RecordDeserializer {
                 "Invalid DeserializationExceptionHandler response."
             );
         } catch (final Exception fatalUserException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             log.error(
                 "Deserialization error callback failed after deserialization error for record {}",
                 rawRecord,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -70,7 +70,9 @@ public class RecordDeserializer {
                 rawRecord.headers(),
                 rawRecord.leaderEpoch()
             );
-        } catch (final RuntimeException deserializationException) {
+        } catch (final Exception deserializationException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor, sourceNode().name());
             return null; //  'handleDeserializationFailure' would either throw or swallow -- if we swallow we need to skip the record by returning 'null'
         }
@@ -78,7 +80,7 @@ public class RecordDeserializer {
 
     public static void handleDeserializationFailure(final DeserializationExceptionHandler deserializationExceptionHandler,
                                                     final ProcessorContext<?, ?> processorContext,
-                                                    final RuntimeException deserializationException,
+                                                    final Exception deserializationException,
                                                     final ConsumerRecord<byte[], byte[]> rawRecord,
                                                     final Logger log,
                                                     final Sensor droppedRecordsSensor,
@@ -100,7 +102,9 @@ public class RecordDeserializer {
                 deserializationExceptionHandler.handle(errorHandlerContext, rawRecord, deserializationException),
                 "Invalid DeserializationExceptionHandler response."
             );
-        } catch (final RuntimeException fatalUserException) {
+        } catch (final Exception fatalUserException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             log.error(
                 "Deserialization error callback failed after deserialization error for record {}",
                 rawRecord,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -924,8 +924,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         } catch (final TaskCorruptedException | TaskMigratedException e) {
             throw e;
         } catch (final Exception processingException) {
-            // while Java distinguishes checked vs unchecked exceptions, other languages like
-            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+            // while Java distinguishes checked vs unchecked exceptions, other languages
+            // like Scala or Kotlin do not, and thus we need to catch `Exception`
+            // (instead of `RuntimeException`) to work well with those languages
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null,
                 recordContext.topic(),
@@ -944,8 +945,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     "Invalid ProcessingExceptionHandler response."
                 );
             } catch (final Exception fatalUserException) {
-                // while Java distinguishes checked vs unchecked exceptions, other languages like
-                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
+                // while Java distinguishes checked vs unchecked exceptions, other languages
+                // like Scala or Kotlin do not, and thus we need to catch `Exception`
+                // (instead of `RuntimeException`) to work well with those languages
                 log.error(
                     "Processing error callback failed after processing error for record: {}",
                     errorHandlerContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -52,8 +52,6 @@ import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -883,18 +881,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         processTimeMs = 0L;
     }
 
-    private String getStacktraceString(final Throwable e) {
-        String stacktrace = null;
-        try (final StringWriter stringWriter = new StringWriter();
-             final PrintWriter printWriter = new PrintWriter(stringWriter)) {
-            e.printStackTrace(printWriter);
-            stacktrace = stringWriter.toString();
-        } catch (final IOException ioe) {
-            log.error("Encountered error extracting stacktrace from this exception", ioe);
-        }
-        return stacktrace;
-    }
-
     /**
      * @throws IllegalStateException if the current node is not null
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
@@ -937,7 +923,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             throw createStreamsException(node.name(), e.getCause());
         } catch (final TaskCorruptedException | TaskMigratedException e) {
             throw e;
-        } catch (final RuntimeException processingException) {
+        } catch (final Exception processingException) {
+            // while Java distinguishes checked vs unchecked exceptions, other languages like
+            // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null,
                 recordContext.topic(),
@@ -955,7 +943,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     processingExceptionHandler.handle(errorHandlerContext, null, processingException),
                     "Invalid ProcessingExceptionHandler response."
                 );
-            } catch (final RuntimeException fatalUserException) {
+            } catch (final Exception fatalUserException) {
+                // while Java distinguishes checked vs unchecked exceptions, other languages like
+                // Scala or Kotlin do no, and thus we need to `Exception` to work well with those languages
                 log.error(
                     "Processing error callback failed after processing error for record: {}",
                     errorHandlerContext,


### PR DESCRIPTION
While Java distinguished between checked vs unchecked exception, other JVM languages do not. Thus, user code might still throw a checked exception even if no checked exception is declared on the implemented interface.

Should be cherry-picked to 3.9 branch.