### PR TITLE
MINOR: Unnecessary changeCapacity in ImplicitLinkedHashCollection

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
@@ -397,7 +397,7 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
         if (newElement.prev() != INVALID_INDEX || newElement.next() != INVALID_INDEX) {
             return false;
         }
-        if ((size + 1) >= elements.length / 2) {
+        if (size >= elements.length / 2) {
             changeCapacity(calculateCapacity(elements.length));
         }
         int slot = addInternal(newElement, elements);
@@ -443,9 +443,7 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
         Element[] newElements = new Element[newCapacity];
         HeadElement newHead = new HeadElement();
         int oldSize = size;
-        for (Iterator<E> iter = iterator(); iter.hasNext(); ) {
-            Element element = iter.next();
-            iter.remove();
+        for (Element element : this) {
             int newSlot = addInternal(element, newElements);
             addToListTail(newHead, newElements, newSlot);
         }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -475,13 +475,17 @@ public class ImplicitLinkedHashCollectionTest {
 
     @Test
     public void testEnlargement() {
-        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>(5);
+        int expectedNumElements = 5;
+        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>(expectedNumElements);
         assertEquals(11, coll.numSlots());
-        for (int i = 0; i < 6; i++) {
+        for (int i = 0; i < expectedNumElements; i++) {
             assertTrue(coll.add(new TestElement(i)));
         }
+        assertEquals(11, coll.numSlots());
+        assertEquals(expectedNumElements, coll.size());
+        assertTrue(coll.add(new TestElement(expectedNumElements)));
         assertEquals(23, coll.numSlots());
-        assertEquals(6, coll.size());
+        assertEquals(expectedNumElements + 1, coll.size());
         expectTraversal(coll.iterator(), 0, 1, 2, 3, 4, 5);
         for (int i = 0; i < 6; i++) {
             assertTrue(coll.contains(new TestElement(i)), "Failed to find element " + i);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ImplicitLinkedHashCollectionBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ImplicitLinkedHashCollectionBenchmark.java
@@ -32,8 +32,11 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -102,12 +105,15 @@ public class ImplicitLinkedHashCollectionBenchmark {
     private int size;
 
     private ImplicitLinkedHashCollection<TestElement> coll;
+    private List<TestElement> elements;
 
     @Setup(Level.Trial)
     public void setup() {
         coll = new ImplicitLinkedHashCollection<>();
+        elements = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             coll.add(new TestElement(Uuid.randomUuid().toString()));
+            elements.add(new TestElement("TestElement-" + i));
         }
     }
 
@@ -118,5 +124,27 @@ public class ImplicitLinkedHashCollectionBenchmark {
     public ImplicitLinkedHashCollection<TestElement> testCollectionSort() {
         coll.sort(TestElementComparator.INSTANCE);
         return coll;
+    }
+
+    @Benchmark
+    public void testCreateFromExpectedNumElements(Blackhole blackhole) {
+        ImplicitLinkedHashCollection<TestElement> sets = new ImplicitLinkedHashCollection<>(elements.size());
+        for (TestElement element : elements) {
+            element.setPrev(ImplicitLinkedHashCollection.INVALID_INDEX);
+            element.setNext(ImplicitLinkedHashCollection.INVALID_INDEX);
+            sets.mustAdd(element);
+        }
+        blackhole.consume(sets);
+    }
+
+    @Benchmark
+    public void testCreateFromEmpty(Blackhole blackhole) {
+        ImplicitLinkedHashCollection<TestElement> sets = new ImplicitLinkedHashCollection<>();
+        for (TestElement element : elements) {
+            element.setPrev(ImplicitLinkedHashCollection.INVALID_INDEX);
+            element.setNext(ImplicitLinkedHashCollection.INVALID_INDEX);
+            sets.mustAdd(element);
+        }
+        blackhole.consume(sets);
     }
 }


### PR DESCRIPTION
1. remove ImplicitLinkedHashCollection.add unnecessary changeCapacity
2. remove ImplicitLinkedHashCollection.changeCapacity unnecessary iterator.remove

#### trunk

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/f44be3b1-22dd-4a18-bcb5-fdb627711a60">

```
Benchmark                                                                (size)  Mode  Cnt       Score       Error  Units
ImplicitLinkedHashCollectionBenchmark.testCreateFromEmpty                 10000  avgt    6    4397.636 ±   326.099  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromEmpty                100000  avgt    6  767246.324 ± 45883.873  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromExpectedNumElements   10000  avgt    6     814.625 ±   421.052  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromExpectedNumElements  100000  avgt    6   34003.380 ±  2006.759  us/op
```

#### this pr
```
Benchmark                                                                (size)  Mode  Cnt      Score      Error  Units
ImplicitLinkedHashCollectionBenchmark.testCreateFromEmpty                 10000  avgt    6    523.661 ±  251.641  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromEmpty                100000  avgt    6  22689.922 ± 1312.356  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromExpectedNumElements   10000  avgt    6    262.020 ±   24.802  us/op
ImplicitLinkedHashCollectionBenchmark.testCreateFromExpectedNumElements  100000  avgt    6   2306.306 ±  253.645  us/op
```