### PR TITLE
[WIP] KAFKA-17243 - MetadataQuorumCommand describe to include CommittedVoters

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4618,6 +4618,10 @@ public class KafkaAdminClient extends AdminClient {
                     .map(this::translateReplicaState)
                     .collect(Collectors.toList());
 
+                List<QuorumInfo.ReplicaState> committedVoters = partition.committedVoters().stream()
+                    .map(this::translateReplicaState)
+                    .collect(Collectors.toList());
+
                 List<QuorumInfo.ReplicaState> observers = partition.observers().stream()
                     .map(this::translateReplicaState)
                     .collect(Collectors.toList());
@@ -4635,6 +4639,7 @@ public class KafkaAdminClient extends AdminClient {
                     partition.leaderEpoch(),
                     partition.highWatermark(),
                     voters,
+                    committedVoters,
                     observers,
                     nodes
                 );

--- a/clients/src/main/java/org/apache/kafka/clients/admin/QuorumInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/QuorumInfo.java
@@ -31,6 +31,7 @@ public class QuorumInfo {
     private final long leaderEpoch;
     private final long highWatermark;
     private final List<ReplicaState> voters;
+    private final List<ReplicaState> committedVoters;
     private final List<ReplicaState> observers;
     private final Map<Integer, Node> nodes;
 
@@ -39,13 +40,15 @@ public class QuorumInfo {
         long leaderEpoch,
         long highWatermark,
         List<ReplicaState> voters,
+        List<ReplicaState> committedVoters,
         List<ReplicaState> observers,
         Map<Integer, Node> nodes
     ) {
         this.leaderId = leaderId;
-        this.leaderEpoch = leaderEpoch;
+        this.leaderEpoch = leaderEpoch; 
         this.highWatermark = highWatermark;
         this.voters = voters;
+        this.committedVoters = committedVoters;
         this.observers = observers;
         this.nodes = nodes;
     }
@@ -64,6 +67,10 @@ public class QuorumInfo {
 
     public List<ReplicaState> voters() {
         return voters;
+    }
+
+    public List<ReplicaState> committedVoters() {
+        return committedVoters;
     }
 
     public List<ReplicaState> observers() {

--- a/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+++ b/clients/src/main/resources/common/message/DescribeQuorumResponse.json
@@ -19,7 +19,8 @@
   "name": "DescribeQuorumResponse",
   // Version 1 adds LastFetchTimeStamp and LastCaughtUpTimestamp in ReplicaState (KIP-836).
   // Version 2 adds ErrorMessage, Nodes, ErrorMessage in ParitionData, ReplicaDirectoryId in ReplicaState (KIP-853).
-  "validVersions": "0-2",
+  // Version 3 adds CommittedVoters in PartitionData
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
@@ -43,6 +44,7 @@
           "about": "The latest known leader epoch"},
         { "name": "HighWatermark", "type": "int64", "versions": "0+"},
         { "name": "CurrentVoters", "type": "[]ReplicaState", "versions": "0+" },
+        { "name": "CommittedVoters", "type": "[]ReplicaState", "versions": "3+", "nullableVersions": "3+", "ignorable": true },
         { "name": "Observers", "type": "[]ReplicaState", "versions": "0+" }
       ]}
     ]},

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -352,7 +352,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     ) {
         final LogOffsetMetadata endOffsetMetadata = log.endOffset();
 
-        if (state.updateLocalState(endOffsetMetadata, partitionState.lastVoterSet())) {
+        Map.Entry<VoterSet, Long> lastVoterSetWithOffset = partitionState.lastVoterSetWithOffset();
+        VoterSet lastVoterSet = lastVoterSetWithOffset.getKey();
+        Long lastVoterSetOffset = lastVoterSetWithOffset.getValue();
+
+        if (state.updateLocalState(endOffsetMetadata, lastVoterSet, lastVoterSetOffset)) {
             onUpdateLeaderHighWatermark(state, currentTimeMs);
         }
 
@@ -1751,7 +1755,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             quorum.localIdOrThrow(),
             leaderState.epoch(),
             leaderState.highWatermark().map(LogOffsetMetadata::offset).orElse(-1L),
-            leaderState.voterStates().values(),
+            leaderState.currentVoterStates().values(),
+            leaderState.committedVoterStates().values(),
             leaderState.observerStates(currentTimeMs).values(),
             currentTimeMs
         );

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -493,9 +493,14 @@ public class RaftUtil {
         int leaderEpoch,
         long highWatermark,
         Collection<LeaderState.ReplicaState> voters,
+        Collection<LeaderState.ReplicaState> committedVoters,
         Collection<LeaderState.ReplicaState> observers,
         long currentTimeMs
     ) {
+        if (apiVersion < 3) {
+            committedVoters = null;
+        }
+
         DescribeQuorumResponseData response = new DescribeQuorumResponseData()
             .setTopics(
                 Collections.singletonList(
@@ -510,6 +515,7 @@ public class RaftUtil {
                                     .setLeaderEpoch(leaderEpoch)
                                     .setHighWatermark(highWatermark)
                                     .setCurrentVoters(toReplicaStates(apiVersion, leaderId, voters, currentTimeMs))
+                                    .setCommittedVoters(toReplicaStates(apiVersion, leaderId, committedVoters, currentTimeMs))
                                     .setObservers(toReplicaStates(apiVersion, leaderId, observers, currentTimeMs))))));
         if (apiVersion >= 2) {
             DescribeQuorumResponseData.NodeCollection nodes = new DescribeQuorumResponseData.NodeCollection(voters.size());

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KRaftControlRecordStateMachine.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KRaftControlRecordStateMachine.java
@@ -34,6 +34,7 @@ import org.apache.kafka.snapshot.SnapshotReader;
 
 import org.slf4j.Logger;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -139,6 +140,17 @@ public final class KRaftControlRecordStateMachine {
     public VoterSet lastVoterSet() {
         synchronized (voterSetHistory) {
             return voterSetHistory.lastValue();
+        }
+    }
+
+    /**
+     * Returns the last voter set with its offset.
+     */
+    public Map.Entry<VoterSet, Long> lastVoterSetWithOffset() {
+        synchronized (voterSetHistory) {
+            VoterSet voters = voterSetHistory.lastValue();
+            Long offset = voterSetHistory.lastVoterSetOffset().orElse(0L);
+            return Map.entry(voters, offset);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -271,6 +271,7 @@ public class MetadataQuorumCommand {
             "\nMaxFollowerLag:         " + maxFollowerLag +
             "\nMaxFollowerLagTimeMs:   " + maxFollowerLagTimeMs +
             "\nCurrentVoters:          " + printVoterState(quorumInfo) +
+            "\nCommittedVoters:        " + printCommittedVoterState(quorumInfo) +
             "\nCurrentObservers:       " + printObserverState(quorumInfo)
         );
     }
@@ -281,7 +282,14 @@ public class MetadataQuorumCommand {
         return printReplicaState(quorumInfo, quorumInfo.voters());
     }
 
+    // Constructs the CommittedVoters string
+    // CommittedVoters: [{"id": 0, "directoryId": "UUID1", "endpoints": ["C://controller-0:1234"]}]
+    private static String printCommittedVoterState(QuorumInfo quorumInfo) {
+        return printReplicaState(quorumInfo, quorumInfo.committedVoters());
+    }
+
     // Constructs the CurrentObservers string
+    // CurrentObservers: [{"id": 0, "directoryId": "UUID1", "endpoints": ["C://controller-0:1234"]}]
     private static String printObserverState(QuorumInfo quorumInfo) {
         return printReplicaState(quorumInfo, quorumInfo.observers());
     }


### PR DESCRIPTION
`kafka-metadata-quorum describe --status` output should include CommittedVoters information, formatted similarly to Voters and Observers

Right now the KafkaRaftClient and KRaftControlRecordStateMachine only track the latest value for the voter set. It doesn't know which voters set is the latest committed voter set. We need to extend those types to keep track of both the latest voter set and the latest committed voter set.

- [KAFKA-17243](https://issues.apache.org/jira/browse/KAFKA-17243)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
