### PR TITLE
KAFKA-18026: migrate KTableSource to use ProcesserSupplier#stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -384,7 +384,8 @@ public class StreamsBuilder {
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal =
             new MaterializedInternal<>(
                 Materialized.with(consumedInternal.keySerde(), consumedInternal.valueSerde()),
-                internalStreamsBuilder, topic + "-",
+                internalStreamsBuilder,
+                topic + "-",
                 true /* force materializing global tables */);
 
         return internalStreamsBuilder.globalTable(topic, consumedInternal, materializedInternal);

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -384,7 +384,8 @@ public class StreamsBuilder {
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal =
             new MaterializedInternal<>(
                 Materialized.with(consumedInternal.keySerde(), consumedInternal.valueSerde()),
-                internalStreamsBuilder, topic + "-");
+                internalStreamsBuilder, topic + "-",
+                true /* force materializing global tables */);
 
         return internalStreamsBuilder.globalTable(topic, consumedInternal, materializedInternal);
     }
@@ -517,7 +518,7 @@ public class StreamsBuilder {
      */
     public synchronized StreamsBuilder addStateStore(final StoreBuilder<?> builder) {
         Objects.requireNonNull(builder, "builder can't be null");
-        internalStreamsBuilder.addStateStore(new StoreBuilderWrapper(builder));
+        internalStreamsBuilder.addStateStore(StoreBuilderWrapper.wrapStoreBuilder(builder));
         return this;
     }
 
@@ -556,7 +557,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         internalStreamsBuilder.addGlobalStore(
-            new StoreBuilderWrapper(storeBuilder),
+            StoreBuilderWrapper.wrapStoreBuilder(storeBuilder),
             topic,
             new ConsumedInternal<>(consumed),
             stateUpdateSupplier,

--- a/streams/src/main/java/org/apache/kafka/streams/Topology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/Topology.java
@@ -34,7 +34,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.SinkNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
-import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreDelegatingProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Set;
@@ -853,14 +853,13 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             null,
             keyDeserializer,
             valueDeserializer,
             topic,
             processorName,
-            stateUpdateSupplier,
+            new StoreDelegatingProcessorSupplier<>(stateUpdateSupplier, Set.of(storeBuilder)),
             true
         );
         return this;
@@ -899,14 +898,13 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             timestampExtractor,
             keyDeserializer,
             valueDeserializer,
             topic,
             processorName,
-            stateUpdateSupplier,
+            new StoreDelegatingProcessorSupplier<>(stateUpdateSupplier, Set.of(storeBuilder)),
             true
         );
         return this;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -140,7 +140,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         final String tableSourceName = named
             .orElseGenerateWithPrefix(this, KTableImpl.SOURCE_NAME);
 
-        final KTableSource<K, V> tableSource = new KTableSource<>(materialized.storeName(), materialized.queryableStoreName());
+        final KTableSource<K, V> tableSource = new KTableSource<>(materialized);
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, tableSourceName);
 
         final TableSourceNode<K, V> tableSourceNode = TableSourceNode.<K, V>tableSourceNodeBuilder()
@@ -148,7 +148,6 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             .withSourceName(sourceName)
             .withNodeName(tableSourceName)
             .withConsumedInternal(consumed)
-            .withMaterializedInternal(materialized)
             .withProcessorParameters(processorParameters)
             .build();
         tableSourceNode.setOutputVersioned(materialized.storeSupplier() instanceof VersionedBytesStoreSupplier);
@@ -186,9 +185,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         final String processorName = named
                 .orElseGenerateWithPrefix(this, KTableImpl.SOURCE_NAME);
 
-        // enforce store name as queryable name to always materialize global table stores
-        final String storeName = materialized.storeName();
-        final KTableSource<K, V> tableSource = new KTableSource<>(storeName, storeName);
+        final KTableSource<K, V> tableSource = new KTableSource<>(materialized);
 
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, processorName);
 
@@ -197,12 +194,12 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             .isGlobalKTable(true)
             .withSourceName(sourceName)
             .withConsumedInternal(consumed)
-            .withMaterializedInternal(materialized)
             .withProcessorParameters(processorParameters)
             .build();
 
         addGraphNode(root, tableSourceNode);
 
+        final String storeName = materialized.storeName();
         return new GlobalKTableImpl<>(new KTableSourceValueGetterSupplier<>(storeName), materialized.queryableStoreName());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -658,10 +658,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             subTopologySourceNodes = this.subTopologySourceNodes;
         }
 
-        final KTableSource<K, V> tableSource = new KTableSource<>(
-            materializedInternal.storeName(),
-            materializedInternal.queryableStoreName()
-        );
+        final KTableSource<K, V> tableSource = new KTableSource<>(materializedInternal);
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, name);
         final GraphNode tableNode = new StreamToTableNode<>(
             name,
@@ -1171,7 +1168,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             bufferStoreName = Optional.of(name + "-Buffer");
             final RocksDBTimeOrderedKeyValueBuffer.Builder<Object, Object> storeBuilder =
                     new RocksDBTimeOrderedKeyValueBuffer.Builder<>(bufferStoreName.get(), joinedInternal.gracePeriod(), name);
-            builder.addStateStore(new StoreBuilderWrapper(storeBuilder));
+            builder.addStateStore(StoreBuilderWrapper.wrapStoreBuilder(storeBuilder));
         }
 
         final ProcessorSupplier<K, V, K, ? extends VR> processorSupplier = new KStreamKTableJoin<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -262,7 +262,7 @@ class KStreamImplJoin {
     private static <K, V> StoreFactory joinWindowStoreBuilderFromSupplier(final WindowBytesStoreSupplier storeSupplier,
                                                                           final Serde<K> keySerde,
                                                                           final Serde<V> valueSerde) {
-        return new StoreBuilderWrapper(Stores.windowStoreBuilder(
+        return StoreBuilderWrapper.wrapStoreBuilder(Stores.windowStoreBuilder(
             storeSupplier,
             keySerde,
             valueSerde

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -590,7 +590,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorGraphNode<K, Change<V>> node = new TableSuppressNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
-            new StoreBuilderWrapper(storeBuilder)
+            StoreBuilderWrapper.wrapStoreBuilder(storeBuilder)
         );
         node.setOutputVersioned(false);
 
@@ -1227,10 +1227,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             materializedInternal.withKeySerde(keySerde);
         }
 
-        final KTableSource<K, VR> resultProcessorSupplier = new KTableSource<>(
-            materializedInternal.storeName(),
-            materializedInternal.queryableStoreName()
-        );
+        final KTableSource<K, VR> resultProcessorSupplier = new KTableSource<>(materializedInternal);
 
         final StoreFactory resultStore =
             new KeyValueStoreMaterializer<>(materializedInternal);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.Set;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.api.Processor;
@@ -33,6 +32,8 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -51,6 +52,7 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
     public KTableSource(
             final MaterializedInternal<KIn, VIn, KeyValueStore<Bytes, byte[]>> materialized) {
         this.storeName = materialized.storeName();
+        Objects.requireNonNull(storeName, "storeName can't be null");
         this.queryableName = materialized.queryableStoreName();
         this.sendOldValues = false;
         this.storeFactory = new KeyValueStoreMaterializer<>(materialized);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -16,20 +16,23 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.Set;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
@@ -40,15 +43,16 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
     private static final Logger LOG = LoggerFactory.getLogger(KTableSource.class);
 
     private final String storeName;
+    private final StoreFactory storeFactory;
     private String queryableName;
     private boolean sendOldValues;
 
-    public KTableSource(final String storeName, final String queryableName) {
-        Objects.requireNonNull(storeName, "storeName can't be null");
-
-        this.storeName = storeName;
-        this.queryableName = queryableName;
+    public KTableSource(
+            final MaterializedInternal<KIn, VIn, KeyValueStore<Bytes, byte[]>> materialized) {
+        this.storeName = materialized.storeName();
+        this.queryableName = materialized.queryableStoreName();
         this.sendOldValues = false;
+        this.storeFactory = new KeyValueStoreMaterializer<>(materialized);
     }
 
     public String queryableName() {
@@ -58,6 +62,15 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
     @Override
     public Processor<KIn, VIn, KIn, Change<VIn>> get() {
         return new KTableSourceProcessor();
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+        if (materialized()) {
+            return Set.of(new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory));
+        } else {
+            return null;
+        }
     }
 
     // when source ktable requires sending old values, we just

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
@@ -39,12 +39,19 @@ public final class MaterializedInternal<K, V, S extends StateStore> extends Mate
     public MaterializedInternal(final Materialized<K, V, S> materialized,
                                 final InternalNameProvider nameProvider,
                                 final String generatedStorePrefix) {
+        this(materialized, nameProvider, generatedStorePrefix, false);
+    }
+
+    public MaterializedInternal(final Materialized<K, V, S> materialized,
+                                final InternalNameProvider nameProvider,
+                                final String generatedStorePrefix,
+                                final boolean forceQueryable) {
         super(materialized);
 
         // if storeName is not provided, the corresponding KTable would never be queryable;
         // but we still need to provide an internal name for it in case we materialize.
-        queryable = storeName() != null;
-        if (!queryable && nameProvider != null) {
+        queryable = forceQueryable || storeName() != null;
+        if (storeName() == null && nameProvider != null) {
             storeName = nameProvider.newStoreName(generatedStorePrefix);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -16,13 +16,14 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import java.util.Set;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StoreDelegatingProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
+
+import java.util.Set;
 
 public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreNode<S> {
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
+import java.util.Set;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreDelegatingProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreNode<S> {
@@ -52,15 +54,16 @@ public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreN
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
         storeBuilder.withLoggingDisabled();
-        topologyBuilder.addGlobalStore(storeBuilder,
-                                       sourceName,
+        topologyBuilder.addGlobalStore(sourceName,
                                        consumed.timestampExtractor(),
                                        consumed.keyDeserializer(),
                                        consumed.valueDeserializer(),
                                        topic,
                                        processorName,
-                                       stateUpdateSupplier,
-                                       reprocessOnRestore);
+                                       new StoreDelegatingProcessorSupplier<>(
+                                               stateUpdateSupplier,
+                                               Set.of(new StoreFactory.FactoryWrappingStoreBuilder<>(storeBuilder))
+                                       ), reprocessOnRestore);
 
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -38,7 +38,15 @@ public class StoreBuilderWrapper implements StoreFactory {
     private final StoreBuilder<?> builder;
     private final Set<String> connectedProcessorNames = new HashSet<>();
 
-    public StoreBuilderWrapper(final StoreBuilder<?> builder) {
+    public static StoreFactory wrapStoreBuilder(final StoreBuilder<?> builder) {
+        if (builder instanceof FactoryWrappingStoreBuilder) {
+            return ((FactoryWrappingStoreBuilder<?>) builder).storeFactory();
+        } else {
+            return new StoreBuilderWrapper(builder);
+        }
+    }
+
+    private StoreBuilderWrapper(final StoreBuilder<?> builder) {
         this.builder = builder;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreDelegatingProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreDelegatingProcessorSupplier.java
@@ -16,10 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.Set;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
+
+import java.util.Set;
 
 public class StoreDelegatingProcessorSupplier<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KOut, VOut> {
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreDelegatingProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreDelegatingProcessorSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.Set;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class StoreDelegatingProcessorSupplier<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KOut, VOut> {
+
+    private final ProcessorSupplier<KIn, VIn, KOut, VOut> delegate;
+    private final Set<StoreBuilder<?>> stores;
+
+    public StoreDelegatingProcessorSupplier(
+            final ProcessorSupplier<KIn, VIn, KOut, VOut> delegate,
+            final Set<StoreBuilder<?>> stores
+    ) {
+        this.delegate = delegate;
+        this.stores = stores;
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+        return stores;
+    }
+
+    @Override
+    public Processor<KIn, VIn, KOut, VOut> get() {
+        return delegate.get();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -19,10 +19,10 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Map;
 import java.util.Set;
-import org.apache.kafka.streams.state.StoreBuilder;
 
 /**
  * What! Another mechanism for obtaining a {@link StateStore}? This isn't just

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -114,7 +114,8 @@ public interface StoreFactory {
 
         @Override
         public StoreBuilder<T> withCachingDisabled() {
-            throw new IllegalStateException("Should not try to modify StoreBuilder wrapper");
+            storeFactory.withCachingDisabled();
+            return this;
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.StateStore;
 
 import java.util.Map;
 import java.util.Set;
+import org.apache.kafka.streams.state.StoreBuilder;
 
 /**
  * What! Another mechanism for obtaining a {@link StateStore}? This isn't just
@@ -74,5 +75,79 @@ public interface StoreFactory {
     StoreFactory withLoggingDisabled();
 
     boolean isCompatibleWith(StoreFactory storeFactory);
+
+    class FactoryWrappingStoreBuilder<T extends StateStore> implements StoreBuilder<T> {
+
+        private final StoreFactory storeFactory;
+
+        public FactoryWrappingStoreBuilder(final StoreFactory storeFactory) {
+            this.storeFactory = storeFactory;
+        }
+
+        public StoreFactory storeFactory() {
+            return storeFactory;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final FactoryWrappingStoreBuilder<?> that = (FactoryWrappingStoreBuilder<?>) o;
+
+            return storeFactory.isCompatibleWith(that.storeFactory);
+        }
+
+        @Override
+        public int hashCode() {
+            return storeFactory.hashCode();
+        }
+
+        @Override
+        public StoreBuilder<T> withCachingEnabled() {
+            throw new IllegalStateException("Should not try to modify StoreBuilder wrapper");
+        }
+
+        @Override
+        public StoreBuilder<T> withCachingDisabled() {
+            throw new IllegalStateException("Should not try to modify StoreBuilder wrapper");
+        }
+
+        @Override
+        public StoreBuilder<T> withLoggingEnabled(final Map<String, String> config) {
+            throw new IllegalStateException("Should not try to modify StoreBuilder wrapper");
+        }
+
+        @Override
+        public StoreBuilder<T> withLoggingDisabled() {
+            storeFactory.withLoggingDisabled();
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public T build() {
+            return (T) storeFactory.build();
+        }
+
+        @Override
+        public Map<String, String> logConfig() {
+            return storeFactory.logConfig();
+        }
+
+        @Override
+        public boolean loggingEnabled() {
+            return storeFactory.loggingEnabled();
+        }
+
+        @Override
+        public String name() {
+            return storeFactory.name();
+        }
+    }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -42,7 +42,7 @@ import org.apache.kafka.streams.processor.internals.NoOpProcessorWrapper;
 import org.apache.kafka.streams.processor.internals.RecordCollectorTest;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.apache.kafka.streams.state.BuiltInDslStoreSuppliers;
-import org.apache.kafka.streams.utils.TestUtils.CountingProcessorWrapper;
+import org.apache.kafka.streams.utils.TestUtils.RecordingProcessorWrapper;
 
 import org.apache.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
@@ -1230,13 +1230,13 @@ public class StreamsConfigTest {
 
     @Test
     public void shouldAllowConfiguringProcessorWrapperWithClass() {
-        props.put(StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG, CountingProcessorWrapper.class);
+        props.put(StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class);
         new StreamsConfig(props);
     }
 
     @Test
     public void shouldAllowConfiguringProcessorWrapperWithClassName() {
-        props.put(StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG, CountingProcessorWrapper.class.getName());
+        props.put(StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class.getName());
         new StreamsConfig(props);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -45,13 +45,14 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
-import org.apache.kafka.streams.utils.TestUtils.CountingProcessorWrapper;
+import org.apache.kafka.streams.utils.TestUtils.RecordingProcessorWrapper;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -71,7 +72,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static java.time.Duration.ofMillis;
@@ -2425,10 +2425,10 @@ public class TopologyTest {
     @Test
     public void shouldWrapProcessors() {
         final Map<Object, Object> props = dummyStreamsConfigMap();
-        props.put(PROCESSOR_WRAPPER_CLASS_CONFIG, CountingProcessorWrapper.class);
+        props.put(PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class);
 
-        final AtomicInteger wrappedProcessorCount = new AtomicInteger();
-        props.put(PROCESSOR_WRAPPER_COUNTER_CONFIG, wrappedProcessorCount);
+        final Set<String> wrappedProcessors = Collections.synchronizedSet(new HashSet<>());
+        props.put(PROCESSOR_WRAPPER_COUNTER_CONFIG, wrappedProcessors);
 
         final Topology topology = new Topology(new TopologyConfig(new StreamsConfig(props)));
 
@@ -2453,7 +2453,8 @@ public class TopologyTest {
             () -> (Processor<Object, Object, Object, Object>) record -> System.out.println("Processing: " + random.nextInt()),
             "p2"
         );
-        assertThat(wrappedProcessorCount.get(), is(3));
+        assertThat(wrappedProcessors.size(), is(3));
+        assertThat(wrappedProcessors, Matchers.containsInAnyOrder("p1", "p2", "p3"));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
@@ -23,18 +23,22 @@ import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode.TableSourceNodeBuilder;
+import org.apache.kafka.streams.processor.api.ProcessorWrapper;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -44,6 +48,12 @@ public class TableSourceNodeTest {
     private static final String TOPIC = "input-topic";
 
     private InternalTopologyBuilder topologyBuilder = mock(InternalTopologyBuilder.class);
+
+    @BeforeEach
+    public void before() {
+        when(topologyBuilder.wrapProcessorSupplier(any(), any()))
+                .thenAnswer(iom -> ProcessorWrapper.asWrapped(iom.getArgument(1)));
+    }
 
     @Test
     public void shouldConnectStateStoreToInputTopicIfInputTopicIsUsedAsChangelog() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
@@ -23,16 +28,12 @@ import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode.TableSourceNodeBuilder;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -59,12 +60,13 @@ public class TableSourceNodeTest {
 
     private void buildTableSourceNode(final boolean shouldReuseSourceTopicForChangelog) {
         final TableSourceNodeBuilder<String, String> tableSourceNodeBuilder = TableSourceNode.tableSourceNodeBuilder();
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>>
+                materializedInternal = new MaterializedInternal<>(Materialized.as(STORE_NAME));
         final TableSourceNode<String, String> tableSourceNode = tableSourceNodeBuilder
             .withTopic(TOPIC)
-            .withMaterializedInternal(new MaterializedInternal<>(Materialized.as(STORE_NAME)))
             .withConsumedInternal(new ConsumedInternal<>(Consumed.as("node-name")))
             .withProcessorParameters(
-                new ProcessorParameters<>(new KTableSource<>(STORE_NAME, STORE_NAME), null))
+                    new ProcessorParameters<>(new KTableSource<>(materializedInternal), null))
             .build();
         tableSourceNode.reuseSourceTopicForChangeLog(shouldReuseSourceTopicForChangelog);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
@@ -29,11 +25,16 @@ import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode.TableSourceNodeBuilder;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestUtils;
 
@@ -108,15 +109,17 @@ public class GlobalStreamThreadTest {
                 }
             };
 
+        final StoreFactory storeFactory =
+                new KeyValueStoreMaterializer<>(materialized).withLoggingDisabled();
+        final StoreBuilder<?> storeBuilder = new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory);
         builder.addGlobalStore(
-            new KeyValueStoreMaterializer<>(materialized).withLoggingDisabled(),
             "sourceName",
             null,
             null,
             null,
             GLOBAL_STORE_TOPIC_NAME,
             "processorName",
-            processorSupplier,
+            new StoreDelegatingProcessorSupplier<>(processorSupplier, Set.of(storeBuilder)),
             false
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -95,7 +95,8 @@ public class InternalTopologyBuilderTest {
 
     private final Serde<String> stringSerde = Serdes.String();
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
-    private final StoreFactory storeBuilder = new MockKeyValueStoreBuilder("testStore", false).asFactory();
+    private final StoreBuilder<?> storeBuilder = new MockKeyValueStoreBuilder("testStore", false);
+    private final StoreFactory storeFactory = new MockKeyValueStoreBuilder("testStore", false).asFactory();
 
     @Test
     public void shouldAddSourceWithOffsetReset() {
@@ -225,7 +226,6 @@ public class InternalTopologyBuilderTest {
         final IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
             () -> builder.addGlobalStore(
-                        new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
                         "globalSource",
                         null,
                         null,
@@ -331,18 +331,20 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void testPatternSourceTopicsWithGlobalTopics() {
+        final StoreBuilder<?> storeBuilder =
+                new MockKeyValueStoreBuilder("global-store", false)
+                        .withLoggingDisabled();
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, Pattern.compile("topic-1"));
         builder.addSource(null, "source-2", null, null, null, Pattern.compile("topic-2"));
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
             null,
             "globalTopic",
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(storeBuilder)),
             false
         );
         builder.initializeSubscription();
@@ -356,18 +358,20 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void testNameSourceTopicsWithGlobalTopics() {
+        final StoreBuilder<?> storeBuilder =
+                new MockKeyValueStoreBuilder("global-store", false)
+                        .withLoggingDisabled();
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSource(null, "source-2", null, null, null, "topic-2");
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
             null,
             "globalTopic",
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(storeBuilder)),
             false
         );
         builder.initializeSubscription();
@@ -427,14 +431,14 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void testAddStateStoreWithNonExistingProcessor() {
-        assertThrows(TopologyException.class, () -> builder.addStateStore(storeBuilder, "no-such-processor"));
+        assertThrows(TopologyException.class, () -> builder.addStateStore(storeFactory, "no-such-processor"));
     }
 
     @Test
     public void testAddStateStoreWithSource() {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         try {
-            builder.addStateStore(storeBuilder, "source-1");
+            builder.addStateStore(storeFactory, "source-1");
             fail("Should throw TopologyException with store cannot be added to source");
         } catch (final TopologyException expected) { /* ok */ }
     }
@@ -444,7 +448,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSink("sink-1", "topic-1", null, null, null, "source-1");
         try {
-            builder.addStateStore(storeBuilder, "sink-1");
+            builder.addStateStore(storeFactory, "sink-1");
             fail("Should throw TopologyException with store cannot be added to sink");
         } catch (final TopologyException expected) { /* ok */ }
     }
@@ -454,7 +458,7 @@ public class InternalTopologyBuilderTest {
         final StoreBuilder<KeyValueStore<Object, Object>> otherBuilder =
             new MockKeyValueStoreBuilder("testStore", false);
 
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
 
         final TopologyException exception = assertThrows(
             TopologyException.class,
@@ -469,24 +473,23 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenFirstStoreIsGlobal() {
-        final StoreFactory globalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
+        final StoreBuilder<?> globalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
 
         builder.addGlobalStore(
-            globalBuilder,
             "global-store",
             null,
             null,
             null,
             "global-topic",
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(globalBuilder)),
             false
         );
 
         final TopologyException exception = assertThrows(
             TopologyException.class,
-            () -> builder.addStateStore(storeBuilder)
+            () -> builder.addStateStore(storeFactory)
         );
 
         assertThat(
@@ -497,22 +500,21 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenSecondStoreIsGlobal() {
-        final StoreFactory globalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
+        final StoreBuilder<?> globalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
 
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
 
         final TopologyException exception = assertThrows(
             TopologyException.class,
             () -> builder.addGlobalStore(
-                globalBuilder,
                 "global-store",
                 null,
                 null,
                 null,
                 "global-topic",
                 "global-processor",
-                new MockApiProcessorSupplier<>(),
+                new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(globalBuilder)),
                 false
             )
         );
@@ -525,34 +527,32 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddGlobalStoresWithSameName() {
-        final StoreFactory firstGlobalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
-        final StoreFactory secondGlobalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
+        final StoreBuilder<KeyValueStore<Object, Object>> firstGlobalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
+        final StoreBuilder<KeyValueStore<Object, Object>> secondGlobalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
 
         builder.addGlobalStore(
-            firstGlobalBuilder,
             "global-store",
             null,
             null,
             null,
             "global-topic",
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(firstGlobalBuilder)),
             false
         );
 
         final TopologyException exception = assertThrows(
             TopologyException.class,
             () -> builder.addGlobalStore(
-                secondGlobalBuilder,
                 "global-store-2",
                 null,
                 null,
                 null,
                 "global-topic",
                 "global-processor-2",
-                new MockApiProcessorSupplier<>(),
+                new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(secondGlobalBuilder)),
                 false
             )
         );
@@ -565,35 +565,35 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void testAddStateStore() {
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addProcessor("processor-1", new MockApiProcessorSupplier<>(), "source-1");
 
         assertEquals(0, builder.buildTopology().stateStores().size());
 
-        builder.connectProcessorAndStateStores("processor-1", storeBuilder.name());
+        builder.connectProcessorAndStateStores("processor-1", storeFactory.name());
 
         final List<StateStore> suppliers = builder.buildTopology().stateStores();
         assertEquals(1, suppliers.size());
-        assertEquals(storeBuilder.name(), suppliers.get(0).name());
+        assertEquals(storeFactory.name(), suppliers.get(0).name());
     }
 
     @Test
     public void testStateStoreNamesForSubtopology() {
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
         builder.setApplicationId("X");
 
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addProcessor("processor-1", new MockApiProcessorSupplier<>(), "source-1");
-        builder.connectProcessorAndStateStores("processor-1", storeBuilder.name());
+        builder.connectProcessorAndStateStores("processor-1", storeFactory.name());
 
         builder.addSource(null, "source-2", null, null, null, "topic-2");
         builder.addProcessor("processor-2", new MockApiProcessorSupplier<>(), "source-2");
 
         builder.buildTopology();
         final Set<String> stateStoreNames = builder.stateStoreNamesForSubtopology(0);
-        assertThat(stateStoreNames, equalTo(Set.of(storeBuilder.name())));
+        assertThat(stateStoreNames, equalTo(Set.of(storeFactory.name())));
 
         final Set<String> emptyStoreNames = builder.stateStoreNamesForSubtopology(1);
         assertThat(emptyStoreNames, equalTo(Set.of()));
@@ -607,13 +607,13 @@ public class InternalTopologyBuilderTest {
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
 
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
         builder.addProcessor("processor-1", new MockApiProcessorSupplier<>(), "source-1");
-        builder.connectProcessorAndStateStores("processor-1", storeBuilder.name());
+        builder.connectProcessorAndStateStores("processor-1", storeFactory.name());
 
-        builder.addStateStore(storeBuilder);
+        builder.addStateStore(storeFactory);
         builder.addProcessor("processor-2", new MockApiProcessorSupplier<>(), "source-1");
-        builder.connectProcessorAndStateStores("processor-2", storeBuilder.name());
+        builder.connectProcessorAndStateStores("processor-2", storeFactory.name());
 
         assertEquals(1, builder.buildTopology().stateStores().size());
     }
@@ -763,15 +763,16 @@ public class InternalTopologyBuilderTest {
         assertNotEquals(oldNodeGroups, newNodeGroups);
 
         oldNodeGroups = newNodeGroups;
+
+        final StoreBuilder<?> globalBuilder = new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled();
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
             null,
             "globalTopic",
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(globalBuilder)),
             false
         );
         newNodeGroups = builder.nodeGroups();
@@ -879,7 +880,7 @@ public class InternalTopologyBuilderTest {
     public void shouldAssociateStateStoreNameWhenStateStoreSupplierIsInternal() {
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-        builder.addStateStore(storeBuilder, "processor");
+        builder.addStateStore(storeFactory, "processor");
         final Map<String, List<String>> stateStoreNameToSourceTopic = builder.stateStoreNameToFullSourceTopicNames();
         assertEquals(1, stateStoreNameToSourceTopic.size());
         assertEquals(Collections.singletonList("topic"), stateStoreNameToSourceTopic.get("testStore"));
@@ -889,7 +890,7 @@ public class InternalTopologyBuilderTest {
     public void shouldAssociateStateStoreNameWhenStateStoreSupplierIsExternal() {
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-        builder.addStateStore(storeBuilder, "processor");
+        builder.addStateStore(storeFactory, "processor");
         final Map<String, List<String>> stateStoreNameToSourceTopic = builder.stateStoreNameToFullSourceTopicNames();
         assertEquals(1, stateStoreNameToSourceTopic.size());
         assertEquals(Collections.singletonList("topic"), stateStoreNameToSourceTopic.get("testStore"));
@@ -901,7 +902,7 @@ public class InternalTopologyBuilderTest {
         builder.addInternalTopic("internal-topic", InternalTopicProperties.empty());
         builder.addSource(null, "source", null, null, null, "internal-topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-        builder.addStateStore(storeBuilder, "processor");
+        builder.addStateStore(storeFactory, "processor");
         final Map<String, List<String>> stateStoreNameToSourceTopic = builder.stateStoreNameToFullSourceTopicNames();
         assertEquals(1, stateStoreNameToSourceTopic.size());
         assertEquals(Collections.singletonList("appId-internal-topic"), stateStoreNameToSourceTopic.get("testStore"));
@@ -975,7 +976,7 @@ public class InternalTopologyBuilderTest {
         builder.setApplicationId("appId");
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-        builder.addStateStore(storeBuilder, "processor");
+        builder.addStateStore(storeFactory, "processor");
         builder.buildTopology();
         final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.subtopologyToTopicsInfo();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
@@ -1183,7 +1184,7 @@ public class InternalTopologyBuilderTest {
     public void shouldConnectRegexMatchedTopicsToStateStore() {
         builder.addSource(null, "ingest", null, null, null, Pattern.compile("topic-\\d+"));
         builder.addProcessor("my-processor", new MockApiProcessorSupplier<>(), "ingest");
-        builder.addStateStore(storeBuilder, "my-processor");
+        builder.addStateStore(storeFactory, "my-processor");
 
         final Set<String> updatedTopics = new HashSet<>();
 
@@ -1195,7 +1196,7 @@ public class InternalTopologyBuilderTest {
         builder.setApplicationId("test-app");
 
         final Map<String, List<String>> stateStoreAndTopics = builder.stateStoreNameToFullSourceTopicNames();
-        final List<String> topics = stateStoreAndTopics.get(storeBuilder.name());
+        final List<String> topics = stateStoreAndTopics.get(storeFactory.name());
 
         assertEquals(2, topics.size(), "Expected to contain two topics");
 
@@ -1208,14 +1209,13 @@ public class InternalTopologyBuilderTest {
     public void shouldNotAllowToAddGlobalStoreWithSourceNameEqualsProcessorName() {
         final String sameNameForSourceAndProcessor = "sameName";
         assertThrows(TopologyException.class, () -> builder.addGlobalStore(
-            storeBuilder,
             sameNameForSourceAndProcessor,
             null,
             null,
             null,
             "anyTopicName",
             sameNameForSourceAndProcessor,
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(storeBuilder)),
             false
         ));
     }
@@ -1351,16 +1351,17 @@ public class InternalTopologyBuilderTest {
     public void shouldConnectGlobalStateStoreToInputTopic() {
         final String globalStoreName = "global-store";
         final String globalTopic = "global-topic";
+        final StoreBuilder<?> storeBuilder =
+                new MockKeyValueStoreBuilder(globalStoreName, false).withLoggingDisabled();
         builder.setApplicationId("X");
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder(globalStoreName, false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
             null,
             globalTopic,
             "global-processor",
-            new MockApiProcessorSupplier<>(),
+            new StoreDelegatingProcessorSupplier<>(new MockApiProcessorSupplier<>(), Set.of(storeBuilder)),
             false
         );
         builder.initializeSubscription();

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
@@ -39,6 +39,6 @@ public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte
     }
 
     public StoreFactory asFactory() {
-        return new StoreBuilderWrapper(this);
+        return StoreBuilderWrapper.wrapStoreBuilder(this);
     }
 }


### PR DESCRIPTION
### Description

This PR is part of the implementation for KIP-1112 ([KAFKA-18026](https://issues.apache.org/jira/browse/KAFKA-18026)). In order to have DSL operators be properly wrapped by the interface suggestion in 1112, we need to make sure they all use the `ConnectedStoreProvider#stores` method to connect stores instead of manually calling `addStateStore`.

### Review Guide

1. Checkout `KTableSource` which now implements the `stores()` method
2. GlobalKTables no longer hack materialized by setting the source name on the builder, instead we pipe a `forceQueryable` into `MaterializedInternal` so that we directly indicate that it should be queryable/materialized instead of relying on a side effect of setting the store name
3. `StoreDelegatingProcessorSupplier` is used only in the case of GlobalKTables because the stores are expected to be passed in separately in the public API -- this PR doesn't change that
4. `FactoryWrappingStoreBuilder` is used so that already created store factories can be typecast as `StoreBuilder`s. 

**NOTE:** For point (3), I think this might be a bug in the current implementation that we may want to change in 4.0 since it's backwards incompatible. If you pass in a `ProcessorSupplier` to `addGlobalTable`, the `stores()` method on that will be ignored.

### Testing

This is a refactor only, there is no new behaviors.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
