### PR TITLE
MINOR Fix test-catalog generation

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -159,6 +159,7 @@ def parse_report(workspace_path, report_path, fp) -> Iterable[TestSuite]:
                 test_time = float(elem.get("time", 0.0))
                 partial_test_case = partial(TestCase, test_name, class_name, test_time)
                 test_case_failed = False
+                test_case_skipped = False
             elif elem.tag == "failure":
                 failure_message = elem.get("message")
                 if failure_message:


### PR DESCRIPTION
Fixes another issue introduced in #17725 where the streaming XML parser would skip over tests that followed a SKIPPED test. This caused a large number of tests to be removed from the test catalog https://github.com/apache/kafka/commit/e4a5eb866a4a614b9abf6e26fba5a308bd0f649e