### PR TITLE
KAFKA-7516: Attempt to dynamically load ManagementFactory class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.Properties;
 
+import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -81,7 +82,7 @@ public class AppInfoParser {
             server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
-        } catch (Throwable e) {
+        } catch (JMException | ReflectiveOperationException e) {
             log.warn("Error registering AppInfo mbean", e);
         }
     }
@@ -96,7 +97,7 @@ public class AppInfoParser {
                 server.unregisterMBean(name);
 
             unregisterMetrics(metrics);
-        } catch (Throwable e) {
+        } catch (JMException | ReflectiveOperationException e) {
             log.warn("Error unregistering AppInfo mbean", e);
         } finally {
             log.info("App info {} for {} unregistered", prefix, id);

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -25,10 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 import java.util.Properties;
 
-import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -36,6 +35,7 @@ public class AppInfoParser {
     private static final Logger log = LoggerFactory.getLogger(AppInfoParser.class);
     private static final String VERSION;
     private static final String COMMIT_ID;
+    private static final Method GET_MBEAN_SERVER;
 
     protected static final String DEFAULT_VALUE = "unknown";
 
@@ -48,6 +48,15 @@ public class AppInfoParser {
         }
         VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
         COMMIT_ID = props.getProperty("commitId", DEFAULT_VALUE).trim();
+
+        Method getMBeanServer;
+        try {
+            Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory");
+            getMBeanServer = managementFactory.getMethod("getPlatformMBeanServer");
+        } catch (ReflectiveOperationException e) {
+            getMBeanServer = null;
+        }
+        GET_MBEAN_SERVER = getMBeanServer;
     }
 
     public static String getVersion() {
@@ -59,9 +68,11 @@ public class AppInfoParser {
     }
 
     public static synchronized void registerAppInfo(String prefix, String id, Metrics metrics, long nowMs) {
+        if (GET_MBEAN_SERVER == null)
+            return;
         try {
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
-            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             if (server.isRegistered(name)) {
                 log.info("The mbean of App info: [{}], id: [{}] already exists, so skipping a new mbean creation.", prefix, id);
                 return;
@@ -70,20 +81,22 @@ public class AppInfoParser {
             server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
-        } catch (JMException e) {
+        } catch (Throwable e) {
             log.warn("Error registering AppInfo mbean", e);
         }
     }
 
     public static synchronized void unregisterAppInfo(String prefix, String id, Metrics metrics) {
-        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        if (GET_MBEAN_SERVER == null)
+            return;
         try {
+            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             if (server.isRegistered(name))
                 server.unregisterMBean(name);
 
             unregisterMetrics(metrics);
-        } catch (JMException e) {
+        } catch (Throwable e) {
             log.warn("Error unregistering AppInfo mbean", e);
         } finally {
             log.info("App info {} for {} unregistered", prefix, id);


### PR DESCRIPTION
Fail gracefully if not found. This can be the case on Android.

With this change, it's no longer necessary for me to stub out JMX classes on Android. I do still need to supply a custom `metric.reporters` configuration to override the default of `org.apache.kafka.common.metrics.JmxReporter`, but that's just configuration.

Unfortunately, I don't know of a way to test a static initialization block in a unit test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
