### PR TITLE
KAFKA-18075: Prevent ClusterInstance default producer and consumer initialization with empty configs

### DIFF
--- a/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java
+++ b/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java
@@ -166,7 +166,7 @@ public interface ClusterInstance {
     }
 
     default <K, V> Producer<K, V> producer() {
-        return new KafkaProducer<>(Map.of());
+        return producer(Map.of());
     }
 
     default <K, V> Consumer<K, V> consumer(Map<String, Object> configs) {
@@ -180,7 +180,7 @@ public interface ClusterInstance {
     }
 
     default <K, V> Consumer<K, V> consumer() {
-        return new KafkaConsumer<>(Map.of());
+        return consumer(Map.of());
     }
 
     default Admin admin(Map<String, Object> configs, boolean usingBootstrapControllers) {


### PR DESCRIPTION
related to KAFKA-18075

In ClusterInstance.java

[0]
```java
default <K, V> Consumer<K, V> consumer() {
    return new KafkaConsumer<>(Map.of());
}
```
[1] 
```java
default <K, V> Producer<K, V> producer() {
    return new KafkaProducer<>(Map.of());
} 
```
should return `consumer(Map.of())` and `producer(Map.of())` in the same class instead of return empty properties.

[0] https://github.com/apache/kafka/blob/trunk/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java#L168
[1] https://github.com/apache/kafka/blob/trunk/test-common/test-common-api/src/main/java/org/apache/kafka/common/test/api/ClusterInstance.java#L182
 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
