### PR TITLE
MINOR Ensure quarantinedTest always copies test reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -546,6 +546,7 @@ subprojects {
   task quarantinedTest(type: Test, dependsOn: compileJava) {
     ext {
       isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+      hadFailure = false  // Used to track if any tests failed, see afterSuite below
     }
 
     // Disable caching and up-to-date for this task. We always want quarantined tests
@@ -584,6 +585,13 @@ subprojects {
       }
     }
 
+    // As we process results, check if there were any test failures.
+    afterSuite { desc, result ->
+      if (result.resultType == TestResult.ResultType.FAILURE) {
+        ext.hadFailure = true
+      }
+    }
+
     // This closure will copy JUnit XML files out of the sub-project's build directory and into
     // a top-level build/junit-xml directory. This is necessary to avoid reporting on tests which
     // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.
@@ -596,6 +604,11 @@ subprojects {
           ant.fileset(dir: "${quarantinedTest.reports.junitXml.entryPoint}") {
             ant.include(name: "**/*.xml")
           }
+        }
+        // If there were any test failures, we want to fail the task to prevent the failures
+        // from being cached.
+        if (ext.hadFailure) {
+          throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
         }
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -546,7 +546,6 @@ subprojects {
   task quarantinedTest(type: Test, dependsOn: compileJava) {
     ext {
       isGithubActions = System.getenv('GITHUB_ACTIONS') != null
-      hadFailure = false  // Used to track if any tests failed, see afterSuite below
     }
 
     // Disable caching and up-to-date for this task. We always want quarantined tests
@@ -585,13 +584,6 @@ subprojects {
       }
     }
 
-    // As we process results, check if there were any test failures.
-    afterSuite { desc, result ->
-      if (result.resultType == TestResult.ResultType.FAILURE) {
-        ext.hadFailure = true
-      }
-    }
-
     // This closure will copy JUnit XML files out of the sub-project's build directory and into
     // a top-level build/junit-xml directory. This is necessary to avoid reporting on tests which
     // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.
@@ -604,11 +596,6 @@ subprojects {
           ant.fileset(dir: "${quarantinedTest.reports.junitXml.entryPoint}") {
             ant.include(name: "**/*.xml")
           }
-        }
-        // If there were any test failures, we want to fail the task to prevent the failures
-        // from being cached.
-        if (ext.hadFailure) {
-          throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
         }
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -585,6 +585,13 @@ subprojects {
       }
     }
 
+    // As we process results, check if there were any test failures.
+    afterSuite { desc, result ->
+      if (result.resultType == TestResult.ResultType.FAILURE) {
+        ext.hadFailure = true
+      }
+    }
+
     // This closure will copy JUnit XML files out of the sub-project's build directory and into
     // a top-level build/junit-xml directory. This is necessary to avoid reporting on tests which
     // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.

--- a/build.gradle
+++ b/build.gradle
@@ -546,6 +546,7 @@ subprojects {
   task quarantinedTest(type: Test, dependsOn: compileJava) {
     ext {
       isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+      hadFailure = false  // Used to track if any tests failed, see afterSuite below
     }
 
     // Disable caching and up-to-date for this task. We always want quarantined tests
@@ -555,7 +556,7 @@ subprojects {
     outputs.cacheIf { false }
 
     maxParallelForks = maxTestForks
-    ignoreFailures = userIgnoreFailures
+    ignoreFailures = userIgnoreFailures || ext.isGithubActions
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs
@@ -596,6 +597,11 @@ subprojects {
           ant.fileset(dir: "${quarantinedTest.reports.junitXml.entryPoint}") {
             ant.include(name: "**/*.xml")
           }
+        }
+        // If there were any test failures, we want to fail the task to prevent the failures
+        // from being cached.
+        if (ext.hadFailure) {
+          throw new GradleException("Failing this task since '${project.name}:${name}' had test failures.")
         }
       }
     }


### PR DESCRIPTION
The quarantinedTest task will fail (exit 1) if a test was too flaky. Our two Gradle test tasks are run with `set +e` so we can capture the exit code after the process exits. Prior to this patch, quarantinedTest was not configured with the Gradle ignoreFailures property which meant that it would exit upon failure. This prevented the test XML files from being copied to the "build-xml" directory for later processing. 

The result was failing tests in the quarantine would _not_ fail the build (but they should!).

The Gradle build scan correctly shows the failing tests.