### PR TITLE
KAFKA-18145: Fix failed e2e ConnectDistributedTest.test_dynamic_logging

### DIFF
--- a/tests/kafkatest/services/templates/connect_log4j.properties
+++ b/tests/kafkatest/services/templates/connect_log4j.properties
@@ -24,3 +24,9 @@ log4j.appender.FILE.ImmediateFlush=true
 log4j.appender.FILE.Append=true
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n
+
+# After removing org.reflections, the initial logger of worker only contains "root" logger.
+# The dynamic logger e2e test requires at least one non-root logger to verify logger operations.
+# Adding this logger configuration ensures admin/logger endpoint returns both "root" and
+# "org.apache.kafka.clients.consumer.ConsumerConfig" loggers.
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR

--- a/tests/kafkatest/services/templates/connect_log4j.properties
+++ b/tests/kafkatest/services/templates/connect_log4j.properties
@@ -26,7 +26,8 @@ log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n
 
 # After removing org.reflections, the initial logger of worker only contains "root" logger.
-# The dynamic logger e2e test requires at least one non-root logger to verify logger operations.
+# The test_dynamic_logging e2e test in ConnectDistributedTest requires at least one non-root logger 
+# to verify logger operations (assert len(initial_loggers) >= 2).
 # Adding this logger configuration ensures admin/logger endpoint returns both "root" and
 # "org.apache.kafka.clients.consumer.ConsumerConfig" loggers.
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR


### PR DESCRIPTION
## Description 
The `org.reflections` is removed, so the initial logger of worker is only "root". However, the e2e needs a non-root logger to verify dynamic logger

We can add a logger to `connect_log4j.properties` to fix this e2e. For example:
```
log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
```

this can make `admin/logger` return two logger - `org.apache.kafka.clients.consumer.ConsumerConfig` and `root`

## E2E test result
### Before changes
```bash
$ TC_PATHS="tests/kafkatest/tests/connect/connect_distributed_test.py::ConnectDistributedTest.test_dynamic_logging" bash tests/docker/run_tests.sh
WARNING: Ignoring custom format, because both --format and --quiet are set.

> Configure project :
Starting build with version 4.0.0-SNAPSHOT (commit id c76fb5cb) using Gradle 8.10.2, Java 23 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=8, maxScalacThreads=8, maxTestRetries=0

BUILD SUCCESSFUL in 3s
226 actionable tasks: 226 up-to-date
docker exec ducker01 bash -c "cd /opt/kafka-dev && ducktape --cluster-file /opt/kafka-dev/tests/docker/build/cluster.json  ./tests/kafkatest/tests/connect/connect_distributed_test.py::ConnectDistributedTest.test_dynamic_logging "
[INFO:2024-12-03 09:49:24,619]: starting test run with session id 2024-12-03--004...
[INFO:2024-12-03 09:49:24,619]: running 1 tests...
[INFO:2024-12-03 09:49:24,620]: Triggering test 1 of 1...
[INFO:2024-12-03 09:49:24,630]: RunnerClient: Loading test {'directory': '/opt/kafka-dev/tests/kafkatest/tests/connect', 'file_name': 'connect_distributed_test.py', 'cls_name': 'ConnectDistributedTest', 'method_name': 'test_dynamic_logging', 'injected_args': {'metadata_quorum': 'ISOLATED_KRAFT'}}
[INFO:2024-12-03 09:49:24,632]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: on run 1/1
[INFO:2024-12-03 09:49:24,632]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Setting up...
[INFO:2024-12-03 09:49:24,633]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Running...
[INFO:2024-12-03 09:49:56,357]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Tearing down...
[INFO:2024-12-03 09:50:19,127]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: FAIL: AssertionError()
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 351, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.7/dist-packages/ducktape/tests/runner_client.py", line 411, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.7/dist-packages/ducktape/mark/_mark.py", line 438, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/connect/connect_distributed_test.py", line 471, in test_dynamic_logging
    assert len(initial_loggers) >= 2
AssertionError
```
### After changes
```bash
$ TC_PATHS="tests/kafkatest/tests/connect/connect_distributed_test.py::ConnectDistributedTest.test_dynamic_logging" bash tests/docker/run_tests.sh
WARNING: Ignoring custom format, because both --format and --quiet are set.

> Configure project :
Starting build with version 4.0.0-SNAPSHOT (commit id c76fb5cb) using Gradle 8.10.2, Java 23 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=8, maxScalacThreads=8, maxTestRetries=0

BUILD SUCCESSFUL in 3s
226 actionable tasks: 226 up-to-date
docker exec ducker01 bash -c "cd /opt/kafka-dev && ducktape --cluster-file /opt/kafka-dev/tests/docker/build/cluster.json  ./tests/kafkatest/tests/connect/connect_distributed_test.py::ConnectDistributedTest.test_dynamic_logging "
[INFO:2024-12-03 09:56:47,950]: starting test run with session id 2024-12-03--007...
[INFO:2024-12-03 09:56:47,950]: running 1 tests...
[INFO:2024-12-03 09:56:47,950]: Triggering test 1 of 1...
[INFO:2024-12-03 09:56:47,962]: RunnerClient: Loading test {'directory': '/opt/kafka-dev/tests/kafkatest/tests/connect', 'file_name': 'connect_distributed_test.py', 'cls_name': 'ConnectDistributedTest', 'method_name': 'test_dynamic_logging', 'injected_args': {'metadata_quorum': 'ISOLATED_KRAFT'}}
[INFO:2024-12-03 09:56:47,965]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: on run 1/1
[INFO:2024-12-03 09:56:47,966]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Setting up...
[INFO:2024-12-03 09:56:47,966]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Running...
[INFO:2024-12-03 09:57:18,237]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Tearing down...
[INFO:2024-12-03 09:57:28,520]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: PASS
[INFO:2024-12-03 09:57:28,520]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT: Data: None
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2024-12-03--007
run time:         40.766 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_dynamic_logging.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   40.555 seconds
--------------------------------------------------------------------------------
```