### PR TITLE
KAFKA-18046: cache calls to LoggerFactory.getLogger() inside LogContext

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
@@ -23,6 +23,8 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * This class provides a way to instrument loggers with a common context which can be used to
  * automatically enrich log messages. For example, in the KafkaConsumer, it is often useful to know
@@ -32,6 +34,7 @@ import org.slf4j.spi.LocationAwareLogger;
  */
 public class LogContext {
 
+    private static final ConcurrentHashMap<Class<?>, Logger> loggerCache = new ConcurrentHashMap<>();
     private final String logPrefix;
 
     public LogContext(String logPrefix) {
@@ -43,7 +46,7 @@ public class LogContext {
     }
 
     public Logger logger(Class<?> clazz) {
-        Logger logger = LoggerFactory.getLogger(clazz);
+        Logger logger = loggerCache.computeIfAbsent(clazz, LoggerFactory::getLogger);
         if (logger instanceof LocationAwareLogger) {
             return new LocationAwareKafkaLogger(logPrefix, (LocationAwareLogger) logger);
         } else {

--- a/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class LogContext {
 
-    private static final ConcurrentHashMap<Class<?>, Logger> loggerCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Class<?>, Logger> LOGGER_CACHE = new ConcurrentHashMap<>();
     private final String logPrefix;
 
     public LogContext(String logPrefix) {
@@ -46,7 +46,7 @@ public class LogContext {
     }
 
     public Logger logger(Class<?> clazz) {
-        Logger logger = loggerCache.computeIfAbsent(clazz, LoggerFactory::getLogger);
+        Logger logger = LOGGER_CACHE.computeIfAbsent(clazz, LoggerFactory::getLogger);
         if (logger instanceof LocationAwareLogger) {
             return new LocationAwareKafkaLogger(logPrefix, (LocationAwareLogger) logger);
         } else {


### PR DESCRIPTION
use ConcurrentHashMap#computeIfAbsent in LogContext#logger since LoggerFactory#getLogger is costly with Log4j2
