### PR TITLE
MINOR: Agent tool should use System.out instead log

### DIFF
--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -41,9 +41,6 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.PrintStream;
 import java.util.Set;
 
@@ -55,8 +52,6 @@ import static net.sourceforge.argparse4j.impl.Arguments.store;
  * The agent process runs tasks.
  */
 public final class Agent {
-    private static final Logger log = LoggerFactory.getLogger(Agent.class);
-
     /**
      * The default Agent port.
      */
@@ -160,7 +155,7 @@ public final class Agent {
     /**
      * Start a task on the agent, and block until it completes.
      *
-     * @param spec          The task specifiction.
+     * @param spec          The task specification.
      * @param out           The output stream to print to.
      *
      * @return              True if the task run successfully; false otherwise.
@@ -248,16 +243,16 @@ public final class Agent {
         JsonRestServer restServer =
             new JsonRestServer(Node.Util.getTrogdorAgentPort(platform.curNode()));
         AgentRestResource resource = new AgentRestResource();
-        log.info("Starting agent process.");
+        System.out.println("Starting agent process.");
         final Agent agent = new Agent(platform, Scheduler.SYSTEM, restServer, resource);
         restServer.start(resource);
         Exit.addShutdownHook("agent-shutdown-hook", () -> {
-            log.warn("Running agent shutdown hook.");
+            System.out.println("Running agent shutdown hook.");
             try {
                 agent.beginShutdown();
                 agent.waitForShutdown();
             } catch (Exception e) {
-                log.error("Got exception while running agent shutdown hook.", e);
+                System.err.println("Got exception while running agent shutdown hook. " + e);
             }
         });
         if (taskSpec != null) {

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -252,7 +252,7 @@ public final class Agent {
                 agent.beginShutdown();
                 agent.waitForShutdown();
             } catch (Exception e) {
-                System.err.println("Got exception while running agent shutdown hook. " + e);
+                System.out.println("Got exception while running agent shutdown hook. " + e);
             }
         });
         if (taskSpec != null) {

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -38,9 +38,6 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.concurrent.ThreadLocalRandom;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
@@ -51,7 +48,6 @@ import static net.sourceforge.argparse4j.impl.Arguments.store;
  * The coordinator manages the agent processes in the cluster. 
  */
 public final class Coordinator {
-    private static final Logger log = LoggerFactory.getLogger(Coordinator.class);
 
     public static final int DEFAULT_PORT = 8889;
 
@@ -169,17 +165,17 @@ public final class Coordinator {
         JsonRestServer restServer = new JsonRestServer(
             Node.Util.getTrogdorCoordinatorPort(platform.curNode()));
         CoordinatorRestResource resource = new CoordinatorRestResource();
-        log.info("Starting coordinator process.");
+        System.out.println("Starting coordinator process.");
         final Coordinator coordinator = new Coordinator(platform, Scheduler.SYSTEM,
             restServer, resource, ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE / 2));
         restServer.start(resource);
         Exit.addShutdownHook("coordinator-shutdown-hook", () -> {
-            log.warn("Running coordinator shutdown hook.");
+            System.out.println("Running coordinator shutdown hook.");
             try {
                 coordinator.beginShutdown(false);
                 coordinator.waitForShutdown();
             } catch (Exception e) {
-                log.error("Got exception while running coordinator shutdown hook.", e);
+                System.out.println("Got exception while running coordinator shutdown hook. " + e);
             }
         });
         coordinator.waitForShutdown();


### PR DESCRIPTION
In command line tool, we almost use System.out.println to show on the console, but there are use log and System.out.println in Agent tool, I think that we should only use one approach to print logs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
