### PR TITLE
MINOR: change Map.of to Collections.singletonMap

### DIFF
--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2566,7 +2566,7 @@ public class RemoteLogManagerTest {
     @Test
     public void testDeleteRetentionMsBiggerThanTimeMs() throws RemoteStorageException, ExecutionException, InterruptedException {
         // add 1 month to the current time to avoid flaky test
-        LogConfig mockLogConfig = new LogConfig(Map.of("retention.ms", time.milliseconds() + 24 * 30 * 60 * 60 * 1000L));
+        LogConfig mockLogConfig = new LogConfig(Collections.singletonMap("retention.ms", time.milliseconds() + 24 * 30 * 60 * 60 * 1000L));
         when(mockLog.config()).thenReturn(mockLogConfig);
 
         RemoteLogManager.RLMExpirationTask leaderTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);


### PR DESCRIPTION
The 3.9 version is complied by JDK 8 which doesn't support `Map.of`.

ref: https://github.com/apache/kafka/pull/17794#issuecomment-2488816212

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
