### PR TITLE
KAFKA-18118: Fix the incorrect soft link of results/latest

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -489,6 +489,24 @@ EOF
     exec 3>&-
 }
 
+correct_latest_link() {
+    local result_dir="${kafka_dir}/results"
+    local latest_link="${result_dir}/latest"
+    local latest_test_dirname=""
+    local latest_test_dir=""
+
+    # Correct the link if it's a symbolic link and broken.
+    if [[ -L "${latest_link}" ]] && [[ ! -e "${latest_link}" ]]; then
+        latest_test_dirname=$(basename "$(readlink "${latest_link}")")
+        latest_test_dir="${result_dir}/${latest_test_dirname}"
+        if [[ ! -d "${latest_test_dir}" ]]; then
+                exit 0
+        fi
+        unlink "${latest_link}" || exit 0
+        ln -s "${latest_test_dir}" "${latest_link}"
+    fi
+}
+
 ducker_test() {
     require_commands docker
     docker inspect ducker01 &>/dev/null || \
@@ -529,7 +547,10 @@ ducker_test() {
 
     cmd="cd /opt/kafka-dev && ${ducktape_cmd} --cluster-file /opt/kafka-dev/tests/docker/build/cluster.json $test_names $ducktape_args"
     echo "docker exec ducker01 bash -c \"${cmd}\""
-    exec docker exec --user=ducker ducker01 bash -c "${cmd}"
+    docker exec --user=ducker ducker01 bash -c "${cmd}"
+    docker_status=$?
+    correct_latest_link
+    exit "${docker_status}"
 }
 
 ducker_ssh() {

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -492,15 +492,12 @@ EOF
 correct_latest_link() {
     local result_dir="${kafka_dir}/results"
     local latest_link="${result_dir}/latest"
-    local latest_test_dirname=""
-    local latest_test_dir=""
 
     # Correct the link if it's a symbolic link and broken.
     if [[ -L "${latest_link}" ]] && [[ ! -e "${latest_link}" ]]; then
-        latest_test_dirname=$(basename "$(readlink "${latest_link}")")
-        latest_test_dir="${result_dir}/${latest_test_dirname}"
+        local latest_test_dirname=$(basename "$(readlink "${latest_link}")")
         unlink "${latest_link}"
-        ln -s "${latest_test_dir}" "${latest_link}"
+        ln -s "${result_dir}/${latest_test_dirname}" "${latest_link}"
     fi
 }
 

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -499,10 +499,7 @@ correct_latest_link() {
     if [[ -L "${latest_link}" ]] && [[ ! -e "${latest_link}" ]]; then
         latest_test_dirname=$(basename "$(readlink "${latest_link}")")
         latest_test_dir="${result_dir}/${latest_test_dirname}"
-        if [[ ! -d "${latest_test_dir}" ]]; then
-                exit 0
-        fi
-        unlink "${latest_link}" || exit 0
+        unlink "${latest_link}"
         ln -s "${latest_test_dir}" "${latest_link}"
     fi
 }


### PR DESCRIPTION
Correct the link after running e2e tests using docker.
The screenshot "before" shows the e2e tests running without the PR, and vice versa.

Before:
![Screenshot from 2024-11-30 14-38-41](https://github.com/user-attachments/assets/2c26ed98-943d-41e9-ba95-a6f7c6dbec54)

After:
![Screenshot from 2024-11-30 14-35-31](https://github.com/user-attachments/assets/3679f66e-bddc-46f2-9067-f17611e429af)
![Screenshot from 2024-11-30 14-36-13](https://github.com/user-attachments/assets/e071735f-19a5-4629-99ed-c5ab9ffa6a9e)

JIRA: https://issues.apache.org/jira/browse/KAFKA-18118

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
