### PR TITLE
KAFKA-18084: Added usage for rollback state while SharePartition acquires records

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2337,7 +2337,7 @@ public class SharePartition {
 
         void updateAcquisitionLockTimeoutTask(AcquisitionLockTimerTask acquisitionLockTimeoutTask) throws IllegalArgumentException {
             if (this.acquisitionLockTimeoutTask != null) {
-                throw new IllegalArgumentException("The acquisition lock timeout task is being overridden");
+                throw new IllegalArgumentException("An already existing acquisition lock timeout task: " + this.acquisitionLockTimeoutTask + " is being overridden for the offset");
             }
             this.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
         }

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -1226,9 +1226,8 @@ public class SharePartition {
                 }
 
                 if (offsetState.getValue().state != RecordState.AVAILABLE || offsetState.getValue().rollbackState() != null) {
-                    log.trace("The offset is not available skipping, offset: {} batch: {}"
-                            + " for the share partition: {}-{}", offsetState.getKey(), inFlightBatch,
-                        groupId, topicIdPartition);
+                    log.trace("The offset {} is not available in share partition: {}-{}, skipping: {}",
+                        offsetState.getKey(), groupId, topicIdPartition, inFlightBatch);
                     continue;
                 }
 

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2188,12 +2188,16 @@ public class SharePartition {
             return lastOffset;
         }
 
-        // Visible for testing.
-        RecordState batchState() {
+        private InFlightState inFlightState() {
             if (batchState == null) {
                 throw new IllegalStateException("The batch state is not available as the offset state is maintained");
             }
-            return batchState.state;
+            return batchState;
+        }
+
+        // Visible for testing.
+        RecordState batchState() {
+            return inFlightState().state;
         }
 
         // Visible for testing.
@@ -2214,17 +2218,11 @@ public class SharePartition {
 
         // Visible for testing.
         AcquisitionLockTimerTask batchAcquisitionLockTimeoutTask() {
-            if (batchState == null) {
-                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
-            }
-            return batchState.acquisitionLockTimeoutTask;
+            return inFlightState().acquisitionLockTimeoutTask;
         }
 
         private RecordState batchRollbackState() {
-            if (batchState == null) {
-                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
-            }
-            return batchState.rollbackState();
+            return inFlightState().rollbackState();
         }
 
         // Visible for testing.
@@ -2233,10 +2231,7 @@ public class SharePartition {
         }
 
         private void archiveBatch(String newMemberId) {
-            if (batchState == null) {
-                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
-            }
-            batchState.archive(newMemberId);
+            inFlightState().archive(newMemberId);
         }
 
         private InFlightState tryUpdateBatchState(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount, String newMemberId) {
@@ -2281,10 +2276,7 @@ public class SharePartition {
         }
 
         private void updateAcquisitionLockTimeout(AcquisitionLockTimerTask acquisitionLockTimeoutTask) {
-            if (batchState == null) {
-                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
-            }
-            batchState.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
+            inFlightState().acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
         }
 
         @Override

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2006,7 +2006,7 @@ public class SharePartition {
                     updateResult.state.id, (short) updateResult.deliveryCount));
 
             // Update acquisition lock timeout task for the batch to null since it is completed now.
-            updateResult.updateAcquisitionLockTimeoutTask(null);
+            updateResult.cancelAndClearAcquisitionLockTimeoutTask();
             if (updateResult.state != RecordState.ARCHIVED) {
                 findNextFetchOffset.set(true);
             }
@@ -2053,7 +2053,7 @@ public class SharePartition {
                     updateResult.state.id, (short) updateResult.deliveryCount));
 
             // Update acquisition lock timeout task for the offset to null since it is completed now.
-            updateResult.updateAcquisitionLockTimeoutTask(null);
+            updateResult.cancelAndClearAcquisitionLockTimeoutTask();
             if (updateResult.state != RecordState.ARCHIVED) {
                 findNextFetchOffset.set(true);
             }
@@ -2352,7 +2352,10 @@ public class SharePartition {
             return acquisitionLockTimeoutTask;
         }
 
-        void updateAcquisitionLockTimeoutTask(AcquisitionLockTimerTask acquisitionLockTimeoutTask) {
+        void updateAcquisitionLockTimeoutTask(AcquisitionLockTimerTask acquisitionLockTimeoutTask) throws IllegalStateException {
+            if (this.acquisitionLockTimeoutTask != null) {
+                throw new IllegalStateException("The acquisition lock timeout task is being overridden");
+            }
             this.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
         }
 

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2221,7 +2221,7 @@ public class SharePartition {
             return batchState.acquisitionLockTimeoutTask;
         }
 
-        RecordState batchRollbackState() {
+        private RecordState batchRollbackState() {
             if (batchState == null) {
                 throw new IllegalStateException("The batch state is not available as the offset state is maintained");
             }
@@ -2339,7 +2339,7 @@ public class SharePartition {
             return memberId;
         }
 
-        RecordState rollbackState() {
+        private RecordState rollbackState() {
             if (rollbackState == null) {
                 // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
                 // been committed.

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2005,7 +2005,7 @@ public class SharePartition {
             stateBatches.add(new PersisterStateBatch(inFlightBatch.firstOffset(), inFlightBatch.lastOffset(),
                     updateResult.state.id, (short) updateResult.deliveryCount));
 
-            // Update acquisition lock timeout task for the batch to null since it is completed now.
+            // Cancel the acquisition lock timeout task for the batch since it is completed now.
             updateResult.cancelAndClearAcquisitionLockTimeoutTask();
             if (updateResult.state != RecordState.ARCHIVED) {
                 findNextFetchOffset.set(true);
@@ -2052,7 +2052,7 @@ public class SharePartition {
             stateBatches.add(new PersisterStateBatch(offsetState.getKey(), offsetState.getKey(),
                     updateResult.state.id, (short) updateResult.deliveryCount));
 
-            // Update acquisition lock timeout task for the offset to null since it is completed now.
+            // Cancel the acquisition lock timeout task for the offset since it is completed now.
             updateResult.cancelAndClearAcquisitionLockTimeoutTask();
             if (updateResult.state != RecordState.ARCHIVED) {
                 findNextFetchOffset.set(true);
@@ -2347,17 +2347,13 @@ public class SharePartition {
             acquisitionLockTimeoutTask = null;
         }
 
-        private RecordState rollbackState() {
+        private boolean hasOngoingStateTransition() {
             if (rollbackState == null) {
                 // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
                 // been committed.
-                return null;
+                return false;
             }
-            return rollbackState.state;
-        }
-
-        private boolean hasOngoingStateTransition() {
-            return rollbackState() != null;
+            return rollbackState.state != null;
         }
 
         /**

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -643,7 +643,7 @@ public class SharePartition {
                         // acquire subset of offsets from the in-flight batch but only if the
                         // complete batch is available yet. Hence, do a pre-check to avoid exploding
                         // the in-flight offset tracking unnecessarily.
-                        if (inFlightBatch.batchState() != RecordState.AVAILABLE || inFlightBatch.batchRollbackState() == RecordState.ACQUIRED) {
+                        if (inFlightBatch.batchState() != RecordState.AVAILABLE || inFlightBatch.batchRollbackState() != null) {
                             log.trace("The batch is not available to acquire in share partition: {}-{}, skipping: {}"
                                     + " skipping offset tracking for batch as well.", groupId,
                                 topicIdPartition, inFlightBatch);
@@ -662,7 +662,7 @@ public class SharePartition {
                 }
 
                 // The in-flight batch is a full match hence change the state of the complete batch.
-                if (inFlightBatch.batchState() != RecordState.AVAILABLE || inFlightBatch.batchRollbackState() == RecordState.ACQUIRED) {
+                if (inFlightBatch.batchState() != RecordState.AVAILABLE || inFlightBatch.batchRollbackState() != null) {
                     log.trace("The batch is not available to acquire in share partition: {}-{}, skipping: {}",
                         groupId, topicIdPartition, inFlightBatch);
                     continue;
@@ -1225,7 +1225,7 @@ public class SharePartition {
                     break;
                 }
 
-                if (offsetState.getValue().state != RecordState.AVAILABLE || offsetState.getValue().rollbackState() == RecordState.ACQUIRED) {
+                if (offsetState.getValue().state != RecordState.AVAILABLE || offsetState.getValue().rollbackState() != null) {
                     log.trace("The offset is not available skipping, offset: {} batch: {}"
                             + " for the share partition: {}-{}", offsetState.getKey(), inFlightBatch,
                         groupId, topicIdPartition);

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2337,7 +2337,7 @@ public class SharePartition {
 
         void updateAcquisitionLockTimeoutTask(AcquisitionLockTimerTask acquisitionLockTimeoutTask) throws IllegalArgumentException {
             if (this.acquisitionLockTimeoutTask != null) {
-                throw new IllegalArgumentException("An already existing acquisition lock timeout task: " + this.acquisitionLockTimeoutTask + " is being overridden for the offset");
+                throw new IllegalArgumentException("Existing acquisition lock timeout exists, cannot override.");
             }
             this.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
         }

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -835,38 +835,54 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
     produceData(topicIdPartition, 10)
-
-    // Send a third Share Fetch request with piggybacked acknowledgements
-    shareSessionEpoch = ShareRequestMetadata.nextEpoch(shareSessionEpoch)
-    metadata = new ShareRequestMetadata(memberId, shareSessionEpoch)
-    acknowledgementsMapForFetch = Map(topicIdPartition -> List(new ShareFetchRequestData.AcknowledgementBatch()
-      .setFirstOffset(0)
-      .setLastOffset(9)
-      .setAcknowledgeTypes(Collections.singletonList(2.toByte))).asJava) // Release the records
-    shareFetchRequest = createShareFetchRequest(groupId, metadata, MAX_PARTITION_BYTES, send, Seq.empty, acknowledgementsMapForFetch)
-    shareFetchResponse = connectAndReceive[ShareFetchResponse](shareFetchRequest)
-
-    shareFetchResponseData = shareFetchResponse.data()
-    assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
-    assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(List(0L, 10L).asJava, List(9L, 19L).asJava, List(2, 1).asJava))
+
+    val acquiredRecords : util.List[AcquiredRecords] = new util.ArrayList[AcquiredRecords]()
+    var releaseAcknowledgementSent = false
+
+    TestUtils.waitUntilTrue(() => {
+      shareSessionEpoch = ShareRequestMetadata.nextEpoch(shareSessionEpoch)
+      metadata = new ShareRequestMetadata(memberId, shareSessionEpoch)
+      if (releaseAcknowledgementSent) {
+        // For fourth share fetch request onwards
+        acknowledgementsMapForFetch = Map.empty
+      } else {
+        // Send a third Share Fetch request with piggybacked acknowledgements
+        acknowledgementsMapForFetch = Map(topicIdPartition -> List(new ShareFetchRequestData.AcknowledgementBatch()
+          .setFirstOffset(0)
+          .setLastOffset(9)
+          .setAcknowledgeTypes(Collections.singletonList(2.toByte))).asJava) // Release the records
+        releaseAcknowledgementSent = true
+      }
+      shareFetchRequest = createShareFetchRequest(groupId, metadata, MAX_PARTITION_BYTES, send, Seq.empty, acknowledgementsMapForFetch)
+      shareFetchResponse = connectAndReceive[ShareFetchResponse](shareFetchRequest)
+
+      shareFetchResponseData = shareFetchResponse.data()
+      assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
+      assertEquals(1, shareFetchResponseData.responses().size())
+      assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
+      val responseSize = shareFetchResponseData.responses().get(0).partitions().size()
+      if (responseSize > 0) {
+        acquiredRecords.addAll(shareFetchResponseData.responses().get(0).partitions().get(0).acquiredRecords())
+      }
+      acquiredRecords.size() == 2
+
+    }, "Share fetch request failed", 5000)
+
     // All the records from offsets 0 to 19 will be fetched. Records from 0 to 9 will have delivery count as 2 because
     // they are re delivered, and records from 10 to 19 will have delivery count as 1 because they are newly acquired
-
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
-    compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
+    assertTrue(expectedFetchPartitionData.acquiredRecords().containsAll(acquiredRecords) &&
+      acquiredRecords.containsAll(expectedFetchPartitionData.acquiredRecords()))
   }
 
   @ClusterTests(

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -875,6 +875,9 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       if (responseSize > 0) {
         acquiredRecords.addAll(shareFetchResponseData.responses().get(0).partitions().get(0).acquiredRecords())
       }
+      // There should be 2 acquired record batches finally -
+      // 1. batch containing 0-9 offsets which were initially acknowledged as RELEASED.
+      // 2. batch containing 10-19 offsets which were produced in the second produceData function call.
       acquiredRecords.size() == 2
 
     }, "Share fetch request failed", 5000)


### PR DESCRIPTION
### About
`SharePartition#acquire` does not honor the rollback state. This causes two issues.

1) leaked `acquisitionLockTimeoutTask - `SharePartition#acquire` create a new `acquisitionLockTimeoutTask` for the "available" batch, however, the available batch in transition already has a `acquisitionLockTimeoutTask`, so the leaked `acquisitionLockTimeoutTask` will corrupt the state later.

2) null `acquisitionLockTimeoutTask` in a "acquired" batch - this can be reproduced by following order.
  a) the batch is in transition - current state is `AVAILABLE` and rollback state is `ACQUIRED`
  b)`SharePartition#rollbackOrProcessStateUpdates` is processing RPC, so it does not call `InFlightState#completeStateTransition`
  c)`SharePartition#acquire` assumes the batch is available, so it changes the state from `AVAILABLE` to `ACQUIRED` and create a new `acquisitionLockTimeoutTask`
  d) `SharePartition#rollbackOrProcessStateUpdates` complete the RPC - it commit the state and cancel the `acquisitionLockTimeoutTask` - that means the batch is in `ACQUIRED` but it does not have `acquisitionLockTimeoutTask`
the next AcknowledgeRequest tries to update the state to `ACKNOWLEDGED` but it encounters NPE `acquisitionLockTimeoutTask` and then the request gets hanging until timeout

### Testing
Added a unit test to verify the changed behaviour and tested with the help of originally present unit/integration tests for share consumers.