### PR TITLE
KAFKA-18100: Fix CoordinatorLoaderImplTest

### DIFF
--- a/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
@@ -312,7 +312,7 @@ class CoordinatorLoaderImplTest {
         .thenThrow(new RuntimeException("Error!"))
 
       val ex = assertFutureThrows(loader.load(tp, coordinator), classOf[RuntimeException])
-      assertEquals("Error!", ex.getMessage)
+      assertEquals(s"Deserializing record DefaultRecord(offset=0, timestamp=-1, key=2 bytes, value=2 bytes) from $tp failed due to: Error!", ex.getMessage)
     }
   }
 


### PR DESCRIPTION
JIRA: KAFKA-18100

This test fails due to the error flow change in #16898. To fix it, we should update the assertion message.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
