### PR TITLE
KAFKA-17750: Extend kafka-consumer-groups command line tool to support new consumer group (part 2)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,9 +43,11 @@ public class ConsumerGroupDescription {
     private final GroupState groupState;
     private final Node coordinator;
     private final Set<AclOperation> authorizedOperations;
+    private final Optional<Integer> groupEpoch;
+    private final Optional<Integer> targetAssignmentEpoch;
 
     /**
-     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupState, Node)}.
+     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set, Optional, Optional)}.
      */
     @Deprecated
     public ConsumerGroupDescription(String groupId,
@@ -57,7 +60,7 @@ public class ConsumerGroupDescription {
     }
 
     /**
-     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupState, Node, Set)}.
+     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set, Optional, Optional)}.
      */
     @Deprecated
     public ConsumerGroupDescription(String groupId,
@@ -71,7 +74,7 @@ public class ConsumerGroupDescription {
     }
 
     /**
-     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set)}.
+     * @deprecated Since 4.0. Use {@link #ConsumerGroupDescription(String, boolean, Collection, String, GroupType, GroupState, Node, Set, Optional, Optional)}.
      */
     @Deprecated
     public ConsumerGroupDescription(String groupId,
@@ -90,25 +93,8 @@ public class ConsumerGroupDescription {
         this.groupState = GroupState.parse(state.name());
         this.coordinator = coordinator;
         this.authorizedOperations = authorizedOperations;
-    }
-
-    public ConsumerGroupDescription(String groupId,
-                                    boolean isSimpleConsumerGroup,
-                                    Collection<MemberDescription> members,
-                                    String partitionAssignor,
-                                    GroupState groupState,
-                                    Node coordinator) {
-        this(groupId, isSimpleConsumerGroup, members, partitionAssignor, groupState, coordinator, Collections.emptySet());
-    }
-
-    public ConsumerGroupDescription(String groupId,
-                                    boolean isSimpleConsumerGroup,
-                                    Collection<MemberDescription> members,
-                                    String partitionAssignor,
-                                    GroupState groupState,
-                                    Node coordinator,
-                                    Set<AclOperation> authorizedOperations) {
-        this(groupId, isSimpleConsumerGroup, members, partitionAssignor, GroupType.CLASSIC, groupState, coordinator, authorizedOperations);
+        this.groupEpoch = Optional.empty();
+        this.targetAssignmentEpoch = Optional.empty();
     }
 
     public ConsumerGroupDescription(String groupId,
@@ -118,7 +104,9 @@ public class ConsumerGroupDescription {
                                     GroupType type,
                                     GroupState groupState,
                                     Node coordinator,
-                                    Set<AclOperation> authorizedOperations) {
+                                    Set<AclOperation> authorizedOperations,
+                                    Optional<Integer> groupEpoch,
+                                    Optional<Integer> targetAssignmentEpoch) {
         this.groupId = groupId == null ? "" : groupId;
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;
         this.members = members == null ? Collections.emptyList() : List.copyOf(members);
@@ -127,6 +115,8 @@ public class ConsumerGroupDescription {
         this.groupState = groupState;
         this.coordinator = coordinator;
         this.authorizedOperations = authorizedOperations;
+        this.groupEpoch = groupEpoch;
+        this.targetAssignmentEpoch = targetAssignmentEpoch;
     }
 
     @Override
@@ -141,12 +131,15 @@ public class ConsumerGroupDescription {
             type == that.type &&
             groupState == that.groupState &&
             Objects.equals(coordinator, that.coordinator) &&
-            Objects.equals(authorizedOperations, that.authorizedOperations);
+            Objects.equals(authorizedOperations, that.authorizedOperations) &&
+            Objects.equals(groupEpoch, that.groupEpoch) &&
+            Objects.equals(targetAssignmentEpoch, that.targetAssignmentEpoch);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, isSimpleConsumerGroup, members, partitionAssignor, type, groupState, coordinator, authorizedOperations);
+        return Objects.hash(groupId, isSimpleConsumerGroup, members, partitionAssignor, type, groupState, coordinator,
+            authorizedOperations, groupEpoch, targetAssignmentEpoch);
     }
 
     /**
@@ -215,6 +208,24 @@ public class ConsumerGroupDescription {
         return authorizedOperations;
     }
 
+    /**
+     * The epoch of the consumer group.
+     * The optional is set to an integer if it is a {@link GroupType#CONSUMER} group, and to empty if it
+     * is a {@link GroupType#CLASSIC} group.
+     */
+    public Optional<Integer> groupEpoch() {
+        return groupEpoch;
+    }
+
+    /**
+     * The epoch of the target assignment.
+     * The optional is set to an integer if it is a {@link GroupType#CONSUMER} group, and to empty if it
+     * is a {@link GroupType#CLASSIC} group.
+     */
+    public Optional<Integer> targetAssignmentEpoch() {
+        return targetAssignmentEpoch;
+    }
+
     @Override
     public String toString() {
         return "(groupId=" + groupId +
@@ -225,6 +236,8 @@ public class ConsumerGroupDescription {
             ", groupState=" + groupState +
             ", coordinator=" + coordinator +
             ", authorizedOperations=" + authorizedOperations +
+            ", groupEpoch=" + groupEpoch.orElse(null) +
+            ", targetAssignmentEpoch=" + targetAssignmentEpoch.orElse(null) +
             ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.GroupType;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -30,13 +32,18 @@ public class MemberDescription {
     private final String host;
     private final MemberAssignment assignment;
     private final Optional<MemberAssignment> targetAssignment;
+    private final Optional<Integer> memberEpoch;
+    private final Optional<Boolean> upgraded;
 
-    public MemberDescription(String memberId,
+    public MemberDescription(
+        String memberId,
         Optional<String> groupInstanceId,
         String clientId,
         String host,
         MemberAssignment assignment,
-        Optional<MemberAssignment> targetAssignment
+        Optional<MemberAssignment> targetAssignment,
+        Optional<Integer> memberEpoch,
+        Optional<Boolean> upgraded
     ) {
         this.memberId = memberId == null ? "" : memberId;
         this.groupInstanceId = groupInstanceId;
@@ -45,8 +52,38 @@ public class MemberDescription {
         this.assignment = assignment == null ?
             new MemberAssignment(Collections.emptySet()) : assignment;
         this.targetAssignment = targetAssignment;
+        this.memberEpoch = memberEpoch;
+        this.upgraded = upgraded;
     }
 
+    /**
+     * @deprecated Since 4.0. Use {@link #MemberDescription(String, Optional, String, String, MemberAssignment, Optional, Optional, Optional)}.
+     */
+    @Deprecated
+    public MemberDescription(
+        String memberId,
+        Optional<String> groupInstanceId,
+        String clientId,
+        String host,
+        MemberAssignment assignment,
+        Optional<MemberAssignment> targetAssignment
+    ) {
+        this(
+            memberId,
+            groupInstanceId,
+            clientId,
+            host,
+            assignment,
+            targetAssignment,
+            Optional.empty(),
+            Optional.empty()
+        );
+    }
+
+    /**
+     * @deprecated Since 4.0. Use {@link #MemberDescription(String, Optional, String, String, MemberAssignment, Optional, Optional, Optional)}.
+     */
+    @Deprecated
     public MemberDescription(
         String memberId,
         Optional<String> groupInstanceId,
@@ -64,6 +101,10 @@ public class MemberDescription {
         );
     }
 
+    /**
+     * @deprecated Since 4.0. Use {@link #MemberDescription(String, Optional, String, String, MemberAssignment, Optional, Optional, Optional)}.
+     */
+    @Deprecated
     public MemberDescription(String memberId,
                              String clientId,
                              String host,
@@ -81,12 +122,14 @@ public class MemberDescription {
             clientId.equals(that.clientId) &&
             host.equals(that.host) &&
             assignment.equals(that.assignment) &&
-            targetAssignment.equals(that.targetAssignment);
+            targetAssignment.equals(that.targetAssignment) &&
+            memberEpoch.equals(that.memberEpoch) &&
+            upgraded.equals(that.upgraded);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(memberId, groupInstanceId, clientId, host, assignment, targetAssignment);
+        return Objects.hash(memberId, groupInstanceId, clientId, host, assignment, targetAssignment, memberEpoch, upgraded);
     }
 
     /**
@@ -131,6 +174,25 @@ public class MemberDescription {
         return targetAssignment;
     }
 
+    /**
+     * The epoch of the group member.
+     * The optional is set to an integer if the member is in a {@link GroupType#CONSUMER} group, and to empty if it
+     * is in a {@link GroupType#CLASSIC} group.
+     */
+    public Optional<Integer> memberEpoch() {
+        return memberEpoch;
+    }
+
+    /**
+     * The flag indicating whether a member within a {@link GroupType#CONSUMER} group uses the
+     * {@link GroupType#CONSUMER} protocol.
+     * The optional is set to true if it does, to false if it does not, and to empty if it is unknown or if the group
+     * is a {@link GroupType#CLASSIC} group.
+     */
+    public Optional<Boolean> upgraded() {
+        return upgraded;
+    }
+
     @Override
     public String toString() {
         return "(memberId=" + memberId +
@@ -138,6 +200,9 @@ public class MemberDescription {
             ", clientId=" + clientId +
             ", host=" + host +
             ", assignment=" + assignment +
-            ", targetAssignment=" + targetAssignment + ")";
+            ", targetAssignment=" + targetAssignment +
+            ", memberEpoch=" + memberEpoch.orElse(null) +
+            ", upgraded=" + upgraded.orElse(null) +
+            ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeClassicGroupsHandler.java
@@ -136,7 +136,10 @@ public class DescribeClassicGroupsHandler extends AdminApiHandler.Batched<Coordi
                     Optional.ofNullable(groupMember.groupInstanceId()),
                     groupMember.clientId(),
                     groupMember.clientHost(),
-                    new MemberAssignment(partitions)));
+                    new MemberAssignment(partitions),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()));
             });
 
             final ClassicGroupDescription classicGroupDescription =

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
@@ -222,7 +222,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                     groupMember.clientId(),
                     groupMember.clientHost(),
                     new MemberAssignment(convertAssignment(groupMember.assignment())),
-                    Optional.of(new MemberAssignment(convertAssignment(groupMember.targetAssignment())))
+                    Optional.of(new MemberAssignment(convertAssignment(groupMember.targetAssignment()))),
+                    Optional.of(groupMember.memberEpoch()),
+                    groupMember.memberType() == -1 ? Optional.empty() : Optional.of(groupMember.memberType() == 1)
                 ))
             );
 
@@ -235,7 +237,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                     GroupType.CONSUMER,
                     GroupState.parse(describedGroup.groupState()),
                     coordinator,
-                    authorizedOperations
+                    authorizedOperations,
+                    Optional.of(describedGroup.groupEpoch()),
+                    Optional.of(describedGroup.assignmentEpoch())
                 );
             completed.put(groupIdKey, consumerGroupDescription);
         }
@@ -281,7 +285,10 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                         Optional.ofNullable(groupMember.groupInstanceId()),
                         groupMember.clientId(),
                         groupMember.clientHost(),
-                        new MemberAssignment(partitions)));
+                        new MemberAssignment(partitions),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
                 }
                 final ConsumerGroupDescription consumerGroupDescription =
                     new ConsumerGroupDescription(groupIdKey.idValue, protocolType.isEmpty(),
@@ -290,7 +297,9 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
                         GroupType.CLASSIC,
                         GroupState.parse(describedGroup.groupState()),
                         coordinator,
-                        authorizedOperations);
+                        authorizedOperations,
+                        Optional.empty(),
+                        Optional.empty());
                 completed.put(groupIdKey, consumerGroupDescription);
             } else {
                 failed.put(groupIdKey, new IllegalArgumentException(

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4057,6 +4057,7 @@ public class KafkaAdminClientTest {
                                                 .setTopicName("foo")
                                                 .setPartitions(singletonList(1))
                                         )))
+                                    .setMemberType((byte) 1)
                             )),
                         new ConsumerGroupDescribeResponseData.DescribedGroup()
                             .setGroupId("grp2")
@@ -4110,14 +4111,18 @@ public class KafkaAdminClientTest {
                         ),
                         Optional.of(new MemberAssignment(
                             Collections.singleton(new TopicPartition("foo", 1))
-                        ))
+                        )),
+                        Optional.of(10),
+                        Optional.of(true)
                     )
                 ),
                 "range",
                 GroupType.CONSUMER,
                 GroupState.STABLE,
                 env.cluster().controller(),
-                Collections.emptySet()
+                Collections.emptySet(),
+                Optional.of(10),
+                Optional.of(10)
             ));
             expectedResult.put("grp2", new ConsumerGroupDescription(
                 "grp2",
@@ -4130,14 +4135,19 @@ public class KafkaAdminClientTest {
                         "clientHost",
                         new MemberAssignment(
                             Collections.singleton(new TopicPartition("bar", 0))
-                        )
+                        ),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
                     )
                 ),
                 "range",
                 GroupType.CLASSIC,
                 GroupState.STABLE,
                 env.cluster().controller(),
-                Collections.emptySet()
+                Collections.emptySet(),
+                Optional.empty(),
+                Optional.empty()
             ));
 
             assertEquals(expectedResult, result.all().get());
@@ -8674,7 +8684,10 @@ public class KafkaAdminClientTest {
                                      Optional.ofNullable(member.groupInstanceId()),
                                      member.clientId(),
                                      member.clientHost(),
-                                     assignment);
+                                     assignment,
+                                     Optional.empty(),
+                                     Optional.empty(),
+                                     Optional.empty());
     }
 
     private static ShareMemberDescription convertToShareMemberDescriptions(ShareGroupDescribeResponseData.Member member,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
@@ -99,5 +99,38 @@ public class MemberDescriptionTest {
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, newInstanceDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newInstanceDescription.hashCode());
+
+        MemberDescription newTargetAssignmentDescription = new MemberDescription(MEMBER_ID,
+                                                                                 INSTANCE_ID,
+                                                                                 CLIENT_ID,
+                                                                                 HOST,
+                                                                                 ASSIGNMENT,
+                                                                                 Optional.of(ASSIGNMENT),
+                                                                                 Optional.empty(),
+                                                                                 Optional.empty());
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION, newTargetAssignmentDescription);
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newTargetAssignmentDescription.hashCode());
+
+        MemberDescription newMemberEpochDescription = new MemberDescription(MEMBER_ID,
+                                                                            INSTANCE_ID,
+                                                                            CLIENT_ID,
+                                                                            HOST,
+                                                                            ASSIGNMENT,
+                                                                            Optional.empty(),
+                                                                            Optional.of(1),
+                                                                            Optional.empty());
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION, newMemberEpochDescription);
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newMemberEpochDescription.hashCode());
+
+        MemberDescription newIsClassicDescription = new MemberDescription(MEMBER_ID,
+                                                                          INSTANCE_ID,
+                                                                          CLIENT_ID,
+                                                                          HOST,
+                                                                          ASSIGNMENT,
+                                                                          Optional.empty(),
+                                                                          Optional.empty(),
+                                                                          Optional.of(false));
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION, newIsClassicDescription);
+        assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newIsClassicDescription.hashCode());
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -139,8 +140,12 @@ public class ConsumerGroupServiceTest {
                 true,
                 Collections.singleton(new MemberDescription("member1", Optional.of("instance1"), "client1", "host1", new MemberAssignment(assignedTopicPartitions))),
                 RangeAssignor.class.getName(),
+                GroupType.CLASSIC,
                 GroupState.STABLE,
-                new Node(1, "localhost", 9092));
+                new Node(1, "localhost", 9092),
+                Set.of(),
+                Optional.empty(),
+                Optional.empty());
 
         Function<Collection<TopicPartition>, ArgumentMatcher<Map<TopicPartition, OffsetSpec>>> offsetsArgMatcher = expectedPartitions ->
                 topicPartitionOffsets -> topicPartitionOffsets != null && topicPartitionOffsets.keySet().equals(expectedPartitions);
@@ -233,8 +238,12 @@ public class ConsumerGroupServiceTest {
                 true,
                 Collections.singleton(member1),
                 RangeAssignor.class.getName(),
+                GroupType.CLASSIC,
                 groupState,
-                new Node(1, "localhost", 9092));
+                new Node(1, "localhost", 9092),
+                Set.of(),
+                Optional.empty(),
+                Optional.empty());
         KafkaFutureImpl<ConsumerGroupDescription> future = new KafkaFutureImpl<>();
         future.complete(description);
         return new DescribeConsumerGroupsResult(Collections.singletonMap(GROUP, future));


### PR DESCRIPTION
* Add fields `groupEpoch` and `targetAssignmentEpoch` to `ConsumerGroupDescription.java`.
* Add fields `memberEpoch` and `upgraded` to `MemberDescription.java`.
* Add assertion to `PlaintextAdminIntegrationTest#testDescribeClassicGroups` to make sure member in classic group returns `upgraded` as `Optional.empty`.
* Add new case `testConsumerGroupWithMemberMigration` to `PlaintextAdminIntegrationTest` to make sure migration member has correct `upgraded` value. Add assertion for `groupEpoch`, `targetAssignmentEpoch`, `memberEpoch` as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
