### PR TITLE
KAFKA-7025: Some Android compatibility for kafka-client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -62,7 +62,7 @@ import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collections;
@@ -220,7 +220,6 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
         TransportLayer transportLayer = null;
         try {
             SocketChannel socketChannel = (SocketChannel) key.channel();
-            Socket socket = socketChannel.socket();
             transportLayer = buildTransportLayer(id, key, socketChannel, metadataRegistry);
             final TransportLayer finalTransportLayer = transportLayer;
             Supplier<Authenticator> authenticatorCreator;
@@ -234,10 +233,11 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                         metadataRegistry);
             } else {
                 LoginManager loginManager = loginManagers.get(clientSaslMechanism);
+                InetSocketAddress remoteAddress = (InetSocketAddress) socketChannel.getRemoteAddress();
                 authenticatorCreator = () -> buildClientAuthenticator(configs,
                         saslCallbackHandlers.get(clientSaslMechanism),
                         id,
-                        socket.getInetAddress().getHostName(),
+                        remoteAddress.getHostName(),
                         loginManager.serviceName(),
                         finalTransportLayer,
                         subjects.get(clientSaslMechanism));

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
@@ -108,13 +108,18 @@ public enum KerberosError {
         return retriable;
     }
 
+    private static Throwable findCause(Exception exception, Class<?> clazz) {
+        Throwable cause = exception.getCause();
+        while (cause != null && !clazz.isInstance(cause)) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
     public static KerberosError fromException(Exception exception) {
         if (KRB_EXCEPTION_CLASS == null || KRB_EXCEPTION_RETURN_CODE_METHOD == null)
             return null;
-        Throwable cause = exception.getCause();
-        while (cause != null && !KRB_EXCEPTION_CLASS.isInstance(cause)) {
-            cause = cause.getCause();
-        }
+        Throwable cause = findCause(exception, KRB_EXCEPTION_CLASS);
         if (cause == null)
             return null;
         else {
@@ -145,10 +150,7 @@ public enum KerberosError {
     public static boolean isRetriableClientGssException(Exception exception) {
         if (GSS_EXCEPTION_CLASS == null || GSS_EXCEPTION_GET_MAJOR_METHOD == null)
             return false;
-        Throwable cause = exception.getCause();
-        while (cause != null && !GSS_EXCEPTION_CLASS.isInstance(cause)) {
-            cause = cause.getCause();
-        }
+        Throwable cause = findCause(exception, GSS_EXCEPTION_CLASS);
         if (cause != null) {
             try {
                 Integer major = (Integer) GSS_EXCEPTION_GET_MAJOR_METHOD.invoke(cause);

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.security.kerberos;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.utils.Java;
 
@@ -53,39 +52,39 @@ public enum KerberosError {
     private static final int GSS_EXCEPTION_NO_CRED;
 
     static {
+        Class<?> krbExceptionClass = null;
+        Method krbExceptionReturnCodeMethod = null;
         try {
             // different IBM JDKs versions include different security implementations
             if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.KrbException")) {
-                KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.KrbException");
+                krbExceptionClass = Class.forName("com.ibm.security.krb5.KrbException");
             } else if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.internal.KrbException")) {
-                KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.internal.KrbException");
-            } else if (Java.isAndroid()) {
-                KRB_EXCEPTION_CLASS = null;
+                krbExceptionClass = Class.forName("com.ibm.security.krb5.internal.KrbException");
             } else {
-                KRB_EXCEPTION_CLASS = Class.forName("sun.security.krb5.KrbException");
+                krbExceptionClass = Class.forName("sun.security.krb5.KrbException");
             }
-            if (KRB_EXCEPTION_CLASS != null) {
-                KRB_EXCEPTION_RETURN_CODE_METHOD = KRB_EXCEPTION_CLASS.getMethod("returnCode");
-            } else {
-                KRB_EXCEPTION_RETURN_CODE_METHOD = null;
-            }
+            krbExceptionReturnCodeMethod = krbExceptionClass.getMethod("returnCode");
         } catch (Exception e) {
-            throw new KafkaException("Kerberos exceptions could not be initialized", e);
+            log.trace("Kerberos exceptions could not be initialized", e);
+            krbExceptionClass = null;
+            krbExceptionReturnCodeMethod = null;
         }
+        KRB_EXCEPTION_CLASS = krbExceptionClass;
+        KRB_EXCEPTION_RETURN_CODE_METHOD = krbExceptionReturnCodeMethod;
 
+        Class<?> gssExceptionClass = null;
+        Method gssExceptionGetMajorMethod = null;
+        int gssExceptionNoCred = -1;
         try {
-            if (Java.isAndroid()) {
-                GSS_EXCEPTION_CLASS = null;
-                GSS_EXCEPTION_GET_MAJOR_METHOD = null;
-                GSS_EXCEPTION_NO_CRED = -1;
-            } else {
-                GSS_EXCEPTION_CLASS = Class.forName("org.ietf.jgss.GSSException");
-                GSS_EXCEPTION_GET_MAJOR_METHOD = GSS_EXCEPTION_CLASS.getMethod("getMajor");
-                GSS_EXCEPTION_NO_CRED = GSS_EXCEPTION_CLASS.getField("NO_CRED").getInt(null);
-            }
+            gssExceptionClass = Class.forName("org.ietf.jgss.GSSException");
+            gssExceptionGetMajorMethod = gssExceptionClass.getMethod("getMajor");
+            gssExceptionNoCred = gssExceptionClass.getField("NO_CRED").getInt(null);
         } catch (Exception e) {
-            throw new KafkaException("GSS-API exceptions could not be initialized", e);
+            log.trace("GSS-API exceptions could not be initialized", e);
         }
+        GSS_EXCEPTION_CLASS = gssExceptionClass;
+        GSS_EXCEPTION_GET_MAJOR_METHOD = gssExceptionGetMajorMethod;
+        GSS_EXCEPTION_NO_CRED = gssExceptionNoCred;
     }
 
     private static boolean canLoad(String clazz) {
@@ -118,7 +117,7 @@ public enum KerberosError {
     }
 
     public static KerberosError fromException(Exception exception) {
-        if (KRB_EXCEPTION_CLASS == null)
+        if (KRB_EXCEPTION_CLASS == null || KRB_EXCEPTION_RETURN_CODE_METHOD == null)
             return null;
         Throwable cause = findCause(exception, KRB_EXCEPTION_CLASS);
         if (cause == null)
@@ -149,7 +148,7 @@ public enum KerberosError {
      * before the subsequent login.
      */
     public static boolean isRetriableClientGssException(Exception exception) {
-        if (GSS_EXCEPTION_CLASS == null)
+        if (GSS_EXCEPTION_CLASS == null || GSS_EXCEPTION_GET_MAJOR_METHOD == null)
             return false;
         Throwable cause = findCause(exception, GSS_EXCEPTION_CLASS);
         if (cause != null) {
@@ -157,7 +156,7 @@ public enum KerberosError {
                 Integer major = (Integer) GSS_EXCEPTION_GET_MAJOR_METHOD.invoke(cause);
                 return major == GSS_EXCEPTION_NO_CRED;
             } catch (Exception e) {
-                log.trace("GSS-API major code could not be determined from {}", exception, e);
+                log.trace("GSS major code could not be determined from {}", exception, e);
             }
         }
         return false;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Checksums.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Checksums.java
@@ -35,12 +35,12 @@ public final class Checksums {
     private static final MethodHandle BYTE_BUFFER_UPDATE;
 
     static {
-        MethodHandle byteBufferUpdate = null;
+        MethodHandle byteBufferUpdate;
         try {
             byteBufferUpdate = MethodHandles.publicLookup().findVirtual(Checksum.class, "update",
                     MethodType.methodType(void.class, ByteBuffer.class));
-        } catch (Throwable t) {
-            handleUpdateThrowable(t);
+        } catch (ReflectiveOperationException e) {
+            byteBufferUpdate = null;
         }
         BYTE_BUFFER_UPDATE = byteBufferUpdate;
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Crc32C.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Crc32C.java
@@ -26,7 +26,7 @@ import java.util.zip.Checksum;
 /**
  * A class that can be used to compute the CRC32C (Castagnoli) of a ByteBuffer or array of bytes.
  *
- * We use java.util.zip.CRC32C (introduced in Java 9).
+ * We use java.util.zip.CRC32C (introduced in Java 9) if it is available and fallback to PureJavaCrc32C, otherwise.
  * java.util.zip.CRC32C is significantly faster on reasonably modern CPUs as it uses the CRC32 instruction introduced
  * in SSE4.2.
  *
@@ -37,8 +37,13 @@ public final class Crc32C {
     private static final MethodHandle CRC32C_CONSTRUCTOR;
 
     static {
+        Class<?> cls;
         try {
-            Class<?> cls = Class.forName("java.util.zip.CRC32C");
+            cls = Class.forName("java.util.zip.CRC32C");
+        } catch (ReflectiveOperationException e) {
+            cls = PureJavaCrc32C.class;
+        }
+        try {
             CRC32C_CONSTRUCTOR = MethodHandles.publicLookup().findConstructor(cls, MethodType.methodType(void.class));
         } catch (ReflectiveOperationException e) {
             // Should never happen

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -27,8 +27,4 @@ public final class Java {
     public static boolean isIbmJdkSemeru() {
         return isIbmJdk() && System.getProperty("java.runtime.name", "").contains("Semeru");
     }
-
-    public static boolean isAndroid() {
-        return System.getProperty("java.vendor").contains("Android");
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -27,4 +27,8 @@ public final class Java {
     public static boolean isIbmJdkSemeru() {
         return isIbmJdk() && System.getProperty("java.runtime.name", "").contains("Semeru");
     }
+
+    public static boolean isAndroid() {
+        return System.getProperty("java.vendor").contains("Android");
+    }
 }


### PR DESCRIPTION
Fixes and workarounds for some of the peculiarities of the Android runtime. This is by no means complete Android support, but gets a little bit closer.
* fix for `Socket.getInetAddress()` returning null when `SocketChannel.configureBlocking(false)` has been called on it.
* A number of runtime-loaded classes and methods were allowed to fail if they couldn't be found:
  * `sun.security.krb5.KrbException`
  * `org.ietf.jgss.GSSException`
  * `java.util.zip.CRC32C`
  * `java.util.zip.Checksum.update()`

There didn't seem to be existing tests for these classes, so none were added. Most of these occur in class static blocks, and would be hard to mock anyway. Behavioral changes include: not throwing exceptions from said class static blocks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
