### PR TITLE
KAFKA-18059: kafka-metadata-quorum.sh add-controller subcommand can't recognize argument --config

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -107,7 +107,8 @@ public class MetadataQuorumCommand {
             .help("A comma-separated list of host:port pairs to use for establishing the connection to the Kafka controllers.");
         parser.addArgument("--command-config")
             .type(Arguments.fileType())
-            .help("Property file containing configs to be passed to Admin Client.");
+            .help("Property file containing configs to be passed to Admin Client. " +
+                "For add-controller, the file is used to specify the controller properties as well.");
         Subparsers subparsers = parser.addSubparsers().dest("command");
         addDescribeSubParser(subparsers);
         addAddControllerSubParser(subparsers);


### PR DESCRIPTION
In [KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes), it uses following command as adding controller example.

```
kafka-metadata-quorum --bootstrap-server <endpoints> add-controller --config controller.properties
```

The script returns "kafka-metadata-quorum: error: unrecognized arguments: '--config'". The correct way to add controller is like following:

```
kafka-metadata-quorum --bootstrap-server <endpoints> --command-config controller.properties add-controller
```

From @chia7712's [suggestion](https://issues.apache.org/jira/browse/KAFKA-18059?focusedCommentId=17899998&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17899998), we keep using `--command-config` to avoid breaking change. However, in `MetadataQuorumCommand`, the `--command-config` description is "Property file containing configs to be passed to Admin Client.". We should update the description to mention it's also used as controller property file for `add-controller` command.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
