### PR TITLE
KAFKA-18135: ShareConsumer HB UnsupportedVersion msg mixed with Consumer HB

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -408,8 +408,10 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
                 // Broker responded with HB not supported, meaning the new protocol is not enabled, so propagate
                 // custom message for it. Note that the case where the protocol is not supported at all should fail
                 // on the client side when building the request and checking supporting APIs (handled on onFailure).
-                logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, errorMessage);
-                handleFatalFailure(error.exception(CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG));
+                if (!handleSpecificError(response, currentTimeMs)) {
+                    logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, errorMessage);
+                    handleFatalFailure(error.exception(errorMessage));
+                }
                 break;
 
             case FENCED_MEMBER_EPOCH:

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -404,16 +404,6 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
                 handleFatalFailure(error.exception(errorMessage));
                 break;
 
-            case UNSUPPORTED_VERSION:
-                // Broker responded with HB not supported, meaning the new protocol is not enabled, so propagate
-                // custom message for it. Note that the case where the protocol is not supported at all should fail
-                // on the client side when building the request and checking supporting APIs (handled on onFailure).
-                if (!handleSpecificError(response, currentTimeMs)) {
-                    logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, errorMessage);
-                    handleFatalFailure(error.exception(errorMessage));
-                }
-                break;
-
             case FENCED_MEMBER_EPOCH:
                 message = String.format("%s failed for member %s because epoch %s is fenced.",
                         heartbeatRequestName(), membershipManager().memberId(), membershipManager().memberEpoch());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -25,8 +25,6 @@ import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.metrics.HeartbeatMetricsManager;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.RetriableException;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -317,29 +315,12 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
                 heartbeatRequestState.remainingBackoffMs(responseTimeMs),
                 exception.getMessage());
             logger.debug(message);
-        } else {
+        } else if (!handleSpecificFailure(exception)) {
             logger.error("{} failed due to fatal error: {}", heartbeatRequestName(), exception.getMessage());
-            if (isHBApiUnsupportedErrorMsg(exception)) {
-                // This is expected to be the case where building the request fails because the node does not support
-                // the API. Propagate custom message.
-                handleFatalFailure(new UnsupportedVersionException(CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG, exception));
-            } else {
-                // This is the case where building the request fails even though the node supports the API (ex.
-                // required version 1 not available when regex in use).
-                handleFatalFailure(exception);
-            }
+            handleFatalFailure(exception);
         }
         // Notify the group manager about the failure after all errors have been handled and propagated.
         membershipManager().onHeartbeatFailure(exception instanceof RetriableException);
-    }
-
-    /***
-     * @return True if the exception is the UnsupportedVersion generated on the client, before sending the request,
-     * when checking if the API is available on the broker.
-     */
-    private boolean isHBApiUnsupportedErrorMsg(Throwable exception) {
-        return exception instanceof UnsupportedVersionException &&
-            exception.getMessage().equals("The node does not support " + ApiKeys.CONSUMER_GROUP_HEARTBEAT);
     }
 
     private void onResponse(final R response, final long currentTimeMs) {
@@ -429,7 +410,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
                 break;
 
             default:
-                if (!handleSpecificError(response, currentTimeMs)) {
+                if (!handleSpecificExceptionInResponse(response, currentTimeMs)) {
                     // If the manager receives an unknown error - there could be a bug in the code or a new error code
                     logger.error("{} failed due to unexpected error {}: {}", heartbeatRequestName(), error, errorMessage);
                     handleFatalFailure(error.exception(errorMessage));
@@ -453,15 +434,24 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         membershipManager().transitionToFatal();
     }
 
+    /**
+     * Error handling specific failure to a group type when sending the request.
+     *
+     * @param exception The exception thrown building the request
+     * @return true if the error was handled, else false
+     */
+    public boolean handleSpecificFailure(Throwable exception) {
+        return false;
+    }
 
     /**
-     * Error handling specific to a group type.
+     * Error handling specific response exception to a group type.
      *
      * @param response The heartbeat response
      * @param currentTimeMs Current time
      * @return true if the error was handled, else false
      */
-    public boolean handleSpecificError(final R response, final long currentTimeMs) {
+    public boolean handleSpecificExceptionInResponse(final R response, final long currentTimeMs) {
         return false;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -100,6 +100,9 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         "group protocol. Set group.protocol=classic on the consumer configs to revert to the CLASSIC protocol " +
         "until the cluster is upgraded.";
 
+    public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the new SHARE " +
+            "group protocol. The cluster must be upgraded to use the share consumer feature.";
+
     AbstractHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -100,9 +100,6 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         "group protocol. Set group.protocol=classic on the consumer configs to revert to the CLASSIC protocol " +
         "until the cluster is upgraded.";
 
-    public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the new SHARE " +
-            "group protocol. The cluster must be upgraded to use the share consumer feature.";
-
     AbstractHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -435,7 +435,8 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
     }
 
     /**
-     * Error handling specific failure to a group type when sending the request.
+     * Error handling specific failure to a group type when sending the request
+     * and no response has been received.
      *
      * @param exception The exception thrown building the request
      * @return true if the error was handled, else false

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
@@ -99,6 +99,9 @@ public class ConsumerHeartbeatRequestManager extends AbstractHeartbeatRequestMan
         boolean errorHandled;
 
         switch (error) {
+            // Broker responded with HB not supported, meaning the new protocol is not enabled, so propagate
+            // custom message for it. Note that the case where the protocol is not supported at all should fail
+            // on the client side when building the request and checking supporting APIs (handled on onFailure).
             case UNSUPPORTED_VERSION:
                 // Handle consumer-specific unsupported version error
                 String message = CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
@@ -38,6 +38,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.REGEX_RESOLUTION_NOT_SUPPORTED_MSG;
+
 /**
  * This is the heartbeat request manager for consumer groups.
  *
@@ -100,7 +102,7 @@ public class ConsumerHeartbeatRequestManager extends AbstractHeartbeatRequestMan
             case UNSUPPORTED_VERSION:
                 // Handle consumer-specific unsupported version error
                 String message = CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG;
-                if (errorMessage.contains("regex")) {
+                if (errorMessage.contains(REGEX_RESOLUTION_NOT_SUPPORTED_MSG)) {
                     // If the error is about regex subscription, use the original error message
                     message = errorMessage;
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
@@ -97,6 +97,18 @@ public class ConsumerHeartbeatRequestManager extends AbstractHeartbeatRequestMan
         boolean errorHandled;
 
         switch (error) {
+            case UNSUPPORTED_VERSION:
+                // Handle consumer-specific unsupported version error
+                String message = CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG;
+                if (errorMessage.contains("regex")) {
+                    // If the error is about regex subscription, use the original error message
+                    message = errorMessage;
+                }
+                logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, message);
+                handleFatalFailure(error.exception(message));
+                errorHandled = true;
+                break;
+
             case UNRELEASED_INSTANCE_ID:
                 logger.error("{} failed due to unreleased instance id {}: {}",
                     heartbeatRequestName(), membershipManager.groupInstanceId().orElse("null"), errorMessage);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManager.java
@@ -101,7 +101,7 @@ public class ConsumerHeartbeatRequestManager extends AbstractHeartbeatRequestMan
             String message = CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG;
             if (errorMessage.equals(REGEX_RESOLUTION_NOT_SUPPORTED_MSG)) {
                 message = REGEX_RESOLUTION_NOT_SUPPORTED_MSG;
-                logger.error("{} failed due to regex resolution not support: {}", heartbeatRequestName(), message);
+                logger.error("{} regex resolution not supported: {}", heartbeatRequestName(), message);
             } else {
                 logger.error("{} failed due to unsupported version while sending request: {}", heartbeatRequestName(), errorMessage);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -50,6 +50,9 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
      */
     private final HeartbeatState heartbeatState;
 
+    public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the share group protocol. " +
+        "To use share groups, the cluster must have the share group protocol enabled.";
+
     public ShareHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -205,4 +205,25 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
             }
         }
     }
+
+    public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the new SHARE " +
+        "group protocol. The cluster must be upgraded to use the share consumer feature.";
+
+    @Override
+    public boolean handleSpecificError(final ShareGroupHeartbeatResponse response, final long currentTimeMs) {
+        Errors error = errorForResponse(response);
+        boolean errorHandled;
+
+        switch (error) {
+            case UNSUPPORTED_VERSION:
+                logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, SHARE_PROTOCOL_NOT_SUPPORTED_MSG);
+                handleFatalFailure(error.exception(SHARE_PROTOCOL_NOT_SUPPORTED_MSG));
+                errorHandled = true;
+                break;
+
+            default:
+                errorHandled = false;
+        }
+        return errorHandled;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -215,6 +215,9 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
         boolean errorHandled;
 
         switch (error) {
+            // Broker responded with HB not supported, meaning the new protocol is not enabled, so propagate
+            // custom message for it. Note that the case where the protocol is not supported at all should fail
+            // on the client side when building the request and checking supporting APIs (handled on onFailure).
             case UNSUPPORTED_VERSION:
                 logger.error("{} failed due to {}: {}", heartbeatRequestName(), error, SHARE_PROTOCOL_NOT_SUPPORTED_MSG);
                 handleFatalFailure(error.exception(SHARE_PROTOCOL_NOT_SUPPORTED_MSG));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -206,9 +206,6 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
         }
     }
 
-    public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the new SHARE " +
-        "group protocol. The cluster must be upgraded to use the share consumer feature.";
-
     @Override
     public boolean handleSpecificError(final ShareGroupHeartbeatResponse response, final long currentTimeMs) {
         Errors error = errorForResponse(response);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -611,9 +611,25 @@ public class ConsumerHeartbeatRequestManagerTest {
      * 2. Required HB API version is not available.
      */
     @ParameterizedTest
+    @ValueSource(strings = {CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG})
+    public void testUnsupportedVersionFromBroker(String errorMsg) {
+        mockResponseWithException(new UnsupportedVersionException(errorMsg), true);
+        ArgumentCaptor<ErrorEvent> errorEventArgumentCaptor = ArgumentCaptor.forClass(ErrorEvent.class);
+        verify(backgroundEventHandler).add(errorEventArgumentCaptor.capture());
+        ErrorEvent errorEvent = errorEventArgumentCaptor.getValue();
+        assertInstanceOf(Errors.UNSUPPORTED_VERSION.exception().getClass(), errorEvent.error());
+        assertEquals(errorMsg, errorEvent.error().getMessage());
+        clearInvocations(backgroundEventHandler);
+    }
+
+    /**
+     * This validates the UnsupportedApiVersion the client generates while building a HB if:
+     * REGEX_RESOLUTION_NOT_SUPPORTED_MSG only generated on the client side.
+     */
+    @ParameterizedTest
     @ValueSource(strings = {CONSUMER_PROTOCOL_NOT_SUPPORTED_MSG, REGEX_RESOLUTION_NOT_SUPPORTED_MSG})
-    public void testUnsupportedVersion(String errorMsg) {
-        mockResponseWithException(new UnsupportedVersionException(errorMsg));
+    public void testUnsupportedVersionFromClient(String errorMsg) {
+        mockResponseWithException(new UnsupportedVersionException(errorMsg), false);
         ArgumentCaptor<ErrorEvent> errorEventArgumentCaptor = ArgumentCaptor.forClass(ErrorEvent.class);
         verify(backgroundEventHandler).add(errorEventArgumentCaptor.capture());
         ErrorEvent errorEvent = errorEventArgumentCaptor.getValue();
@@ -633,14 +649,14 @@ public class ConsumerHeartbeatRequestManagerTest {
         result.unsentRequests.get(0).handler().onComplete(response);
     }
 
-    private void mockResponseWithException(UnsupportedVersionException exception) {
+    private void mockResponseWithException(UnsupportedVersionException exception, boolean isFromBroker) {
         time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
 
         when(subscriptions.hasAutoAssignedPartitions()).thenReturn(true);
         ClientResponse response = createHeartbeatResponseWithException(
-            result.unsentRequests.get(0), exception);
+            result.unsentRequests.get(0), exception, isFromBroker);
         result.unsentRequests.get(0).handler().onComplete(response);
     }
 
@@ -1044,9 +1060,13 @@ public class ConsumerHeartbeatRequestManagerTest {
 
     private ClientResponse createHeartbeatResponseWithException(
         final NetworkClientDelegate.UnsentRequest request,
-        final UnsupportedVersionException exception
+        final UnsupportedVersionException exception,
+        final boolean isFromBroker
     ) {
-        ConsumerGroupHeartbeatResponse response = new ConsumerGroupHeartbeatResponse(null);
+        ConsumerGroupHeartbeatResponse response = null;
+        if (isFromBroker) {
+            response = new ConsumerGroupHeartbeatResponse(null);
+        }
         return new ClientResponse(
             new RequestHeader(ApiKeys.CONSUMER_GROUP_HEARTBEAT, ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion(), "client-id", 1),
             request.handler(),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -58,6 +59,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.kafka.clients.consumer.internals.AbstractHeartbeatRequestManager.SHARE_PROTOCOL_NOT_SUPPORTED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -67,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -363,7 +366,7 @@ public class ShareHeartbeatRequestManagerTest {
     @ParameterizedTest
     @MethodSource("errorProvider")
     public void testHeartbeatResponseOnErrorHandling(final Errors error, final boolean isFatal) {
-        // Handling errors on the second heartbeat
+       // Handling errors on the second heartbeat
         time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
@@ -420,6 +423,29 @@ public class ShareHeartbeatRequestManagerTest {
             result = heartbeatRequestManager.poll(time.milliseconds());
             assertEquals(1, result.unsentRequests.size());
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {SHARE_PROTOCOL_NOT_SUPPORTED_MSG})
+    public void testUnsupportedVersion(String errorMsg) {
+        // Handling errors on the second heartbeat
+        time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
+        UnsupportedVersionException exception = new UnsupportedVersionException(errorMsg);
+        NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, result.unsentRequests.size());
+
+        // Manually completing the response to test error handling
+        when(subscriptions.hasAutoAssignedPartitions()).thenReturn(true);
+        ClientResponse response = createHeartbeatResponseWithException(
+                result.unsentRequests.get(0),
+                exception);
+        result.unsentRequests.get(0).handler().onComplete(response);
+        ArgumentCaptor<ErrorEvent> errorEventArgumentCaptor = ArgumentCaptor.forClass(ErrorEvent.class);
+        verify(backgroundEventHandler).add(errorEventArgumentCaptor.capture());
+        ErrorEvent errorEvent = errorEventArgumentCaptor.getValue();
+        assertInstanceOf(Errors.UNSUPPORTED_VERSION.exception().getClass(), errorEvent.error());
+        assertEquals(errorMsg, errorEvent.error().getMessage());
+        clearInvocations(backgroundEventHandler);
     }
 
     @Test
@@ -642,6 +668,25 @@ public class ShareHeartbeatRequestManagerTest {
                 time.milliseconds(),
                 false,
                 null,
+                null,
+                response);
+    }
+
+    private ClientResponse createHeartbeatResponseWithException(
+            final NetworkClientDelegate.UnsentRequest request,
+            final UnsupportedVersionException exception
+    ) {
+        ShareGroupHeartbeatResponse response = new ShareGroupHeartbeatResponse(new ShareGroupHeartbeatResponseData()
+                .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+                .setErrorMessage(exception.getMessage()));
+        return new ClientResponse(
+                new RequestHeader(ApiKeys.SHARE_GROUP_HEARTBEAT, ApiKeys.SHARE_GROUP_HEARTBEAT.latestVersion(), "client-id", 1),
+                request.handler(),
+                "0",
+                time.milliseconds(),
+                time.milliseconds(),
+                false,
+                exception,
                 null,
                 response);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -59,7 +59,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.kafka.clients.consumer.internals.AbstractHeartbeatRequestManager.SHARE_PROTOCOL_NOT_SUPPORTED_MSG;
+import static org.apache.kafka.clients.consumer.internals.ShareHeartbeatRequestManager.SHARE_PROTOCOL_NOT_SUPPORTED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;


### PR DESCRIPTION
UnsupportedVersion error is handled in the parent AbstractHeartbeatRequestManager, so used by consumer and share consumer. If a share consumer gets the errors, it will end up with a msg that is currently specific to consumer

https://github.com/apache/kafka/blob/6fd951a9c0aa773060cd6bbf8a8b8c47ee9d2965/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java#L384-L386

Handle the UnsupportedVersion separately in the existing 
handleSpecificError (note that the unsupported version for consumer may also end up containing a msg specific to SubscriptionPattern not supported in HB v0, if regex is used without the required v1)

- [x] add `onSpecificFailure` for consumerHB and shareHB
- [x] add `testUnsupportedVersionGeneratedOnTheBroker` to cover both handleSpecificError and handleSpecificFailure/exception