### PR TITLE
KAFKA-18131: Improve logs for voters

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -156,7 +156,10 @@ public class LeaderState<T> implements EpochState {
                 "Current fetched voters are {}, and voters are {}",
                 checkQuorumTimeoutMs,
                 fetchedVoters,
-                voterStates.values().stream().map(voter -> voter.replicaKey)
+                voterStates.values()
+                    .stream()
+                    .map(voter -> voter.replicaKey)
+                    .collect(Collectors.toUnmodifiableSet())
             );
         }
         return remainingMs;

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicaKey.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicaKey.java
@@ -70,7 +70,7 @@ public final class ReplicaKey implements Comparable<ReplicaKey> {
 
     @Override
     public String toString() {
-        return String.format("ReplicaKey(id=%d, directoryId=%s)", id, directoryId);
+        return String.format("ReplicaKey(id=%d, directoryId=%s)", id, directoryId.map(Uuid::toString).orElse("<undefined>"));
     }
 
     public static ReplicaKey of(int id, Uuid directoryId) {


### PR DESCRIPTION
JIRA: KAFKA-18131

Currently, the log of `LeaderState#timeUntilCheckQuorumExpires` uses streams without a terminal operator, resulting in output like `java.util.stream.ReferencePipeline$3@39660237`. 
This PR aims to fix this issue and improve the log message.

log after this PR:
```
[2024-12-04 17:40:06,184] INFO Did not receive fetch request from the majority of the voters within 3000ms. Current fetched voters are [3], and voters are [ReplicaKey(id=3, directoryId=Viibdq8iQpWShRTAzqWS4Q), ReplicaKey(id=4, directoryId=0fYZLl_RSXyW9pD51y-SSA), ReplicaKey(id=2, directoryId=TszqnKezTXKIKZt5aJl32A), ReplicaKey(id=0, directoryId=HSOI7G7iTBOd3aSG7us-Sg), ReplicaKey(id=1, directoryId=OdpwGEzaQcSrW8qP6bXU6Q)] (org.apache.kafka.raft.LeaderState:154)
[2024-12-04 17:40:06,201] INFO Did not receive fetch request from the majority of the voters within 3000ms. Current fetched voters are [3], and voters are [ReplicaKey(id=2, directoryId=<undefined>), ReplicaKey(id=3, directoryId=<undefined>), ReplicaKey(id=4, directoryId=<undefined>), ReplicaKey(id=0, directoryId=<undefined>), ReplicaKey(id=1, directoryId=<undefined>)] (org.apache.kafka.raft.LeaderState:154)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
