### PR TITLE
KAFKA-18167 - Disable TLS session ticket extension

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -283,7 +283,7 @@ fi
 # JVM performance options
 # MaxInlineLevel=15 is the default since JDK 14 and can be removed once older JDKs are no longer supported
 if [ -z "$KAFKA_JVM_PERFORMANCE_OPTS" ]; then
-  KAFKA_JVM_PERFORMANCE_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true"
+  KAFKA_JVM_PERFORMANCE_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true -Djdk.tls.server.enableSessionTicketExtension=false"
 fi
 
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
### What
Disables TLS session extension for brokers. JDK 14 enabled TLS session tickets by default. This adds non-trivial CPU overhead for workloads that create short-lived TLS connections. For some older JDK-17 distributions, this can result in extreme CPU regressions, eg: https://bugs.openjdk.org/browse/JDK-8298381 calls out a case where a user running AK saw a significant performance regression.

From what I can tell, the `kafka-run-class.sh` script is used for running servers or for running classes in the tools package which takes a dependency on the server module, so adding the flag here should be safe.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
