### PR TITLE
Fix docker test

### DIFF
--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r docker/requirements.txt
+        pip install --upgrade --force-reinstall --no-cache-dir docker-compose && ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
     - name: Build image and run tests
       working-directory: ./docker
       env:

--- a/.github/workflows/docker_official_image_build_and_test.yml
+++ b/.github/workflows/docker_official_image_build_and_test.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r docker/requirements.txt
+        pip install --upgrade --force-reinstall --no-cache-dir docker-compose && ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
     - name: Build image and run tests
       working-directory: ./docker
       env:


### PR DESCRIPTION
Docker tests rely on docker compose. In recent runs it has been observed that github actions does not provide support for docker compose, so we are installing it explicitly in the workflow.

Failing for 3.7.2 docker: https://github.com/apache/kafka/actions/runs/12130482854

Tested on a local fork.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
