### PR TITLE
KAFKA-17898: Refine Epoch Bumping Logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -564,6 +564,9 @@ public class TransactionManager {
         this.partitionsWithUnresolvedSequences.clear();
     }
 
+    /**
+     * This method is used to trigger an epoch bump for non-transactional idempotent producers.
+     */
     synchronized void requestIdempotentEpochBumpForPartition(TopicPartition tp) {
         clientSideEpochBumpRequired = true;
         this.partitionsToRewriteSequences.add(tp);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -780,6 +780,21 @@ public class TransactionManagerTest {
         return batch;
     }
 
+    private ProducerBatch writeTransactionalBatchWithValue(
+        TransactionManager manager,
+        TopicPartition tp,
+        String value
+    ) {
+        manager.maybeUpdateProducerIdAndEpoch(tp);
+        int seq = manager.sequenceNumber(tp);
+        manager.incrementSequenceNumber(tp, 1);
+        ProducerBatch batch = batchWithValue(tp, value);
+        batch.setProducerState(manager.producerIdAndEpoch(), seq, true);
+        manager.addInFlightBatch(batch);
+        batch.close();
+        return batch;
+    }
+
     private ProducerBatch batchWithValue(TopicPartition tp, String value) {
         MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(64),
                 Compression.NONE, TimestampType.CREATE_TIME, 0L);
@@ -2948,7 +2963,7 @@ public class TransactionManagerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testEpochBumpAfterLastInflightBatchFails(boolean transactionV2Enabled) {
+    public void testEpochBumpAfterLastInFlightBatchFailsIdempotentProducer(boolean transactionV2Enabled) {
         initializeTransactionManager(Optional.empty(), transactionV2Enabled);
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
         initializeIdempotentProducerId(producerId, epoch);
@@ -2978,6 +2993,39 @@ public class TransactionManagerTest {
         runUntil(() -> transactionManager.producerIdAndEpoch().epoch == 2);
         assertFalse(transactionManager.hasUnresolvedSequences());
         assertEquals(0, transactionManager.sequenceNumber(tp0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testMaybeResolveSequencesTransactionalProducer(boolean transactionV2Enabled) throws Exception {
+        initializeTransactionManager(Optional.of(transactionalId), transactionV2Enabled);
+
+        // Initialize transaction with initial producer ID and epoch.
+        doInitTransactions(producerId, epoch);
+
+        transactionManager.beginTransaction();
+        transactionManager.maybeAddPartition(tp0);
+        prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, producerId);
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
+
+        ProducerBatch b1 = writeTransactionalBatchWithValue(transactionManager, tp0, "1");
+        assertEquals(Integer.valueOf(1), transactionManager.sequenceNumber(tp0));
+
+        transactionManager.markSequenceUnresolved(b1);
+        assertTrue(transactionManager.hasUnresolvedSequences());
+
+        transactionManager.handleFailedBatch(b1, new TimeoutException(), false);
+        // Call maybeResolveSequences to trigger resolution logic
+        transactionManager.maybeResolveSequences();
+
+        // Verify the type of error state the transaction is in.
+        if (transactionManager.isTransactionV2Enabled() || transactionManager.canTriggerEpochBump()) {
+            // Expected to throw an abortable error when epoch bumping is allowed
+            assertTrue(transactionManager.hasAbortableError());
+        } else {
+            // Expected to throw a fatal error when epoch bumping is not allowed
+            assertTrue(transactionManager.hasFatalError());
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -3019,7 +3019,7 @@ public class TransactionManagerTest {
         transactionManager.maybeResolveSequences();
 
         // Verify the type of error state the transaction is in.
-        if (transactionManager.isTransactionV2Enabled() || transactionManager.canTriggerEpochBump()) {
+        if (transactionManager.isTransactionV2Enabled() || transactionManager.needToTriggerEpochBumpFromClient()) {
             // Expected to throw an abortable error when epoch bumping is allowed
             assertTrue(transactionManager.hasAbortableError());
         } else {
@@ -3554,13 +3554,13 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testCanTriggerEpochBumpDuringCoordinatorDisconnect() {
+    public void testNeedToTriggerEpochBumpFromClientDuringCoordinatorDisconnect() {
         doInitTransactions(0, (short) 0);
         runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
-        assertTrue(transactionManager.canTriggerEpochBump());
+        assertTrue(transactionManager.needToTriggerEpochBumpFromClient());
 
         apiVersions.remove(transactionManager.coordinator(CoordinatorType.TRANSACTION).idString());
-        assertTrue(transactionManager.canTriggerEpochBump());
+        assertTrue(transactionManager.needToTriggerEpochBumpFromClient());
     }
 
     @ParameterizedTest

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -678,7 +678,7 @@ public class TransactionManagerTest {
         assertEquals(2, transactionManager.sequenceNumber(tp0));
 
         // The producerId might be reset due to a failure on another partition
-        transactionManager.requestEpochBumpForPartition(tp1);
+        transactionManager.requestIdempotentEpochBumpForPartition(tp1);
         transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
         initializeIdempotentProducerId(producerId + 1, (short) 0);
 
@@ -814,7 +814,7 @@ public class TransactionManagerTest {
         transactionManager.incrementSequenceNumber(tp1, 3);
         assertEquals(transactionManager.sequenceNumber(tp1), 3);
 
-        transactionManager.requestEpochBumpForPartition(tp0);
+        transactionManager.requestIdempotentEpochBumpForPartition(tp0);
         transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
         assertEquals(transactionManager.sequenceNumber(tp0), 0);
         assertEquals(transactionManager.sequenceNumber(tp1), 3);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -3506,13 +3506,13 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testCanBumpEpochDuringCoordinatorDisconnect() {
+    public void testCanTriggerEpochBumpDuringCoordinatorDisconnect() {
         doInitTransactions(0, (short) 0);
         runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
-        assertTrue(transactionManager.canBumpEpoch());
+        assertTrue(transactionManager.canTriggerEpochBump());
 
         apiVersions.remove(transactionManager.coordinator(CoordinatorType.TRANSACTION).idString());
-        assertTrue(transactionManager.canBumpEpoch());
+        assertTrue(transactionManager.canTriggerEpochBump());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
With [KAFKA-14562](https://issues.apache.org/jira/browse/KAFKA-14562), we implemented epoch bump on both the client and the server. Mentioned below are the different epoch bump scenarios we have on hand after enabled tv2

**Non-Transactional Producers**
	•	Epoch bumping is always allowed.
	•	Different code paths are used to handle epoch bumping.

**Transactional Producers**

1. No Epoch Bump Allowed
	•	coordinatorSupportsBumpingEpoch = false when initPIDVersion < 3 or initPIDVersion = null.

2. Client-Triggered Epoch Bump Allowed
	•	coordinatorSupportsBumpingEpoch = true when initPIDVersion >= 3.
	•	TransactionVersion2Enabled = false when endTxnVersion < 5.

3. Only Server-Triggered Epoch Bump Allowed
	•	TransactionVersion2Enabled = true and endTxnVersion >= 5.

We want to refine the code and make it more structured to correctly handle epoch bumping in the above mentioned cases.

The changes made in this patch are:

- Rename epochBumpRequired to epochBumpTriggerRequired to symbolize a manual epoch bump request from the client 
- Modify canEpochBump method according to the above mentioned scenarios