### PR TITLE
KAFKA-18192: generator module should run under java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
   minClientJavaVersion = 11
   minNonClientJavaVersion = 17
   // The connect:api module also belongs to the clients module, but it has already been bumped to JDK 17 as part of KIP-1032.
-  modulesNeedingJava11 = [":clients", ":streams", ":streams:test-utils", ":streams-scala", ":test-common:test-common-runtime"]
+  modulesNeedingJava11 = [":clients", ":generator", ":streams", ":streams:test-utils", ":streams-scala", ":test-common:test-common-runtime"]
 
   buildVersionFileName = "kafka-version.properties"
 


### PR DESCRIPTION
JIRA: KAFKA-18192

> Both Streams and Clients are now using Java 11, but the Generator modules are not. This discrepancy causes an issue where developers cannot use JDK 11 to run tests for both modules.

Please refer to the discussion of #17522 for further details

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
