### PR TITLE
KAFKA-18024 ConcurrentModificationException in Kafka OffsetFetcher - Proposal for Thread-Safety Fix - Update OffsetFetcher.java

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -140,7 +141,7 @@ public class OffsetFetcher {
         if (timestampsToSearch.isEmpty())
             return result;
 
-        Map<TopicPartition, Long> remainingToSearch = new HashMap<>(timestampsToSearch);
+        Map<TopicPartition, Long> remainingToSearch = new ConcurrentHashMap<>(timestampsToSearch);
         do {
             RequestFuture<ListOffsetResult> future = sendListOffsetsRequests(remainingToSearch, requireTimestamps);
 


### PR DESCRIPTION
KAFKA-18024 ConcurrentModificationException in Kafka OffsetFetcher - Proposal for Thread-Safety Fix 
replaced `HashMap` with `ConcurrentHashMap` to ensure thread safety during concurrent modifications

More detailed description available in [KAFKA-18024](https://issues.apache.org/jira/browse/KAFKA-18024)

All tests before and after the change pass in the same way. Unfortunately, I did not add additional tests specifically for this change, as it is difficult to test this type of modification.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

@kamalcph 
