### PR TITLE
KAFKA-18159:Remove onPartitionsRevoked and onPartitionsAssigned from SinkTask

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -152,14 +152,6 @@ public abstract class SinkTask implements Task {
      *                   partitions previously assigned to the task)
      */
     public void open(Collection<TopicPartition> partitions) {
-        this.onPartitionsAssigned(partitions);
-    }
-
-    /**
-     * @deprecated Use {@link #open(Collection)} for partition initialization.
-     */
-    @Deprecated
-    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
     }
 
     /**
@@ -175,14 +167,6 @@ public abstract class SinkTask implements Task {
      * @param partitions The list of partitions that should be closed
      */
     public void close(Collection<TopicPartition> partitions) {
-        this.onPartitionsRevoked(partitions);
-    }
-
-    /**
-     * @deprecated Use {@link #close(Collection)} instead for partition cleanup.
-     */
-    @Deprecated
-    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -109,9 +109,7 @@ public class BlockingConnectorTest {
     private static final String SINK_TASK_FLUSH = "SinkTask::flush";
     private static final String SINK_TASK_PRE_COMMIT = "SinkTask::preCommit";
     private static final String SINK_TASK_OPEN = "SinkTask::open";
-    private static final String SINK_TASK_ON_PARTITIONS_ASSIGNED = "SinkTask::onPartitionsAssigned";
     private static final String SINK_TASK_CLOSE = "SinkTask::close";
-    private static final String SINK_TASK_ON_PARTITIONS_REVOKED = "SinkTask::onPartitionsRevoked";
     private static final String SOURCE_TASK_INITIALIZE = "SourceTask::initialize";
     private static final String SOURCE_TASK_POLL = "SourceTask::poll";
     private static final String SOURCE_TASK_COMMIT = "SourceTask::commit";
@@ -870,23 +868,9 @@ public class BlockingConnectorTest {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
-            public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-                block.maybeBlockOn(SINK_TASK_ON_PARTITIONS_ASSIGNED);
-                super.onPartitionsAssigned(partitions);
-            }
-
-            @Override
             public void close(Collection<TopicPartition> partitions) {
                 block.maybeBlockOn(SINK_TASK_CLOSE);
                 super.close(partitions);
-            }
-
-            @Override
-            @SuppressWarnings("deprecation")
-            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-                block.maybeBlockOn(SINK_TASK_ON_PARTITIONS_REVOKED);
-                super.onPartitionsRevoked(partitions);
             }
         }
     }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -137,6 +137,9 @@
                         <li>The <code>whitelist</code> and <code>blacklist</code> configurations were removed from the <code>org.apache.kafka.connect.transforms.ReplaceField</code> transformation.
                             Please use <code>include</code> and <code>exclude</code> respectively instead.
                         </li>
+                        <li>The <code>onPartitionsRevoked(Collection&lt;TopicPartition&gt;)</code> and <code>onPartitionsAssigned(Collection&lt;TopicPartition&gt;)</code> methods
+                            were removed from <code>SinkTask</code>.
+                        </li>
                     </ul>
                 </li>
                 <li><b>Consumer</b>


### PR DESCRIPTION
Remove onPartitionsRevoked and onPartitionsAssigned from SinkTask

jira:https://issues.apache.org/jira/browse/KAFKA-18159

<img width="633" alt="20204-12-5" src="https://github.com/user-attachments/assets/f5140b55-a857-4ec7-bdbb-0c5e30382aad">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
