### PR TITLE
MINOR: KStreamRepartitionIntegrationTest  bug 

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -169,9 +169,12 @@ public class KStreamRepartitionIntegrationTest {
 
         final Properties streamsConfiguration = createStreamsConfig(topologyOptimization);
         try (final KafkaStreams ks = new KafkaStreams(builder.build(streamsConfiguration), streamsConfiguration)) {
-                  ks.setUncaughtExceptionHandler(exception -> { expectedThrowable.set(exception); return SHUTDOWN_CLIENT; });
-                  ks.start();
-                  TestUtils.waitForCondition(() -> ks.state() == ERROR, 30_000, "Kafka Streams never went into error state");
+            ks.setUncaughtExceptionHandler(exception -> {
+                expectedThrowable.set(exception);
+                return SHUTDOWN_CLIENT;
+            });
+            ks.start();
+            TestUtils.waitForCondition(() -> ks.state() == ERROR, 30_000, "Kafka Streams never went into error state");
             final String expectedMsg = String.format("Number of partitions [%s] of repartition topic [%s] " +
                             "doesn't match number of partitions [%s] of the source topic.",
                     inputTopicRepartitionedNumOfPartitions,

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -42,6 +41,7 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.test.TestUtils;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;


### PR DESCRIPTION
The `KStreamRepartitionIntegrationTest.shouldThrowAnExceptionWhenNumberOfPartitionsOfRepartitionOperationDoNotMatchSourceTopicWhenJoining` test was taking two minutes due not reaching an expected condition.  By updating to have the `StreamsUncaughtExceptionHandler` return a response of `SHUTDOWN_CLIENT` the expected `ERROR` state is now reached.   The root cause was using the `Thread.UncaughtExceptionHandler` to handle the exception.

Without this fix, the test takes 2 minutes to run, and now it's 1 second.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
