### PR TITLE
MINOR Increase operations for stale PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           debug-only: ${{ inputs.dryRun || false }}
-          operations-per-run: ${{ inputs.operationsPerRun || 100 }}
+          operations-per-run: ${{ inputs.operationsPerRun || 500 }}
           ascending: true
           days-before-stale: 90
           days-before-close: 30  # Since adding 'stale' will update the PR, days-before-close is relative to that.


### PR DESCRIPTION
The Stale PRs workflow is only able to act on a relatively small number of PRs due to the API operations limit. This patch increases the limit from 100 to 500.