### PR TITLE
KAFKA-17299: Fix Kafka streams consumer hang issue

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -786,7 +786,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
             // after processing this record, if its partition queue's buffered size has been
             // decreased to the threshold, we can then resume the consumption on this partition
-            if (recordInfo.queue().size() == maxBufferedSize) {
+            if (recordInfo.queue().size() <= maxBufferedSize) {
                 partitionsToResume.add(partition);
             }
 


### PR DESCRIPTION
Kafka streams consumption completely stops and doesn't recover even after restart of the consumer instance/pod in some special cases where the deserialisation errors occurs for the first message in a batch.

This PR fixes the problem.