### PR TITLE
KAFKA-18070: Update kafka-metadata-quorum.sh output in docs to match post-KIP-853 appearance

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1366,8 +1366,9 @@ queued.max.requests=[number of concurrent requests]</code></pre>
   <p>If the data in the cluster metadata directory is lost either because of hardware failure or the hardware needs to be replaced, care should be taken when provisioning the new controller node. The new controller node should not be formatted and started until the majority of the controllers have all of the committed data. To determine if the majority of the controllers have the committed data, run the kafka-metadata-quorum.sh tool to describe the replication status:</p>
 
   <pre><code class="language-bash">$ bin/kafka-metadata-quorum.sh --bootstrap-server localhost:9092 describe --replication
-NodeId  LogEndOffset    Lag     LastFetchTimestamp      LastCaughtUpTimestamp   Status
-1       25806           0       1662500992757           1662500992757           Leader
+NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTimestamp	Status
+1     	dDo1k_pRSD-VmReEpu383g	966         	0  	1732367153528     	1732367153528        	Leader
+2     	wQWaQMJYpcifUPMBGeRHqg	966         	0  	1732367153304     	1732367153304        	Observer
 ...     ...             ...     ...                     ...                     ...</code></pre>
 
   <p>Check and wait until the <code>Lag</code> is small for a majority of the controllers. If the leader's end offset is not increasing, you can wait until the lag is 0 for a majority; otherwise, you can pick the latest leader end offset and wait until all replicas have reached it. Check and wait until the <code>LastFetchTimestamp</code> and <code>LastCaughtUpTimestamp</code> are close to each other for the majority of the controllers. At this point it is safer to format the controller's metadata log directory. This can be done by running the kafka-storage.sh command.</p>


### PR DESCRIPTION
related to KAFKA-18070, 

add missing DirectoryId field in kafka-metadata-quorum.sh --replication console output

before:
![image](https://github.com/user-attachments/assets/662e3158-abcf-40ad-b144-e5f56b3562d9)

after:
![Screenshot from 2024-11-23 21-19-49](https://github.com/user-attachments/assets/c577156b-d675-436d-a808-d750fcef49a9)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
