### PR TITLE
KAFKA-18077: Remove deprecated JmxReporter(String)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -69,20 +69,7 @@ public class JmxReporter implements MetricsReporter {
     private final Map<String, KafkaMbean> mbeans = new HashMap<>();
     private Predicate<String> mbeanPredicate = s -> true;
 
-    public JmxReporter() {
-        this("");
-    }
-
-    /**
-     * Create a JMX reporter that prefixes all metrics with the given string.
-     *  @deprecated Since 2.6.0. Use {@link JmxReporter#JmxReporter()}
-     *  Initialize JmxReporter with {@link JmxReporter#contextChange(MetricsContext)}
-     *  Populate prefix by adding _namespace/prefix key value pair to {@link MetricsContext}
-     */
-    @Deprecated
-    public JmxReporter(String prefix) {
-        this.prefix = prefix != null ? prefix : "";
-    }
+    public JmxReporter() {}
 
     @Override
     public void configure(Map<String, ?> configs) {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -69,7 +69,9 @@ public class JmxReporter implements MetricsReporter {
     private final Map<String, KafkaMbean> mbeans = new HashMap<>();
     private Predicate<String> mbeanPredicate = s -> true;
 
-    public JmxReporter() {}
+    public JmxReporter() {
+        this.prefix = "";
+    }
 
     @Override
     public void configure(Map<String, ?> configs) {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -177,23 +177,4 @@ public class JmxReporterTest {
             metrics.close();
         }
     }
-
-    @Test
-    public void testDeprecatedJmxPrefixWithDefaultMetrics() throws Exception {
-        @SuppressWarnings("deprecation")
-        JmxReporter reporter = new JmxReporter("my-prefix");
-
-        // for backwards compatibility, ensure prefix does not get overridden by the default empty namespace in metricscontext
-        MetricConfig metricConfig = new MetricConfig();
-        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Collections.singletonList(reporter)), Time.SYSTEM);
-
-        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        try {
-            Sensor sensor = metrics.sensor("my-sensor");
-            sensor.add(metrics.metricName("pack.bean1.avg", "grp1"), new Avg());
-            assertEquals("my-prefix", server.getObjectInstance(new ObjectName("my-prefix:type=grp1")).getObjectName().getDomain());
-        } finally {
-            metrics.close();
-        }
-    }
 }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -32,6 +32,9 @@
                         <li>The <code>auto.include.jmx.reporter</code> configuration was removed. The <code>metric.reporters</code> configuration
                             is now set to <code>org.apache.kafka.common.metrics.JmxReporter</code> by default.
                         </li>
+                        <li>The constructor <code>org.apache.kafka.common.metrics.JmxReporter</code> with string argument was removed.
+                            See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-606%3A+Add+Metadata+Context+to+MetricsReporter">KIP-606</a> for details.
+                        </li>
                         <li>The <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>, and <code>iotime-total</code> metrics were removed.
                             Please use <code>bufferpool-wait-time-ns-total</code>, <code>io-wait-time-ns-total</code>, and <code>io-time-ns-total</code> metrics as replacements, respectively.
                         </li>
@@ -53,7 +56,7 @@
                         <li>The original MirrorMaker (MM1) and related classes were removed. Please use the Connect-based
                             MirrorMaker (MM2), as described in the <a href="/{{version}}/documentation/#georeplication">Geo-Replication section.</a>.
                         </li>
-                        <li>The <code>use.incremental.alter.configs</code> configuration was removedfrom <code>MirrorSourceConnector</code>.
+                        <li>The <code>use.incremental.alter.configs</code> configuration was removed from <code>MirrorSourceConnector</code>.
                             The modified behavior is identical to the previous <code>required</code> configuration, therefore users should ensure that brokers in the target cluster are at least running 2.3.0.
                         </li>
                         <li>The <code>add.source.alias.to.metrics</code> configuration was removed from <code>MirrorSourceConnector</code>.


### PR DESCRIPTION
Remove the following code about the deprecated JmxReporter(String).
> - Remove initial JmxReporter constructor with string and refactor default constructor.
> - Remove related test fucntion for testDeprecatedJmxPrefixWithDefaultMetrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
