### PR TITLE
Implement support for streams groups in kafka-groups.sh

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/GroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupState.java
@@ -32,17 +32,18 @@ import java.util.stream.Collectors;
  * The following table shows the correspondence between the group states and types.
  * <table>
  *     <thead>
- *         <tr><th>State</th><th>Classic group</th><th>Consumer group</th><th>Share group</th></tr>
+ *         <tr><th>State</th><th>Classic group</th><th>Consumer group</th><th>Share group</th><th>Streams group</th></tr>
  *     </thead>
  *     <tbody>
- *         <tr><td>UNKNOWN</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
- *         <tr><td>PREPARING_REBALANCE</td><td>Yes</td><td>Yes</td><td></td></tr>
- *         <tr><td>COMPLETING_REBALANCE</td><td>Yes</td><td>Yes</td><td></td></tr>
- *         <tr><td>STABLE</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
- *         <tr><td>DEAD</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
- *         <tr><td>EMPTY</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
- *         <tr><td>ASSIGNING</td><td></td><td>Yes</td><td></td></tr>
- *         <tr><td>RECONCILING</td><td></td><td>Yes</td><td></td></tr>
+ *         <tr><td>UNKNOWN</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ *         <tr><td>PREPARING_REBALANCE</td><td>Yes</td><td>Yes</td><td></td><td>Yes</td></tr>
+ *         <tr><td>COMPLETING_REBALANCE</td><td>Yes</td><td>Yes</td><td></td><td>Yes</td></tr>
+ *         <tr><td>STABLE</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ *         <tr><td>DEAD</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ *         <tr><td>EMPTY</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ *         <tr><td>ASSIGNING</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
+ *         <tr><td>RECONCILING</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
+ *         <tr><td>NOT_READY</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
  *     </tbody>
  * </table>
  */
@@ -55,7 +56,8 @@ public enum GroupState {
     DEAD("Dead"),
     EMPTY("Empty"),
     ASSIGNING("Assigning"),
-    RECONCILING("Reconciling");
+    RECONCILING("Reconciling"),
+    NOT_READY("NotReady");
 
     private static final Map<String, GroupState> NAME_TO_ENUM = Arrays.stream(values())
             .collect(Collectors.toMap(state -> state.name.toUpperCase(Locale.ROOT), Function.identity()));
@@ -79,6 +81,8 @@ public enum GroupState {
             return Set.of(PREPARING_REBALANCE, COMPLETING_REBALANCE, STABLE, DEAD, EMPTY);
         } else if (type == GroupType.CONSUMER) {
             return Set.of(PREPARING_REBALANCE, COMPLETING_REBALANCE, STABLE, DEAD, EMPTY, ASSIGNING, RECONCILING);
+        } else if (type == GroupType.STREAMS) {
+            return Set.of(PREPARING_REBALANCE, COMPLETING_REBALANCE, STABLE, DEAD, EMPTY, ASSIGNING, RECONCILING, NOT_READY);
         } else if (type == GroupType.SHARE) {
             return Set.of(STABLE, DEAD, EMPTY);
         } else {

--- a/clients/src/main/java/org/apache/kafka/common/GroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupState.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  *         <tr><td>EMPTY</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
  *         <tr><td>ASSIGNING</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
  *         <tr><td>RECONCILING</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
- *         <tr><td>NOT_READY</td><td></td><td>Yes</td><td></td><td>Yes</td></tr>
+ *         <tr><td>NOT_READY</td><td></td><td></td><td></td><td>Yes</td></tr>
  *     </tbody>
  * </table>
  */

--- a/clients/src/main/java/org/apache/kafka/common/GroupType.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupType.java
@@ -26,7 +26,8 @@ public enum GroupType {
     UNKNOWN("Unknown"),
     CONSUMER("Consumer"),
     CLASSIC("Classic"),
-    SHARE("Share");
+    SHARE("Share"),
+    STREAMS("Streams");
 
     private static final Map<String, GroupType> NAME_TO_ENUM = Arrays.stream(values())
         .collect(Collectors.toMap(type -> type.name.toLowerCase(Locale.ROOT), Function.identity()));

--- a/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
@@ -46,8 +46,8 @@
         { "name": "AssignmentEpoch", "type": "int32", "versions": "0+",
           "about": "The assignment epoch." },
 
-        { "name":  "Topology", "type": "Topology", "versions": "0+",
-          "about": "The topology metadata currently initialized for the streams application.",
+        { "name":  "Topology", "type": "Topology", "versions": "0+", "nullableVersions": "0+", "default": "null",
+          "about": "The topology metadata currently initialized for the streams application. Can be null in case of a describe error.",
           "fields": [
             { "name": "Epoch", "type": "int32", "versions": "0+",
               "about": "The epoch of the currently initialized topology for this group." },

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -63,6 +63,11 @@ import static org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGro
  */
 public class StreamsGroup implements Group {
 
+    /**
+     * The protocol type for streams groups. There is only one protocol type, "streams".
+     */
+    private static final String PROTOCOL_TYPE = "streams";
+
     public enum StreamsGroupState {
         EMPTY("Empty"),
         NOT_READY("Not Ready"),
@@ -249,7 +254,7 @@ public class StreamsGroup implements Group {
     public ListGroupsResponseData.ListedGroup asListedGroup(long committedOffset) {
         return new ListGroupsResponseData.ListedGroup()
             .setGroupId(groupId)
-            .setProtocolType("streams")
+            .setProtocolType(PROTOCOL_TYPE)
             .setGroupState(state.get(committedOffset).toString())
             .setGroupType(type().toString());
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
-import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
@@ -40,7 +39,6 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
 import org.apache.kafka.timeline.TimelineObject;
-
 import org.slf4j.Logger;
 
 import java.util.Collections;
@@ -251,7 +249,7 @@ public class StreamsGroup implements Group {
     public ListGroupsResponseData.ListedGroup asListedGroup(long committedOffset) {
         return new ListGroupsResponseData.ListedGroup()
             .setGroupId(groupId)
-            .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+            .setProtocolType("streams")
             .setGroupState(state.get(committedOffset).toString())
             .setGroupType(type().toString());
     }

--- a/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterInstance;
@@ -38,6 +39,13 @@ import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestExtensions;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -107,6 +115,14 @@ public class GroupsCommandTest {
         assertTrue(opts.hasListOption());
         assertTrue(opts.hasShareOption());
     }
+    
+    @Test
+    public void testOptionsListStreamsFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--streams"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.hasStreamsOption());
+    }
 
     @Test
     public void testOptionsListProtocolFilterSucceeds() {
@@ -124,6 +140,15 @@ public class GroupsCommandTest {
         assertTrue(opts.hasListOption());
         assertTrue(opts.groupType().isPresent());
         assertEquals(GroupType.SHARE, opts.groupType().get());
+    }
+
+    @Test
+    public void testOptionsListTypeStreamsFilterSucceeds() {
+        GroupsCommand.GroupsCommandOptions opts = new GroupsCommand.GroupsCommandOptions(
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--group-type", "streams"});
+        assertTrue(opts.hasListOption());
+        assertTrue(opts.groupType().isPresent());
+        assertEquals(GroupType.STREAMS, opts.groupType().get());
     }
 
     @Test
@@ -150,6 +175,18 @@ public class GroupsCommandTest {
     }
 
     @Test
+    public void testOptionsListShareAndStreamsFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--share", "--streams"});
+    }
+
+    @Test
+    public void testOptionsListConsumerAndStreamsFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--consumer", "--streams"});
+    }
+
+    @Test
     public void testOptionsListConsumerAndProtocolFilterFails() {
         assertInitializeInvalidOptionsExitCode(1,
                 new String[] {"--bootstrap-server", bootstrapServer, "--list", "--consumer", "--protocol", "anyproto"});
@@ -172,7 +209,19 @@ public class GroupsCommandTest {
         assertInitializeInvalidOptionsExitCode(1,
             new String[] {"--bootstrap-server", bootstrapServer, "--list", "--share", "--group-type", "classic"});
     }
+    
+    @Test
+    public void testOptionsListStreamsAndProtocolFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--streams", "--protocol", "anyproto"});
+    }
 
+    @Test
+    public void testOptionsListStreamsAndTypeFilterFails() {
+        assertInitializeInvalidOptionsExitCode(1,
+            new String[] {"--bootstrap-server", bootstrapServer, "--list", "--streams", "--group-type", "classic"});
+    }
+    
     @Test
     public void testListGroupsEmpty() {
         Admin adminClient = mock(Admin.class);
@@ -201,7 +250,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -217,7 +267,8 @@ public class GroupsCommandTest {
         assertCapturedListOutput(capturedOutput,
                 new String[]{"CGclassic", "Classic", "consumer"},
                 new String[]{"CGconsumer", "Consumer", "consumer"},
-                new String[]{"SG", "Share", "share"});
+                new String[]{"SG", "Share", "share"},
+                new String[]{"StrG", "Streams", "streams"});
     }
 
     @Test
@@ -228,7 +279,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -254,7 +306,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
             new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
             new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-            new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+            new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+            new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -272,6 +325,32 @@ public class GroupsCommandTest {
     }
 
     @Test
+    public void testListGroupsStreamsFilter() {
+        Admin adminClient = mock(Admin.class);
+        GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
+
+        ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
+            new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
+            new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
+            new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+            new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
+        );
+        when(adminClient.listGroups()).thenReturn(result);
+
+        String capturedOutput = ToolsTestUtils.captureStandardOut(() -> {
+            try {
+                service.listGroups(new GroupsCommand.GroupsCommandOptions(
+                    new String[]{"--bootstrap-server", bootstrapServer, "--list", "--streams"}
+                ));
+            } catch (Throwable t) {
+                fail(t);
+            }
+        });
+        assertCapturedListOutput(capturedOutput,
+            new String[]{"StrG", "Streams", "streams"});
+    }
+
+    @Test
     public void testListGroupsProtocolFilter() {
         Admin adminClient = mock(Admin.class);
         GroupsCommand.GroupsService service = new GroupsCommand.GroupsService(adminClient);
@@ -279,7 +358,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -305,7 +385,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -330,7 +411,8 @@ public class GroupsCommandTest {
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGclassic", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE)),
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -354,7 +436,8 @@ public class GroupsCommandTest {
 
         ListGroupsResult result = AdminClientTestUtils.listGroupsResult(
                 new GroupListing("CGconsumer", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE)),
-                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE))
+                new GroupListing("SG", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE)),
+                new GroupListing("StrG", Optional.of(GroupType.STREAMS), "streams", Optional.of(GroupState.STABLE))
         );
         when(adminClient.listGroups()).thenReturn(result);
 
@@ -383,21 +466,24 @@ public class GroupsCommandTest {
         )));
     }
 
-    @SuppressWarnings("NPathComplexity")
+    @SuppressWarnings({"NPathComplexity", "CyclomaticComplexity"})
     @ClusterTest(
         serverProperties = {
-            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,share"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,share,streams"),
             @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
             @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         }
     )
     public void testGroupCommand(ClusterInstance clusterInstance) throws Exception {
         String topic = "topic";
+        String outputTopic = "output-topic";
         String classicGroupId = "classic_group";
         String consumerGroupId = "consumer_group";
         String shareGroupId = "share_group";
+        String streamsGroupId = "streams_group";
         String simpleGroupId = "simple_group";
-        clusterInstance.createTopic("topic", 1, (short) 1);
+        clusterInstance.createTopic(topic, 1, (short) 1);
+        clusterInstance.createTopic(outputTopic, 1, (short) 1);
         TopicPartition topicPartition = new TopicPartition(topic, 0);
 
         Properties props = new Properties();
@@ -406,6 +492,7 @@ public class GroupsCommandTest {
         try (KafkaConsumer<String, String> classicGroup = createKafkaConsumer(clusterInstance, classicGroupId, GroupProtocol.CLASSIC);
              KafkaConsumer<String, String> consumerGroup = createKafkaConsumer(clusterInstance, consumerGroupId, GroupProtocol.CONSUMER);
              KafkaShareConsumer<String, String> shareGroup = createKafkaShareConsumer(clusterInstance, shareGroupId);
+             KafkaStreams streams = createKafkaStreams(clusterInstance, streamsGroupId, topic, outputTopic);
              Admin admin = clusterInstance.admin();
              GroupsCommand.GroupsService groupsCommand = new GroupsCommand.GroupsService(props)
         ) {
@@ -415,6 +502,7 @@ public class GroupsCommandTest {
             consumerGroup.poll(Duration.ofMillis(1000));
             shareGroup.subscribe(List.of(topic));
             shareGroup.poll(Duration.ofMillis(1000));
+            streams.start();
 
             AlterConsumerGroupOffsetsResult result = admin.alterConsumerGroupOffsets(simpleGroupId, Map.of(topicPartition, new OffsetAndMetadata(0L)));
             assertNull(result.all().get());
@@ -423,12 +511,13 @@ public class GroupsCommandTest {
                 Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
                     assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
                         List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list").toArray(new String[0])))));
-                if (res.getKey().split("\n").length == 5 && res.getValue().isEmpty()) {
+                if (res.getKey().split("\n").length == 6 && res.getValue().isEmpty()) {
                     assertCapturedListOutput(res.getKey(),
                         new String[]{classicGroupId, "Classic", "consumer"},
                         new String[]{consumerGroupId, "Consumer", "consumer"},
                         new String[]{simpleGroupId, "Classic"},
-                        new String[]{shareGroupId, "Share", "share"});
+                        new String[]{shareGroupId, "Share", "share"},
+                        new String[]{streamsGroupId, "Streams", "streams"});
                     return true;
                 }
                 return false;
@@ -488,6 +577,18 @@ public class GroupsCommandTest {
             TestUtils.waitForCondition(() -> {
                 Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
                     assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--group-type", "streams").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{streamsGroupId, "Streams", "streams"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return streams type groups");
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
                         List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--share").toArray(new String[0])))));
                 if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
                     assertCapturedListOutput(res.getKey(),
@@ -496,6 +597,19 @@ public class GroupsCommandTest {
                 }
                 return false;
             }, "Waiting for listing groups to return share type groups");
+
+
+            TestUtils.waitForCondition(() -> {
+                Map.Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(() ->
+                    assertDoesNotThrow(() -> groupsCommand.listGroups(new GroupsCommand.GroupsCommandOptions(
+                        List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--streams").toArray(new String[0])))));
+                if (res.getKey().split("\n").length == 2 && res.getValue().isEmpty()) {
+                    assertCapturedListOutput(res.getKey(),
+                        new String[]{streamsGroupId, "Streams", "streams"});
+                    return true;
+                }
+                return false;
+            }, "Waiting for listing groups to return streams type groups");
         }
     }
 
@@ -536,5 +650,19 @@ public class GroupsCommandTest {
             ConsumerConfig.GROUP_ID_CONFIG, groupId,
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()));
+    }
+
+    private KafkaStreams createKafkaStreams(ClusterInstance clusterInstance, String groupId, String inputTopic, String outputTopic) {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Long, String> input = builder.stream(inputTopic);
+        input.map((key, value) -> new KeyValue<>(key, key)).to(outputTopic, Produced.with(Serdes.Long(), Serdes.Long()));
+        Topology topology = builder.build();
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, groupId);
+        properties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        return new KafkaStreams(topology, properties);
     }
 }


### PR DESCRIPTION
Add support for streams groups in `kafka-groups.sh`, including a little integration test that spins up a kafka streams application and lists the group.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
