### PR TITLE
MINOR: remove some obsolete zk tests

### DIFF
--- a/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
-import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.ListOffsetsResponse
 import org.apache.kafka.common.utils.{MockTime, Time, Utils}
 import org.apache.kafka.server.config.ServerLogConfigs
@@ -45,7 +44,6 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
   private val topicNameWithCustomConfigs = "foo2"
   private var adminClient: Admin = _
   private val mockTime: Time = new MockTime(1)
-  private var version = RecordBatch.MAGIC_VALUE_V2
   private val dataFolder = Seq(tempDir().getAbsolutePath, tempDir().getAbsolutePath)
 
   @BeforeEach
@@ -72,20 +70,6 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
     assertEquals(ListOffsetsResponse.UNKNOWN_OFFSET, maxTimestampOffset.offset())
     assertEquals(ListOffsetsResponse.UNKNOWN_TIMESTAMP, maxTimestampOffset.timestamp())
   }
-
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testListVersion0(quorum: String): Unit = {
-    // create records for version 0
-    createMessageFormatBrokers(RecordBatch.MAGIC_VALUE_V0)
-    produceMessagesInSeparateBatch()
-
-    // update version to version 1 to list offset for max timestamp
-    createMessageFormatBrokers(RecordBatch.MAGIC_VALUE_V1)
-    // the offset of max timestamp is always -1 if the batch version is 0
-    verifyListOffsets(expectedMaxTimestampOffset = -1)
-  }
-
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft"))
@@ -129,38 +113,6 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
     verifyListOffsets(topic = topicNameWithCustomConfigs, 2)
   }
 
-  // The message conversion test only run in ZK mode because KRaft mode doesn't support "inter.broker.protocol.version" < 3.0
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testThreeRecordsInOneBatchWithMessageConversion(quorum: String): Unit = {
-    createMessageFormatBrokers(RecordBatch.MAGIC_VALUE_V1)
-    produceMessagesInOneBatch()
-    verifyListOffsets()
-
-    // test LogAppendTime case
-    setUpForLogAppendTimeCase()
-    produceMessagesInOneBatch(topic = topicNameWithCustomConfigs)
-    // In LogAppendTime's case, the maxTimestampOffset should be the first message of the batch.
-    // So in this one batch test, it'll be the first offset 0
-    verifyListOffsets(topic = topicNameWithCustomConfigs, 0)
-  }
-
-  // The message conversion test only run in ZK mode because KRaft mode doesn't support "inter.broker.protocol.version" < 3.0
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testThreeRecordsInSeparateBatchWithMessageConversion(quorum: String): Unit = {
-    createMessageFormatBrokers(RecordBatch.MAGIC_VALUE_V1)
-    produceMessagesInSeparateBatch()
-    verifyListOffsets()
-
-    // test LogAppendTime case
-    setUpForLogAppendTimeCase()
-    produceMessagesInSeparateBatch(topic = topicNameWithCustomConfigs)
-    // In LogAppendTime's case, the maxTimestampOffset is the message in the last batch since we advance the time
-    // for each batch, So it'll be the last offset 2
-    verifyListOffsets(topic = topicNameWithCustomConfigs, 2)
-  }
-
   @ParameterizedTest
   @ValueSource(strings = Array("kraft"))
   def testThreeRecordsInOneBatchHavingDifferentCompressionTypeWithServer(quorum: String): Unit = {
@@ -201,15 +153,6 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
     createTopicWithConfig(topicNameWithCustomConfigs, props)
   }
 
-  private def createMessageFormatBrokers(recordVersion: Byte): Unit = {
-    version = recordVersion
-    recreateBrokers(reconfigure = true, startup = true)
-    Utils.closeQuietly(adminClient, "ListOffsetsAdminClient")
-    adminClient = Admin.create(Map[String, Object](
-      AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers()
-    ).asJava)
-  }
-
   private def createTopicWithConfig(topic: String, props: Properties): Unit = {
     createTopic(topic, 1, 1.toShort, topicConfig = props)
   }
@@ -224,12 +167,9 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
 
       val maxTimestampOffset = runFetchOffsets(adminClient, OffsetSpec.maxTimestamp(), topic)
       assertEquals(expectedMaxTimestampOffset, maxTimestampOffset.offset())
-      if (version >= RecordBatch.MAGIC_VALUE_V2)
-        // the epoch is related to the returned offset.
-        // Hence, it should be zero (the earliest leader epoch), regardless of new leader election
-        assertEquals(Optional.of(0), maxTimestampOffset.leaderEpoch())
-      else
-        assertEquals(Optional.empty(), maxTimestampOffset.leaderEpoch())
+      // the epoch is related to the returned offset.
+      // Hence, it should be zero (the earliest leader epoch), regardless of new leader election
+      assertEquals(Optional.of(0), maxTimestampOffset.leaderEpoch())
     }
 
     // case 0: test the offsets from leader's append path
@@ -336,15 +276,7 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
   }
 
   def generateConfigs: Seq[KafkaConfig] = {
-    TestUtils.createBrokerConfigs(2, zkConnectOrNull).zipWithIndex.map{ case (props, index) =>
-      if (version == RecordBatch.MAGIC_VALUE_V0) {
-        props.setProperty("log.message.format.version", "0.9.0")
-        props.setProperty("inter.broker.protocol.version", "0.9.0")
-      }
-      if (version == RecordBatch.MAGIC_VALUE_V1) {
-        props.setProperty("log.message.format.version", "0.10.0")
-        props.setProperty("inter.broker.protocol.version", "0.10.0")
-      }
+    TestUtils.createBrokerConfigs(2, null).zipWithIndex.map{ case (props, index) =>
      // We use mock timer so the records can get removed if the test env is too busy to complete
      // tests before kafka-log-retention. Hence, we disable the retention to avoid failed tests
      props.setProperty(ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG, "-1")

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -52,7 +52,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
   overridingProps.put(JmxReporter.EXCLUDE_CONFIG, s"$requiredKafkaServerPrefix=ClusterId")
 
   def generateConfigs: Seq[KafkaConfig] =
-    TestUtils.createBrokerConfigs(numNodes, zkConnectOrNull, enableControlledShutdown = false).
+    TestUtils.createBrokerConfigs(numNodes, null, enableControlledShutdown = false).
       map(KafkaConfig.fromProps(_, overridingProps))
 
   val nMessages = 2
@@ -212,29 +212,6 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     TestUtils.consumeTopicRecords(brokers, topic, nMessages, GroupProtocol.of(groupProtocol))
 
     assertTrue(TestUtils.meterCount(bytesOut) > initialBytesOut)
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testZkControllerMetrics(quorum: String): Unit = {
-    val metrics = KafkaYammerMetrics.defaultRegistry.allMetrics
-
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ActiveControllerCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=OfflinePartitionsCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalTopicCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalPartitionCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsToDeleteCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasToDeleteCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsIneligibleToDeleteCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasIneligibleToDeleteCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ActiveBrokerCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=FencedBrokerCount"), 1)
-    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ZkMigrationState"), 1)
-
-    val zkStateMetricName = metrics.keySet.asScala.filter(_.getMBeanName == "kafka.controller:type=KafkaController,name=ZkMigrationState").head
-    val zkStateGauge = metrics.get(zkStateMetricName).asInstanceOf[Gauge[Int]]
-    assertEquals(ZkMigrationState.ZK.value().intValue(), zkStateGauge.value())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -22,7 +22,6 @@ import kafka.log.UnifiedLog
 import kafka.log.remote.RemoteLogManager
 import kafka.utils.TestUtils.random
 import kafka.utils._
-import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasOptions, AlterConfigOp, Config, ConfigEntry}
@@ -32,23 +31,20 @@ import org.apache.kafka.common.metrics.Quota
 import org.apache.kafka.common.quota.ClientQuotaAlteration.Op
 import org.apache.kafka.common.quota.ClientQuotaEntity.{CLIENT_ID, IP, USER}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
-import org.apache.kafka.common.record.{CompressionType, RecordVersion}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupConfig
-import org.apache.kafka.server.common.MetadataVersion.IBP_3_0_IV1
-import org.apache.kafka.server.config.{ConfigType, QuotaConfig, ServerLogConfigs, ZooKeeperInternals}
+import org.apache.kafka.server.config.{ConfigType, QuotaConfig, ServerLogConfigs}
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{Test, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 
 import java.net.InetAddress
-import java.nio.charset.StandardCharsets
 import java.util
 import java.util.Collections.{singletonList, singletonMap}
 import java.util.concurrent.ExecutionException
@@ -60,7 +56,7 @@ import scala.jdk.CollectionConverters._
 @Timeout(100)
 class DynamicConfigChangeTest extends KafkaServerTestHarness {
   override def generateConfigs: Seq[KafkaConfig] = {
-    val cfg = TestUtils.createBrokerConfig(0, zkConnectOrNull)
+    val cfg = TestUtils.createBrokerConfig(0, null)
     List(KafkaConfig.fromProps(cfg))
   }
 
@@ -98,10 +94,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       } finally {
         admin.close()
       }
-    } else {
-      val newProps = new Properties()
-      newProps.setProperty(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, newVal.toString)
-      adminZkClient.changeTopicConfig(tp.topic, newProps)
     }
     TestUtils.retry(10000) {
       assertEquals(newVal, this.brokers.head.logManager.getLog(tp).get.config.flushInterval)
@@ -133,12 +125,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       } finally {
         admin.close()
       }
-    } else {
-      val newProps = new Properties()
-      newProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, newSegmentSize.toString)
-      adminZkClient.changeTopicConfig(tp.topic, newProps)
     }
-
     val log = brokers.head.logManager.getLog(tp).get
     TestUtils.retry(10000) {
       assertEquals(newSegmentSize, log.config.segmentSize)
@@ -147,35 +134,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     (1 to 50).foreach(i => TestUtils.produceMessage(brokers, tp.topic, i.toString))
     // Verify that the new config is used for all segments
     assertTrue(log.logSegments.stream.allMatch(_.size > 1000), "Log segment size change not applied")
-  }
-
-  @nowarn("cat=deprecation")
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testMessageFormatVersionChange(quorum: String): Unit = {
-    val tp = new TopicPartition("test", 0)
-    val logProps = new Properties()
-    logProps.put(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG, "0.10.2")
-    createTopic(tp.topic, 1, 1, logProps)
-    val server = servers.head
-    TestUtils.waitUntilTrue(() => server.logManager.getLog(tp).isDefined,
-      "Topic metadata propagation failed")
-    val log = server.logManager.getLog(tp).get
-    // message format version should always be 3.0 if inter-broker protocol is 3.0 or higher
-    assertEquals(IBP_3_0_IV1, log.config.messageFormatVersion)
-    assertEquals(RecordVersion.V2, log.config.recordVersion)
-
-    val compressionType = CompressionType.LZ4
-    logProps.put(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG, "0.11.0")
-    // set compression type so that we can detect when the config change has propagated
-    logProps.put(TopicConfig.COMPRESSION_TYPE_CONFIG, compressionType.name)
-    adminZkClient.changeTopicConfig(tp.topic, logProps)
-    TestUtils.waitUntilTrue(() =>
-      server.logManager.getLog(tp).get.config.compression.isPresent &&
-      server.logManager.getLog(tp).get.config.compression.get.`type` == compressionType,
-      "Topic config change propagation failed")
-    assertEquals(IBP_3_0_IV1, log.config.messageFormatVersion)
-    assertEquals(RecordVersion.V2, log.config.recordVersion)
   }
 
   private def testQuotaConfigChange(entity: ClientQuotaEntity,
@@ -280,38 +238,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testQuotaInitialization(quorum: String): Unit = {
-    val server = servers.head
-    val clientIdProps = new Properties()
-    server.shutdown()
-    clientIdProps.put(QuotaConfig.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, "1000")
-    clientIdProps.put(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG, "2000")
-    val userProps = new Properties()
-    userProps.put(QuotaConfig.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, "10000")
-    userProps.put(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG, "20000")
-    val userClientIdProps = new Properties()
-    userClientIdProps.put(QuotaConfig.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, "100000")
-    userClientIdProps.put(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG, "200000")
-
-    adminZkClient.changeClientIdConfig("overriddenClientId", clientIdProps)
-    adminZkClient.changeUserOrUserClientIdConfig("overriddenUser", userProps)
-    adminZkClient.changeUserOrUserClientIdConfig("ANONYMOUS/clients/overriddenUserClientId", userClientIdProps)
-
-    // Remove config change znodes to force quota initialization only through loading of user/client quotas
-    zkClient.getChildren(ConfigEntityChangeNotificationZNode.path).foreach { p => zkClient.deletePath(ConfigEntityChangeNotificationZNode.path + "/" + p) }
-    server.startup()
-    val quotaManagers = server.dataPlaneRequestProcessor.quotas
-
-    assertEquals(Quota.upperBound(1000),  quotaManagers.produce.quota("someuser", "overriddenClientId"))
-    assertEquals(Quota.upperBound(2000),  quotaManagers.fetch.quota("someuser", "overriddenClientId"))
-    assertEquals(Quota.upperBound(10000),  quotaManagers.produce.quota("overriddenUser", "someclientId"))
-    assertEquals(Quota.upperBound(20000),  quotaManagers.fetch.quota("overriddenUser", "someclientId"))
-    assertEquals(Quota.upperBound(100000),  quotaManagers.produce.quota("ANONYMOUS", "overriddenUserClientId"))
-    assertEquals(Quota.upperBound(200000),  quotaManagers.fetch.quota("ANONYMOUS", "overriddenUserClientId"))
-  }
-
-  @ParameterizedTest
   @ValueSource(strings = Array("kraft"))
   def testIpQuotaInitialization(quorum: String): Unit = {
     val broker = brokers.head
@@ -327,22 +253,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       } finally {
         admin.close()
       }
-    } else {
-      broker.shutdown()
-
-      val ipDefaultProps = new Properties()
-      ipDefaultProps.put(QuotaConfig.IP_CONNECTION_RATE_OVERRIDE_CONFIG, "20")
-      adminZkClient.changeIpConfig(ZooKeeperInternals.DEFAULT_STRING, ipDefaultProps)
-
-      val ipOverrideProps = new Properties()
-      ipOverrideProps.put(QuotaConfig.IP_CONNECTION_RATE_OVERRIDE_CONFIG, "10")
-      adminZkClient.changeIpConfig("1.2.3.4", ipOverrideProps)
-
-      // Remove config change znodes to force quota initialization only through loading of ip quotas
-      zkClient.getChildren(ConfigEntityChangeNotificationZNode.path).foreach { p =>
-        zkClient.deletePath(ConfigEntityChangeNotificationZNode.path + "/" + p)
-      }
-      broker.startup()
     }
     TestUtils.retry(10000) {
       val connectionQuotas = broker.socketServer.connectionQuotas
@@ -393,15 +303,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testConfigChangeOnNonExistingTopic(quorum: String): Unit = {
-    val topic = tempTopic()
-    val logProps = new Properties()
-    logProps.put(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, 10000: java.lang.Integer)
-    assertThrows(classOf[UnknownTopicOrPartitionException], () => adminZkClient.changeTopicConfig(topic, logProps))
-  }
-
   private def tempTopic() : String = "testTopic" + random.nextInt(1000000)
 
   @ParameterizedTest
@@ -420,39 +321,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     } finally {
       admin.close()
     }
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk"))
-  def testProcessNotification(quorum: String): Unit = {
-    val props = new Properties()
-    props.put("a.b", "10")
-
-    // Create a mock ConfigHandler to record config changes it is asked to process
-    val handler: ConfigHandler = mock(classOf[ConfigHandler])
-
-    val configManager = new ZkConfigManager(zkClient, Map(ConfigType.TOPIC -> handler))
-    // Notifications created using the old TopicConfigManager are ignored.
-    configManager.ConfigChangedNotificationHandler.processNotification("not json".getBytes(StandardCharsets.UTF_8))
-
-    // Incorrect Map. No version
-    var jsonMap: Map[String, Any] = Map("v" -> 1, "x" -> 2)
-
-    assertThrows(classOf[Throwable], () => configManager.ConfigChangedNotificationHandler.processNotification(Json.encodeAsBytes(jsonMap.asJava)))
-    // Version is provided. EntityType is incorrect
-    jsonMap = Map("version" -> 1, "entity_type" -> "garbage", "entity_name" -> "x")
-    assertThrows(classOf[Throwable], () => configManager.ConfigChangedNotificationHandler.processNotification(Json.encodeAsBytes(jsonMap.asJava)))
-
-    // EntityName isn't provided
-    jsonMap = Map("version" -> 1, "entity_type" -> ConfigType.TOPIC)
-    assertThrows(classOf[Throwable], () => configManager.ConfigChangedNotificationHandler.processNotification(Json.encodeAsBytes(jsonMap.asJava)))
-
-    // Everything is provided
-    jsonMap = Map("version" -> 1, "entity_type" -> ConfigType.TOPIC, "entity_name" -> "x")
-    configManager.ConfigChangedNotificationHandler.processNotification(Json.encodeAsBytes(jsonMap.asJava))
-
-    // Verify that processConfigChanges was only called once
-    verify(handler).processConfigChanges(anyString, any[Properties])
   }
 
   @ParameterizedTest
@@ -501,15 +369,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
       } finally {
         admin.close()
       }
-    } else {
-      val newProps = new Properties()
-      if (op == OpType.SET) {
-        newProps.put(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-        newProps.put(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, newValue.toString)
-        newProps.put(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, newValue.toString)
-      }
-      val brokerIdOption = if (brokerId != "") Option(brokerId.toInt) else None
-      adminZkClient.changeBrokerConfig(brokerIdOption, newProps)
     }
   }
 


### PR DESCRIPTION
Remove all zk tests from MetricsTest.scala,
CreateTopicsRequestTest.scala, DynamicConfigChangeTest.scala, MetadataRequestTest.scala.

Convert CreateTopicsRequestTest.testCreateTopicsRequestVersions to KRaft.