### PR TITLE
KAFKA-10731: add support for SSL hot reload

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -98,6 +98,11 @@ public class SslConfigs {
         + "If a password is not set, trust store file configured will still be used, but integrity checking is disabled. "
         + "Trust store password is not supported for PEM format.";
 
+
+    public static final String SSL_HOT_RELOAD = "ssl.hot.reload";
+    public static final Boolean DEFAULT_SSL_HOT_RELOAD = false;
+    public static final String SSL_HOT_RELOAD_DOC = "Indicates whether to monitor the keystore and truststore directories for changes and automatically reload the SSL Engine Factory with updated keystore/truststore files. ";
+
     public static final String SSL_KEYMANAGER_ALGORITHM_CONFIG = "ssl.keymanager.algorithm";
     public static final String SSL_KEYMANAGER_ALGORITHM_DOC = "The algorithm used by key manager factory for SSL connections. "
             + "Default value is the key manager factory algorithm configured for the Java Virtual Machine.";
@@ -138,6 +143,7 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_TRUSTSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC)
+                .define(SslConfigs.SSL_HOT_RELOAD, ConfigDef.Type.BOOLEAN, SslConfigs.DEFAULT_SSL_HOT_RELOAD, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_HOT_RELOAD_DOC)
                 .define(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_KEYMANGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslWatcher.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslWatcher.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.apache.kafka.common.utils.KafkaThread;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Watches files and directories and triggers a callback on change.
+ *
+ */
+class SslWatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(SslWatcher.class);
+
+    // the duration that no file changes should occur before reconfiguring
+    // this is not configurable to avoid having different values for the
+    // watchService's poll
+    private static Duration quietPeriod = Duration.ofSeconds(30);
+
+    private static final Object LOCK = new Object();
+
+    private static WatcherThread thread;
+
+    private static SslWatcher instance;
+
+    private SslWatcher() {
+    }
+
+    // VisibleForTesting
+    static void setQuietPeriod(Duration duration) {
+        SslWatcher.quietPeriod = duration;
+    }
+
+    /**
+     * Returns the singleton instance of {@code SslWatcher}.
+     * Ensures thread-safety by using synchronized initialization.
+     * 
+     * @return the singleton instance of {@code SslWatcher}
+     */
+    public static synchronized SslWatcher getInstance() {
+        if (instance == null) {
+            instance = new SslWatcher();
+        }
+        return instance;
+    }
+
+    /**
+     * Watch the given files or directories for changes.
+	 * <p>The specified {@code action} will be executed after a change is detected, 
+	 * but only after a "quiet period" of at least 30 seconds has elapsed since the last change. 
+ 	 * This helps avoid triggering the action for multiple rapid, successive changes.</p>
+     * 
+     * @param paths  the files or directories to watch
+     * @param action the action to take when changes are detected
+     */
+    Registration watch(Set<Path> paths, Runnable action) {
+        if (paths == null || action == null) {
+            throw new IllegalStateException("Paths and action must not be null.");
+        }
+        if (paths.isEmpty()) {
+            return null;
+        }
+        Registration registration = null;
+        synchronized (SslWatcher.LOCK) {
+            try {
+                if (SslWatcher.thread == null) {
+                    SslWatcher.thread = new WatcherThread();
+                    SslWatcher.thread.start();
+                }
+                registration = new Registration(paths, action);
+                SslWatcher.thread.register(registration);
+                return registration;
+
+            } catch (IOException ex) {
+                throw new UncheckedIOException("Failed to register paths for watching: " + paths, ex);
+            }
+        }
+    }
+
+    /**
+     * Closes the given {@link Registration} and stops the SSL watcher thread 
+     * if there are no remaining registrations. The method synchronizes access 
+     * to the thread, interrupts it, and waits for its termination before setting 
+     * the thread reference to {@code null}.
+     *
+     * @param registration the {@link Registration} to be closed. The thread is stopped 
+     *                     only if there are no remaining registrations.
+     * @throws IOException if an I/O error occurs during the close operation.
+     * @throws InterruptedException if interrupted while waiting for the thread to terminate.
+     */
+    public static void close(Registration registration) throws IOException {
+        if (instance != null) {
+            synchronized (SslWatcher.LOCK) {
+                if (SslWatcher.thread != null) {
+                    boolean stopped = SslWatcher.thread.close(registration);
+                    if (stopped) {
+
+                        SslWatcher.thread.interrupt();
+                        try {
+                            SslWatcher.thread.join();
+                        } catch (InterruptedException ex) {
+                            Thread.currentThread().interrupt();
+                        }
+                        SslWatcher.thread = null;
+                    }
+                }
+            }
+        }
+
+    }
+
+    private static class WatcherThread extends KafkaThread {
+
+        private final WatchService watchService = FileSystems.getDefault().newWatchService();
+
+        private final Set<Registration> registrations = new HashSet<>();
+
+        private volatile boolean running = true;
+
+        public WatcherThread() throws IOException {
+            // Daemon KafkaThread
+            super("ssl-watcher", true);
+        }
+
+        void register(Registration registration) throws IOException {
+            for (Path path : registration.getPaths()) {
+                if (!Files.isRegularFile(path) && !Files.isDirectory(path)) {
+                    throw new IOException(String.format("'%s' is neither a file nor a directory", path));
+                }
+                Path directory = Files.isDirectory(path) ? path : path.getParent();
+                if (directory != null) {
+                    log.debug("Registering '%s'", directory);
+                    directory.register(this.watchService, StandardWatchEventKinds.ENTRY_CREATE,
+                        StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_DELETE);
+                }
+            }
+            this.registrations.add(registration);
+        }
+
+        @Override
+        public void run() {
+            log.debug("Watch thread started");
+            Set<Runnable> actions = new HashSet<>();
+            while (this.running) {
+                try {
+                    long timeout = SslWatcher.quietPeriod.toMillis();
+                    WatchKey key = this.watchService.poll(timeout, TimeUnit.MILLISECONDS);
+                    if (key == null) {
+                        actions.forEach(this::runSafely);
+                        actions.clear();
+                    } else {
+                        accumulate(key, actions);
+                    }
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                } catch (ClosedWatchServiceException ex) {
+                    log.debug("SslWatcher has been closed");
+                    this.running = false;
+                }
+            }
+            log.debug("SslWatcher thread stopped");
+        }
+
+        private void runSafely(Runnable action) {
+            try {
+                action.run();
+            } catch (Throwable ex) {
+                log.error("Unexpected SSL reconfigure error", ex);
+            }
+        }
+
+        private void accumulate(WatchKey key, Set<Runnable> actions) {
+            boolean resetKey = false;
+            Path directory = (Path) key.watchable();
+            for (WatchEvent<?> event : key.pollEvents()) {
+                Path file = directory.resolve((Path) event.context());
+                for (Registration registration : this.registrations) {
+                    if (registration.getPaths().contains(file.toAbsolutePath())) {
+                        actions.add(registration.getAction());
+                        resetKey = true;
+                    }
+                }
+            }
+            if (resetKey)
+                key.reset();
+        }
+
+        /**
+         * Closes the registration and shuts down the watch service and stops the thread if no more registrations remain.
+         *
+         * @param registration the {@link Registration} to be removed and closed
+         * @return {@code true} if the watch service was stopped (i.e., no registrations left), 
+         *         {@code false} otherwise
+         * @throws IOException if an I/O error occurs while closing the watch service
+         */
+        public boolean close(Registration registration) throws IOException {
+            boolean stopped = false;
+
+            this.registrations.remove(registration);
+            if (this.registrations.isEmpty()) {
+                this.running = false;
+                this.watchService.close();
+                stopped = true;
+            }
+            return stopped;
+        }
+
+    }
+
+    public static class Registration {
+
+        private final Set<Path> paths;
+        private final Runnable action;
+
+        public Registration(Set<Path> paths, Runnable action) {
+            this.paths = paths.stream()
+                    .map(Path::toAbsolutePath)
+                    .collect(Collectors.toSet());
+            this.action = action;
+        }
+
+        public Set<Path> getPaths() {
+            return paths;
+        }
+
+        public Runnable getAction() {
+            return action;
+        }
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -578,6 +578,7 @@ public class TestSslUtils {
         String algorithm;
         CertificateBuilder certBuilder;
         boolean usePem;
+        boolean sslHotReload;
 
         public SslConfigsBuilder(ConnectionMode connectionMode) {
             this.connectionMode = connectionMode;
@@ -639,6 +640,11 @@ public class TestSslUtils {
             return this;
         }
 
+        public SslConfigsBuilder sslHotReload(boolean sslHotReload) {
+            this.sslHotReload = sslHotReload;
+            return this;
+        }
+
         public  Map<String, Object> build() throws IOException, GeneralSecurityException {
             if (usePem) {
                 return buildPem();
@@ -686,6 +692,8 @@ public class TestSslUtils {
             sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
             sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "JKS");
             sslConfigs.put(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, TrustManagerFactory.getDefaultAlgorithm());
+            sslConfigs.put(SslConfigs.SSL_HOT_RELOAD, sslHotReload);
+
 
             List<String> enabledProtocols  = new ArrayList<>();
             enabledProtocols.add(tlsProtocol);


### PR DESCRIPTION
# Introduction
This PR proposes a change to add support for SSL hot reloading.

I am not sure if this changes warrants a KIP or not. Please let me know if it does.

# Motivation
SSL certificates are typically short-lived, and while Kafka brokers support dynamic SSL certificate reloads via dynamic configuration, other components still require disruptive restarts to apply updated certificates. This change aims to eliminate such disruptions by allowing SSL certificates to be reloaded dynamically when changes occur. The goal is to improve system uptime and reduce operational overhead.

# Description
Inspired by [Spring Boot's SSL hot reload feature](https://docs.spring.io/spring-boot/reference/features/ssl.html#features.ssl.reloading), this implementation triggers an `SslFactory` reconfiguration whenever the keystore or truststore files are modified. Java's `WatchService` API from `java.nio` is used for file changes monitoring. 

A new **`ssl.hot.reload` configuration** is introduced. It can be used by any SslClient (brokers, consumers, producers).

All `SslFactories` within a single JVM share the same `WatcherService`. To prevent redundant reconfigurations, a `Quiet Period` is enforced across all watched files, ensuring that related changes do not trigger multiple reconfigurations.

# Testing Instruction

1. Generate a keystore and truststore.
2. Append the following to `config/kraft/reconfig-server.properties` :
```
security.protocol=SSL
ssl.key.password=<password>
ssl.keystore.location=/path/to/keystore.p12
ssl.keystore.password=<password>
ssl.truststore.location=/path/to/ca.p12
ssl.truststore.password=<password>
# new option
ssl.hot.reload=true
```
3. Build the code in this branch `./gradlew jar`.
4. Start the broker `bin/kafka-server-start.sh config/kraft/reconfig-server.properties`.
5. Replace the `PLAINTEXT` listener with `SSL` then restart the broker.
```
listeners=SSL://:9092,CONTROLLER://:9093
inter.broker.listener.name=SSL
advertised.listeners=CONTROLLER://localhost:9093,SSL://localhost:9092
```
6. Create a `producer.properties` file:
```
security.protocol=SSL
ssl.key.password=<password>
ssl.keystore.location=/path/to/keystore.p12
ssl.keystore.password=<password>
ssl.truststore.location=/path/to/ca.p12
ssl.truststore.password=<password>
ssl.endpoint.identification.algorithm=
# new option
ssl.hot.reload=true
```
7. let's increase logging level for `tool` to `INFO` so changes are reflected in logs:
```
sed -i 's/WARN/INFO/g'  ./config/tools-log4j.properties
```
8. Start a console producer:
```
./bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic test1 --producer.config path/to/producer.properties
```
9. Let's simulate a certificate renewal by moving the keystore to a different location then bringing it back.
``` mv /path/to/keystore.p12  /other/path/to/keystore.p12 && mv  /other/path/to/keystore.p12 /path/to/keystore.p12```

After 30 seconds

Producer logs:
```
[2024-11-29 12:39:47,712] INFO Created new CLIENT SSL engine builder with keystore java.security.KeyStore@3f7ebffe truststore java.security.KeyStore@3a500477 (org.apache.kafka.common.security.ssl.SslFactory)
```
Broker logs:
```
[2024-11-29 12:39:47,392] INFO Created new SERVER SSL engine builder with keystore java.security.KeyStore@385167fc truststore java.security.KeyStore@16ebfb9 (org.apache.kafka.common.security.ssl.SslFactory)
[2024-11-29 12:39:47,412] INFO Created new CLIENT SSL engine builder with keystore java.security.KeyStore@1fb5e6a0 truststore java.security.KeyStore@14181670 (org.apache.kafka.common.security.ssl.SslFactory)
[2024-11-29 12:39:47,444] INFO Created new SERVER SSL engine builder with keystore java.security.KeyStore@2d931fe9 truststore java.security.KeyStore@4924c819 (org.apache.kafka.common.security.ssl.SslFactory)
[2024-11-29 12:39:47,461] INFO Created new CLIENT SSL engine builder with keystore java.security.KeyStore@5400441c truststore java.security.KeyStore@62c51d22 (org.apache.kafka.common.security.ssl.SslFactory)
[2024-11-29 12:39:47,486] INFO Created new SERVER SSL engine builder with keystore java.security.KeyStore@3897543e truststore java.security.KeyStore@6e61d794 (org.apache.kafka.common.security.ssl.SslFactory)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
