### PR TITLE
KAFKA-18084: Added write locks in SharePartition where locks were async calls were being made

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -47,6 +47,7 @@
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity" files="SharePartitionManagerTest"/>
+    <suppress checks="CyclomaticComplexity" files="SharePartition.java"/>
 
     <!-- server tests -->
     <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -47,7 +47,6 @@
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity" files="SharePartitionManagerTest"/>
-    <suppress checks="CyclomaticComplexity" files="SharePartition.java"/>
 
     <!-- server tests -->
     <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -380,6 +380,14 @@ public class SharePartition {
 
             // Update state to initializing to avoid any concurrent requests to be processed.
             partitionState = SharePartitionState.INITIALIZING;
+        } catch (Exception e) {
+            log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
+            completeInitializationWithException(future, e);
+            return future;
+        } finally {
+            lock.writeLock().unlock();
+        }
+        try {
             // Initialize the share partition by reading the state from the persister.
             persister.readState(new ReadShareGroupStateParameters.Builder()
                 .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
@@ -471,8 +479,6 @@ public class SharePartition {
         } catch (Exception e) {
             log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
             completeInitializationWithException(future, e);
-        } finally {
-            lock.writeLock().unlock();
         }
 
         return future;

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -389,79 +389,84 @@ public class SharePartition {
                     .build())
                 .build()
             ).whenComplete((result, exception) -> {
-                if (exception != null) {
-                    log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, exception);
-                    completeInitializationWithException(future, exception);
-                    return;
-                }
-
-                if (result == null || result.topicsData() == null || result.topicsData().size() != 1) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid state found: {}.",
-                        groupId, topicIdPartition, result);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                TopicData<PartitionAllData> state = result.topicsData().get(0);
-                if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid topic partition response: {}.",
-                        groupId, topicIdPartition, result);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                PartitionAllData partitionData = state.partitions().get(0);
-                if (partitionData.partition() != topicIdPartition.partition()) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid partition response: {}.",
-                        groupId, topicIdPartition, partitionData);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                if (partitionData.errorCode() != Errors.NONE.code()) {
-                    KafkaException ex = fetchPersisterError(partitionData.errorCode(), partitionData.errorMessage());
-                    log.error("Failed to initialize the share partition: {}-{}. Exception occurred: {}.",
-                        groupId, topicIdPartition, partitionData);
-                    completeInitializationWithException(future, ex);
-                    return;
-                }
-
+                lock.writeLock().lock();
                 try {
-                    startOffset = startOffsetDuringInitialization(partitionData.startOffset());
-                } catch (Exception e) {
-                    completeInitializationWithException(future, e);
-                    return;
-                }
-                stateEpoch = partitionData.stateEpoch();
+                    if (exception != null) {
+                        log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, exception);
+                        completeInitializationWithException(future, exception);
+                        return;
+                    }
 
-                List<PersisterStateBatch> stateBatches = partitionData.stateBatches();
-                for (PersisterStateBatch stateBatch : stateBatches) {
-                    if (stateBatch.firstOffset() < startOffset) {
-                        log.error("Invalid state batch found for the share partition: {}-{}. The base offset: {}"
-                                + " is less than the start offset: {}.", groupId, topicIdPartition,
-                            stateBatch.firstOffset(), startOffset);
+                    if (result == null || result.topicsData() == null || result.topicsData().size() != 1) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid state found: {}.",
+                            groupId, topicIdPartition, result);
                         completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
                         return;
                     }
-                    InFlightBatch inFlightBatch = new InFlightBatch(EMPTY_MEMBER_ID, stateBatch.firstOffset(),
-                        stateBatch.lastOffset(), RecordState.forId(stateBatch.deliveryState()), stateBatch.deliveryCount(), null);
-                    cachedState.put(stateBatch.firstOffset(), inFlightBatch);
+
+                    TopicData<PartitionAllData> state = result.topicsData().get(0);
+                    if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid topic partition response: {}.",
+                            groupId, topicIdPartition, result);
+                        completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                        return;
+                    }
+
+                    PartitionAllData partitionData = state.partitions().get(0);
+                    if (partitionData.partition() != topicIdPartition.partition()) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid partition response: {}.",
+                            groupId, topicIdPartition, partitionData);
+                        completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                        return;
+                    }
+
+                    if (partitionData.errorCode() != Errors.NONE.code()) {
+                        KafkaException ex = fetchPersisterError(partitionData.errorCode(), partitionData.errorMessage());
+                        log.error("Failed to initialize the share partition: {}-{}. Exception occurred: {}.",
+                            groupId, topicIdPartition, partitionData);
+                        completeInitializationWithException(future, ex);
+                        return;
+                    }
+
+                    try {
+                        startOffset = startOffsetDuringInitialization(partitionData.startOffset());
+                    } catch (Exception e) {
+                        completeInitializationWithException(future, e);
+                        return;
+                    }
+                    stateEpoch = partitionData.stateEpoch();
+
+                    List<PersisterStateBatch> stateBatches = partitionData.stateBatches();
+                    for (PersisterStateBatch stateBatch : stateBatches) {
+                        if (stateBatch.firstOffset() < startOffset) {
+                            log.error("Invalid state batch found for the share partition: {}-{}. The base offset: {}"
+                                    + " is less than the start offset: {}.", groupId, topicIdPartition,
+                                stateBatch.firstOffset(), startOffset);
+                            completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                            return;
+                        }
+                        InFlightBatch inFlightBatch = new InFlightBatch(EMPTY_MEMBER_ID, stateBatch.firstOffset(),
+                            stateBatch.lastOffset(), RecordState.forId(stateBatch.deliveryState()), stateBatch.deliveryCount(), null);
+                        cachedState.put(stateBatch.firstOffset(), inFlightBatch);
+                    }
+                    // Update the endOffset of the partition.
+                    if (!cachedState.isEmpty()) {
+                        // If the cachedState is not empty, findNextFetchOffset flag is set to true so that any AVAILABLE records
+                        // in the cached state are not missed
+                        findNextFetchOffset.set(true);
+                        endOffset = cachedState.lastEntry().getValue().lastOffset();
+                        // In case the persister read state RPC result contains no AVAILABLE records, we can update cached state
+                        // and start/end offsets.
+                        maybeUpdateCachedStateAndOffsets();
+                    } else {
+                        endOffset = startOffset;
+                    }
+                    // Set the partition state to Active and complete the future.
+                    partitionState = SharePartitionState.ACTIVE;
+                    future.complete(null);
+                } finally {
+                    lock.writeLock().unlock();
                 }
-                // Update the endOffset of the partition.
-                if (!cachedState.isEmpty()) {
-                    // If the cachedState is not empty, findNextFetchOffset flag is set to true so that any AVAILABLE records
-                    // in the cached state are not missed
-                    findNextFetchOffset.set(true);
-                    endOffset = cachedState.lastEntry().getValue().lastOffset();
-                    // In case the persister read state RPC result contains no AVAILABLE records, we can update cached state
-                    // and start/end offsets.
-                    maybeUpdateCachedStateAndOffsets();
-                } else {
-                    endOffset = startOffset;
-                }
-                // Set the partition state to Active and complete the future.
-                partitionState = SharePartitionState.ACTIVE;
-                future.complete(null);
             });
         } catch (Exception e) {
             log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
@@ -1645,35 +1650,35 @@ public class SharePartition {
                 future.complete(null);
                 return;
             }
-
-            writeShareGroupState(stateBatches).whenComplete((result, exception) -> {
-                lock.writeLock().lock();
-                try {
-                    if (exception != null) {
-                        log.error("Failed to write state to persister for the share partition: {}-{}",
-                            groupId, topicIdPartition, exception);
-                        updatedStates.forEach(state -> state.completeStateTransition(false));
-                        future.completeExceptionally(exception);
-                        return;
-                    }
-
-                    log.trace("State change request successful for share partition: {}-{}",
-                        groupId, topicIdPartition);
-                    updatedStates.forEach(state -> {
-                        state.completeStateTransition(true);
-                        // Cancel the acquisition lock timeout task for the state since it is acknowledged/released successfully.
-                        state.cancelAndClearAcquisitionLockTimeoutTask();
-                    });
-                    // Update the cached state and start and end offsets after acknowledging/releasing the acquired records.
-                    maybeUpdateCachedStateAndOffsets();
-                    future.complete(null);
-                } finally {
-                    lock.writeLock().unlock();
-                }
-            });
         } finally {
             lock.writeLock().unlock();
         }
+
+        writeShareGroupState(stateBatches).whenComplete((result, exception) -> {
+            lock.writeLock().lock();
+            try {
+                if (exception != null) {
+                    log.error("Failed to write state to persister for the share partition: {}-{}",
+                        groupId, topicIdPartition, exception);
+                    updatedStates.forEach(state -> state.completeStateTransition(false));
+                    future.completeExceptionally(exception);
+                    return;
+                }
+
+                log.trace("State change request successful for share partition: {}-{}",
+                    groupId, topicIdPartition);
+                updatedStates.forEach(state -> {
+                    state.completeStateTransition(true);
+                    // Cancel the acquisition lock timeout task for the state since it is acknowledged/released successfully.
+                    state.cancelAndClearAcquisitionLockTimeoutTask();
+                });
+                // Update the cached state and start and end offsets after acknowledging/releasing the acquired records.
+                maybeUpdateCachedStateAndOffsets();
+                future.complete(null);
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
     }
 
     private void maybeUpdateCachedStateAndOffsets() {

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -389,79 +389,84 @@ public class SharePartition {
                     .build())
                 .build()
             ).whenComplete((result, exception) -> {
-                if (exception != null) {
-                    log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, exception);
-                    completeInitializationWithException(future, exception);
-                    return;
-                }
-
-                if (result == null || result.topicsData() == null || result.topicsData().size() != 1) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid state found: {}.",
-                        groupId, topicIdPartition, result);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                TopicData<PartitionAllData> state = result.topicsData().get(0);
-                if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid topic partition response: {}.",
-                        groupId, topicIdPartition, result);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                PartitionAllData partitionData = state.partitions().get(0);
-                if (partitionData.partition() != topicIdPartition.partition()) {
-                    log.error("Failed to initialize the share partition: {}-{}. Invalid partition response: {}.",
-                        groupId, topicIdPartition, partitionData);
-                    completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
-                    return;
-                }
-
-                if (partitionData.errorCode() != Errors.NONE.code()) {
-                    KafkaException ex = fetchPersisterError(partitionData.errorCode(), partitionData.errorMessage());
-                    log.error("Failed to initialize the share partition: {}-{}. Exception occurred: {}.",
-                        groupId, topicIdPartition, partitionData);
-                    completeInitializationWithException(future, ex);
-                    return;
-                }
-
+                lock.writeLock().lock();
                 try {
-                    startOffset = startOffsetDuringInitialization(partitionData.startOffset());
-                } catch (Exception e) {
-                    completeInitializationWithException(future, e);
-                    return;
-                }
-                stateEpoch = partitionData.stateEpoch();
+                    if (exception != null) {
+                        log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, exception);
+                        completeInitializationWithException(future, exception);
+                        return;
+                    }
 
-                List<PersisterStateBatch> stateBatches = partitionData.stateBatches();
-                for (PersisterStateBatch stateBatch : stateBatches) {
-                    if (stateBatch.firstOffset() < startOffset) {
-                        log.error("Invalid state batch found for the share partition: {}-{}. The base offset: {}"
-                                + " is less than the start offset: {}.", groupId, topicIdPartition,
-                            stateBatch.firstOffset(), startOffset);
+                    if (result == null || result.topicsData() == null || result.topicsData().size() != 1) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid state found: {}.",
+                            groupId, topicIdPartition, result);
                         completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
                         return;
                     }
-                    InFlightBatch inFlightBatch = new InFlightBatch(EMPTY_MEMBER_ID, stateBatch.firstOffset(),
-                        stateBatch.lastOffset(), RecordState.forId(stateBatch.deliveryState()), stateBatch.deliveryCount(), null);
-                    cachedState.put(stateBatch.firstOffset(), inFlightBatch);
+
+                    TopicData<PartitionAllData> state = result.topicsData().get(0);
+                    if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid topic partition response: {}.",
+                            groupId, topicIdPartition, result);
+                        completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                        return;
+                    }
+
+                    PartitionAllData partitionData = state.partitions().get(0);
+                    if (partitionData.partition() != topicIdPartition.partition()) {
+                        log.error("Failed to initialize the share partition: {}-{}. Invalid partition response: {}.",
+                            groupId, topicIdPartition, partitionData);
+                        completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                        return;
+                    }
+
+                    if (partitionData.errorCode() != Errors.NONE.code()) {
+                        KafkaException ex = fetchPersisterError(partitionData.errorCode(), partitionData.errorMessage());
+                        log.error("Failed to initialize the share partition: {}-{}. Exception occurred: {}.",
+                            groupId, topicIdPartition, partitionData);
+                        completeInitializationWithException(future, ex);
+                        return;
+                    }
+
+                    try {
+                        startOffset = startOffsetDuringInitialization(partitionData.startOffset());
+                    } catch (Exception e) {
+                        completeInitializationWithException(future, e);
+                        return;
+                    }
+                    stateEpoch = partitionData.stateEpoch();
+
+                    List<PersisterStateBatch> stateBatches = partitionData.stateBatches();
+                    for (PersisterStateBatch stateBatch : stateBatches) {
+                        if (stateBatch.firstOffset() < startOffset) {
+                            log.error("Invalid state batch found for the share partition: {}-{}. The base offset: {}"
+                                    + " is less than the start offset: {}.", groupId, topicIdPartition,
+                                stateBatch.firstOffset(), startOffset);
+                            completeInitializationWithException(future, new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition)));
+                            return;
+                        }
+                        InFlightBatch inFlightBatch = new InFlightBatch(EMPTY_MEMBER_ID, stateBatch.firstOffset(),
+                            stateBatch.lastOffset(), RecordState.forId(stateBatch.deliveryState()), stateBatch.deliveryCount(), null);
+                        cachedState.put(stateBatch.firstOffset(), inFlightBatch);
+                    }
+                    // Update the endOffset of the partition.
+                    if (!cachedState.isEmpty()) {
+                        // If the cachedState is not empty, findNextFetchOffset flag is set to true so that any AVAILABLE records
+                        // in the cached state are not missed
+                        findNextFetchOffset.set(true);
+                        endOffset = cachedState.lastEntry().getValue().lastOffset();
+                        // In case the persister read state RPC result contains no AVAILABLE records, we can update cached state
+                        // and start/end offsets.
+                        maybeUpdateCachedStateAndOffsets();
+                    } else {
+                        endOffset = startOffset;
+                    }
+                    // Set the partition state to Active and complete the future.
+                    partitionState = SharePartitionState.ACTIVE;
+                    future.complete(null);
+                } finally {
+                    lock.writeLock().unlock();
                 }
-                // Update the endOffset of the partition.
-                if (!cachedState.isEmpty()) {
-                    // If the cachedState is not empty, findNextFetchOffset flag is set to true so that any AVAILABLE records
-                    // in the cached state are not missed
-                    findNextFetchOffset.set(true);
-                    endOffset = cachedState.lastEntry().getValue().lastOffset();
-                    // In case the persister read state RPC result contains no AVAILABLE records, we can update cached state
-                    // and start/end offsets.
-                    maybeUpdateCachedStateAndOffsets();
-                } else {
-                    endOffset = startOffset;
-                }
-                // Set the partition state to Active and complete the future.
-                partitionState = SharePartitionState.ACTIVE;
-                future.complete(null);
             });
         } catch (Exception e) {
             log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
@@ -1647,24 +1652,29 @@ public class SharePartition {
             }
 
             writeShareGroupState(stateBatches).whenComplete((result, exception) -> {
-                if (exception != null) {
-                    log.error("Failed to write state to persister for the share partition: {}-{}",
-                        groupId, topicIdPartition, exception);
-                    updatedStates.forEach(state -> state.completeStateTransition(false));
-                    future.completeExceptionally(exception);
-                    return;
-                }
+                lock.writeLock().lock();
+                try {
+                    if (exception != null) {
+                        log.error("Failed to write state to persister for the share partition: {}-{}",
+                            groupId, topicIdPartition, exception);
+                        updatedStates.forEach(state -> state.completeStateTransition(false));
+                        future.completeExceptionally(exception);
+                        return;
+                    }
 
-                log.trace("State change request successful for share partition: {}-{}",
-                    groupId, topicIdPartition);
-                updatedStates.forEach(state -> {
-                    state.completeStateTransition(true);
-                    // Cancel the acquisition lock timeout task for the state since it is acknowledged/released successfully.
-                    state.cancelAndClearAcquisitionLockTimeoutTask();
-                });
-                // Update the cached state and start and end offsets after acknowledging/releasing the acquired records.
-                maybeUpdateCachedStateAndOffsets();
-                future.complete(null);
+                    log.trace("State change request successful for share partition: {}-{}",
+                        groupId, topicIdPartition);
+                    updatedStates.forEach(state -> {
+                        state.completeStateTransition(true);
+                        // Cancel the acquisition lock timeout task for the state since it is acknowledged/released successfully.
+                        state.cancelAndClearAcquisitionLockTimeoutTask();
+                    });
+                    // Update the cached state and start and end offsets after acknowledging/releasing the acquired records.
+                    maybeUpdateCachedStateAndOffsets();
+                    future.complete(null);
+                } finally {
+                    lock.writeLock().unlock();
+                }
             });
         } finally {
             lock.writeLock().unlock();

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -490,11 +490,14 @@ public class SharePartitionTest {
             if (!executorService.awaitTermination(30, TimeUnit.MILLISECONDS))
                 executorService.shutdown();
         }
+        int futuresCompleted = 0;
 
         for (CompletableFuture<Void> result : results) {
             assertTrue(result.isDone());
-            assertFalse(result.isCompletedExceptionally());
+            if (!result.isCompletedExceptionally())
+                futuresCompleted++;
         }
+        assertTrue(futuresCompleted > 0 && futuresCompleted < 10);
 
         assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
         // Verify the persister read state is called only once.

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -490,14 +490,8 @@ public class SharePartitionTest {
             if (!executorService.awaitTermination(30, TimeUnit.MILLISECONDS))
                 executorService.shutdown();
         }
-        int futuresCompleted = 0;
-
-        for (CompletableFuture<Void> result : results) {
-            assertTrue(result.isDone());
-            if (!result.isCompletedExceptionally())
-                futuresCompleted++;
-        }
-        assertTrue(futuresCompleted > 0 && futuresCompleted < 10);
+        assertTrue(results.stream().allMatch(CompletableFuture::isDone));
+        assertFalse(results.stream().allMatch(CompletableFuture::isCompletedExceptionally));
 
         assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
         // Verify the persister read state is called only once.

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -4456,6 +4456,17 @@ public class SharePartitionTest {
         CompletableFuture<Void> writeResult = sharePartition.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(writeResult, IllegalStateException.class);
+
+        persister = Mockito.mock(Persister.class);
+        // Throw exception for write state.
+        mockPersisterReadStateMethod(persister);
+        sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+
+        Mockito.when(persister.writeState(Mockito.any())).thenThrow(new RuntimeException("Write exception"));
+        writeResult = sharePartition.writeShareGroupState(anyList());
+        assertTrue(writeResult.isCompletedExceptionally());
+        assertFutureThrows(writeResult, IllegalStateException.class);
+
     }
 
     @Test

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -768,24 +768,20 @@ public class SharePartitionTest {
         Persister persister = Mockito.mock(Persister.class);
         // Complete the future exceptionally for read state.
         Mockito.when(persister.readState(Mockito.any())).thenReturn(FutureUtils.failedFuture(new RuntimeException("Read exception")));
-        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+        SharePartition sharePartition1 = SharePartitionBuilder.builder().withPersister(persister).build();
 
-        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        CompletableFuture<Void> result = sharePartition1.maybeInitialize();
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
         assertFutureThrows(result, RuntimeException.class);
-        assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
+        assertEquals(SharePartitionState.FAILED, sharePartition1.partitionState());
 
         persister = Mockito.mock(Persister.class);
         // Throw exception for read state.
         Mockito.when(persister.readState(Mockito.any())).thenThrow(new RuntimeException("Read exception"));
-        sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+        SharePartition sharePartition2 = SharePartitionBuilder.builder().withPersister(persister).build();
 
-        result = sharePartition.maybeInitialize();
-        assertTrue(result.isDone());
-        assertTrue(result.isCompletedExceptionally());
-        assertFutureThrows(result, RuntimeException.class);
-        assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
+        assertThrows(RuntimeException.class, sharePartition2::maybeInitialize);
     }
 
     @Test
@@ -4450,23 +4446,20 @@ public class SharePartitionTest {
     public void testWriteShareGroupStateWithWriteException() {
         Persister persister = Mockito.mock(Persister.class);
         mockPersisterReadStateMethod(persister);
-        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+        SharePartition sharePartition1 = SharePartitionBuilder.builder().withPersister(persister).build();
 
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(FutureUtils.failedFuture(new RuntimeException("Write exception")));
-        CompletableFuture<Void> writeResult = sharePartition.writeShareGroupState(anyList());
+        CompletableFuture<Void> writeResult = sharePartition1.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(writeResult, IllegalStateException.class);
 
         persister = Mockito.mock(Persister.class);
         // Throw exception for write state.
         mockPersisterReadStateMethod(persister);
-        sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+        SharePartition sharePartition2 = SharePartitionBuilder.builder().withPersister(persister).build();
 
         Mockito.when(persister.writeState(Mockito.any())).thenThrow(new RuntimeException("Write exception"));
-        writeResult = sharePartition.writeShareGroupState(anyList());
-        assertTrue(writeResult.isCompletedExceptionally());
-        assertFutureThrows(writeResult, IllegalStateException.class);
-
+        assertThrows(RuntimeException.class, () -> sharePartition2.writeShareGroupState(anyList()));
     }
 
     @Test

--- a/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -79,7 +79,12 @@ public class DefaultStatePersister implements Persister {
      * @return A completable future of WriteShareGroupStateResult
      */
     public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) throws IllegalArgumentException {
-        validate(request);
+        try {
+            validate(request);
+        } catch (Exception e) {
+            log.error("Unable to validate write state request", e);
+            return CompletableFuture.failedFuture(e);
+        }
         GroupTopicPartitionData<PartitionStateBatchData> gtp = request.groupTopicPartitionData();
         String groupId = gtp.groupId();
 
@@ -170,7 +175,12 @@ public class DefaultStatePersister implements Persister {
      * @return A completable future of ReadShareGroupStateResult
      */
     public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) throws IllegalArgumentException {
-        validate(request);
+        try {
+            validate(request);
+        } catch (Exception e) {
+            log.error("Unable to validate read state request", e);
+            return CompletableFuture.failedFuture(e);
+        }
         GroupTopicPartitionData<PartitionIdLeaderEpochData> gtp = request.groupTopicPartitionData();
         String groupId = gtp.groupId();
         Map<Uuid, Map<Integer, CompletableFuture<ReadShareGroupStateResponse>>> futureMap = new HashMap<>();

--- a/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/share/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -78,7 +78,7 @@ public class DefaultStatePersister implements Persister {
      * @param request WriteShareGroupStateParameters
      * @return A completable future of WriteShareGroupStateResult
      */
-    public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) throws IllegalArgumentException {
+    public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) {
         try {
             validate(request);
         } catch (Exception e) {
@@ -174,7 +174,7 @@ public class DefaultStatePersister implements Persister {
      * @param request ReadShareGroupStateParameters
      * @return A completable future of ReadShareGroupStateResult
      */
-    public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) throws IllegalArgumentException {
+    public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) {
         try {
             validate(request);
         } catch (Exception e) {

--- a/share/src/main/java/org/apache/kafka/server/share/persister/Persister.java
+++ b/share/src/main/java/org/apache/kafka/server/share/persister/Persister.java
@@ -40,7 +40,7 @@ public interface Persister {
      * @param request Request parameters
      * @return A {@link CompletableFuture} that completes with the result.
      */
-    CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) throws IllegalArgumentException;
+    CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request);
 
     /**
      * Write share-partition state.
@@ -48,7 +48,7 @@ public interface Persister {
      * @param request Request parameters
      * @return A {@link CompletableFuture} that completes with the result.
      */
-    CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) throws IllegalArgumentException;
+    CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request);
 
     /**
      * Delete share-partition state.

--- a/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/share/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -50,8 +50,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.kafka.test.TestUtils.assertFutureThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -132,68 +132,71 @@ class DefaultStatePersisterTest {
         int incorrectPartition = -1;
 
         // Request Parameters are null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(null);
-        });
+        DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        CompletableFuture<WriteShareGroupStateResult> result = defaultStatePersister.writeState(null);
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // groupTopicPartitionData is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder().setGroupTopicPartitionData(null).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder().setGroupTopicPartitionData(null).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // groupId is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
-                    .setGroupId(null).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                .setGroupId(null).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // topicsData is empty
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.emptyList()).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.emptyList()).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // topicId is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(null,
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(null,
                         Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
-                            partition, 1, 0, 0, null))))
-                    ).build()).build());
-        });
+                            partition, 1, 0, 0, null))))).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // partitionData is empty
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
-                        Collections.emptyList()))
-                    ).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(topicId, Collections.emptyList()))).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // partition value is incorrect
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.writeState(new WriteShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
                         Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
-                            incorrectPartition, 1, 0, 0, null))))
-                    ).build()).build());
-        });
+                            incorrectPartition, 1, 0, 0, null))))).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
     }
 
     @Test
@@ -205,68 +208,70 @@ class DefaultStatePersisterTest {
         int incorrectPartition = -1;
 
         // Request Parameters are null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(null);
-        });
+        DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        CompletableFuture<ReadShareGroupStateResult> result = defaultStatePersister.readState(null);
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // groupTopicPartitionData is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder().setGroupTopicPartitionData(null).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder().setGroupTopicPartitionData(null).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // groupId is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
-                    .setGroupId(null).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
+                .setGroupId(null).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // topicsData is empty
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.emptyList()).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.emptyList()).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // topicId is null
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(null,
-                        Collections.singletonList(PartitionFactory.newPartitionIdLeaderEpochData(
-                            partition, 1))))
-                    ).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(null,
+                        Collections.singletonList(PartitionFactory.newPartitionIdLeaderEpochData(partition, 1))))
+                ).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // partitionData is empty
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
-                        Collections.emptyList()))
-                    ).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(topicId, Collections.emptyList()))).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
 
         // partition value is incorrect
-        assertThrows(IllegalArgumentException.class, () -> {
-            DefaultStatePersister defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
-            defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
-                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
-                    .setGroupId(groupId)
-                    .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
-                        Collections.singletonList(PartitionFactory.newPartitionIdLeaderEpochData(
-                            incorrectPartition, 1))))
-                    ).build()).build());
-        });
+        defaultStatePersister = DefaultStatePersisterBuilder.builder().build();
+        result = defaultStatePersister.readState(new ReadShareGroupStateParameters.Builder()
+            .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
+                .setGroupId(groupId)
+                .setTopicsData(Collections.singletonList(new TopicData<>(topicId,
+                        Collections.singletonList(PartitionFactory.newPartitionIdLeaderEpochData(incorrectPartition, 1))))).build()).build());
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertFutureThrows(result, IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
### About
Added write locks in `SharePartition` where locks were async calls were being made and no locks were used. This could potentially lead to race condition when updating the state of offsets/batches in `SharePartition`.

### Testing
The code is tested with the help of already present unit and integration tests.