### PR TITLE
KAFKA-18039: Test all versions of quorum responses in RequestResponseTest 

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1614,7 +1614,7 @@ public class RequestResponseTest {
                 .setCurrentVoters(singletonList(replicaState))
                 .setObservers(singletonList(replicaState));
         DescribeQuorumResponseData.TopicData topicData = new DescribeQuorumResponseData.TopicData()
-                .setTopicName("topic1")
+                .setTopicName("__cluster_metadata")
                 .setPartitions(singletonList(partitionData));
         DescribeQuorumResponseData data = new DescribeQuorumResponseData()
                 .setErrorCode(Errors.NONE.code())

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1133,9 +1133,9 @@ public class RequestResponseTest {
             case DESCRIBE_USER_SCRAM_CREDENTIALS: return createDescribeUserScramCredentialsResponse();
             case ALTER_USER_SCRAM_CREDENTIALS: return createAlterUserScramCredentialsResponse();
             case VOTE: return createVoteResponse(version);
-            case BEGIN_QUORUM_EPOCH: return createBeginQuorumEpochResponse();
-            case END_QUORUM_EPOCH: return createEndQuorumEpochResponse();
-            case DESCRIBE_QUORUM: return createDescribeQuorumResponse();
+            case BEGIN_QUORUM_EPOCH: return createBeginQuorumEpochResponse(version);
+            case END_QUORUM_EPOCH: return createEndQuorumEpochResponse(version);
+            case DESCRIBE_QUORUM: return createDescribeQuorumResponse(version);
             case ALTER_PARTITION: return createAlterPartitionResponse(version);
             case UPDATE_FEATURES: return createUpdateFeaturesResponse();
             case ENVELOPE: return createEnvelopeResponse();
@@ -1599,9 +1599,38 @@ public class RequestResponseTest {
         return new DescribeQuorumRequest.Builder(data).build(version);
     }
 
-    private DescribeQuorumResponse createDescribeQuorumResponse() {
+    private DescribeQuorumResponse createDescribeQuorumResponse(short version) {
+        DescribeQuorumResponseData.ReplicaState replicaState = new DescribeQuorumResponseData.ReplicaState()
+                .setReplicaId(1);
+        if (version >= 1) {
+            replicaState.setLastFetchTimestamp(123L)
+                .setLastCaughtUpTimestamp(123L);
+        }
+        if (version >= 2) {
+            replicaState.setReplicaDirectoryId(Uuid.randomUuid());
+        }
+        DescribeQuorumResponseData.PartitionData partitionData = new DescribeQuorumResponseData.PartitionData()
+                .setPartitionIndex(0)
+                .setCurrentVoters(singletonList(replicaState))
+                .setObservers(singletonList(replicaState));
+        DescribeQuorumResponseData.TopicData topicData = new DescribeQuorumResponseData.TopicData()
+                .setTopicName("topic1")
+                .setPartitions(singletonList(partitionData));
         DescribeQuorumResponseData data = new DescribeQuorumResponseData()
-                .setErrorCode(Errors.NONE.code());
+                .setErrorCode(Errors.NONE.code())
+                .setTopics(singletonList(topicData));
+        if (version >= 2) {
+            DescribeQuorumResponseData.NodeCollection nodes = new DescribeQuorumResponseData.NodeCollection(1);
+            DescribeQuorumResponseData.ListenerCollection listeners = new DescribeQuorumResponseData.ListenerCollection(1);
+            listeners.add(new DescribeQuorumResponseData.Listener()
+                    .setName("CONTROLLER")
+                    .setHost("localhost")
+                    .setPort(9012));
+            nodes.add(new DescribeQuorumResponseData.Node()
+                    .setNodeId(1)
+                    .setListeners(listeners));
+            data.setNodes(nodes);
+        }
         return new DescribeQuorumResponse(data);
     }
 
@@ -1618,7 +1647,7 @@ public class RequestResponseTest {
         return new EndQuorumEpochRequest.Builder(data).build(version);
     }
 
-    private EndQuorumEpochResponse createEndQuorumEpochResponse() {
+    private EndQuorumEpochResponse createEndQuorumEpochResponse(short version) {
         EndQuorumEpochResponseData data = new EndQuorumEpochResponseData()
                 .setErrorCode(Errors.NONE.code())
                 .setTopics(singletonList(new EndQuorumEpochResponseData.TopicData()
@@ -1626,6 +1655,17 @@ public class RequestResponseTest {
                                 .setErrorCode(Errors.NONE.code())
                                 .setLeaderEpoch(1)))
                         .setTopicName("topic1")));
+
+        if (version >= 1) {
+            EndQuorumEpochResponseData.NodeEndpointCollection nodeEndpoints = new EndQuorumEpochResponseData.NodeEndpointCollection(1);
+            nodeEndpoints.add(
+                new EndQuorumEpochResponseData.NodeEndpoint()
+                        .setNodeId(1)
+                        .setHost("localhost")
+                        .setPort(9092)
+            );
+            data.setNodeEndpoints(nodeEndpoints);
+        }
         return new EndQuorumEpochResponse(data);
     }
 
@@ -1640,7 +1680,7 @@ public class RequestResponseTest {
         return new BeginQuorumEpochRequest.Builder(data).build(version);
     }
 
-    private BeginQuorumEpochResponse createBeginQuorumEpochResponse() {
+    private BeginQuorumEpochResponse createBeginQuorumEpochResponse(short version) {
         BeginQuorumEpochResponseData data = new BeginQuorumEpochResponseData()
                 .setErrorCode(Errors.NONE.code())
                 .setTopics(singletonList(new BeginQuorumEpochResponseData.TopicData()
@@ -1649,6 +1689,17 @@ public class RequestResponseTest {
                                 .setLeaderEpoch(0)
                                 .setLeaderId(1)
                                 .setPartitionIndex(2)))));
+        if (version >= 1) {
+            BeginQuorumEpochResponseData.NodeEndpointCollection nodeEndpoints = new BeginQuorumEpochResponseData.NodeEndpointCollection(1);
+            nodeEndpoints.add(
+                new BeginQuorumEpochResponseData.NodeEndpoint()
+                        .setNodeId(1)
+                        .setHost("localhost")
+                        .setPort(9092)
+            );
+
+            data.setNodeEndpoints(nodeEndpoints);
+        }
         return new BeginQuorumEpochResponse(data);
     }
 


### PR DESCRIPTION
Following should support accepting `version` as they have more than one version
```
case BEGIN_QUORUM_EPOCH: return createBeginQuorumEpochResponse();
case END_QUORUM_EPOCH: return createEndQuorumEpochResponse();
case DESCRIBE_QUORUM: return createDescribeQuorumResponse();
```

### Related links
- [KAFKA-18039](https://issues.apache.org/jira/browse/KAFKA-18039)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
