### PR TITLE
MINOR: Return exception cause from wrapped exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -154,6 +154,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -534,7 +535,7 @@ public enum Errors {
      * @return The throwable itself or its cause if it is an instance of a commonly wrapped exception type
      */
     public static Throwable maybeUnwrapException(Throwable t) {
-        if (t instanceof CompletionException || t instanceof ExecutionException) {
+        if (t instanceof CompletionException || t instanceof ExecutionException || t instanceof CancellationException) {
             return t.getCause();
         } else {
             return t;


### PR DESCRIPTION
The completable future exceptions can be wrapped either in CompletionException or ExectionException or CancellationException. The method currently unwraps first 2. In the recent commit https://github.com/apache/kafka/pull/17409, though there is other JDK issue, but we have added support for unwrapping CancellationException as well. 

Not all code in Kafka uses KafkaFutureImpl rather a lot also use CompletableFuture directly. Where the unwrapping of exception is missing CancellationException type.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
