### PR TITLE
KAFKA-18132: Remove "session.timeout.ms" from connect-distributed.properties to fix connect e2e

### DIFF
--- a/tests/kafkatest/tests/connect/templates/connect-distributed.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-distributed.properties
@@ -52,11 +52,6 @@ offset.flush.interval.ms=5000
 
 rest.advertised.host.name = {{ node.account.hostname }}
 
-
-# Reduce session timeouts so tests that kill workers don't need to wait as long to recover
-session.timeout.ms=10000
-consumer.session.timeout.ms=10000
-
 # Reduce the admin client request timeouts so that we don't wait the default 120 sec before failing to connect the admin client
 request.timeout.ms=30000
 


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18132

Due to CONSUMER group protocol can not config `session.timeout.ms`, thus we should remove this setting in e2e test
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
