### PR TITLE
KAFKA-18064: SASL mechanisms that do support neihter integrity nor co…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
@@ -127,17 +127,17 @@ public class OAuthBearerSaslClient implements SaslClient {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
+        throw new IllegalStateException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
+        throw new IllegalStateException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -128,13 +127,17 @@ public class OAuthBearerSaslClient implements SaslClient {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClient.java
@@ -129,16 +129,12 @@ public class OAuthBearerSaslClient implements SaslClient {
 
     @Override
     public byte[] unwrap(byte[] incoming, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(incoming, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(outgoing, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
@@ -130,17 +130,17 @@ public class OAuthBearerSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
+        throw new IllegalStateException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
+        throw new IllegalStateException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -131,17 +130,17 @@ public class OAuthBearerSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) {
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(incoming, offset, offset + len);
+        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) {
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(outgoing, offset, offset + len);
+        throw new SaslException("OAUTHBEARER supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -158,17 +158,17 @@ public class PlainSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("PLAIN supports neither integrity nor privacy");
+        throw new IllegalStateException("PLAIN supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("PLAIN supports neither integrity nor privacy");
+        throw new IllegalStateException("PLAIN supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.security.plain.PlainAuthenticateCallback;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -159,13 +158,17 @@ public class PlainSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("PLAIN supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("PLAIN supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -160,16 +160,12 @@ public class PlainSaslServer implements SaslServer {
 
     @Override
     public byte[] unwrap(byte[] incoming, int offset, int len) {
-        if (!complete)
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(incoming, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) {
-        if (!complete)
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(outgoing, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
@@ -159,17 +159,17 @@ public class ScramSaslClient implements SaslClient {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("SCRAM supports neither integrity nor privacy");
+        throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("SCRAM supports neither integrity nor privacy");
+        throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
@@ -159,13 +159,17 @@ public class ScramSaslClient implements SaslClient {
     }
 
     @Override
-    public byte[] unwrap[B(byte[] incoming, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslClient.java
@@ -159,17 +159,13 @@ public class ScramSaslClient implements SaslClient {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(incoming, offset, offset + len);
+    public byte[] unwrap[B(byte[] incoming, int offset, int len) {
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(outgoing, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
@@ -201,17 +201,17 @@ public class ScramSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("SCRAM supports neither integrity nor privacy");
+        throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!isComplete())
             throw new IllegalStateException("Authentication exchange has not completed");
-        throw new SaslException("SCRAM supports neither integrity nor privacy");
+        throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -202,13 +201,17 @@ public class ScramSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) {
-        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!isComplete())
+            throw new IllegalStateException("Authentication exchange has not completed");
+        throw new SaslException("SCRAM supports neither integrity nor privacy");
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
@@ -203,16 +203,12 @@ public class ScramSaslServer implements SaslServer {
 
     @Override
     public byte[] unwrap(byte[] incoming, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(incoming, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) {
-        if (!isComplete())
-            throw new IllegalStateException("Authentication exchange has not completed");
-        return Arrays.copyOfRange(outgoing, offset, offset + len);
+        throw new IllegalStateException("Mechanism does not support integrity nor confidentality");
     }
 
     @Override


### PR DESCRIPTION
…nfidentality should throw exception on wrap/unwrap

The current implementation does not implement wrap/unwrap correctly.
This may cause security issues, if the code using the mechanisms does
not check for QOP correctly.

No testing done, if this breaks something, then calling code must be fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
