### PR TITLE
MINOR: Fix README for running a Kafka broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ fail due to code changes. You can just run:
 Using compiled files:
 
     KAFKA_CLUSTER_ID="$(./bin/kafka-storage.sh random-uuid)"
-    ./bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties
+    ./bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties
     ./bin/kafka-server-start.sh config/kraft/reconfig-server.properties
 
 Using docker image:

--- a/docker/docker_official_images/3.7.0/jvm/jsa_launch
+++ b/docker/docker_official_images/3.7.0/jvm/jsa_launch
@@ -17,7 +17,7 @@
 KAFKA_CLUSTER_ID="$(opt/kafka/bin/kafka-storage.sh random-uuid)"
 TOPIC="test-topic"
 
-KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/reconfig-server.properties
+KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/reconfig-server.properties
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=kafka.jsa" opt/kafka/bin/kafka-server-start.sh opt/kafka/config/kraft/reconfig-server.properties &
 

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -17,7 +17,7 @@
 KAFKA_CLUSTER_ID="$(opt/kafka/bin/kafka-storage.sh random-uuid)"
 TOPIC="test-topic"
 
-KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/reconfig-server.properties
+KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/reconfig-server.properties
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=kafka.jsa" opt/kafka/bin/kafka-server-start.sh opt/kafka/config/kraft/reconfig-server.properties &
 

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -106,7 +106,7 @@ $ cd kafka_{{scalaVersion}}-{{fullDotVersion}}</code></pre>
   Format Log Directories
 </p>
 
-<pre><code class="language-bash">$ bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties</code></pre>
+<pre><code class="language-bash">$ bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties</code></pre>
 
 <p>
   Start the Kafka Server

--- a/trogdor/README.md
+++ b/trogdor/README.md
@@ -12,7 +12,7 @@ Running Kafka in Kraft mode:
 
 ```
 KAFKA_CLUSTER_ID="$(./bin/kafka-storage.sh random-uuid)"
-./bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties
+./bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties
 ./bin/kafka-server-start.sh config/kraft/reconfig-server.properties  &> /tmp/kafka.log &
 ```
 Then, we want to run a Trogdor Agent, plus a Trogdor Coordinator.


### PR DESCRIPTION
After [#17567](https://github.com/apache/kafka/pull/17567), we switched to using reconfig-server.properties and now need to specify --standalone, --initial-controllers, or --no-initial-controllers.

Otherwise:
```
$ /bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/reconfig-server.properties 
Because controller.quorum.voters is not set on this controller, you must specify one of the following: --standalone, --initial-controllers, or --no-initial-controllers.
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
