### PR TITLE
KAFKA-18138: The controller must add all extant brokers to BrokerHeartbeatTracker when activating

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -306,8 +306,11 @@ public class ClusterControlManager {
      */
     public void activate() {
         heartbeatManager = new BrokerHeartbeatManager(logContext, time, sessionTimeoutNs);
+        long nowNs = time.nanoseconds();
         for (BrokerRegistration registration : brokerRegistrations.values()) {
             heartbeatManager.register(registration.id(), registration.fenced());
+            heartbeatManager.tracker().updateContactTime(
+                new BrokerIdAndEpoch(registration.id(), registration.epoch()), nowNs);
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PeriodicTaskControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PeriodicTaskControlManager.java
@@ -148,7 +148,7 @@ class PeriodicTaskControlManager {
         Time time,
         QueueAccessor queueAccessor
     ) {
-        this.log = logContext.logger(OffsetControlManager.class);
+        this.log = logContext.logger(PeriodicTaskControlManager.class);
         this.time = time;
         this.queueAccessor = queueAccessor;
         this.active = false;


### PR DESCRIPTION
The controller must add all extant brokers to BrokerHeartbeatTracker when activating. Otherwise, we could end up in a situation where a broker fails exactly as a controller failover occurs, and we never fence it.

Also, fix a bug where the slf4j logger object in PeriodicTaskControlManager was initialized as though it belonged to OffsetControlManager.