### PR TITLE
KAFKA-18129: `SharePartition#maybeInitialize` should complete the future outsize the write lock

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -47,6 +47,7 @@
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity" files="SharePartitionManagerTest"/>
+    <suppress checks="CyclomaticComplexity" files="SharePartition.java"/>
 
     <!-- server tests -->
     <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -47,7 +47,7 @@
     <suppress checks="JavaNCSS"
               files="(RemoteLogManagerTest|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity" files="SharePartitionManagerTest"/>
-    <suppress checks="CyclomaticComplexity" files="SharePartition.java"/>
+    <suppress checks="CyclomaticComplexity|ClassDataAbstractionCoupling" files="SharePartition.java"/>
 
     <!-- server tests -->
     <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -374,7 +374,7 @@ public class SharePartition {
         CompletableFuture<Void> future = new CompletableFuture<>();
         AtomicReference<Optional<Throwable>> futureException = new AtomicReference<>(Optional.empty());
         // Check if the share partition is already initialized.
-        InitializationResult initializationResult = maybeCompleteInitialization();
+        InitializationResult initializationResult = checkInitializationCompletion();
         if (initializationResult.isComplete()) {
             if (initializationResult.throwable() != null) {
                 future.completeExceptionally(initializationResult.throwable());
@@ -390,12 +390,10 @@ public class SharePartition {
         boolean shouldFutureBeCompleted = false;
         try {
             // Re-check the state to verify if previous requests has already initialized the share partition.
-            initializationResult = maybeCompleteInitialization();
+            initializationResult = checkInitializationCompletion();
             if (initializationResult.isComplete()) {
                 if (initializationResult.throwable() != null) {
                     futureException.set(Optional.of(initializationResult.throwable()));
-                } else {
-                    futureException.set(Optional.empty());
                 }
                 shouldFutureBeCompleted = true;
                 return future;
@@ -1185,7 +1183,7 @@ public class SharePartition {
         }
     }
 
-    private InitializationResult maybeCompleteInitialization() {
+    private InitializationResult checkInitializationCompletion() {
         SharePartitionState currentState = partitionState();
         switch (currentState) {
             case ACTIVE:

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -390,7 +390,7 @@ public class SharePartition {
         boolean shouldFutureBeCompleted = false;
         try {
             // Re-check the state to verify if previous requests has already initialized the share partition.
-            maybeCompleteInitialization();
+            initializationResult = maybeCompleteInitialization();
             if (initializationResult.isComplete()) {
                 if (initializationResult.throwable() != null) {
                     futureException.set(Optional.of(initializationResult.throwable()));


### PR DESCRIPTION
### About
In reference to comment https://github.com/apache/kafka/pull/17957#discussion_r1862570482 ,

It might be better not to complete the future while holding the write lock. The registered action for the future could potentially try to acquire another lock that is held by a different thread, which, in turn, could be waiting on the write lock - resulting in a deadlock.

### Testing
The code is being tested with the help of already present unit and integration tests.