### PR TITLE
MINOR Increase Gradle daemon heap size to 4Gb

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,5 @@ scalaVersion=2.13.15
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25
 task=build
-org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
We have been seeing OOM errors on trunk and PRs recently during the checkstyle step. This has led to failing builds and confusing output.

