### PR TITLE
KAFKA-18109: Fix failed SaslClientsWithInvalidCredentialsTest in tools module

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/SaslClientsWithInvalidCredentialsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/SaslClientsWithInvalidCredentialsTest.java
@@ -45,7 +45,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
+import org.apache.kafka.common.config.SaslConfigs;
 import scala.Option;
 import scala.Some$;
 import scala.collection.Seq;
@@ -114,6 +114,8 @@ public class SaslClientsWithInvalidCredentialsTest extends AbstractSaslTest {
     public void setUp(TestInfo testInfo) {
         startSasl(jaasSections(KAFKA_SERVER_SASL_MECHANISMS, Some$.MODULE$.apply(KAFKA_CLIENT_SASL_MECHANISM), Both$.MODULE$,
             JaasTestUtils.KAFKA_SERVER_CONTEXT_NAME));
+        String superuserLoginContext = jaasAdminLoginModule(KAFKA_CLIENT_SASL_MECHANISM, Option.empty());
+        this.superuserClientConfig().put(SaslConfigs.SASL_JAAS_CONFIG, superuserLoginContext);
         super.setUp(testInfo);
         try (Admin admin = createPrivilegedAdminClient()) {
             admin.createTopics(Collections.singletonList(

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/SaslClientsWithInvalidCredentialsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/SaslClientsWithInvalidCredentialsTest.java
@@ -23,6 +23,7 @@ import kafka.security.JaasTestUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -45,7 +46,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.kafka.common.config.SaslConfigs;
+
 import scala.Option;
 import scala.Some$;
 import scala.collection.Seq;


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18109

Root cause: supserUser did not set sasl mechanism so it will throw `AuthorizationException` when creating internal topic (__consumer_offset).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
