### PR TITLE
KAFKA-18128: Fix failed test MetadataSchemaCheckerToolTest.testVerifyEvolutionGit in PR

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
@@ -35,6 +35,7 @@ import org.eclipse.jgit.treewalk.filter.PathFilter;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -122,13 +123,18 @@ class CheckerUtils {
     /**
      * Read a MessageSpec file from remote git repo.
      *
-     * @param filePath   The file to read from remote git repo.
-     * @return                     The file contents.
+     * @param filePath The file to read from remote git repo.
+     * @param ref The specific git reference to be used for testing.
+     * @return The file contents.
      */
-    static String GetDataFromGit(String filePath, Path gitPath) throws IOException {
+    static String getDataFromGit(String filePath, Path gitPath, String ref) throws IOException {
         Git git = Git.open(new File(gitPath + "/.git"));
         Repository repository = git.getRepository();
-        Ref head = git.getRepository().getRefDatabase().firstExactRef("refs/heads/trunk");
+        Ref head = repository.getRefDatabase().findRef(ref);
+        if (head == null) {
+            throw new IllegalStateException("Cannot find " + ref + " in the repository.");
+        }
+
         try (RevWalk revWalk = new RevWalk(repository)) {
             RevCommit commit = revWalk.parseCommit(head.getObjectId());
             RevTree tree = commit.getTree();
@@ -141,7 +147,7 @@ class CheckerUtils {
                 }
                 ObjectId objectId = treeWalk.getObjectId(0);
                 ObjectLoader loader = repository.open(objectId);
-                return new String(loader.getBytes(), "UTF-8");
+                return new String(loader.getBytes(), StandardCharsets.UTF_8);
             }
         }
     }

--- a/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
@@ -29,7 +29,12 @@ public class MetadataSchemaCheckerToolTest {
     @Test
     public void testVerifyEvolutionGit() throws Exception {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            MetadataSchemaCheckerTool.run(new String[]{"verify-evolution-git", "--file", "AbortTransactionRecord.json"}, new PrintStream(stream));
+            MetadataSchemaCheckerTool.run(
+                // In the CI environment because the CI fetch command only creates HEAD and refs/remotes/pull/... references.
+                // Since there may not be other branches like refs/heads/trunk in CI, HEAD serves as the baseline reference.
+                new String[]{"verify-evolution-git", "--file", "AbortTransactionRecord.json", "--ref", "HEAD"},
+                new PrintStream(stream)
+            );
             assertEquals("Successfully verified evolution of file: AbortTransactionRecord.json",
                 stream.toString().trim());
         }


### PR DESCRIPTION
JIRA: KAFKA-18128

> There are two issues in MetadataSchemaCheckerToolTest
it assumes the root folder name is `kafka`
 it assumes the root folder has ref "refs/heads/trunk" but it is not existent in PR. see the fetch command used by CI
```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +e2aee931410fe32dd62ac8b832b437f058c1f43e:refs/remotes/pull/17980/merge
```
>That means the refs in PR repo are only "HEAD" and "refs/remotes/pull/17980/merge"


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
