### PR TITLE
MINOR: limit checkStyle memory usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,11 @@ allprojects {
     options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
   }
 
+  tasks.withType(Checkstyle) {
+    minHeapSize = "200m"
+    maxHeapSize = "1g"
+  }
+
   clean {
     delete "${projectDir}/src/generated"
     delete "${projectDir}/src/generated-test"


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/18067#issuecomment-2522046281
After increasing gradle memory usage, we still meet checkStyle OOM.
We need to limit checkStyle memory usage in `gradle.build`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
