### PR TITLE
MINOR: Fix incorrect scala example in README of test-common

### DIFF
--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/README.md
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/README.md
@@ -28,8 +28,8 @@ Multiple `@ClusterTest` annotations can be given to generate more than one test 
 
 ```scala
 @ClusterTests(Array(
-  @ClusterTest(brokerSecurityProtocol = SecurityProtocol.PLAINTEXT),
-  @ClusterTest(securityProtocol = SecurityProtocol.SASL_PLAINTEXT)
+  new ClusterTest(brokerSecurityProtocol = SecurityProtocol.PLAINTEXT),
+  new ClusterTest(brokerSecurityProtocol = SecurityProtocol.SASL_PLAINTEXT)
 ))
 def testSomething(): Unit = { ... }
 ```


### PR DESCRIPTION
This PR fixes incorrect syntax in the JUnit extension example for Scala. In Scala, `new` is required instead of `@` to create instances. When dealing with nested structures such as arrays or nested annotations, explicit instantiation with `new` is required to ensure syntax compatibility with Java annotations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
