### PR TITLE
KAFKA-10790: Add deadlock detection to producer#flush

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -19,6 +19,16 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
+<h4><a id="upgrade_4_1_0" href="#upgrade_4_1_0">Upgrading to 4.1.0 from any version 0.8.x through 4.0.x</a></h4>
+    <h5><a id="upgrade_410_notable" href="#upgrade_410_notable">Notable changes in 4.1.0</a></h5>
+        <ul>
+            <li><b>Producer</b>
+                <ul>
+                    <li>The <code>flush</code> method now detects potential deadlocks and prohibits its use inside a callback. This change prevents unintended blocking behavior, which was a known risk in earlier versions.
+                    </li>
+                </ul>
+            </li>
+        </ul>
 <h4><a id="upgrade_4_0_0" href="#upgrade_4_0_0">Upgrading to 4.0.0 from any version 0.8.x through 3.9.x</a></h4>
     <h5><a id="upgrade_400_notable" href="#upgrade_400_notable">Notable changes in 4.0.0</a></h5>
     <ul>


### PR DESCRIPTION
JIRA: KAFKA-10790

As we already know, the `callback` of `Producer#send` is executed by the `ioThread`. Due to this design, many application bugs have been caused by calling `Producer#flush` in callback，which leads to deadlocks. This PR aims to add protection against such scenarios.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
