### PR TITLE
KAFKA-18164: Clear existing acknowledgements on share session epoch reset.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -990,16 +990,17 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             }
 
             ShareAcknowledgeRequest.Builder requestBuilder = sessionHandler.newShareAcknowledgeBuilder(groupId, fetchConfig);
-            Node nodeToSend = metadata.fetch().nodeById(nodeId);
 
             log.trace("Building acknowledgements to send : {}", finalAcknowledgementsToSend);
-            nodesWithPendingRequests.add(nodeId);
             isProcessed = false;
 
             if (requestBuilder == null) {
                 handleSessionErrorCode(Errors.SHARE_SESSION_NOT_FOUND);
                 return null;
             } else {
+                Node nodeToSend = metadata.fetch().nodeById(nodeId);
+                nodesWithPendingRequests.add(nodeId);
+
                 inFlightAcknowledgements.putAll(finalAcknowledgementsToSend);
                 if (incompleteAcknowledgements.isEmpty()) {
                     acknowledgementsToSend.clear();
@@ -1082,12 +1083,16 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * being sent.
          */
         void handleSessionErrorCode(Errors errorCode) {
-            inFlightAcknowledgements.forEach((tip, acks) -> {
+            Map<TopicIdPartition, Acknowledgements> acknowledgementsMapToClear =
+                    incompleteAcknowledgements.isEmpty() ? acknowledgementsToSend : incompleteAcknowledgements;
+
+            acknowledgementsMapToClear.forEach((tip, acks) -> {
                 if (acks != null) {
                     acks.setAcknowledgeErrorCode(errorCode);
                 }
                 resultHandler.complete(tip, acks, onCommitAsync());
             });
+            acknowledgementsMapToClear.clear();
             processingComplete();
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -991,7 +991,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
             ShareAcknowledgeRequest.Builder requestBuilder = sessionHandler.newShareAcknowledgeBuilder(groupId, fetchConfig);
 
-            log.trace("Building acknowledgements to send : {}", finalAcknowledgementsToSend);
             isProcessed = false;
 
             if (requestBuilder == null) {
@@ -1000,6 +999,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             } else {
                 Node nodeToSend = metadata.fetch().nodeById(nodeId);
                 nodesWithPendingRequests.add(nodeId);
+
+                log.trace("Building acknowledgements to send : {}", finalAcknowledgementsToSend);
 
                 inFlightAcknowledgements.putAll(finalAcknowledgementsToSend);
                 if (incompleteAcknowledgements.isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -178,6 +178,8 @@ public class ShareSessionHandler {
     public ShareAcknowledgeRequest.Builder newShareAcknowledgeBuilder(String groupId, FetchConfig fetchConfig) {
         if (nextMetadata.isNewSession()) {
             // A share session cannot be started with a ShareAcknowledge request
+            nextPartitions.clear();
+            nextAcknowledgements.clear();
             return null;
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -369,7 +369,7 @@ public class ShareConsumeRequestManagerTest {
     }
 
     @Test
-    public void testServerDisconnectedOnShareAcknowledge() {
+    public void testServerDisconnectedOnShareAcknowledge() throws InterruptedException {
         buildRequestManager();
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
@@ -384,22 +384,46 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        fetchRecords();
+
         Acknowledgements acknowledgements = Acknowledgements.empty();
         acknowledgements.add(1L, AcknowledgeType.ACCEPT);
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Collections.singletonMap(tip0, acknowledgements));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
+        Acknowledgements acknowledgements2 = Acknowledgements.empty();
+        acknowledgements2.add(3L, AcknowledgeType.REJECT);
+
+        shareConsumeRequestManager.commitAsync(Collections.singletonMap(tip0, acknowledgements2));
+
         client.prepareResponse(null, true);
         networkClientDelegate.poll(time.timer(0));
-        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         assertEquals(Errors.UNKNOWN_SERVER_ERROR, completedAcknowledgements.get(0).get(tip0).getAcknowledgeErrorCode());
         completedAcknowledgements.clear();
+
+        assertEquals(1, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
+
+        TestUtils.retryOnExceptionWithTimeout(() -> {
+            assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
+            // We expect the remaining acknowledgements to be cleared due to share session epoch being set to 0.
+            assertNull(shareConsumeRequestManager.requestStates(0));
+            // The callback for these unsent acknowledgements will be invoked with an error code.
+            assertEquals(Collections.singletonMap(tip0, acknowledgements2), completedAcknowledgements.get(0));
+            assertEquals(Errors.SHARE_SESSION_NOT_FOUND, completedAcknowledgements.get(0).get(tip0).getAcknowledgeErrorCode());
+        });
+
+        // Attempt a normal fetch to check if nodesWithPendingRequests is empty.
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, records, acquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicIdPartition;
@@ -41,6 +42,7 @@ import java.util.Map;
 
 import static org.apache.kafka.common.requests.ShareRequestMetadata.INITIAL_EPOCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -413,6 +415,39 @@ public class ShareSessionHandlerTest {
         // Should have the same session ID and epoch 2.
         assertEquals(memberId.toString(), requestData3.memberId(), "Did not use same session");
         assertEquals(2, requestData3.shareSessionEpoch(), "Did not have the correct session epoch");
+    }
+
+    @Test
+    public void testNextAcknowledgementsClearedOnInvalidRequest() {
+        String groupId = "G1";
+        Uuid memberId = Uuid.randomUuid();
+        ShareSessionHandler handler = new ShareSessionHandler(LOG_CONTEXT, 1, memberId);
+
+        Map<String, Uuid> topicIds = new HashMap<>();
+        Map<Uuid, String> topicNames = new HashMap<>();
+        Uuid fooId = addTopicId(topicIds, topicNames, "foo");
+        TopicIdPartition foo0 = new TopicIdPartition(fooId, 0, "foo");
+
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        acknowledgements.add(0L, AcknowledgeType.ACCEPT);
+
+        handler.addPartitionToFetch(foo0, acknowledgements);
+
+        // As we start with a ShareAcknowledge on epoch 0, we expect a null response.
+        assertNull(handler.newShareAcknowledgeBuilder(groupId, fetchConfig));
+
+        // Attempt a new ShareFetch
+        TopicIdPartition foo1 = new TopicIdPartition(fooId, 1, "foo");
+        handler.addPartitionToFetch(foo1, null);
+        ShareFetchRequestData requestData = handler.newShareFetchBuilder(groupId, fetchConfig).build().data();
+
+        // We should have cleared the unsent acknowledgements before this ShareFetch.
+        assertEquals(0, requestData.topics().get(0).partitions().get(0).acknowledgementBatches().size());
+
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(fooId, 1, "foo"));
+        assertListEquals(expectedToSend1, reqFetchList(requestData, topicNames));
+        assertEquals(memberId.toString(), requestData.memberId());
     }
 
     private Uuid addTopicId(Map<String, Uuid> topicIds, Map<Uuid, String> topicNames, String name) {


### PR DESCRIPTION
*What*
If there were acknowledgements to be sent, and we had a share session epoch of 0, we were still attempting to send these acknowledgements, as this map was not cleared at all.
This led to the consumer hanging, it assumed it had sent the acknowledgements, but it is actually just re-attempting forever, but the `ShareSessionHandler` would not allow a `ShareAcknowledge` to be sent on epoch = 0.
This meant both fetching and acknowledging were blocked in the consumers.

PR fixes this bug and the one mentioned in https://issues.apache.org/jira/browse/KAFKA-18165 where we were not updating `nodesWithPendingRequests` correctly in one case.