### PR TITLE
KAFKA-18083: ClusterInstance custom controllerListener not work

### DIFF
--- a/test-common/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
+++ b/test-common/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
@@ -111,7 +111,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
         private final String brokerSecurityProtocol;
         private final String controllerSecurityProtocol;
 
-
         public Builder(TestKitNodes nodes) {
             this.nodes = nodes;
             this.brokerListenerName = nodes.brokerListenerName().value();
@@ -169,7 +168,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                     append("@").
                     append("localhost").
                     append(":").
-                    append(socketFactoryManager.getOrCreatePortForListener(nodeId, "CONTROLLER"));
+                    append(socketFactoryManager.getOrCreatePortForListener(nodeId, controllerListenerName));
                 prefix = ",";
             }
             props.put(QuorumConfig.QUORUM_VOTERS_CONFIG, quorumVoterStringBuilder.toString());
@@ -199,7 +198,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
             try {
                 baseDirectory = new File(nodes.baseDirectory());
                 for (TestKitNode node : nodes.controllerNodes().values()) {
-                    socketFactoryManager.getOrCreatePortForListener(node.id(), "CONTROLLER");
+                    socketFactoryManager.getOrCreatePortForListener(node.id(), controllerListenerName);
                 }
                 for (TestKitNode node : nodes.controllerNodes().values()) {
                     setupNodeDirectories(baseDirectory, node.metadataDirectory(), Collections.emptyList());
@@ -316,6 +315,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
     private final File baseDirectory;
     private final SimpleFaultHandlerFactory faultHandlerFactory;
     private final PreboundSocketFactoryManager socketFactoryManager;
+    private final String controllerListenerName;
 
     private KafkaClusterTestKit(
         TestKitNodes nodes,
@@ -338,6 +338,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         this.baseDirectory = baseDirectory;
         this.faultHandlerFactory = faultHandlerFactory;
         this.socketFactoryManager = socketFactoryManager;
+        this.controllerListenerName = nodes.controllerListenerName().value();
     }
 
     public void format() throws Exception {
@@ -389,7 +390,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 nodes.bootstrapMetadata().featureLevel(KRaftVersion.FEATURE_NAME));
             formatter.setUnstableFeatureVersionsEnabled(true);
             formatter.setIgnoreFormatted(false);
-            formatter.setControllerListenerName("CONTROLLER");
+            formatter.setControllerListenerName(controllerListenerName);
             if (writeMetadataDirectory) {
                 formatter.setMetadataLogDirectory(ensemble.metadataLogDir().get());
             } else {
@@ -400,7 +401,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 String prefix = "";
                 for (TestKitNode controllerNode : nodes.controllerNodes().values()) {
                     int port = socketFactoryManager.
-                        getOrCreatePortForListener(controllerNode.id(), "CONTROLLER");
+                        getOrCreatePortForListener(controllerNode.id(), controllerListenerName);
                     dynamicVotersBuilder.append(prefix);
                     prefix = ",";
                     dynamicVotersBuilder.append(String.format("%d@localhost:%d:%s",

--- a/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
@@ -322,4 +322,12 @@ public class ClusterTestExtensionsTest {
             assertEquals(value, records.get(0).value());
         }
     }
+
+    @ClusterTest(types = {Type.CO_KRAFT, Type.KRAFT}, controllerListener = "FOO")
+    public void testControllerListenerName(ClusterInstance cluster) throws ExecutionException, InterruptedException {
+        assertEquals("FOO", cluster.controllerListenerName().get().value());
+        try (Admin admin = cluster.admin(Map.of(), true)) {
+            assertEquals(1, admin.describeMetadataQuorum().quorumInfo().get().nodes().size());
+        }
+    }
 }


### PR DESCRIPTION
related to KAFKA-18083, 

this is something missed in https://issues.apache.org/jira/browse/KAFKA-17721, plenty of places are still using hardcoded "CONTROLLER" controller listener name and cause `controllerListener` property not work.
e.g.
1. https://github.com/apache/kafka/blob/trunk/test-common/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java#L172
2. https://github.com/apache/kafka/blob/trunk/test-common/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java#L392
3. https://github.com/apache/kafka/blob/trunk/test-common/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java#L403

and we should add corresponding test case in ClusterTestExtensionsTest.java

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
