### PR TITLE
KAFKA-18085: Abort inflight requests on existing connections while rebootstrapping

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -123,12 +123,6 @@ public interface KafkaClient extends Closeable {
     void close(String nodeId);
 
     /**
-     * Closes connections to all nodes. All requests on the connections will be cleared.  ClientRequest
-     * callbacks will not be invoked for the cleared requests, nor will they be returned from poll().
-     */
-    void closeAll();
-
-    /**
      * Choose the node with the fewest outstanding requests. This method will prefer a node with an existing connection,
      * but will potentially choose a node for which we don't yet have a connection if all existing connections are in
      * use.

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -86,6 +86,23 @@ public interface MetadataUpdater extends Closeable {
     void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse);
 
     /**
+     * Returns true if metadata couldn't be fetched for `rebootstrapTriggerMs` or if server requested rebootstrap.
+     *
+     * @param now Current time in milliseconds
+     * @param rebootstrapTriggerMs Configured timeout after which rebootstrap is triggered
+     */
+    default boolean needsRebootstrap(long now, long rebootstrapTriggerMs) {
+        return false;
+    }
+
+    /**
+     * Performs rebootstrap, replacing the existing cluster with the bootstrap cluster.
+     *
+     * @param now Current time in milliseconds
+     */
+    default void rebootstrap(long now) {}
+
+    /**
      * Close this updater.
      */
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -140,6 +140,16 @@ public class AdminMetadataManager {
         }
 
         @Override
+        public boolean needsRebootstrap(long now, long rebootstrapTriggerMs) {
+            return AdminMetadataManager.this.needsRebootstrap(now, rebootstrapTriggerMs);
+        }
+
+        @Override
+        public void rebootstrap(long now) {
+            AdminMetadataManager.this.rebootstrap(now);
+        }
+
+        @Override
         public void close() {
         }
     }
@@ -312,7 +322,6 @@ public class AdminMetadataManager {
     }
 
     public void initiateRebootstrap() {
-        requestUpdate();
         this.metadataAttemptStartMs = Optional.of(0L);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -589,11 +589,6 @@ public class MockClient implements KafkaClient {
     }
 
     @Override
-    public void closeAll() {
-        connections.clear();
-    }
-
-    @Override
     public LeastLoadedNode leastLoadedNode(long now) {
         // Consistent with NetworkClient, we do not return nodes awaiting reconnect backoff
         for (Node node : metadataUpdater.fetchNodes()) {


### PR DESCRIPTION
When disconnecting channels before rebootstrapping due to the rebootstrap conditions introduced in KIP-1102, we should ensure that inflight requests are aborted similar to other disconnections like request timeout in clients. With the earlier rebootstrapping from KIP-899, we only rebootstrapped when there were no connections, so no disconnections are required.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
