### PR TITLE
KAFKA-17750: Extend kafka-consumer-groups command line tool to support new consumer group

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,8 @@ public class ConsumerGroupDescription {
     private final GroupState groupState;
     private final Node coordinator;
     private final Set<AclOperation> authorizedOperations;
+    private Optional<Integer> groupEpoch = Optional.empty();
+    private Optional<Integer> targetAssignmentEpoch = Optional.empty();
 
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupState, Node)}.
@@ -71,7 +74,7 @@ public class ConsumerGroupDescription {
     }
 
     /**
-     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set)}.
+     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set, Optional, Optional)}.
      */
     @Deprecated
     public ConsumerGroupDescription(String groupId,
@@ -108,7 +111,7 @@ public class ConsumerGroupDescription {
                                     GroupState groupState,
                                     Node coordinator,
                                     Set<AclOperation> authorizedOperations) {
-        this(groupId, isSimpleConsumerGroup, members, partitionAssignor, GroupType.CLASSIC, groupState, coordinator, authorizedOperations);
+        this(groupId, isSimpleConsumerGroup, members, partitionAssignor, GroupType.CLASSIC, groupState, coordinator, authorizedOperations, Optional.empty(), Optional.empty());
     }
 
     public ConsumerGroupDescription(String groupId,
@@ -118,7 +121,9 @@ public class ConsumerGroupDescription {
                                     GroupType type,
                                     GroupState groupState,
                                     Node coordinator,
-                                    Set<AclOperation> authorizedOperations) {
+                                    Set<AclOperation> authorizedOperations,
+                                    Optional<Integer> groupEpoch,
+                                    Optional<Integer> targetAssignmentEpoch) {
         this.groupId = groupId == null ? "" : groupId;
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;
         this.members = members == null ? Collections.emptyList() : List.copyOf(members);
@@ -127,6 +132,8 @@ public class ConsumerGroupDescription {
         this.groupState = groupState;
         this.coordinator = coordinator;
         this.authorizedOperations = authorizedOperations;
+        this.groupEpoch = groupEpoch;
+        this.targetAssignmentEpoch = targetAssignmentEpoch;
     }
 
     @Override
@@ -141,12 +148,15 @@ public class ConsumerGroupDescription {
             type == that.type &&
             groupState == that.groupState &&
             Objects.equals(coordinator, that.coordinator) &&
-            Objects.equals(authorizedOperations, that.authorizedOperations);
+            Objects.equals(authorizedOperations, that.authorizedOperations) &&
+            Objects.equals(groupEpoch, that.groupEpoch) &&
+            Objects.equals(targetAssignmentEpoch, that.targetAssignmentEpoch);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, isSimpleConsumerGroup, members, partitionAssignor, type, groupState, coordinator, authorizedOperations);
+        return Objects.hash(groupId, isSimpleConsumerGroup, members, partitionAssignor, type, groupState, coordinator, authorizedOperations,
+            groupEpoch, targetAssignmentEpoch);
     }
 
     /**
@@ -215,6 +225,20 @@ public class ConsumerGroupDescription {
         return authorizedOperations;
     }
 
+    /**
+     * The epoch of the consumer group.
+     */
+    public Optional<Integer> groupEpoch() {
+        return groupEpoch;
+    }
+
+    /**
+     * The epoch of the target assignment.
+     */
+    public Optional<Integer> targetAssignmentEpoch() {
+        return targetAssignmentEpoch;
+    }
+
     @Override
     public String toString() {
         return "(groupId=" + groupId +
@@ -225,6 +249,8 @@ public class ConsumerGroupDescription {
             ", groupState=" + groupState +
             ", coordinator=" + coordinator +
             ", authorizedOperations=" + authorizedOperations +
+            ", groupEpoch=" + groupEpoch.orElse(null) +
+            ", targetAssignmentEpoch=" + targetAssignmentEpoch.orElse(null) +
             ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
@@ -30,13 +30,17 @@ public class MemberDescription {
     private final String host;
     private final MemberAssignment assignment;
     private final Optional<MemberAssignment> targetAssignment;
+    private final Optional<Integer> memberEpoch;
+    private final Boolean isClassic;
 
     public MemberDescription(String memberId,
         Optional<String> groupInstanceId,
         String clientId,
         String host,
         MemberAssignment assignment,
-        Optional<MemberAssignment> targetAssignment
+        Optional<MemberAssignment> targetAssignment,
+        Optional<Integer> memberEpoch,
+        Boolean isClassic
     ) {
         this.memberId = memberId == null ? "" : memberId;
         this.groupInstanceId = groupInstanceId;
@@ -45,6 +49,8 @@ public class MemberDescription {
         this.assignment = assignment == null ?
             new MemberAssignment(Collections.emptySet()) : assignment;
         this.targetAssignment = targetAssignment;
+        this.memberEpoch = memberEpoch;
+        this.isClassic = isClassic;
     }
 
     public MemberDescription(
@@ -52,7 +58,9 @@ public class MemberDescription {
         Optional<String> groupInstanceId,
         String clientId,
         String host,
-        MemberAssignment assignment
+        MemberAssignment assignment,
+        Optional<Integer> memberEpoch,
+        Boolean isClassic
     ) {
         this(
             memberId,
@@ -60,7 +68,9 @@ public class MemberDescription {
             clientId,
             host,
             assignment,
-            Optional.empty()
+            Optional.empty(),
+            memberEpoch,
+            isClassic
         );
     }
 
@@ -68,7 +78,7 @@ public class MemberDescription {
                              String clientId,
                              String host,
                              MemberAssignment assignment) {
-        this(memberId, Optional.empty(), clientId, host, assignment);
+        this(memberId, Optional.empty(), clientId, host, assignment, Optional.empty(), false);
     }
 
     @Override
@@ -81,12 +91,14 @@ public class MemberDescription {
             clientId.equals(that.clientId) &&
             host.equals(that.host) &&
             assignment.equals(that.assignment) &&
-            targetAssignment.equals(that.targetAssignment);
+            targetAssignment.equals(that.targetAssignment) &&
+            memberEpoch.equals(that.memberEpoch) &&
+            isClassic.equals(that.isClassic);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(memberId, groupInstanceId, clientId, host, assignment, targetAssignment);
+        return Objects.hash(memberId, groupInstanceId, clientId, host, assignment, targetAssignment, memberEpoch, isClassic);
     }
 
     /**
@@ -131,6 +143,20 @@ public class MemberDescription {
         return targetAssignment;
     }
 
+    /**
+     * The epoch of the group member.
+     */
+    public Optional<Integer> memberEpoch() {
+        return memberEpoch;
+    }
+
+    /**
+     * The flag indicating whether a member is classic.
+     */
+    public Boolean isClassic() {
+        return isClassic;
+    }
+
     @Override
     public String toString() {
         return "(memberId=" + memberId +
@@ -138,6 +164,9 @@ public class MemberDescription {
             ", clientId=" + clientId +
             ", host=" + host +
             ", assignment=" + assignment +
-            ", targetAssignment=" + targetAssignment + ")";
+            ", targetAssignment=" + targetAssignment +
+            ", memberEpoch=" + memberEpoch.orElse(null) +
+            ", isClassic=" + isClassic +
+            ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
@@ -136,7 +136,9 @@ public class DescribeClassicGroupsHandler extends AdminApiHandler.Batched<Coordi
                     Optional.ofNullable(groupMember.groupInstanceId()),
                     groupMember.clientId(),
                     groupMember.clientHost(),
-                    new MemberAssignment(partitions)));
+                    new MemberAssignment(partitions),
+                    Optional.empty(),
+                    true));
             });
 
             final ClassicGroupDescription classicGroupDescription =

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
@@ -220,8 +220,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                     groupMember.clientId(),
                     groupMember.clientHost(),
                     new MemberAssignment(convertAssignment(groupMember.assignment())),
-                    Optional.of(new MemberAssignment(convertAssignment(groupMember.targetAssignment())))
-                ))
+                    Optional.of(new MemberAssignment(convertAssignment(groupMember.targetAssignment()))),
+                    Optional.of(groupMember.memberEpoch()),
+                    groupMember.isClassic()))
             );
 
             final ConsumerGroupDescription consumerGroupDescription =
@@ -233,7 +234,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                     GroupType.CONSUMER,
                     GroupState.parse(describedGroup.groupState()),
                     coordinator,
-                    authorizedOperations
+                    authorizedOperations,
+                    Optional.of(describedGroup.groupEpoch()),
+                    Optional.of(describedGroup.assignmentEpoch())
                 );
             completed.put(groupIdKey, consumerGroupDescription);
         }
@@ -279,7 +282,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                         Optional.ofNullable(groupMember.groupInstanceId()),
                         groupMember.clientId(),
                         groupMember.clientHost(),
-                        new MemberAssignment(partitions)));
+                        new MemberAssignment(partitions),
+                        Optional.empty(),
+                        true));
                 }
                 final ConsumerGroupDescription consumerGroupDescription =
                     new ConsumerGroupDescription(groupIdKey.idValue, protocolType.isEmpty(),
@@ -288,7 +293,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                         GroupType.CLASSIC,
                         GroupState.parse(describedGroup.groupState()),
                         coordinator,
-                        authorizedOperations);
+                        authorizedOperations,
+                        Optional.empty(),
+                        Optional.empty());
                 completed.put(groupIdKey, consumerGroupDescription);
             } else {
                 failed.put(groupIdKey, new IllegalArgumentException(

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -120,9 +121,12 @@ public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<Coordina
             describedGroup.members().forEach(groupMember ->
                 memberDescriptions.add(new MemberDescription(
                     groupMember.memberId(),
+                    Optional.empty(),
                     groupMember.clientId(),
                     groupMember.clientHost(),
-                    new MemberAssignment(convertAssignment(groupMember.assignment()))
+                    new MemberAssignment(convertAssignment(groupMember.assignment())),
+                    Optional.of(groupMember.memberEpoch()),
+                    false
                 ))
             );
 

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ConsumerGroupDescribeRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 69,
   "type": "response",
   "name": "ConsumerGroupDescribeResponse",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
@@ -69,7 +69,9 @@
             { "name": "Assignment", "type": "Assignment", "versions": "0+",
               "about": "The current assignment." },
             { "name": "TargetAssignment", "type": "Assignment", "versions": "0+",
-              "about": "The target assignment." }
+              "about": "The target assignment." },
+            { "name": "IsClassic", "type": "bool", "versions": "1+", "ignorable": true,
+              "about": "True for classic member." }
           ]},
         { "name": "AuthorizedOperations", "type": "int32", "versions": "0+", "default": "-2147483648",
           "about": "32-bit bitfield to represent authorized operations for this group." }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4103,14 +4103,18 @@ public class KafkaAdminClientTest {
                         ),
                         Optional.of(new MemberAssignment(
                             Collections.singleton(new TopicPartition("foo", 1))
-                        ))
+                        )),
+                        Optional.of(10),
+                        false
                     )
                 ),
                 "range",
                 GroupType.CONSUMER,
                 GroupState.STABLE,
                 env.cluster().controller(),
-                Collections.emptySet()
+                Collections.emptySet(),
+                Optional.of(10),
+                Optional.of(10)
             ));
             expectedResult.put("grp2", new ConsumerGroupDescription(
                 "grp2",
@@ -4123,14 +4127,18 @@ public class KafkaAdminClientTest {
                         "clientHost",
                         new MemberAssignment(
                             Collections.singleton(new TopicPartition("bar", 0))
-                        )
+                        ),
+                        Optional.empty(),
+                        true
                     )
                 ),
                 "range",
                 GroupType.CLASSIC,
                 GroupState.STABLE,
                 env.cluster().controller(),
-                Collections.emptySet()
+                Collections.emptySet(),
+                Optional.empty(),
+                Optional.empty()
             ));
 
             assertEquals(expectedResult, result.all().get());
@@ -8608,7 +8616,9 @@ public class KafkaAdminClientTest {
                                      Optional.ofNullable(member.groupInstanceId()),
                                      member.clientId(),
                                      member.clientHost(),
-                                     assignment);
+                                     assignment,
+                                     Optional.empty(),
+                                     false);
     }
 
     private static MemberDescription convertToMemberDescriptions(ShareGroupDescribeResponseData.Member member,
@@ -8617,7 +8627,9 @@ public class KafkaAdminClientTest {
                                      Optional.empty(),
                                      member.clientId(),
                                      member.clientHost(),
-                                     assignment);
+                                     assignment,
+                                     Optional.empty(),
+                                     false);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
@@ -41,7 +41,9 @@ public class MemberDescriptionTest {
                                                           INSTANCE_ID,
                                                           CLIENT_ID,
                                                           HOST,
-                                                          ASSIGNMENT);
+                                                          ASSIGNMENT,
+                                                          Optional.empty(),
+                                                          false);
     }
 
     @Test
@@ -74,7 +76,9 @@ public class MemberDescriptionTest {
                                                                       INSTANCE_ID,
                                                                       CLIENT_ID,
                                                                       HOST,
-                                                                      ASSIGNMENT);
+                                                                      ASSIGNMENT,
+                                                                      Optional.empty(),
+                                                                      false);
 
         assertEquals(STATIC_MEMBER_DESCRIPTION, identityDescription);
         assertEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), identityDescription.hashCode());
@@ -86,7 +90,9 @@ public class MemberDescriptionTest {
                                                                        INSTANCE_ID,
                                                                        CLIENT_ID,
                                                                        HOST,
-                                                                       ASSIGNMENT);
+                                                                       ASSIGNMENT,
+                                                          Optional.empty(),
+                                                               false);
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, newMemberDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newMemberDescription.hashCode());
@@ -95,9 +101,33 @@ public class MemberDescriptionTest {
                                                                          Optional.of("new_instance"),
                                                                          CLIENT_ID,
                                                                          HOST,
-                                                                         ASSIGNMENT);
+                                                                         ASSIGNMENT,
+                                                                         Optional.empty(),
+                                                                         false);
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, newInstanceDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newInstanceDescription.hashCode());
+
+        MemberDescription newMemberEpochDescription = new MemberDescription(MEMBER_ID,
+                                                                            INSTANCE_ID,
+                                                                            CLIENT_ID,
+                                                                            HOST,
+                                                                            ASSIGNMENT,
+                                                                            Optional.of(10),
+                                                                    false);
+
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION, newMemberEpochDescription);
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newMemberEpochDescription.hashCode());
+
+        MemberDescription newIsClassicDescription = new MemberDescription(MEMBER_ID,
+                                                                          INSTANCE_ID,
+                                                                          CLIENT_ID,
+                                                                          HOST,
+                                                                          ASSIGNMENT,
+                                                             Optional.empty(),
+                                                                 true);
+
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION, newIsClassicDescription);
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newIsClassicDescription.hashCode());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -164,7 +165,9 @@ public class DescribeConsumerGroupsHandlerTest {
             Optional.of(new MemberAssignment(Set.of(
                 new TopicPartition("foo", 1),
                 new TopicPartition("bar",  2)
-            )))
+            ))),
+            Optional.of(10),
+            false
         ));
         ConsumerGroupDescription expected = new ConsumerGroupDescription(
             groupId1,
@@ -172,9 +175,11 @@ public class DescribeConsumerGroupsHandlerTest {
             members,
             "range",
             GroupType.CONSUMER,
-            ConsumerGroupState.STABLE,
+            GroupState.STABLE,
             coordinator,
-            Collections.emptySet()
+            Collections.emptySet(),
+            Optional.of(10),
+            Optional.of(10)
         );
         AdminApiHandler.ApiResult<CoordinatorKey, ConsumerGroupDescription> result = handler.handleResponse(
             coordinator,
@@ -221,6 +226,7 @@ public class DescribeConsumerGroupsHandlerTest {
                                                 .setTopicName("bar")
                                                 .setPartitions(Collections.singletonList(2))
                                         )))
+                                    .setIsClassic(false)
                             ))
                     ))
             )
@@ -232,9 +238,12 @@ public class DescribeConsumerGroupsHandlerTest {
     public void testSuccessfulHandleClassicGroupResponse() {
         Collection<MemberDescription> members = singletonList(new MemberDescription(
                 "memberId",
+                Optional.empty(),
                 "clientId",
                 "host",
-                new MemberAssignment(tps)));
+                new MemberAssignment(tps),
+                Optional.empty(),
+                true));
         ConsumerGroupDescription expected = new ConsumerGroupDescription(
                 groupId1,
                 true,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -408,7 +408,8 @@ public class ConsumerGroupMember extends ModernGroupMember {
             .setInstanceId(instanceId)
             .setRackId(rackId)
             .setSubscribedTopicNames(subscribedTopicNames == null ? null : new ArrayList<>(subscribedTopicNames))
-            .setSubscribedTopicRegex(subscribedTopicRegex);
+            .setSubscribedTopicRegex(subscribedTopicRegex)
+            .setIsClassic(useClassicProtocol());
     }
 
     private static List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitionsFromMap(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.image.MetadataImage;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -246,8 +248,9 @@ public class ConsumerGroupMemberTest {
         assertEquals(mkAssignment(mkTopicAssignment(topicId2, 3, 4, 5)), member.partitionsPendingRevocation());
     }
 
-    @Test
-    public void testAsConsumerGroupDescribeMember() {
+    @ParameterizedTest(name = "{displayName}.withClassicMemberMetadata={0}")
+    @ValueSource(booleans = {true, false})
+    public void testAsConsumerGroupDescribeMember(boolean withClassicMemberMetadata) {
         Uuid topicId1 = Uuid.randomUuid();
         Uuid topicId2 = Uuid.randomUuid();
         Uuid topicId3 = Uuid.randomUuid();
@@ -287,6 +290,8 @@ public class ConsumerGroupMemberTest {
             .setClientHost(clientHost)
             .setSubscribedTopicNames(subscribedTopicNames)
             .setSubscribedTopicRegex(subscribedTopicRegex)
+            .setClassicMemberMetadata(withClassicMemberMetadata ? new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                .setSupportedProtocols(toClassicProtocolCollection("range")) : null)
             .build();
 
         ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(targetAssignment, metadataImage.topics());
@@ -315,7 +320,8 @@ public class ConsumerGroupMemberTest {
                             .setTopicName("topic4")
                             .setPartitions(new ArrayList<>(item.getValue()))
                     ).collect(Collectors.toList()))
-            );
+            )
+            .setIsClassic(withClassicMemberMetadata);
 
         assertEquals(expected, actual);
     }
@@ -344,7 +350,8 @@ public class ConsumerGroupMemberTest {
 
         ConsumerGroupDescribeResponseData.Member expected = new ConsumerGroupDescribeResponseData.Member()
             .setMemberId(memberId.toString())
-            .setSubscribedTopicRegex("");
+            .setSubscribedTopicRegex("")
+            .setIsClassic(false);
         ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(null,
             new MetadataImageBuilder()
                 .addTopic(Uuid.randomUuid(), "foo", 3)

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/GroupInformation.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/GroupInformation.java
@@ -19,18 +19,25 @@ package org.apache.kafka.tools.consumer.group;
 import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.Node;
 
+import java.util.Optional;
+
 class GroupInformation {
     final String group;
     final Node coordinator;
     final String assignmentStrategy;
     final GroupState groupState;
     final int numMembers;
+    final Optional<Integer> groupEpoch;
+    final Optional<Integer> targetAssignmentEpoch;
 
-    GroupInformation(String group, Node coordinator, String assignmentStrategy, GroupState groupState, int numMembers) {
+    GroupInformation(String group, Node coordinator, String assignmentStrategy, GroupState groupState, int numMembers,
+                     Optional<Integer> groupEpoch, Optional<Integer> targetAssignmentEpoch) {
         this.group = group;
         this.coordinator = coordinator;
         this.assignmentStrategy = assignmentStrategy;
         this.groupState = groupState;
         this.numMembers = numMembers;
+        this.groupEpoch = groupEpoch;
+        this.targetAssignmentEpoch = targetAssignmentEpoch;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/MemberAssignmentState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/MemberAssignmentState.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.tools.consumer.group;
 
+import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 class MemberAssignmentState {
     final String group;
@@ -28,9 +31,14 @@ class MemberAssignmentState {
     final String groupInstanceId;
     final int numPartitions;
     final List<TopicPartition> assignment;
+    final List<TopicPartition> targetAssignment;
+    final Optional<Integer> currentEpoch;
+    final Optional<Integer> targetEpoch;
+    final Boolean isClassic;
 
     MemberAssignmentState(String group, String consumerId, String host, String clientId, String groupInstanceId,
-                                 int numPartitions, List<TopicPartition> assignment) {
+                          int numPartitions, List<TopicPartition> assignment, Optional<MemberAssignment> targetAssignment,
+                          Optional<Integer> currentEpoch, Optional<Integer> targetEpoch, Boolean isClassic) {
         this.group = group;
         this.consumerId = consumerId;
         this.host = host;
@@ -38,5 +46,10 @@ class MemberAssignmentState {
         this.groupInstanceId = groupInstanceId;
         this.numPartitions = numPartitions;
         this.assignment = assignment;
+        this.targetAssignment = targetAssignment.isPresent() ?
+            new ArrayList<>(targetAssignment.get().topicPartitions()) : List.of();
+        this.currentEpoch = currentEpoch;
+        this.targetEpoch = targetEpoch;
+        this.isClassic = isClassic;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/PartitionAssignmentState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/PartitionAssignmentState.java
@@ -31,11 +31,12 @@ class PartitionAssignmentState {
     final Optional<String> host;
     final Optional<String> clientId;
     final Optional<Long> logEndOffset;
+    final Optional<Integer> leaderEpoch;
 
     PartitionAssignmentState(String group, Optional<Node> coordinator, Optional<String> topic,
                                     Optional<Integer> partition, Optional<Long> offset, Optional<Long> lag,
                                     Optional<String> consumerId, Optional<String> host, Optional<String> clientId,
-                                    Optional<Long> logEndOffset) {
+                                    Optional<Long> logEndOffset, Optional<Integer> leaderEpoch) {
         this.group = group;
         this.coordinator = coordinator;
         this.topic = topic;
@@ -46,5 +47,6 @@ class PartitionAssignmentState {
         this.host = host;
         this.clientId = clientId;
         this.logEndOffset = logEndOffset;
+        this.leaderEpoch = leaderEpoch;
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTestUtils.java
@@ -105,7 +105,7 @@ class ConsumerGroupCommandTestUtils {
                 consumer -> consumer.subscribe(Collections.singleton(topic)));
     }
 
-    private static <T> AutoCloseable buildConsumers(int numberOfConsumers,
+    static <T> AutoCloseable buildConsumers(int numberOfConsumers,
                                                     boolean syncCommit,
                                                     Supplier<KafkaConsumer<T, T>> consumerSupplier,
                                                     Consumer<KafkaConsumer<T, T>> setPartitions) {
@@ -141,7 +141,7 @@ class ConsumerGroupCommandTestUtils {
                                          AtomicBoolean closed) {
         try (KafkaConsumer<T, T> kafkaConsumer = consumerSupplier.get()) {
             while (!closed.get()) {
-                kafkaConsumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                kafkaConsumer.poll(Duration.ofMillis(1000));
                 if (syncCommit)
                     kafkaConsumer.commitSync();
             }


### PR DESCRIPTION
The new consumer groups have more state available to troubleshoot issues. For instance, each member has an epoch, an assignment, a target assignment, etc. It would be useful to display those too in order to give administrator a detailed view of the state of the groups.

KIP: https://cwiki.apache.org/confluence/display/KAFKA/KIP-1099%3A+Extend+kafka-consumer-groups+command+line+tool+to+support+new+consumer+group

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
