### PR TITLE
KAFKA-18079: consumer-config does not work with console-share-consumer

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -182,7 +182,8 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
     }
 
     private Properties buildConsumerProps(Properties consumerPropsFromFile, Properties extraConsumerProps, Set<String> groupIdsProvided) {
-        Properties consumerProps = new Properties(consumerPropsFromFile);
+        Properties consumerProps = new Properties();
+        consumerProps.putAll(consumerPropsFromFile);
         consumerProps.putAll(extraConsumerProps);
         consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer());
         if (consumerProps.getProperty(ConsumerConfig.CLIENT_ID_CONFIG) == null) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.tools.consumer;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.tools.ToolsTestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -101,8 +102,11 @@ public class ConsoleShareConsumerOptionsTest {
 
         ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);
 
-        assertEquals("1000", config.consumerProps().getProperty("request.timeout.ms"));
-        assertEquals("group1", config.consumerProps().getProperty("group.id"));
+        // KafkaShareConsumer uses Utils.propsToMap to convert the properties to a map,
+        // so using the same method to check the map has the expected values
+        Map<String, Object> configMap = Utils.propsToMap(config.consumerProps());
+        assertEquals("1000", configMap.get("request.timeout.ms"));
+        assertEquals("group1", configMap.get("group.id"));
     }
 
     @Test


### PR DESCRIPTION
The `new Properties(consumerPropsFromFile)`[0] does not honor the `consumerPropsFromFile` when it is viewed as a hash map. The `KafkaShareConsumer`[1] converts the properties to a map so the configured values are totally ignored.

[0] https://github.com/apache/kafka/blob/337e2e150657b504cd77a91afe8cc4d160c2124c/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java#L185

[1]
https://github.com/apache/kafka/blob/337e2e150657b504cd77a91afe8cc4d160c2124c/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java#L386

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
