### PR TITLE
KAFKA-18078: Fix failed MetricsTest.testJMXFilter

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -19,8 +19,7 @@ package kafka.server
 import java.io.File
 import java.util.concurrent.CompletableFuture
 import kafka.log.UnifiedLog
-import kafka.metrics.KafkaMetricsReporter
-import kafka.utils.{CoreUtils, Logging, Mx4jLoader, VerifiableProperties}
+import kafka.utils.{CoreUtils, Logging, Mx4jLoader}
 import org.apache.kafka.common.config.{ConfigDef, ConfigResource}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.utils.{AppInfoParser, Time}
@@ -32,7 +31,6 @@ import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsem
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.{ProcessRole, ServerSocketFactory}
 import org.apache.kafka.server.config.ServerTopicConfigSynonyms
-import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.slf4j.Logger
 
@@ -53,8 +51,6 @@ class KafkaRaftServer(
 ) extends Server with Logging {
 
   this.logIdent = s"[KafkaRaftServer nodeId=${config.nodeId}] "
-  KafkaMetricsReporter.startReporters(VerifiableProperties(config.originals))
-  KafkaYammerMetrics.INSTANCE.configure(config.originals)
 
   private val (metaPropsEnsemble, bootstrapMetadata) =
     KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logIdent)

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -17,9 +17,10 @@
 
 package kafka.server
 
+import kafka.metrics.KafkaMetricsReporter
 import kafka.raft.KafkaRaftManager
 import kafka.server.Server.MetricsPrefix
-import kafka.utils.{CoreUtils, Logging}
+import kafka.utils.{CoreUtils, Logging, VerifiableProperties}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
@@ -101,6 +102,9 @@ class SharedServer(
   val faultHandlerFactory: FaultHandlerFactory,
   val socketFactory: ServerSocketFactory
 ) extends Logging {
+  KafkaMetricsReporter.startReporters(VerifiableProperties(sharedServerConfig.originals))
+  KafkaYammerMetrics.INSTANCE.configure(sharedServerConfig.originals)
+
   private val logContext: LogContext = new LogContext(s"[SharedServer id=${sharedServerConfig.nodeId}] ")
   this.logIdent = logContext.logPrefix
   private var started = false


### PR DESCRIPTION
related to KAFKA-18078

The root cause is that in KRaft mode, KafkaYammerMetrics.INSTANCE is configured by KafkaRaftServer [0], which is not executed by the test infrastructure. In contrast, in ZK mode, KafkaYammerMetrics.INSTANCE is configured by KafkaServer [1], so it is in the execution path of the test infrastructure.

[0] https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaRaftServer.scala#L57
[1] https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaServer.scala#L277

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
