### PR TITLE
KAFKA-18047: Add org.apache.kafka.automatic.config.providers to System Properties section

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -293,7 +293,7 @@
     <li>
       <h4><a id="org.apache.kafka.disallowed.login.modules"></a><a id="systemproperties_org.apache.kafka.disallowed.login.modules" href="#systemproperties_org.apache.kafka.disallowed.login.modules">org.apache.kafka.disallowed.login.modules</a></h4>
       <p>This system property is used to disable the problematic login modules usage in SASL JAAS configuration. This property accepts comma-separated list of loginModule names. By default <b>com.sun.security.auth.module.JndiLoginModule</b> loginModule is disabled.
-      <p>If users want to enable JndiLoginModule, users need to explicitly reset the system property like below. We advise the users to validate configurations and only allow trusted JNDI configurations. For more details <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-25194">CVE-2023-25194</a>.
+      <p>If users want to enable JndiLoginModule, users need to explicitly reset the system property like below. We advise the users to validate configurations and only allow trusted JNDI configurations. For more details <a href="https://kafka.apache.org/cve-list#CVE-2023-25194">CVE-2023-25194</a>.
       <p><pre><code class="language-bash">-Dorg.apache.kafka.disallowed.login.modules=</code></pre>
       <p>To disable more loginModules, update the system property with comma-separated loginModule names. Make sure to explicitly add <b>JndiLoginModule</b> module name to the comma-separated list like below.
       <p><pre><code class="language-bash">-Dorg.apache.kafka.disallowed.login.modules=com.sun.security.auth.module.JndiLoginModule,com.ibm.security.auth.module.LdapLoginModule,com.ibm.security.auth.module.Krb5LoginModule</code></pre>
@@ -301,6 +301,22 @@
       <tr><th>Since:</th><td>3.4.0</td></tr>
       <tr><th>Default Value:</th><td>com.sun.security.auth.module.JndiLoginModule</td></tr>
       </tbody></table>
+    </li>
+    <li>
+      <h4><a id="org.apache.kafka.automatic.config.providers"></a><a id="systemproperties_org.apache.kafka.automatic.config.providers" href="#systemproperties_org.apache.kafka.automatic.config.providers">org.apache.kafka.automatic.config.providers</a></h4>
+      <p>This system property controls the automatic loading of ConfigProvider implementations in Apache Kafka. ConfigProviders are used to dynamically supply configuration values from sources such as files, directories, or environment variables. This property accepts a comma-separated list of ConfigProvider names. By default, all built-in ConfigProviders are enabled, including <b>FileConfigProvider</b>, <b>DirectoryConfigProvider</b>, and <b>EnvVarConfigProvider</b>.</p>
+      <p>If users want to disable all automatic ConfigProviders, they need to explicitly set the system property as shown below. Disabling automatic ConfigProviders is recommended in environments where configuration data comes from untrusted sources or where increased security is required. For more details, see <a href="https://kafka.apache.org/cve-list#CVE-2024-31141">CVE-2024-31141</a>.</p>
+      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=none</code></pre>
+      <p>To allow specific ConfigProviders, update the system property with a comma-separated list of ConfigProvider names. For example, to enable only the <b>EnvVarConfigProvider</b>, set the property as follows:</p>
+      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=env</code></pre>
+      <p>To use multiple ConfigProviders, include their names in a comma-separated list as shown below:</p>
+      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=file,env</code></pre>
+      <table>
+        <tbody>
+        <tr><th>Since:</th><td>3.8.0</td></tr>
+        <tr><th>Default Value:</th><td>All built-in ConfigProviders are enabled</td></tr>
+        </tbody>
+      </table>
     </li>
   </ul>
 


### PR DESCRIPTION
JIRA: KAFKA-18047

Add documentation of `org.apache.kafka.automatic.config.providers` to System Properties section.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
