### PR TITLE
KAFKA-17593; [9/N] Mark ConsumerGroupHeartbeat API v1 as stable

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json
@@ -21,7 +21,6 @@
   // Version 1 adds SubscribedTopicRegex (KIP-848), and requires the consumer to generate their own Member ID (KIP-1082)
   "validVersions": "0-1",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The group identifier." },

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -50,8 +50,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
   )
   def testConsumerGroupHeartbeatIsInaccessibleWhenDisabledByStaticConfig(): Unit = {
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequest.Builder(
-      new ConsumerGroupHeartbeatRequestData(),
-      true
+      new ConsumerGroupHeartbeatRequestData()
     ).build()
 
     val consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
@@ -66,8 +65,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
   )
   def testConsumerGroupHeartbeatIsInaccessibleWhenFeatureFlagNotEnabled(): Unit = {
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequest.Builder(
-      new ConsumerGroupHeartbeatRequestData(),
-      true
+      new ConsumerGroupHeartbeatRequestData()
     ).build()
 
     val consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
@@ -97,8 +95,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -126,8 +123,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ConsumerGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch),
-        true
+          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch)
       ).build()
 
       // This is the expected assignment.
@@ -153,8 +149,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ConsumerGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(-1),
-        true
+          .setMemberEpoch(-1)
       ).build()
 
       consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
@@ -188,8 +183,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicRegex("foo*")
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -217,8 +211,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ConsumerGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch),
-        true
+          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch)
       ).build()
 
       // This is the expected assignment.
@@ -265,8 +258,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicRegex("[")
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -307,8 +299,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -337,8 +328,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setGroupId("grp")
           .setInstanceId(instanceId)
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch),
-        true
+          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch)
       ).build()
 
       // This is the expected assignment.
@@ -368,8 +358,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setGroupId("grp")
           .setInstanceId(instanceId)
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(-2),
-        true
+          .setMemberEpoch(-2)
       ).build()
 
       consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
@@ -386,8 +375,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
@@ -432,8 +420,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -462,8 +449,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setGroupId("grp")
           .setInstanceId(instanceId)
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch),
-        true
+          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch)
       ).build()
 
       // This is the expected assignment.
@@ -493,8 +479,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Validating that trying to join with an in-use instanceId would throw an UnreleasedInstanceIdException.
@@ -548,8 +533,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       // Send the request until receiving a successful response. There is a delay
@@ -579,8 +563,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setGroupId(consumerGroupId)
           .setInstanceId(instanceId)
           .setMemberId(consumerGroupHeartbeatResponse.data.memberId)
-          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch),
-        true
+          .setMemberEpoch(consumerGroupHeartbeatResponse.data.memberEpoch)
       ).build()
 
       // Verify the response. The heartbeat interval was updated.
@@ -613,8 +596,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setMemberEpoch(0)
           .setRebalanceTimeoutMs(5 * 60 * 1000)
           .setSubscribedTopicNames(List("foo").asJava)
-          .setTopicPartitions(List.empty.asJava),
-        true
+          .setTopicPartitions(List.empty.asJava)
       ).build()
 
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
@@ -645,8 +627,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         .setMemberEpoch(0)
         .setRebalanceTimeoutMs(5 * 60 * 1000)
         .setSubscribedTopicNames(List("foo").asJava)
-        .setTopicPartitions(List.empty.asJava),
-      true
+        .setTopicPartitions(List.empty.asJava)
     ).build(0)
 
     var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -606,8 +606,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
         .setRebalanceTimeoutMs(rebalanceTimeoutMs)
         .setSubscribedTopicNames(subscribedTopicNames.asJava)
         .setServerAssignor(serverAssignor)
-        .setTopicPartitions(topicPartitions.asJava),
-      true
+        .setTopicPartitions(topicPartitions.asJava)
     ).build(version)
 
     // Send the request until receiving a successful response. There is a delay

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -11150,7 +11150,7 @@ class KafkaApisTest extends Logging {
   def testConsumerGroupHeartbeatReturnsUnsupportedVersion(): Unit = {
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequestData().setGroupId("group")
 
-    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest, true).build())
+    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest).build())
     metadataCache = MetadataCache.kRaftMetadataCache(brokerId, () => KRaftVersion.KRAFT_VERSION_1)
     kafkaApis = createKafkaApis(raftSupport = true)
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
@@ -11167,7 +11167,7 @@ class KafkaApisTest extends Logging {
 
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequestData().setGroupId("group")
 
-    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest, true).build())
+    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest).build())
 
     val future = new CompletableFuture[ConsumerGroupHeartbeatResponseData]()
     when(groupCoordinator.consumerGroupHeartbeat(
@@ -11194,7 +11194,7 @@ class KafkaApisTest extends Logging {
 
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequestData().setGroupId("group")
 
-    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest, true).build())
+    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest).build())
 
     val future = new CompletableFuture[ConsumerGroupHeartbeatResponseData]()
     when(groupCoordinator.consumerGroupHeartbeat(
@@ -11218,7 +11218,7 @@ class KafkaApisTest extends Logging {
 
     val consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequestData().setGroupId("group")
 
-    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest, true).build())
+    val requestChannelRequest = buildRequest(new ConsumerGroupHeartbeatRequest.Builder(consumerGroupHeartbeatRequest).build())
 
     val authorizer: Authorizer = mock(classOf[Authorizer])
     when(authorizer.authorize(any[RequestContext], any[util.List[Action]]))

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -683,10 +683,10 @@ class RequestQuotaTest extends BaseRequestTest {
           new AllocateProducerIdsRequest.Builder(new AllocateProducerIdsRequestData())
 
         case ApiKeys.CONSUMER_GROUP_HEARTBEAT =>
-          new ConsumerGroupHeartbeatRequest.Builder(new ConsumerGroupHeartbeatRequestData(), true)
+          new ConsumerGroupHeartbeatRequest.Builder(new ConsumerGroupHeartbeatRequestData())
 
         case ApiKeys.CONSUMER_GROUP_DESCRIBE =>
-          new ConsumerGroupDescribeRequest.Builder(new ConsumerGroupDescribeRequestData(), true)
+          new ConsumerGroupDescribeRequest.Builder(new ConsumerGroupDescribeRequestData())
 
         case ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS =>
           new GetTelemetrySubscriptionsRequest.Builder(new GetTelemetrySubscriptionsRequestData())


### PR DESCRIPTION
This patch marks the ConsumerGroupHeartbeat API v1 as stable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
