### PR TITLE
KAFKA-18186: set `options.release` to make Intellij configure suitable language level automatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ ext {
 
     options.compilerArgs << "-encoding" << "UTF-8"
     options.release = releaseVersion
+//    project.project(projectPath).sourceCompatibility = releaseVersion
 
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"

--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,7 @@ ext {
     def releaseVersion = modulesNeedingJava11.any { projectPath == it } ? minClientJavaVersion : minNonClientJavaVersion
 
     options.compilerArgs << "-encoding" << "UTF-8"
-    options.compilerArgs += ["--release", String.valueOf(releaseVersion)]
-    project.project(projectPath).sourceCompatibility = releaseVersion
+    options.release = releaseVersion
 
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,6 @@ ext {
 
     options.compilerArgs << "-encoding" << "UTF-8"
     options.release = releaseVersion
-//    project.project(projectPath).sourceCompatibility = releaseVersion
 
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"

--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,6 @@ println("Starting build with version $version (commit id ${commitId == null ? "n
 println("Build properties: ignoreFailures=$userIgnoreFailures, maxParallelForks=$maxTestForks, maxScalacThreads=$maxScalacThreads, maxTestRetries=$userMaxTestRetries")
 
 subprojects {
-  
 
   // enable running :dependencies task recursively on all subprojects
   // eg: ./gradlew allDeps

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ ext {
 
     options.compilerArgs << "-encoding" << "UTF-8"
     options.compilerArgs += ["--release", String.valueOf(releaseVersion)]
+    project.sourceCompatibility = String.valueOf(releaseVersion)
 
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"
@@ -291,6 +292,7 @@ println("Starting build with version $version (commit id ${commitId == null ? "n
 println("Build properties: ignoreFailures=$userIgnoreFailures, maxParallelForks=$maxTestForks, maxScalacThreads=$maxScalacThreads, maxTestRetries=$userMaxTestRetries")
 
 subprojects {
+  
 
   // enable running :dependencies task recursively on all subprojects
   // eg: ./gradlew allDeps

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ ext {
 
     options.compilerArgs << "-encoding" << "UTF-8"
     options.compilerArgs += ["--release", String.valueOf(releaseVersion)]
-    project.sourceCompatibility = String.valueOf(releaseVersion)
+    project.project(projectPath).sourceCompatibility = releaseVersion
 
     if (name in ["compileTestJava", "compileTestScala"]) {
       options.compilerArgs << "-parameters"


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18186

To enhance the developer experience, when the user runs `./gradlew idea`, IntelliJ IDEA should automatically configure the Java settings.

test in my local
![CleanShot 2024-12-10 at 00 28 04@2x](https://github.com/user-attachments/assets/be6ef114-d4f2-40a3-8287-afaf10d79510)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
