### PR TITLE
MINOR: Use JDK 17 in Vagrant after dropping JDK 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ ec2_iam_instance_profile_name = nil
 ebs_volume_type = 'gp3'
 
 jdk_major = '11'
-jdk_full="11.0.2-linux-x64"
+jdk_full = '11.0.2-linux-x64'
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,8 +55,8 @@ ec2_iam_instance_profile_name = nil
 
 ebs_volume_type = 'gp3'
 
-jdk_major = '8'
-jdk_full = '8u202-linux-x64'
+jdk_major = '11'
+jdk_full="11.0.2-linux-x64"
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,8 +55,8 @@ ec2_iam_instance_profile_name = nil
 
 ebs_volume_type = 'gp3'
 
-jdk_major = '11'
-jdk_full = '11.0.2-linux-x64'
+jdk_major = '17'
+jdk_full = '17-linux-x64'
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -36,8 +36,8 @@ fetch_jdk_tgz() {
   fi
 }
 
-JDK_MAJOR="${JDK_MAJOR:-8}"
-JDK_FULL="${JDK_FULL:-8u202-linux-x64}"
+JDK_MAJOR="${JDK_MAJOR:-11}"
+JDK_FULL="${JDK_FULL:-11.0.2-linux-x64}"
 
 if [ -z `which javac` ]; then
     apt-get -y update

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -36,8 +36,8 @@ fetch_jdk_tgz() {
   fi
 }
 
-JDK_MAJOR="${JDK_MAJOR:-11}"
-JDK_FULL="${JDK_FULL:-11.0.2-linux-x64}"
+JDK_MAJOR="${JDK_MAJOR:-17}"
+JDK_FULL="${JDK_FULL:-17-linux-x64}"
 
 if [ -z `which javac` ]; then
     apt-get -y update
@@ -150,6 +150,28 @@ get_kafka 3.8.1 2.12
 chmod a+rw /opt/kafka-3.8.1
 get_kafka 3.9.0 2.12
 chmod a+rw /opt/kafka-3.9.0
+
+# To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper
+# client from version 3.4.x to 3.5.7 in Kafka versions 2.1.1, 2.2.2, and 2.3.1, as the older Zookeeper
+# client is incompatible with JDK 17. See KAFKA-17888 for more details.
+curl -s "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.5.7/zookeeper-3.5.7.jar" -o /opt/zookeeper-3.5.7.jar
+curl -s "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/3.5.7/zookeeper-jute-3.5.7.jar" -o /opt/zookeeper-jute-3.5.7.jar
+rm -f /opt/kafka-2.1.1/libs/zookeeper-*
+rm -f /opt/kafka-2.2.2/libs/zookeeper-*
+rm -f /opt/kafka-2.3.1/libs/zookeeper-*
+
+cp /opt/zookeeper-3.5.7.jar /opt/kafka-2.1.1/libs/zookeeper-3.5.7.jar
+chmod a+rw /opt/kafka-2.1.1/libs/zookeeper-3.5.7.jar
+cp /opt/zookeeper-3.5.7.jar /opt/kafka-2.2.2/libs/zookeeper-3.5.7.jar
+chmod a+rw /opt/kafka-2.2.2/libs/zookeeper-3.5.7.jar
+cp /opt/zookeeper-3.5.7.jar /opt/kafka-2.3.1/libs/zookeeper-3.5.7.jar
+chmod a+rw /opt/kafka-2.3.1/libs/zookeeper-3.5.7.jar
+cp /opt/zookeeper-jute-3.5.7.jar /opt/kafka-2.1.1/libs/zookeeper-jute-3.5.7.jar
+chmod a+rw /opt/kafka-2.1.1/libs/zookeeper-jute-3.5.7.jar
+cp /opt/zookeeper-jute-3.5.7.jar /opt/kafka-2.2.2/libs/zookeeper-jute-3.5.7.jar
+chmod a+rw /opt/kafka-2.2.2/libs/zookeeper-jute-3.5.7.jar
+cp /opt/zookeeper-jute-3.5.7.jar /opt/kafka-2.3.1/libs/zookeeper-jute-3.5.7.jar
+chmod a+rw /opt/kafka-2.3.1/libs/zookeeper-jute-3.5.7.jar
 
 # For EC2 nodes, we want to use /mnt, which should have the local disk. On local
 # VMs, we can just create it if it doesn't exist and use it like we'd use


### PR DESCRIPTION
We have dropped JDK 8 and now use JDK 11 as the minimum version. This PR updates the `jdk_major` and `jdk_full` versions used by Vagrant to JDK 17. Also for zk compatibility with jdk 17, the patch replaces the ZK client JARs for kafka versions 2.1 through 2.13.

[Link to the test result from the whole test suite](https://confluent-open-source-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/trunk/2024-11-18--001.f95a8430-046e-4832-b8f6-cf53568f8057--1731982772--confluentinc--update-vagrant-jdk-version-to-17--5392ea7f8d/report.html).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
