### PR TITLE
KAFKA-17750: Extend kafka-consumer-groups command line tool to support new consumer group (part 1)

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -18,7 +18,9 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ConsumerGroupDescribeRequest",
-  "validVersions": "0",
+  // Version 1 adds MemberType field to ConsumerGroupDescribeResponse (KIP-1099).
+  // For ConsumerGroupDescribeRequest, version 1 is same as version 0.
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -17,7 +17,8 @@
   "apiKey": 69,
   "type": "response",
   "name": "ConsumerGroupDescribeResponse",
-  "validVersions": "0",
+  // Version 1 adds MemberType field (KIP-1099).
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
@@ -69,7 +70,9 @@
             { "name": "Assignment", "type": "Assignment", "versions": "0+",
               "about": "The current assignment." },
             { "name": "TargetAssignment", "type": "Assignment", "versions": "0+",
-              "about": "The target assignment." }
+              "about": "The target assignment." },
+            { "name": "MemberType", "type": "int8", "versions": "1+", "default": "-1", "ignorable": true,
+              "about": "-1 for unknown. 0 for classic member. +1 for consumer member." }
           ]},
         { "name": "AuthorizedOperations", "type": "int32", "versions": "0+", "default": "-2147483648",
           "about": "32-bit bitfield to represent authorized operations for this group." }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -408,7 +408,8 @@ public class ConsumerGroupMember extends ModernGroupMember {
             .setInstanceId(instanceId)
             .setRackId(rackId)
             .setSubscribedTopicNames(subscribedTopicNames == null ? null : new ArrayList<>(subscribedTopicNames))
-            .setSubscribedTopicRegex(subscribedTopicRegex);
+            .setSubscribedTopicRegex(subscribedTopicRegex)
+            .setMemberType(useClassicProtocol() ? (byte) 0 : (byte) 1);
     }
 
     private static List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitionsFromMap(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1278,9 +1278,11 @@ public class ConsumerGroupTest {
                 new ConsumerGroupDescribeResponseData.Member()
                     .setMemberId("member1")
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
-                    .setSubscribedTopicRegex(""),
+                    .setSubscribedTopicRegex("")
+                    .setMemberType((byte) 1),
                 new ConsumerGroupDescribeResponseData.Member().setMemberId("member2")
                     .setSubscribedTopicRegex("")
+                    .setMemberType((byte) 1)
             ));
         ConsumerGroupDescribeResponseData.DescribedGroup actual = group.asDescribedGroup(1, "",
             new MetadataImageBuilder().build().topics());


### PR DESCRIPTION
* Bump `validVersions` of `ConsumerGroupDescribeRequest.json` and `ConsumerGroupDescribeResponse.json` to `"0-1"`.
* Add `MemberType` field to `ConsumerGroupDescribeResponse.json`. Default value is -1 (unknown). 0 is for classic member and 1 is for consumer member.
* When `ConsumerGroupMember#useClassicProtocol` is true, return `MemberType` field as `0`. Otherwise, return `1`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
