### PR TITLE
MINOR: Add tiered-storage label automatically to PRs

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -131,3 +131,8 @@ dependencies:
       - "grade/dependencies.gradle"
       - "LICENSE-binary"
 
+tiered-storage:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '*/src/*/java/org/apache/kafka/server/log/remote/**'
+      - '*/src/*/java/kafka/log/remote/**'


### PR DESCRIPTION
The Tiered Storage files today primarily reside at two different modules, core & storage, at the following places:
1. https://github.com/apache/kafka/tree/trunk/core/src/main/java/kafka/log/remote
2. https://github.com/apache/kafka/tree/trunk/storage/src/main/java/org/apache/kafka/server/log/remote

This change does not assume the module (core or storage) since we expect it to work after refactoring as well.