### PR TITLE
Use LeaveOnClose event with Streams membership manager

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -119,7 +119,7 @@
               files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer|NetworkClient)Test.java"/>
+              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer|NetworkClient|ApplicationEventProcessor)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="MockAdminClient.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -103,7 +103,7 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
 
     @Override
     public NetworkClientDelegate.PollResult poll(long currentTimeMs) {
-        if (!coordinatorRequestManager.coordinator().isPresent() || membershipManager.shouldSkipHeartbeat()) {
+        if (coordinatorRequestManager.coordinator().isEmpty() || membershipManager.shouldSkipHeartbeat()) {
             membershipManager.transitionToUnsubscribeIfLeaving();
             return NetworkClientDelegate.PollResult.EMPTY;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -455,12 +455,15 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
     }
 
     private void process(final LeaveGroupOnCloseEvent event) {
-        if (requestManagers.consumerMembershipManager.isEmpty())
-            return;
-
-        log.debug("Signal the ConsumerMembershipManager to leave the consumer group since the consumer is closing");
-        CompletableFuture<Void> future = requestManagers.consumerMembershipManager.get().leaveGroupOnClose();
-        future.whenComplete(complete(event.future()));
+        if (requestManagers.consumerMembershipManager.isPresent()) {
+            CompletableFuture<Void> future = requestManagers.consumerMembershipManager.get().leaveGroupOnClose();
+            future.whenComplete(complete(event.future()));
+            log.debug("Signal the ConsumerMembershipManager to leave the consumer group since the consumer is closing");
+        } else if (requestManagers.streamsMembershipManager.isPresent()) {
+            CompletableFuture<Void> future = requestManagers.streamsMembershipManager.get().leaveGroupOnClose();
+            future.whenComplete(complete(event.future()));
+            log.debug("Signal the StreamsMembershipManager to leave the Streams group since the member is closing");
+        }
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerHeartbeatRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMembershipManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
+import org.apache.kafka.clients.consumer.internals.ConsumerUtils;
 import org.apache.kafka.clients.consumer.internals.CoordinatorRequestManager;
 import org.apache.kafka.clients.consumer.internals.FetchRequestManager;
 import org.apache.kafka.clients.consumer.internals.MockRebalanceListener;
@@ -63,8 +64,10 @@ import static org.apache.kafka.clients.consumer.internals.events.CompletableEven
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -584,6 +587,69 @@ public class ApplicationEventProcessorTest {
         setupProcessorWithStreamsMembershipManager();
         processor.process(event);
         verify(streamsMembershipManager).onAllTasksLostCallbackCompleted(event);
+    }
+
+
+    @Test
+    public void testLeaveOnCloseWithStreamsMembershipManager() {
+        LeaveGroupOnCloseEvent event = new LeaveGroupOnCloseEvent(ConsumerUtils.DEFAULT_CLOSE_TIMEOUT_MS);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        when(streamsMembershipManager.leaveGroupOnClose()).thenReturn(future);
+
+        setupProcessorWithStreamsMembershipManager();
+        processor.process(event);
+        verifyLeaveOnClose(event, future);
+    }
+
+    @Test
+    public void testLeaveOnCloseCompletesExceptionallyWithStreamsMembershipManager() {
+        LeaveGroupOnCloseEvent event = new LeaveGroupOnCloseEvent(ConsumerUtils.DEFAULT_CLOSE_TIMEOUT_MS);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        when(streamsMembershipManager.leaveGroupOnClose()).thenReturn(future);
+
+        setupProcessorWithStreamsMembershipManager();
+        processor.process(event);
+        verifyLeaveOnCloseCompletesExceptionally(event, future);
+    }
+
+    @Test
+    public void testLeaveOnCloseWithConsumerMembershipManager() {
+        LeaveGroupOnCloseEvent event = new LeaveGroupOnCloseEvent(ConsumerUtils.DEFAULT_CLOSE_TIMEOUT_MS);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        when(membershipManager.leaveGroupOnClose()).thenReturn(future);
+
+        setupProcessor(true);
+        processor.process(event);
+        verifyLeaveOnClose(event, future);
+    }
+
+    @Test
+    public void testLeaveOnCloseCompletesExceptionallyWithConsumerMembershipManager() {
+        LeaveGroupOnCloseEvent event = new LeaveGroupOnCloseEvent(ConsumerUtils.DEFAULT_CLOSE_TIMEOUT_MS);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        when(membershipManager.leaveGroupOnClose()).thenReturn(future);
+
+        setupProcessor(true);
+        processor.process(event);
+        verifyLeaveOnCloseCompletesExceptionally(event, future);
+    }
+
+    private void verifyLeaveOnClose(LeaveGroupOnCloseEvent event, CompletableFuture<Void> future) {
+        assertFalse(event.future().isDone());
+        future.complete(null);
+        assertTrue(event.future().isDone());
+        assertFalse(event.future().isCompletedExceptionally());
+    }
+
+    private void verifyLeaveOnCloseCompletesExceptionally(LeaveGroupOnCloseEvent event, CompletableFuture<Void> future) {
+        assertFalse(event.future().isDone());
+        RuntimeException exception = new RuntimeException("Nobody expects the Spanish Inquisition!");
+        future.completeExceptionally(exception);
+        assertTrue(event.future().isDone());
+        assertTrue(event.future().isCompletedExceptionally());
+        ExecutionException thrown = assertThrows(ExecutionException.class, () -> event.future().get());
+        assertInstanceOf(RuntimeException.class, thrown.getCause());
+        assertEquals(exception.getMessage(), thrown.getCause().getMessage());
     }
 
     private List<NetworkClientDelegate.UnsentRequest> mockCommitResults() {


### PR DESCRIPTION
The Streams membership manager did not use the LeaveOnClose event to faster leaving the group on closing. With the event the Streams membership manager leaves the group without invoking any callback for releasing the active tasks.

With this commit the Streams membership member uses the LeaveOnClose event.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
