### PR TITLE
KAFKA-18184:Remove the unnecessary project path check from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,7 @@ ext {
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"
     } else if (name in ["compileJava", "compileScala"]) {
-      if (!project.path.startsWith(":connect") && !project.path.startsWith(":storage"))
-        options.compilerArgs << "-Xlint:-rawtypes"
+      options.compilerArgs << "-Xlint:-rawtypes"
       options.compilerArgs << "-Xlint:all"
       options.compilerArgs << "-Xlint:-serial"
       options.compilerArgs << "-Xlint:-try"


### PR DESCRIPTION
jira:https://issues.apache.org/jira/browse/KAFKA-18184

In the build.gradle file, the project path is not initialized, so the project.path should always refer to the root path ':'

The condition:
`if (!project.path.startsWith(":connect") && !project.path.startsWith(":storage"))`
will always evaluate to true, so this check is unnecessary and can be removed.

If we print the parameter `project.path`
```
println "Project path is '${project.path}'"
if (!project.path.startsWith(":connect") && !project.path.startsWith(":storage"))
  options.compilerArgs << "-Xlint:-rawtypes"
```


we can see outputs like the following:

> Starting Gradle Daemon...
> Connected to the target VM, address: '127.0.0.1:55024', transport: 'socket'
> Gradle Daemon started in 1 s 333 ms
> 
>  Configure project :
> Starting build with version 4.0.0-SNAPSHOT (commit id 104fa579) using Gradle 8.10.2, Java 23 and Scala 2.13.15
> Build properties: ignoreFailures=false, maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0
> Project path is ':'


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
