### PR TITLE
KAFKA-18067: Kafka Streams can leak Producer client under EOS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -119,7 +119,8 @@ class ActiveTaskCreator {
     }
 
     public void reInitializeProducer() {
-        streamsProducer.resetProducer(producer());
+        if (!streamsProducer.isClosed())
+            streamsProducer.resetProducer(producer());
     }
 
     StreamsProducer streamsProducer() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -70,6 +70,7 @@ public class StreamsProducer {
     private Producer<byte[], byte[]> producer;
     private boolean transactionInFlight = false;
     private boolean transactionInitialized = false;
+    private boolean closed = false;
     private double oldProducerTotalBlockedTime = 0;
     // we have a single `StreamsProducer` per thread, and thus a single `sendException` instance,
     // which we share across all tasks, ie, all `RecordCollectorImpl`
@@ -96,6 +97,10 @@ public class StreamsProducer {
 
     boolean transactionInFlight() {
         return transactionInFlight;
+    }
+
+    boolean isClosed() {
+        return closed;
     }
 
     /**
@@ -320,6 +325,7 @@ public class StreamsProducer {
 
     void close() {
         producer.close();
+        closed = true;
         transactionInFlight = false;
         transactionInitialized = false;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -190,7 +190,21 @@ public class ActiveTaskCreatorTest {
 
         activeTaskCreator.close();
 
+        assertThat(activeTaskCreator.streamsProducer().isClosed(), is(true));
         assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+    }
+
+    @Test
+    public void shouldNotReInitializeProducerOnClose() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        activeTaskCreator.streamsProducer().close();
+        activeTaskCreator.reInitializeProducer();
+        // If streamsProducer is not closed, clientSupplier will recreate a producer,
+        // resulting in more than one producer being created.
+        assertThat(mockClientSupplier.producers.size(), is(1));
     }
 
     // error handling


### PR DESCRIPTION
JIRA: KAFKA-18067

To avoid leaking producers, we should add a 'closed` flag to `StreamProducer` indicating whether we should reset prouder.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
