### PR TITLE
KAFKA-18096: Allow join with regex if no matching topics 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -613,7 +613,6 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
         // to the broker on the next poll. Note that this is done even if no topics matched
         // the regex, to ensure the member joins the group if needed (with empty subscription).
         requestManagers.consumerHeartbeatRequestManager.get().membershipManager().onSubscriptionUpdated();
-
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -608,9 +608,12 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
         if (subscriptions.subscribeFromPattern(topicsToSubscribe)) {
             this.metadataVersionSnapshot = metadata.requestUpdateForNewTopics();
 
-            // Join the group if not already part of it, or just send the new subscription to the broker on the next poll.
-            requestManagers.consumerHeartbeatRequestManager.get().membershipManager().onSubscriptionUpdated();
         }
+        // Join the group if not already part of it, or just send the updated subscription
+        // to the broker on the next poll. Note that this is done even if no topics matched
+        // the regex, to ensure the member joins the group if needed (with empty subscription).
+        requestManagers.consumerHeartbeatRequestManager.get().membershipManager().onSubscriptionUpdated();
+
     }
 
     // Visible for testing

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -66,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -332,6 +333,31 @@ public class ApplicationEventProcessorTest {
         // verify member state doesn't transition to JOINING.
         verify(membershipManager, never()).onConsumerPoll();
         assertDoesNotThrow(() -> event.future().get());
+    }
+
+    @Test
+    public void testTopicPatternSubscriptionTriggersJoin() {
+        TopicPatternSubscriptionChangeEvent event = new TopicPatternSubscriptionChangeEvent(
+            Pattern.compile("topic.*"), Optional.of(new MockRebalanceListener()), 12345);
+        setupProcessor(true);
+        Cluster cluster = mock(Cluster.class);
+        when(metadata.fetch()).thenReturn(cluster);
+        when(heartbeatRequestManager.membershipManager()).thenReturn(membershipManager);
+
+        // Initial subscription where no topics match the pattern. Membership manager
+        // should still be notified so it joins if not in the group (with empty subscription).
+        when(subscriptionState.subscribeFromPattern(any())).thenReturn(false);
+        processor.process(event);
+        verify(membershipManager).onSubscriptionUpdated();
+
+        clearInvocations(membershipManager);
+
+        // Subscription where some topics match so subscription is updated. Membership manager
+        // should be notified so it joins if not in the group.
+        when(subscriptionState.subscribeFromPattern(any())).thenReturn(true);
+        processor.process(event);
+        verify(membershipManager).onSubscriptionUpdated();
+
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -357,7 +357,6 @@ public class ApplicationEventProcessorTest {
         when(subscriptionState.subscribeFromPattern(any())).thenReturn(true);
         processor.process(event);
         verify(membershipManager).onSubscriptionUpdated();
-
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -1049,7 +1049,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
-  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersClassicGroupProtocolOnly_KAFKA_17696"))
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testPatternSubscriptionWithNoTopicAccess(quorum: String, groupProtocol: String): Unit = {
     val assignSemaphore = new Semaphore(0)
     createTopicWithBrokerPrincipal(topic)


### PR DESCRIPTION
Fix to allow members to join the group after subscribing to a java pattern, even if no topics match the regex.

Enable authorizer test that was failing only for the new consumer due to this gap, and add new test.
