### PR TITLE
MINOR: Convert DynamicBrokerReconfigurationTest to KRaft

### DIFF
--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -840,7 +840,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       "", mayReceiveDuplicates = false)
     verifyThreadPoolResize(SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG, config.numNetworkThreads,
       networkThreadPrefix, mayReceiveDuplicates = true)
-    System.out.println("config.listeners = " + config.listeners)
     verifyThreads("data-plane-kafka-socket-acceptor-", config.listeners.size, 1)
 
     verifyProcessorMetrics()

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -29,13 +29,12 @@ import java.util.concurrent._
 import javax.management.ObjectName
 import com.yammer.metrics.core.MetricName
 import kafka.admin.ConfigCommand
-import kafka.api.{KafkaSasl, SaslSetup}
+import kafka.api.SaslSetup
 import kafka.log.UnifiedLog
 import kafka.network.{DataPlaneAcceptor, Processor, RequestChannel}
 import kafka.security.JaasTestUtils
 import kafka.utils._
 import kafka.utils.Implicits._
-import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.ConfigEntry.{ConfigSource, ConfigSynonym}
@@ -43,7 +42,7 @@ import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{ClusterResource, ClusterResourceListener, Reconfigurable, TopicPartition, TopicPartitionInfo}
-import org.apache.kafka.common.config.{ConfigException, ConfigResource, SaslConfigs}
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.config.SslConfigs._
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.config.types.Password
@@ -55,21 +54,19 @@ import org.apache.kafka.common.network.{ConnectionMode, ListenerName}
 import org.apache.kafka.common.network.CertStores.{KEYSTORE_PROPS, TRUSTSTORE_PROPS}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.network.SocketServerConfigs
-import org.apache.kafka.security.{PasswordEncoder, PasswordEncoderConfigs}
-import org.apache.kafka.server.config.{ConfigType, ReplicationConfigs, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms, ZkConfigs}
+import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.metrics.{KafkaYammerMetrics, MetricConfigs}
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.ShutdownableThread
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
 import org.apache.kafka.test.TestSslUtils
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Disabled, TestInfo}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{CsvSource, MethodSource}
+import org.junit.jupiter.params.provider.MethodSource
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
@@ -107,6 +104,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   private val sslProperties2 = JaasTestUtils.sslConfigs(ConnectionMode.SERVER, false, Optional.of(trustStoreFile2), "kafka")
   private val invalidSslProperties = invalidSslConfigs
 
+  override def kraftControllerConfigs(testInfo: TestInfo): Seq[Properties] = {
+    val propsSeq = super.kraftControllerConfigs(testInfo)
+    propsSeq.foreach(props => props.put(ReplicationConfigs.UNCLEAN_LEADER_ELECTION_INTERVAL_MS_CONFIG, "100"))
+    propsSeq
+  }
+
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     startSasl(jaasSections(kafkaServerSaslMechanisms, Some(kafkaClientSaslMechanism)))
@@ -116,15 +119,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     (0 until numServers).foreach { brokerId =>
 
-      val props = if (isKRaftTest()) {
-        val properties = TestUtils.createBrokerConfig(brokerId, null)
-        properties.put(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
-        properties
-      } else {
-        val properties = TestUtils.createBrokerConfig(brokerId, zkConnect)
-        properties.put(ZkConfigs.ZK_ENABLE_SECURE_ACLS_CONFIG, "true")
-        properties
-      }
+      val props = TestUtils.createBrokerConfig(brokerId, null)
+      props.put(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
       props ++= securityProps(sslProperties1, TRUSTSTORE_PROPS)
       // Ensure that we can support multiple listeners per security protocol and multiple security protocols
       props.put(SocketServerConfigs.LISTENERS_CONFIG, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
@@ -135,7 +131,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       props.put(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, kafkaServerSaslMechanisms.mkString(","))
       props.put(ServerLogConfigs.LOG_SEGMENT_BYTES_CONFIG, "2000") // low value to test log rolling on config update
       props.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "2") // greater than one to test reducing threads
-      props.put(PasswordEncoderConfigs.PASSWORD_ENCODER_SECRET_CONFIG, "dynamic-config-secret")
       props.put(ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG, 1680000000.toString)
       props.put(ServerLogConfigs.LOG_RETENTION_TIME_HOURS_CONFIG, 168.toString)
 
@@ -149,9 +144,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       props ++= securityProps(sslProperties1, KEYSTORE_PROPS, listenerPrefix(SecureExternal))
 
       val kafkaConfig = KafkaConfig.fromProps(props)
-      if (!isKRaftTest()) {
-        configureDynamicKeystoreInZooKeeper(kafkaConfig, sslProperties1)
-      }
 
       servers += createBroker(kafkaConfig)
     }
@@ -711,16 +703,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     }
   }
 
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic, consumer"))
-  def testUncleanLeaderElectionEnable(groupProtocol: String): Unit = {
-    val controller = servers.find(_.config.brokerId == TestUtils.waitUntilControllerElected(zkClient)).get
-    val controllerId = controller.config.brokerId
-
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testUncleanLeaderElectionEnable(quorum: String, groupProtocol: String): Unit = {
     // Create a topic with two replicas on brokers other than the controller
     val topic = "testtopic2"
-    val assignment = Map(0 -> Seq((controllerId + 1) % servers.size, (controllerId + 2) % servers.size))
-    TestUtils.createTopic(zkClient, topic, assignment, servers)
+    TestUtils.createTopicWithAdmin(adminClients.head, topic, servers, controllerServers, replicaAssignment = Map(0 -> Seq(0, 1)))
 
     val producer = ProducerBuilder().acks(1).build()
     val consumer = ConsumerBuilder("unclean-leader-test", groupProtocol).enableAutoCommit(false).topic(topic).build()
@@ -755,7 +743,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val newProps = new Properties
     newProps.put(ReplicationConfigs.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = false).all.get
-    waitForConfigOnServer(controller, ReplicationConfigs.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+    TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
 
     // Verify that the old follower with missing records is elected as the new leader
     val (newLeader, elected) = TestUtils.computeUntilTrue(partitionInfo.leader)(leader => leader != null)
@@ -773,9 +761,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     consumer.commitSync()
   }
 
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic, consumer"))
-  def testThreadPoolResize(groupProtocol: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testThreadPoolResize(quorum: String, groupProtocol: String): Unit = {
     val requestHandlerPrefix = "data-plane-kafka-request-handler-"
     val networkThreadPrefix = "data-plane-kafka-network-thread-"
     val fetcherThreadPrefix = "ReplicaFetcherThread-"
@@ -852,7 +840,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       "", mayReceiveDuplicates = false)
     verifyThreadPoolResize(SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG, config.numNetworkThreads,
       networkThreadPrefix, mayReceiveDuplicates = true)
-    verifyThreads("data-plane-kafka-socket-acceptor-", config.listeners.size)
+    System.out.println("config.listeners = " + config.listeners)
+    verifyThreads("data-plane-kafka-socket-acceptor-", config.listeners.size, 1)
 
     verifyProcessorMetrics()
     verifyMarkPartitionsForTruncation()
@@ -893,9 +882,13 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   // to obtain partition assignment
   private def verifyMarkPartitionsForTruncation(): Unit = {
     val leaderId = 0
-    val partitions = (0 until numPartitions).map(i => new TopicPartition(topic, i)).filter { tp =>
-      zkClient.getLeaderForPartition(tp).contains(leaderId)
-    }
+    val topicDescription = adminClients.head.
+      describeTopics(java.util.Arrays.asList(topic)).
+      allTopicNames().
+      get(3, TimeUnit.MINUTES).get(topic)
+    val partitions = topicDescription.partitions().asScala.
+      filter(p => p.leader().id() == leaderId).
+      map(p => new TopicPartition(topic, p.partition()))
     assertTrue(partitions.nonEmpty, s"Partitions not found with leader $leaderId")
     partitions.foreach { tp =>
       (1 to 2).foreach { i =>
@@ -912,21 +905,24 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     }
   }
 
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic, consumer"))
-  def testMetricsReporterUpdate(groupProtocol: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testMetricsReporterUpdate(quorum: String, groupProtocol: String): Unit = {
     // Add a new metrics reporter
     val newProps = new Properties
     newProps.put(TestMetricsReporter.PollingIntervalProp, "100")
     configureMetricsReporters(Seq(classOf[JmxReporter], classOf[TestMetricsReporter]), newProps)
 
-    val reporters = TestMetricsReporter.waitForReporters(servers.size)
+    val reporters = TestMetricsReporter.waitForReporters(servers.size + controllerServers.size)
     reporters.foreach { reporter =>
       reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 100)
       assertFalse(reporter.kafkaMetrics.isEmpty, "No metrics found")
-      reporter.verifyMetricValue("request-total", "socket-server-metrics")
+      TestUtils.retry(30_000) {
+        reporter.verifyMetricValue("request-total", "socket-server-metrics")
+      }
     }
-    assertEquals(servers.map(_.config.brokerId).toSet, TestMetricsReporter.configuredBrokers.toSet)
+    assertEquals(Set(controllerServer.config.nodeId) ++ servers.map(_.config.brokerId),
+      TestMetricsReporter.configuredBrokers.toSet)
 
     // non-default value to trigger a new metric
     val clientId = "test-client-1"
@@ -960,7 +956,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Verify recreation of metrics reporter
     newProps.put(TestMetricsReporter.PollingIntervalProp, "2000")
     configureMetricsReporters(Seq(classOf[TestMetricsReporter]), newProps)
-    val newReporters = TestMetricsReporter.waitForReporters(servers.size)
+    val newReporters = TestMetricsReporter.waitForReporters(servers.size + controllerServers.size)
     newReporters.foreach(_.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 2000))
 
     // Verify that validation failure of metrics reporter fails reconfiguration and leaves config unchanged
@@ -1000,160 +996,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     stopAndVerifyProduceConsume(producerThread, consumerThread)
   }
 
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic"))
-  // Modifying advertised listeners is not supported in KRaft
-  def testAdvertisedListenerUpdate(groupProtocol: String): Unit = {
-    val adminClient = adminClients.head
-    val externalAdminClient = createAdminClient(SecurityProtocol.SASL_SSL, SecureExternal)
-
-    // Ensure connections are made to brokers before external listener is made inaccessible
-    describeConfig(externalAdminClient)
-
-    // Update broker external listener to use invalid listener address
-    // any address other than localhost is sufficient to fail (either connection or host name verification failure)
-    val invalidHost = "192.168.0.1"
-    alterAdvertisedListener(adminClient, externalAdminClient, "localhost", invalidHost)
-
-    def validateEndpointsInZooKeeper(server: KafkaServer, endpointMatcher: String => Boolean): Unit = {
-      val brokerInfo = zkClient.getBroker(server.config.brokerId)
-      assertTrue(brokerInfo.nonEmpty, "Broker not registered")
-      val endpoints = brokerInfo.get.endPoints.toString
-      assertTrue(endpointMatcher(endpoints), s"Endpoint update not saved $endpoints")
-    }
-
-    // Verify that endpoints have been updated in ZK for all brokers
-    servers.foreach { server =>
-      validateEndpointsInZooKeeper(server.asInstanceOf[KafkaServer], endpoints => endpoints.contains(invalidHost))
-    }
-
-    // Trigger session expiry and ensure that controller registers new advertised listener after expiry
-    val controllerEpoch = zkClient.getControllerEpoch
-    val controllerServer = servers(zkClient.getControllerId.getOrElse(throw new IllegalStateException("No controller"))).asInstanceOf[KafkaServer]
-    val controllerZkClient = controllerServer.zkClient
-    val sessionExpiringClient = createZooKeeperClientToTriggerSessionExpiry(controllerZkClient.currentZooKeeper)
-    sessionExpiringClient.close()
-    TestUtils.waitUntilTrue(() => zkClient.getControllerEpoch != controllerEpoch,
-      "Controller not re-elected after ZK session expiry")
-    TestUtils.retry(10000)(validateEndpointsInZooKeeper(controllerServer, endpoints => endpoints.contains(invalidHost)))
-
-    // Verify that producer connections fail since advertised listener is invalid
-    val bootstrap = TestUtils.bootstrapServers(servers, new ListenerName(SecureExternal))
-      .replaceAll(invalidHost, "localhost") // allow bootstrap connection to succeed
-    val producer1 = ProducerBuilder()
-      .trustStoreProps(sslProperties1)
-      .maxRetries(0)
-      .requestTimeoutMs(1000)
-      .deliveryTimeoutMs(1000)
-      .bootstrapServers(bootstrap)
-      .build()
-
-    val future = producer1.send(new ProducerRecord(topic, "key", "value"))
-    assertTrue(assertThrows(classOf[ExecutionException], () => future.get(2, TimeUnit.SECONDS))
-      .getCause.isInstanceOf[org.apache.kafka.common.errors.TimeoutException])
-
-    alterAdvertisedListener(adminClient, externalAdminClient, invalidHost, "localhost")
-    servers.foreach { server =>
-      validateEndpointsInZooKeeper(server.asInstanceOf[KafkaServer], endpoints => !endpoints.contains(invalidHost))
-    }
-
-    // Verify that produce/consume work now
-    val topic2 = "testtopic2"
-    TestUtils.createTopic(zkClient, topic2, numPartitions, replicationFactor = numServers, servers)
-    val producer = ProducerBuilder().trustStoreProps(sslProperties1).maxRetries(0).build()
-    val consumer = ConsumerBuilder("group2", groupProtocol).trustStoreProps(sslProperties1).topic(topic2).build()
-    verifyProduceConsume(producer, consumer, 10, topic2)
-
-    // Verify updating inter-broker listener
-    val props = new Properties
-    props.put(ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG, SecureExternal)
-    val e = assertThrows(classOf[ExecutionException], () => reconfigureServers(props, perBrokerConfig = true, (ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG, SecureExternal)))
-    assertTrue(e.getCause.isInstanceOf[InvalidRequestException], s"Unexpected exception ${e.getCause}")
-    servers.foreach(server => assertEquals(SecureInternal, server.config.interBrokerListenerName.value))
-  }
-
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic, consumer"))
-  @Disabled // Re-enable once we make it less flaky (KAFKA-6824)
-  def testAddRemoveSslListener(groupProtocol: String): Unit = {
-    verifyAddListener("SSL", SecurityProtocol.SSL, Seq.empty, groupProtocol)
-
-    // Restart servers and check secret rotation
-    servers.foreach(_.shutdown())
-    servers.foreach(_.awaitShutdown())
-    adminClients.foreach(_.close())
-    adminClients.clear()
-
-    // All passwords are currently encoded with password.encoder.secret. Encode with password.encoder.old.secret
-    // and update ZK. When each server is started, it should decode using password.encoder.old.secret and update
-    // ZK with newly encoded values using password.encoder.secret.
-    servers.foreach { server =>
-      val props = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)
-      val propsEncodedWithOldSecret = props.clone().asInstanceOf[Properties]
-      val config = server.config
-      val oldSecret = "old-dynamic-config-secret"
-      config.dynamicConfig.staticBrokerConfigs.put(PasswordEncoderConfigs.PASSWORD_ENCODER_OLD_SECRET_CONFIG, oldSecret)
-      val passwordConfigs = props.asScala.filter { case (k, _) => DynamicBrokerConfig.isPasswordConfig(k) }
-      assertTrue(passwordConfigs.nonEmpty, "Password configs not found")
-      val passwordDecoder = createPasswordEncoder(config, config.passwordEncoderSecret)
-      val passwordEncoder = createPasswordEncoder(config, Some(new Password(oldSecret)))
-      passwordConfigs.foreach { case (name, value) =>
-        val decoded = passwordDecoder.decode(value).value
-        propsEncodedWithOldSecret.put(name, passwordEncoder.encode(new Password(decoded)))
-      }
-      val brokerId = server.config.brokerId
-      adminZkClient.changeBrokerConfig(Seq(brokerId), propsEncodedWithOldSecret)
-      val updatedProps = adminZkClient.fetchEntityConfig(ConfigType.BROKER, brokerId.toString)
-      passwordConfigs.foreach { case (name, value) => assertNotEquals(props.get(value), updatedProps.get(name)) }
-
-      server.startup()
-      TestUtils.retry(10000) {
-        val newProps = adminZkClient.fetchEntityConfig(ConfigType.BROKER, brokerId.toString)
-        passwordConfigs.foreach { case (name, value) =>
-          assertEquals(passwordDecoder.decode(value), passwordDecoder.decode(newProps.getProperty(name))) }
-      }
-    }
-
-    verifyListener(SecurityProtocol.SSL, None, "add-ssl-listener-group2", groupProtocol)
-    createAdminClient(SecurityProtocol.SSL, SecureInternal)
-    verifyRemoveListener("SSL", SecurityProtocol.SSL, Seq.empty, groupProtocol)
-  }
-
-  @ParameterizedTest(name = "{displayName}.groupProtocol={0}")
-  @CsvSource(Array("classic, consumer"))
-  def testAddRemoveSaslListeners(groupProtocol: String): Unit = {
-    createScramCredentials(adminClients.head, JaasTestUtils.KAFKA_SCRAM_USER, JaasTestUtils.KAFKA_SCRAM_PASSWORD)
-    createScramCredentials(adminClients.head, JaasTestUtils.KAFKA_SCRAM_ADMIN, JaasTestUtils.KAFKA_SCRAM_ADMIN_PASSWORD)
-    initializeKerberos()
-    // make sure each server's credential cache has all the created credentials
-    // (check after initializing Kerberos to minimize delays)
-    List(JaasTestUtils.KAFKA_SCRAM_USER, JaasTestUtils.KAFKA_SCRAM_ADMIN).foreach { scramUser =>
-      servers.foreach { server =>
-        ScramMechanism.values().filter(_ != ScramMechanism.UNKNOWN).foreach(mechanism =>
-          TestUtils.waitUntilTrue(() => server.credentialProvider.credentialCache.cache(
-            mechanism.mechanismName(), classOf[ScramCredential]).get(scramUser) != null,
-            s"$mechanism credentials not created for $scramUser"))
-      }}
-
-    //verifyAddListener("SASL_SSL", SecurityProtocol.SASL_SSL, Seq("SCRAM-SHA-512", "SCRAM-SHA-256", "PLAIN"))
-    verifyAddListener("SASL_PLAINTEXT", SecurityProtocol.SASL_PLAINTEXT, Seq("GSSAPI"), groupProtocol)
-    //verifyRemoveListener("SASL_SSL", SecurityProtocol.SASL_SSL, Seq("SCRAM-SHA-512", "SCRAM-SHA-256", "PLAIN"))
-    verifyRemoveListener("SASL_PLAINTEXT", SecurityProtocol.SASL_PLAINTEXT, Seq("GSSAPI"), groupProtocol)
-
-    // Verify that a listener added to a subset of servers doesn't cause any issues
-    // when metadata is processed by the client.
-    addListener(servers.tail, "SCRAM_LISTENER", SecurityProtocol.SASL_PLAINTEXT, Seq("SCRAM-SHA-256"))
-    val bootstrap = TestUtils.bootstrapServers(servers.tail, new ListenerName("SCRAM_LISTENER"))
-    val producer = ProducerBuilder().bootstrapServers(bootstrap)
-      .securityProtocol(SecurityProtocol.SASL_PLAINTEXT)
-      .saslMechanism("SCRAM-SHA-256")
-      .maxRetries(1000)
-      .build()
-    val partitions = producer.partitionsFor(topic).asScala
-    assertEquals(0, partitions.count(p => p.leader != null && p.leader.id == servers.head.config.brokerId))
-    assertTrue(partitions.exists(_.leader == null), "Did not find partitions with no leader")
-  }
-
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testReconfigureRemovedListener(quorum: String, groupProtocol: String): Unit = {
@@ -1181,57 +1023,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     TestUtils.waitUntilTrue(() => acceptors.size == 2,
       s"failed to remove DataPlaneAcceptor. current: ${acceptors.map(_.endPoint.toString).mkString(",")}")
-  }
-
-  private def addListener(servers: Seq[KafkaBroker], listenerName: String, securityProtocol: SecurityProtocol,
-                          saslMechanisms: Seq[String]): Unit = {
-    val config = servers.head.config
-    val existingListenerCount = config.listeners.size
-    val listeners = config.listeners
-      .map(e => s"${e.listenerName.value}://${e.host}:${e.port}")
-      .mkString(",") + s",$listenerName://localhost:0"
-    val listenerMap = config.effectiveListenerSecurityProtocolMap
-      .map { case (name, protocol) => s"${name.value}:${protocol.name}" }
-      .mkString(",") + s",$listenerName:${securityProtocol.name}"
-
-    val props = fetchBrokerConfigsFromZooKeeper(servers.head)
-    props.put(SocketServerConfigs.LISTENERS_CONFIG, listeners)
-    props.put(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, listenerMap)
-    securityProtocol match {
-      case SecurityProtocol.SSL =>
-        addListenerPropsSsl(listenerName, props)
-      case SecurityProtocol.SASL_PLAINTEXT =>
-        addListenerPropsSasl(listenerName, saslMechanisms, props)
-      case SecurityProtocol.SASL_SSL =>
-        addListenerPropsSasl(listenerName, saslMechanisms, props)
-        addListenerPropsSsl(listenerName, props)
-      case SecurityProtocol.PLAINTEXT => // no additional props
-    }
-
-    // Add a config to verify that configs whose types are not known are not returned by describeConfigs()
-    val unknownConfig = "some.config"
-    props.put(unknownConfig, "some.config.value")
-
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, props, perBrokerConfig = true).all.get
-
-    TestUtils.waitUntilTrue(() => servers.forall(server => server.config.listeners.size == existingListenerCount + 1),
-      "Listener config not updated")
-    TestUtils.waitUntilTrue(() => servers.forall(server => {
-      try {
-        server.socketServer.boundPort(new ListenerName(listenerName)) > 0
-      } catch {
-        case _: Exception => false
-      }
-    }), "Listener not created")
-
-    val brokerConfigs = describeConfig(adminClients.head, servers).entries.asScala
-    props.asScala.foreach { case (name, value) =>
-      val entry = brokerConfigs.find(_.name == name).getOrElse(throw new IllegalArgumentException(s"Config not found $name"))
-      if (DynamicBrokerConfig.isPasswordConfig(name) || name == unknownConfig)
-        assertNull(entry.value, s"Password or unknown config returned $entry")
-      else
-        assertEquals(value, entry.value)
-    }
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
@@ -1264,111 +1055,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     updatedProps.put(TransactionLogConfig.TRANSACTION_PARTITION_VERIFICATION_ENABLE_CONFIG, "true")
     alterConfigsUsingConfigCommand(updatedProps)
     verifyConfiguration(true)
-  }
-
-  private def verifyAddListener(listenerName: String, securityProtocol: SecurityProtocol,
-                                saslMechanisms: Seq[String],
-                                groupProtocol: String): Unit = {
-    addListener(servers, listenerName, securityProtocol, saslMechanisms)
-    TestUtils.waitUntilTrue(() => servers.forall(hasListenerMetric(_, listenerName)),
-      "Processors not started for new listener")
-    if (saslMechanisms.nonEmpty)
-      saslMechanisms.foreach { mechanism =>
-        verifyListener(securityProtocol, Some(mechanism), s"add-listener-group-$securityProtocol-$mechanism", groupProtocol)
-      }
-    else
-      verifyListener(securityProtocol, None, s"add-listener-group-$securityProtocol", groupProtocol)
-  }
-
-  private def verifyRemoveListener(listenerName: String, securityProtocol: SecurityProtocol,
-                                   saslMechanisms: Seq[String],
-                                   groupProtocol: String): Unit = {
-    val saslMechanism = if (saslMechanisms.isEmpty) "" else saslMechanisms.head
-    val producer1 = ProducerBuilder().listenerName(listenerName)
-      .securityProtocol(securityProtocol)
-      .saslMechanism(saslMechanism)
-      .maxRetries(1000)
-      .build()
-    val consumer1 = ConsumerBuilder(s"remove-listener-group-$securityProtocol", groupProtocol)
-      .listenerName(listenerName)
-      .securityProtocol(securityProtocol)
-      .saslMechanism(saslMechanism)
-      .autoOffsetReset("latest")
-      .build()
-    verifyProduceConsume(producer1, consumer1, numRecords = 10, topic)
-
-    val config = servers.head.config
-    val existingListenerCount = config.listeners.size
-    val listeners = config.listeners
-      .filter(e => e.listenerName.value != securityProtocol.name)
-      .map(e => s"${e.listenerName.value}://${e.host}:${e.port}")
-      .mkString(",")
-    val listenerMap = config.effectiveListenerSecurityProtocolMap
-      .filter { case (listenerName, _) => listenerName.value != securityProtocol.name }
-      .map { case (listenerName, protocol) => s"${listenerName.value}:${protocol.name}" }
-      .mkString(",")
-
-    val props = fetchBrokerConfigsFromZooKeeper(servers.head)
-    val deleteListenerProps = new Properties()
-    deleteListenerProps ++= props.asScala.filter(entry => entry._1.startsWith(listenerPrefix(listenerName)))
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, deleteListenerProps, perBrokerConfig = true, opType = OpType.DELETE).all.get
-
-    props.clear()
-    props.put(SocketServerConfigs.LISTENERS_CONFIG, listeners)
-    props.put(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, listenerMap)
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, props, perBrokerConfig = true).all.get
-
-    TestUtils.waitUntilTrue(() => servers.forall(server => server.config.listeners.size == existingListenerCount - 1),
-      "Listeners not updated")
-    // Wait until metrics of the listener have been removed to ensure that processors have been shutdown before
-    // verifying that connections to the removed listener fail.
-    TestUtils.waitUntilTrue(() => !servers.exists(hasListenerMetric(_, listenerName)),
-      "Processors not shutdown for removed listener")
-
-    // Test that connections using deleted listener don't work
-    val producerFuture = verifyConnectionFailure(producer1)
-    val consumerFuture = verifyConnectionFailure(consumer1)
-
-    // Test that other listeners still work
-    val topic2 = "testtopic2"
-    TestUtils.createTopic(zkClient, topic2, numPartitions, replicationFactor = numServers, servers)
-    val producer2 = ProducerBuilder().trustStoreProps(sslProperties1).maxRetries(0).build()
-    val consumer2 = ConsumerBuilder(s"remove-listener-group2-$securityProtocol", groupProtocol)
-      .trustStoreProps(sslProperties1)
-      .topic(topic2)
-      .autoOffsetReset("latest")
-      .build()
-    verifyProduceConsume(producer2, consumer2, numRecords = 10, topic2)
-
-    // Verify that producer/consumer using old listener don't work
-    verifyTimeout(producerFuture)
-    verifyTimeout(consumerFuture)
-  }
-
-  private def verifyListener(securityProtocol: SecurityProtocol, saslMechanism: Option[String], groupId: String, groupProtocol: String): Unit = {
-    val mechanism = saslMechanism.getOrElse("")
-    val retries = 1000 // since it may take time for metadata to be updated on all brokers
-    val producer = ProducerBuilder().listenerName(securityProtocol.name)
-      .securityProtocol(securityProtocol)
-      .saslMechanism(mechanism)
-      .maxRetries(retries)
-      .build()
-    val consumer = ConsumerBuilder(groupId, groupProtocol)
-      .listenerName(securityProtocol.name)
-      .securityProtocol(securityProtocol)
-      .saslMechanism(mechanism)
-      .autoOffsetReset("latest")
-      .build()
-    verifyProduceConsume(producer, consumer, numRecords = 10, topic)
-  }
-
-  private def hasListenerMetric(server: KafkaBroker, listenerName: String): Boolean = {
-    server.socketServer.metrics.metrics.keySet.asScala.exists(_.tags.get("listener") == listenerName)
-  }
-
-  private def fetchBrokerConfigsFromZooKeeper(server: KafkaBroker): Properties = {
-    val props = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)
-    server.config.dynamicConfig.fromPersistentProps(props, perBrokerConfig = true)
   }
 
   private def awaitInitialPositions(consumer: Consumer[_, _]): Unit = {
@@ -1482,40 +1168,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     waitForConfig(s"$configPrefix$SSL_KEYSTORE_LOCATION_CONFIG", props.getProperty(SSL_KEYSTORE_LOCATION_CONFIG))
   }
 
-  private def serverEndpoints(adminClient: Admin): String = {
-    val nodes = adminClient.describeCluster().nodes().get
-    nodes.asScala.map { node =>
-      s"${node.host}:${node.port}"
-    }.mkString(",")
-  }
-
-  @nowarn("cat=deprecation")
-  private def alterAdvertisedListener(adminClient: Admin, externalAdminClient: Admin, oldHost: String, newHost: String): Unit = {
-    val configs = servers.map { server =>
-      val resource = new ConfigResource(ConfigResource.Type.BROKER, server.config.brokerId.toString)
-      val newListeners = server.config.effectiveAdvertisedBrokerListeners.map { e =>
-        if (e.listenerName.value == SecureExternal)
-          s"${e.listenerName.value}://$newHost:${server.boundPort(e.listenerName)}"
-        else
-          s"${e.listenerName.value}://${e.host}:${server.boundPort(e.listenerName)}"
-      }.mkString(",")
-      val configEntry = new ConfigEntry(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG, newListeners)
-      (resource, new Config(Collections.singleton(configEntry)))
-    }.toMap.asJava
-    adminClient.alterConfigs(configs).all.get
-    servers.foreach { server =>
-      TestUtils.retry(10000) {
-        val externalListener = server.config.effectiveAdvertisedBrokerListeners.find(_.listenerName.value == SecureExternal)
-          .getOrElse(throw new IllegalStateException("External listener not found"))
-        assertEquals(newHost, externalListener.host, "Config not updated")
-      }
-    }
-    val (endpoints, altered) = TestUtils.computeUntilTrue(serverEndpoints(externalAdminClient)) { endpoints =>
-      !endpoints.contains(oldHost)
-    }
-    assertTrue(altered, s"Advertised listener update not propagated by controller: $endpoints")
-  }
-
   @nowarn("cat=deprecation")
   private def alterConfigsOnServer(server: KafkaBroker, props: Properties): Unit = {
     val configEntries = props.asScala.map { case (k, v) => new ConfigEntry(k, v) }.toList.asJava
@@ -1547,8 +1199,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       val oldProps = servers.head.config.values.asScala.filter { case (k, _) => newProps.containsKey(k) }
       val brokerResources = if (perBrokerConfig)
         servers.map(server => new ConfigResource(ConfigResource.Type.BROKER, server.config.brokerId.toString))
-      else
+      else {
         Seq(new ConfigResource(ConfigResource.Type.BROKER, ""))
+      }
       brokerResources.foreach { brokerResource =>
         val exception = assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get)
         assertEquals(classOf[InvalidRequestException], exception.getCause.getClass)
@@ -1569,49 +1222,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
   private def listenerPrefix(name: String): String = new ListenerName(name).configPrefix
 
-  private def configureDynamicKeystoreInZooKeeper(kafkaConfig: KafkaConfig, sslProperties: Properties): Unit = {
-    val externalListenerPrefix = listenerPrefix(SecureExternal)
-    val sslStoreProps = new Properties
-    sslStoreProps ++= securityProps(sslProperties, KEYSTORE_PROPS, externalListenerPrefix)
-    sslStoreProps.put(PasswordEncoderConfigs.PASSWORD_ENCODER_SECRET_CONFIG, kafkaConfig.passwordEncoderSecret.map(_.value).orNull)
-    zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
-
-    val entityType = ConfigType.BROKER
-    val entityName = kafkaConfig.brokerId.toString
-
-    val passwordConfigs = sslStoreProps.asScala.keySet.filter(DynamicBrokerConfig.isPasswordConfig)
-    val passwordEncoder = createPasswordEncoder(kafkaConfig, kafkaConfig.passwordEncoderSecret)
-
-    if (passwordConfigs.nonEmpty) {
-      passwordConfigs.foreach { configName =>
-        val encodedValue = passwordEncoder.encode(new Password(sslStoreProps.getProperty(configName)))
-        sslStoreProps.setProperty(configName, encodedValue)
-      }
-    }
-    sslStoreProps.remove(PasswordEncoderConfigs.PASSWORD_ENCODER_SECRET_CONFIG)
-    adminZkClient.changeConfigs(entityType, entityName, sslStoreProps)
-
-    val brokerProps = adminZkClient.fetchEntityConfig("brokers", kafkaConfig.brokerId.toString)
-    assertEquals(4, brokerProps.size)
-    assertEquals(sslProperties.get(SSL_KEYSTORE_TYPE_CONFIG),
-      brokerProps.getProperty(s"$externalListenerPrefix$SSL_KEYSTORE_TYPE_CONFIG"))
-    assertEquals(sslProperties.get(SSL_KEYSTORE_LOCATION_CONFIG),
-      brokerProps.getProperty(s"$externalListenerPrefix$SSL_KEYSTORE_LOCATION_CONFIG"))
-    assertEquals(sslProperties.get(SSL_KEYSTORE_PASSWORD_CONFIG),
-      passwordEncoder.decode(brokerProps.getProperty(s"$externalListenerPrefix$SSL_KEYSTORE_PASSWORD_CONFIG")))
-    assertEquals(sslProperties.get(SSL_KEY_PASSWORD_CONFIG),
-      passwordEncoder.decode(brokerProps.getProperty(s"$externalListenerPrefix$SSL_KEY_PASSWORD_CONFIG")))
-  }
-
-  private def createPasswordEncoder(config: KafkaConfig, secret: Option[Password]): PasswordEncoder = {
-    val encoderSecret = secret.getOrElse(throw new IllegalStateException("Password encoder secret not configured"))
-    PasswordEncoder.encrypting(encoderSecret,
-      config.passwordEncoderKeyFactoryAlgorithm,
-      config.passwordEncoderCipherAlgorithm,
-      config.passwordEncoderKeyLength,
-      config.passwordEncoderIterations)
-  }
-
   private def waitForConfig(propName: String, propValue: String, maxWaitMs: Long = 10000): Unit = {
     servers.foreach { server => waitForConfigOnServer(server, propName, propValue, maxWaitMs) }
   }
@@ -1627,6 +1237,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val reporterStr = reporters.map(_.getName).mkString(",")
     props.put(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, reporterStr)
     reconfigureServers(props, perBrokerConfig, (MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, reporterStr))
+    TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
   }
 
   private def invalidSslConfigs: Properties = {
@@ -1678,56 +1289,11 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     assertFalse(consumerThread.outOfOrder, "Some messages received out of order")
   }
 
-  private def verifyConnectionFailure(producer: KafkaProducer[String, String]): Future[_] = {
-    val executor = Executors.newSingleThreadExecutor
-    executors += executor
-    val future = executor.submit(new Runnable() {
-      def run(): Unit = {
-        producer.send(new ProducerRecord(topic, "key", "value")).get
-      }
-    })
-    verifyTimeout(future)
-    future
-  }
-
-  private def verifyConnectionFailure(consumer: Consumer[String, String]): Future[_] = {
-    val executor = Executors.newSingleThreadExecutor
-    executors += executor
-    val future = executor.submit(new Runnable() {
-      def run(): Unit = {
-        consumer.commitSync()
-      }
-    })
-    verifyTimeout(future)
-    future
-  }
-
-  private def verifyTimeout(future: Future[_]): Unit = {
-    assertThrows(classOf[TimeoutException], () => future.get(100, TimeUnit.MILLISECONDS))
-  }
-
   private def configValueAsString(value: Any): String = {
     value match {
       case password: Password => password.value
       case list: util.List[_] => list.asScala.map(_.toString).mkString(",")
       case _ => value.toString
-    }
-  }
-
-  private def addListenerPropsSsl(listenerName: String, props: Properties): Unit = {
-    props ++= securityProps(sslProperties1, KEYSTORE_PROPS, listenerPrefix(listenerName))
-    props ++= securityProps(sslProperties1, TRUSTSTORE_PROPS, listenerPrefix(listenerName))
-  }
-
-  private def addListenerPropsSasl(listener: String, mechanisms: Seq[String], props: Properties): Unit = {
-    val listenerName = new ListenerName(listener)
-    val prefix = listenerName.configPrefix
-    props.put(prefix + BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, mechanisms.mkString(","))
-    props.put(prefix + SaslConfigs.SASL_KERBEROS_SERVICE_NAME, "kafka")
-    mechanisms.foreach { mechanism =>
-      val jaasSection = jaasSections(Seq(mechanism), None, KafkaSasl, "").head
-      val jaasConfig = jaasSection.getModules.get(0).toString
-      props.put(listenerName.saslMechanismConfigPrefix(mechanism) + SaslConfigs.SASL_JAAS_CONFIG, jaasConfig)
     }
   }
 
@@ -1994,7 +1560,7 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
     val matchingMetrics = kafkaMetrics.filter(metric => metric.metricName.name == name && metric.metricName.group == group)
     assertTrue(matchingMetrics.nonEmpty, "Metric not found")
     val total = matchingMetrics.foldLeft(0.0)((total, metric) => total + metric.metricValue.asInstanceOf[Double])
-    assertTrue(total > 0.0, "Invalid metric value")
+    assertTrue(total > 0.0, "Invalid metric value " + total + " for name " + name + " , group " + group)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1014,8 +1014,8 @@ object TestUtils extends Logging {
     TestUtils.waitUntilTrue(
       () => {
         brokers.forall { broker =>
-          val metadataOffset = broker.asInstanceOf[BrokerServer].sharedServer.loader.lastAppliedOffset()
-          metadataOffset >= controllerOffset
+          val loader = broker.asInstanceOf[BrokerServer].sharedServer.loader
+          loader == null || loader.lastAppliedOffset() >= controllerOffset
         }
       }, msg)
   }


### PR DESCRIPTION
Convert testUncleanLeaderElectionEnable and testMetricsReporterUpdate to KRaft.

Remove testAdvertisedListenerUpdate, testAddRemoveSslListener, testAddRemoveSaslListeners since we no longer support dynamically adding or removing network listeners when in KRaft mode.

Make TestUtils.ensureConsistentKRaftMetadata robust against brokers that don't have sharedServer.loader initialized yet (or have shut down).