### PR TITLE
KAFKA-18176: Fix verifiable consumer with unsupported protocol configs

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -649,8 +649,9 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             if (groupRemoteAssignor != null)
                 consumerProps.put(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, groupRemoteAssignor);
         } else {
-            // This means we're using the old consumer group protocol.
+            // This means we're using the CLASSIC consumer group protocol.
             consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, res.getString("assignmentStrategy"));
+            consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(res.getInt("sessionTimeout")));
         }
 
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, res.getString("groupId"));
@@ -664,7 +665,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, useAutoCommit);
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, res.getString("resetPolicy"));
-        consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(res.getInt("sessionTimeout")));
 
         StringDeserializer deserializer = new StringDeserializer();
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps, deserializer, deserializer);


### PR DESCRIPTION
Ensure session timeout is only provided if the CLASSIC protocol is used, as it is not allowed under CONSUMER and makes the consumer creation fail.
