### PR TITLE
KAFKA-18086: Enable propagation of the error message when writing state

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -304,14 +304,13 @@ public class SharePartitionManager implements AutoCloseable {
             Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = new HashMap<>();
             futures.forEach((topicIdPartition, future) -> {
                 ShareAcknowledgeResponseData.PartitionData partitionData = new ShareAcknowledgeResponseData.PartitionData()
-                        .setPartitionIndex(topicIdPartition.partition());
+                    .setPartitionIndex(topicIdPartition.partition());
                 Throwable t = future.join();
                 if (t == null) {
-                    partitionData.setErrorCode(Errors.NONE.code())
-                            .setErrorMessage(Errors.NONE.message());
+                    partitionData.setErrorCode(Errors.NONE.code());
                 } else {
                     partitionData.setErrorCode(Errors.forException(t).code())
-                            .setErrorMessage(t.getMessage());
+                        .setErrorMessage(t.getMessage());
                 }
                 result.put(topicIdPartition, partitionData);
             });
@@ -383,14 +382,13 @@ public class SharePartitionManager implements AutoCloseable {
             Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = new HashMap<>();
             futuresMap.forEach((topicIdPartition, future) -> {
                 ShareAcknowledgeResponseData.PartitionData partitionData = new ShareAcknowledgeResponseData.PartitionData()
-                        .setPartitionIndex(topicIdPartition.partition());
+                    .setPartitionIndex(topicIdPartition.partition());
                 Throwable t = future.join();
                 if (t == null) {
-                    partitionData.setErrorCode(Errors.NONE.code())
-                            .setErrorMessage(Errors.NONE.message());
+                    partitionData.setErrorCode(Errors.NONE.code());
                 } else {
                     partitionData.setErrorCode(Errors.forException(t).code())
-                            .setErrorMessage(t.getMessage());
+                        .setErrorMessage(t.getMessage());
                 }
                 result.put(topicIdPartition, partitionData);
             });

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -301,7 +301,7 @@ public class SharePartitionManager implements AutoCloseable {
 
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(
             futures.values().toArray(new CompletableFuture[0]));
-        return allFutures.handle((results, exception) -> {
+        return allFutures.handle((unused, exception) -> {
             Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = new HashMap<>();
             futures.forEach((topicIdPartition, future) -> {
                 try {
@@ -309,7 +309,8 @@ public class SharePartitionManager implements AutoCloseable {
                     result.put(topicIdPartition,
                             new ShareAcknowledgeResponseData.PartitionData()
                                     .setPartitionIndex(topicIdPartition.partition())
-                                    .setErrorCode(error.code()));
+                                    .setErrorCode(error.code())
+                                    .setErrorMessage(error.message()));
                 } catch (CompletionException e) {
                     Throwable t = e.getCause();
                     result.put(topicIdPartition,
@@ -383,14 +384,15 @@ public class SharePartitionManager implements AutoCloseable {
 
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(
             futuresMap.values().toArray(new CompletableFuture[0]));
-        return allFutures.handle((results, exception) -> {
+        return allFutures.handle((unused, exception) -> {
             Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = new HashMap<>();
             futuresMap.forEach((topicIdPartition, future) -> {
                 try {
                     Errors error = future.join();
                     result.put(topicIdPartition, new ShareAcknowledgeResponseData.PartitionData()
                             .setPartitionIndex(topicIdPartition.partition())
-                            .setErrorCode(error.code()));
+                            .setErrorCode(error.code())
+                            .setErrorMessage(error.message()));
                 } catch (CompletionException e) {
                     Throwable t = e.getCause();
                     result.put(topicIdPartition,

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -306,9 +306,7 @@ public class SharePartitionManager implements AutoCloseable {
                 ShareAcknowledgeResponseData.PartitionData partitionData = new ShareAcknowledgeResponseData.PartitionData()
                     .setPartitionIndex(topicIdPartition.partition());
                 Throwable t = future.join();
-                if (t == null) {
-                    partitionData.setErrorCode(Errors.NONE.code());
-                } else {
+                if (t != null) {
                     partitionData.setErrorCode(Errors.forException(t).code())
                         .setErrorMessage(t.getMessage());
                 }
@@ -384,9 +382,7 @@ public class SharePartitionManager implements AutoCloseable {
                 ShareAcknowledgeResponseData.PartitionData partitionData = new ShareAcknowledgeResponseData.PartitionData()
                     .setPartitionIndex(topicIdPartition.partition());
                 Throwable t = future.join();
-                if (t == null) {
-                    partitionData.setErrorCode(Errors.NONE.code());
-                } else {
+                if (t != null) {
                     partitionData.setErrorCode(Errors.forException(t).code())
                         .setErrorMessage(t.getMessage());
                 }

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1324,12 +1324,14 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp3));
         assertEquals(0, result.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp1).errorCode());
+        assertEquals(Errors.NONE.message(), result.get(tp1).errorMessage());
         assertEquals(2, result.get(tp2).partitionIndex());
         assertEquals(Errors.INVALID_RECORD_STATE.code(), result.get(tp2).errorCode());
         assertEquals("Unable to release acquired records for the batch", result.get(tp2).errorMessage());
         // tp3 was not a part of partitionCacheMap.
         assertEquals(4, result.get(tp3).partitionIndex());
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp3).errorCode());
+        assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.message(), result.get(tp3).errorMessage());
     }
 
     @Test
@@ -1458,6 +1460,7 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp));
         assertEquals(0, result.get(tp).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp).errorCode());
+        assertEquals(Errors.NONE.message(), result.get(tp).errorMessage());
     }
 
     @Test
@@ -1508,10 +1511,13 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp3));
         assertEquals(0, result.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp1).errorCode());
+        assertEquals(Errors.NONE.message(), result.get(tp1).errorMessage());
         assertEquals(0, result.get(tp2).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp2).errorCode());
+        assertEquals(Errors.NONE.message(), result.get(tp2).errorMessage());
         assertEquals(0, result.get(tp3).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp3).errorCode());
+        assertEquals(Errors.NONE.message(), result.get(tp3).errorMessage());
 
         Map<MetricName, Consumer<Double>> expectedMetrics = new HashMap<>();
         expectedMetrics.put(
@@ -1584,6 +1590,7 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp));
         assertEquals(0, result.get(tp).partitionIndex());
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp).errorCode());
+        assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.message(), result.get(tp).errorMessage());
     }
 
     @Test
@@ -1637,6 +1644,7 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp));
         assertEquals(3, result.get(tp).partitionIndex());
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp).errorCode());
+        assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.message(), result.get(tp).errorMessage());
     }
 
     @Test

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1324,7 +1324,6 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp3));
         assertEquals(0, result.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp1).errorCode());
-        assertEquals(Errors.NONE.message(), result.get(tp1).errorMessage());
         assertEquals(2, result.get(tp2).partitionIndex());
         assertEquals(Errors.INVALID_RECORD_STATE.code(), result.get(tp2).errorCode());
         assertEquals("Unable to release acquired records for the batch", result.get(tp2).errorMessage());
@@ -1460,7 +1459,6 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp));
         assertEquals(0, result.get(tp).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp).errorCode());
-        assertEquals(Errors.NONE.message(), result.get(tp).errorMessage());
     }
 
     @Test
@@ -1511,13 +1509,10 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp3));
         assertEquals(0, result.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp1).errorCode());
-        assertEquals(Errors.NONE.message(), result.get(tp1).errorMessage());
         assertEquals(0, result.get(tp2).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp2).errorCode());
-        assertEquals(Errors.NONE.message(), result.get(tp2).errorMessage());
         assertEquals(0, result.get(tp3).partitionIndex());
         assertEquals(Errors.NONE.code(), result.get(tp3).errorCode());
-        assertEquals(Errors.NONE.message(), result.get(tp3).errorMessage());
 
         Map<MetricName, Consumer<Double>> expectedMetrics = new HashMap<>();
         expectedMetrics.put(

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1326,6 +1326,7 @@ public class SharePartitionManagerTest {
         assertEquals(Errors.NONE.code(), result.get(tp1).errorCode());
         assertEquals(2, result.get(tp2).partitionIndex());
         assertEquals(Errors.INVALID_RECORD_STATE.code(), result.get(tp2).errorCode());
+        assertEquals("Unable to release acquired records for the batch", result.get(tp2).errorMessage());
         // tp3 was not a part of partitionCacheMap.
         assertEquals(4, result.get(tp3).partitionIndex());
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), result.get(tp3).errorCode());
@@ -1613,6 +1614,7 @@ public class SharePartitionManagerTest {
         assertTrue(result.containsKey(tp));
         assertEquals(0, result.get(tp).partitionIndex());
         assertEquals(Errors.INVALID_REQUEST.code(), result.get(tp).errorCode());
+        assertEquals("Member is not the owner of batch record", result.get(tp).errorMessage());
     }
 
     @Test


### PR DESCRIPTION
Propagate the error message in the writing state when calling SharePartitionManager.acknowledge and SharePartitionManager.releaseSession, and add corresponding tests to verify that the expected error message is propagated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
