### PR TITLE
KAFKA-18015: add byDuration auto.offset.reset to Kafka Streams

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AutoOffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AutoOffsetResetStrategy.java
@@ -129,6 +129,10 @@ public class AutoOffsetResetStrategy {
             return Optional.empty();
     }
 
+    public Optional<Duration> duration() {
+        return duration;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -272,6 +272,12 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <Class name="org.apache.kafka.streams.processor.internals.TopologyMetadata"/>
+        <Method name="offsetResetStrategy"/>
+        <Bug pattern="NP_OPTIONAL_RETURN_NULL"/>
+    </Match>
+
+    <Match>
         <!-- Suppress warnings about ignoring the return value of await.
              This is done intentionally because we use other clues to determine
              if the wait was cut short. -->

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -288,7 +288,7 @@ public class StreamsBuilder {
      * @return a {@link KTable} for the specified topic
      */
     public synchronized <K, V> KTable<K, V> table(final String topic) {
-        return table(topic, new ConsumedInternal<>());
+        return table(topic, Consumed.with(null, null));
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/Topology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/Topology.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.AutoOffsetResetInternal;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.ConnectedStoreProvider;
@@ -81,6 +82,19 @@ public class Topology {
         EARLIEST, LATEST
     }
 
+    @Deprecated
+    private static AutoOffsetResetInternal convertOldToNew(final Topology.AutoOffsetReset resetPolicy) {
+        if (resetPolicy == null) {
+            return null;
+        }
+
+        return new AutoOffsetResetInternal(
+            resetPolicy == org.apache.kafka.streams.Topology.AutoOffsetReset.EARLIEST
+                ? org.apache.kafka.streams.AutoOffsetReset.earliest()
+                : org.apache.kafka.streams.AutoOffsetReset.latest()
+        );
+    }
+
     /**
      * Add a new source that consumes the named topics and forward the records to child processor and/or sink nodes.
      * The source will use the {@link StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG default key deserializer} and
@@ -139,7 +153,7 @@ public class Topology {
     public synchronized Topology addSource(final AutoOffsetReset offsetReset,
                                            final String name,
                                            final String... topics) {
-        internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topics);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, null, null, null, topics);
         return this;
     }
 
@@ -156,8 +170,7 @@ public class Topology {
     public synchronized Topology addSource(final org.apache.kafka.streams.AutoOffsetReset offsetReset,
                                            final String name,
                                            final String... topics) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topics);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, null, null, null, topics);
         return this;
     }
 
@@ -181,7 +194,7 @@ public class Topology {
     public synchronized Topology addSource(final AutoOffsetReset offsetReset,
                                            final String name,
                                            final Pattern topicPattern) {
-        internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topicPattern);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, null, null, null, topicPattern);
         return this;
     }
 
@@ -203,8 +216,7 @@ public class Topology {
     public synchronized Topology addSource(final org.apache.kafka.streams.AutoOffsetReset offsetReset,
                                            final String name,
                                            final Pattern topicPattern) {
-        // TODO: mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topicPattern);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, null, null, null, topicPattern);
         return this;
     }
 
@@ -273,7 +285,7 @@ public class Topology {
                                            final TimestampExtractor timestampExtractor,
                                            final String name,
                                            final String... topics) {
-        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topics);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, timestampExtractor, null, null, topics);
         return this;
     }
 
@@ -293,8 +305,7 @@ public class Topology {
                                            final TimestampExtractor timestampExtractor,
                                            final String name,
                                            final String... topics) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topics);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, timestampExtractor, null, null, topics);
         return this;
     }
 
@@ -321,7 +332,7 @@ public class Topology {
                                            final TimestampExtractor timestampExtractor,
                                            final String name,
                                            final Pattern topicPattern) {
-        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topicPattern);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, timestampExtractor, null, null, topicPattern);
         return this;
     }
 
@@ -341,8 +352,7 @@ public class Topology {
                                            final TimestampExtractor timestampExtractor,
                                            final String name,
                                            final Pattern topicPattern) {
-        // TODO
-        //internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topicPattern);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, timestampExtractor, null, null, topicPattern);
         return this;
     }
 
@@ -421,7 +431,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final String... topics) {
-        internalTopologyBuilder.addSource(offsetReset, name, null, keyDeserializer, valueDeserializer, topics);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, null, keyDeserializer, valueDeserializer, topics);
         return this;
     }
 
@@ -448,8 +458,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final String... topics) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, null, keyDeserializer, valueDeserializer, topics);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, null, keyDeserializer, valueDeserializer, topics);
         return this;
     }
 
@@ -479,7 +488,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final Pattern topicPattern) {
-        internalTopologyBuilder.addSource(offsetReset, name, null, keyDeserializer, valueDeserializer, topicPattern);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, null, keyDeserializer, valueDeserializer, topicPattern);
         return this;
     }
 
@@ -506,8 +515,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final Pattern topicPattern) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, null, keyDeserializer, valueDeserializer, topicPattern);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, null, keyDeserializer, valueDeserializer, topicPattern);
         return this;
     }
 
@@ -537,7 +545,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final String... topics) {
-        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valueDeserializer, topics);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, timestampExtractor, keyDeserializer, valueDeserializer, topics);
         return this;
     }
 
@@ -564,8 +572,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final String... topics) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valueDeserializer, topics);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, timestampExtractor, keyDeserializer, valueDeserializer, topics);
         return this;
     }
 
@@ -598,7 +605,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final Pattern topicPattern) {
-        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valueDeserializer, topicPattern);
+        internalTopologyBuilder.addSource(convertOldToNew(offsetReset), name, timestampExtractor, keyDeserializer, valueDeserializer, topicPattern);
         return this;
     }
 
@@ -628,8 +635,7 @@ public class Topology {
                                            final Deserializer<?> keyDeserializer,
                                            final Deserializer<?> valueDeserializer,
                                            final Pattern topicPattern) {
-        // TODO mjsax
-        //internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valueDeserializer, topicPattern);
+        internalTopologyBuilder.addSource(new AutoOffsetResetInternal(offsetReset), name, timestampExtractor, keyDeserializer, valueDeserializer, topicPattern);
         return this;
     }
 
@@ -987,7 +993,14 @@ public class Topology {
                                                                   final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         storeBuilder.withLoggingDisabled();
 
-        internalTopologyBuilder.addSource(AutoOffsetReset.EARLIEST, sourceName, timestampExtractor, keyDeserializer, valueDeserializer, topic);
+        internalTopologyBuilder.addSource(
+            new AutoOffsetResetInternal(org.apache.kafka.streams.AutoOffsetReset.earliest()),
+            sourceName,
+            timestampExtractor,
+            keyDeserializer,
+            valueDeserializer,
+            topic
+        );
         internalTopologyBuilder.addProcessor(processorName, stateUpdateSupplier, sourceName);
         internalTopologyBuilder.addStateStore(storeBuilder, processorName);
         internalTopologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topic);

--- a/streams/src/main/java/org/apache/kafka/streams/internals/AutoOffsetResetInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/AutoOffsetResetInternal.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy.Strat
 import org.apache.kafka.streams.AutoOffsetReset;
 
 import java.time.Duration;
-import java.util.Optional;
 
 public class AutoOffsetResetInternal extends AutoOffsetReset {
 
@@ -31,7 +30,9 @@ public class AutoOffsetResetInternal extends AutoOffsetReset {
     public StrategyType offsetResetStrategy() {
         return offsetResetStrategy;
     }
-    public Optional<Duration> duration() {
-        return duration;
+
+    @SuppressWarnings("all")
+    public Duration duration() {
+        return duration.get();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Consumed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Consumed.java
@@ -76,10 +76,6 @@ public class Consumed<K, V> implements NamedOperation<Consumed<K, V>> {
         this.processorName = processorName;
     }
 
-    /**
-     * Create an instance of {@link Consumed} from an existing instance.
-     * @param consumed  the instance of {@link Consumed} to copy
-     */
     protected Consumed(final Consumed<K, V> consumed) {
         this(
             consumed.keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ConsumedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ConsumedInternal.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.internals.AutoOffsetResetInternal;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -27,17 +26,6 @@ public class ConsumedInternal<K, V> extends Consumed<K, V> {
 
     public ConsumedInternal(final Consumed<K, V> consumed) {
         super(consumed);
-    }
-
-    public ConsumedInternal(final Serde<K> keySerde,
-                            final Serde<V> valueSerde,
-                            final TimestampExtractor timestampExtractor,
-                            final AutoOffsetResetInternal offsetReset) {
-        this(Consumed.with(keySerde, valueSerde, timestampExtractor, offsetReset));
-    }
-
-    public ConsumedInternal() {
-        this(Consumed.with(null, null));
     }
 
     public Serde<K> keySerde() {
@@ -62,12 +50,6 @@ public class ConsumedInternal<K, V> extends Consumed<K, V> {
 
     public AutoOffsetResetInternal offsetResetPolicy() {
         return resetPolicy == null ? null : new AutoOffsetResetInternal(resetPolicy);
-    }
-
-    @SuppressWarnings("deprecation")
-    // TODO mjsax remove
-    public Topology.AutoOffsetReset legacyOffsetResetPolicy() {
-        return legacyResetPolicy;
     }
 
     public String name() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -73,16 +73,14 @@ public class StreamSourceNode<K, V> extends SourceGraphNode<K, V> {
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
 
         if (topicPattern().isPresent()) {
-            // TODO mjsax
-            topologyBuilder.addSource(consumedInternal().legacyOffsetResetPolicy(),
+            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
                                       nodeName(),
                                       consumedInternal().timestampExtractor(),
                                       consumedInternal().keyDeserializer(),
                                       consumedInternal().valueDeserializer(),
                                       topicPattern().get());
         } else {
-            // TODO mjsax
-            topologyBuilder.addSource(consumedInternal().legacyOffsetResetPolicy(),
+            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
                                       nodeName(),
                                       consumedInternal().timestampExtractor(),
                                       consumedInternal().keyDeserializer(),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -96,8 +96,7 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
                 false
             );
         } else {
-            // TODO mjsax
-            topologyBuilder.addSource(consumedInternal().legacyOffsetResetPolicy(),
+            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
                                       sourceName,
                                       consumedInternal().timestampExtractor(),
                                       consumedInternal().keyDeserializer(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1367,7 +1367,7 @@ public class InternalTopologyBuilder {
     }
 
     public AutoOffsetResetStrategy offsetResetStrategy(final String topic) {
-        Optional<Duration> resetDuration;
+        final Optional<Duration> resetDuration;
 
         if (maybeDecorateInternalSourceTopics(noneResetTopics).contains(topic) ||
             noneResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -22,10 +22,10 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.internals.ApiUtils;
+import org.apache.kafka.streams.internals.AutoOffsetResetInternal;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -148,13 +149,21 @@ public class InternalTopologyBuilder {
     // all global topics
     private final Set<String> globalTopics = new HashSet<>();
 
+    private final Set<String> noneResetTopics = new HashSet<>();
+
     private final Set<String> earliestResetTopics = new HashSet<>();
 
     private final Set<String> latestResetTopics = new HashSet<>();
 
+    private final Map<String, Duration> durationResetTopics = new HashMap<>();
+
+    private final Set<Pattern> noneResetPatterns = new HashSet<>();
+
     private final Set<Pattern> earliestResetPatterns = new HashSet<>();
 
     private final Set<Pattern> latestResetPatterns = new HashSet<>();
+
+    private final Map<Pattern, Duration> durationResetPatterns = new HashMap<>();
 
     private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
 
@@ -333,7 +342,7 @@ public class InternalTopologyBuilder {
 
         @Override
         Source describe() {
-            return new Source(name, topics.size() == 0 ? null : new HashSet<>(topics), pattern);
+            return new Source(name, topics.isEmpty() ? null : new HashSet<>(topics), pattern);
         }
     }
 
@@ -438,8 +447,7 @@ public class InternalTopologyBuilder {
         return this;
     }
 
-    @SuppressWarnings("deprecation")
-    public final void addSource(final Topology.AutoOffsetReset offsetReset,
+    public final void addSource(final AutoOffsetResetInternal offsetReset,
                                 final String name,
                                 final TimestampExtractor timestampExtractor,
                                 final Deserializer<?> keyDeserializer,
@@ -456,7 +464,7 @@ public class InternalTopologyBuilder {
         for (final String topic : topics) {
             Objects.requireNonNull(topic, "topic names cannot be null");
             validateTopicNotAlreadyRegistered(topic);
-            maybeAddToResetList(earliestResetTopics, latestResetTopics, offsetReset, topic);
+            maybeAddToResetList(noneResetTopics, earliestResetTopics, latestResetTopics, durationResetTopics, offsetReset, topic);
             rawSourceTopicNames.add(topic);
         }
 
@@ -466,8 +474,7 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
-    @SuppressWarnings("deprecation")
-    public final void addSource(final Topology.AutoOffsetReset offsetReset,
+    public final void addSource(final AutoOffsetResetInternal offsetReset,
                                 final String name,
                                 final TimestampExtractor timestampExtractor,
                                 final Deserializer<?> keyDeserializer,
@@ -486,7 +493,7 @@ public class InternalTopologyBuilder {
             }
         }
 
-        maybeAddToResetList(earliestResetPatterns, latestResetPatterns, offsetReset, topicPattern);
+        maybeAddToResetList(noneResetPatterns, earliestResetPatterns, latestResetPatterns, durationResetPatterns, offsetReset, topicPattern);
 
         nodeFactories.put(name, new SourceNodeFactory<>(name, null, topicPattern, timestampExtractor, keyDeserializer, valDeserializer));
         nodeToSourcePatterns.put(name, topicPattern);
@@ -914,21 +921,27 @@ public class InternalTopologyBuilder {
                 Collections.unmodifiableSet(sourcePatterns)
             );
         }
-
     }
 
-    @SuppressWarnings("deprecation")
-    private <T> void maybeAddToResetList(final Collection<T> earliestResets,
+    private <T> void maybeAddToResetList(final Collection<T> noneResets,
+                                         final Collection<T> earliestResets,
                                          final Collection<T> latestResets,
-                                         final Topology.AutoOffsetReset offsetReset,
+                                         final Map<T, Duration> durationReset,
+                                         final AutoOffsetResetInternal offsetReset,
                                          final T item) {
         if (offsetReset != null) {
-            switch (offsetReset) {
+            switch (offsetReset.offsetResetStrategy()) {
+                case NONE:
+                    noneResets.add(item);
+                    break;
                 case EARLIEST:
                     earliestResets.add(item);
                     break;
                 case LATEST:
                     latestResets.add(item);
+                    break;
+                case BY_DURATION:
+                    durationReset.put(item, offsetReset.duration());
                     break;
                 default:
                     throw new TopologyException(String.format("Unrecognized reset format %s", offsetReset));
@@ -1347,19 +1360,30 @@ public class InternalTopologyBuilder {
     }
 
     public boolean hasOffsetResetOverrides() {
-        return !(earliestResetTopics.isEmpty() && earliestResetPatterns.isEmpty()
-            && latestResetTopics.isEmpty() && latestResetPatterns.isEmpty());
+        return noneResetTopics.size() + noneResetPatterns.size()
+            + earliestResetTopics.size() + earliestResetPatterns.size()
+            + latestResetTopics.size() + latestResetPatterns.size()
+            + durationResetTopics.size() + durationResetPatterns.size() > 0;
     }
 
     public AutoOffsetResetStrategy offsetResetStrategy(final String topic) {
-        if (maybeDecorateInternalSourceTopics(earliestResetTopics).contains(topic) ||
+        Optional<Duration> resetDuration;
+
+        if (maybeDecorateInternalSourceTopics(noneResetTopics).contains(topic) ||
+            noneResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
+            return AutoOffsetResetStrategy.NONE;
+        } else if (maybeDecorateInternalSourceTopics(earliestResetTopics).contains(topic) ||
             earliestResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
             return AutoOffsetResetStrategy.EARLIEST;
         } else if (maybeDecorateInternalSourceTopics(latestResetTopics).contains(topic) ||
             latestResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
             return AutoOffsetResetStrategy.LATEST;
+        } else if (maybeDecorateInternalSourceTopics(durationResetTopics.keySet()).contains(topic)) {
+            return AutoOffsetResetStrategy.fromString("by_duration:" + durationResetTopics.get(topic).toString());
+        } else if ((resetDuration = findDuration(topic)).isPresent()) {
+            return AutoOffsetResetStrategy.fromString("by_duration:" + resetDuration.get());
         } else if (containsTopic(topic)) {
-            return AutoOffsetResetStrategy.NONE;
+            return null;
         } else {
             throw new IllegalStateException(String.format(
                 "Unable to lookup offset reset strategy for the following topic as it does not exist in the topology%s: %s",
@@ -1367,6 +1391,19 @@ public class InternalTopologyBuilder {
                 topic)
             );
         }
+    }
+
+    private Optional<Duration> findDuration(final String topic) {
+        final List<Duration> resetDuration = durationResetPatterns.entrySet().stream()
+            .filter(e -> e.getKey().matcher(topic).matches())
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toList());
+
+        if (resetDuration.size() > 1) {
+            throw new IllegalStateException("Found more than one reset duration for topic: " + topic);
+        }
+
+        return resetDuration.isEmpty() ? Optional.empty() : resetDuration.stream().findAny();
     }
 
     /**
@@ -1450,9 +1487,10 @@ public class InternalTopologyBuilder {
                                             + "applicationId hasn't been set. Call "
                                             + "setApplicationId first");
         }
-        final String prefix = topologyConfigs == null ?
-                                applicationId :
-                                ProcessorContextUtils.topicNamePrefix(topologyConfigs.applicationConfigs.originals(), applicationId);
+
+        final String prefix = topologyConfigs == null
+            ? applicationId
+            : ProcessorContextUtils.topicNamePrefix(topologyConfigs.applicationConfigs.originals(), applicationId);
 
         if (hasNamedTopology()) {
             return prefix + "-" + topologyName + "-" + topic;
@@ -1460,7 +1498,6 @@ public class InternalTopologyBuilder {
             return prefix + "-" + topic;
         }
     }
-
 
     void initializeSubscription() {
         if (usesPatternSubscription()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1886,7 +1886,7 @@ public class TaskManager {
         }
     }
 
-    private Task getActiveTask(final TopicPartition partition) {
+    Task getActiveTask(final TopicPartition partition) {
         final Task activeTask = tasks.activeTasksForInputPartition(partition);
 
         if (activeTask == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -427,10 +427,10 @@ public class TopologyMetadata {
         return hasNamedTopologies() || evaluateConditionIsTrueForAnyBuilders(InternalTopologyBuilder::hasOffsetResetOverrides);
     }
 
-    public AutoOffsetResetStrategy offsetResetStrategy(final String topic) {
+    public Optional<AutoOffsetResetStrategy> offsetResetStrategy(final String topic) {
         for (final InternalTopologyBuilder builder : builders.values()) {
             if (builder.containsTopic(topic)) {
-                return builder.offsetResetStrategy(topic);
+                return Optional.ofNullable(builder.offsetResetStrategy(topic));
             }
         }
         log.warn("Unable to look up offset reset strategy for topic {} " +
@@ -439,6 +439,9 @@ public class TopologyMetadata {
                 "persist or appear frequently.",
             topic, namedTopologiesView()
         );
+        // returning `null` for an Optional return type triggers spotbugs
+        // we added an exception for NP_OPTIONAL_RETURN_NULL for this method
+        // when we remove NamedTopologies, we can remove this exception
         return null;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/AutoOffsetResetTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/AutoOffsetResetTest.java
@@ -21,31 +21,37 @@ import org.apache.kafka.streams.internals.AutoOffsetResetInternal;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AutoOffsetResetTest {
 
     @Test
-    void latestShouldReturnAnEmptyDuration() {
-        final AutoOffsetResetInternal latest = new AutoOffsetResetInternal(AutoOffsetReset.latest());
-        assertTrue(latest.duration().isEmpty(), "Latest should have an empty duration.");
+    void shouldThrowExceptionOnDurationForNoneReset() {
+        final AutoOffsetResetInternal none = new AutoOffsetResetInternal(AutoOffsetReset.none());
+        assertThrows(NoSuchElementException.class, none::duration, "None should not have a duration.");
     }
 
     @Test
-    void earliestShouldReturnAnEmptyDuration() {
+    void shouldThrowExceptionOnDurationForEarliestReset() {
         final AutoOffsetResetInternal earliest = new AutoOffsetResetInternal(AutoOffsetReset.earliest());
-        assertTrue(earliest.duration().isEmpty(), "Earliest should have an empty duration.");
+        assertThrows(NoSuchElementException.class, earliest::duration, "Earliest should not have a duration.");
+    }
+
+    @Test
+    void shouldThrowExceptionOnDurationForLastetReset() {
+        final AutoOffsetResetInternal latest = new AutoOffsetResetInternal(AutoOffsetReset.latest());
+        assertThrows(NoSuchElementException.class, latest::duration, "Latest should not have a duration.");
     }
 
     @Test
     void customDurationShouldMatchExpectedValue() {
         final Duration duration = Duration.ofSeconds(10L);
         final AutoOffsetResetInternal custom = new AutoOffsetResetInternal(AutoOffsetReset.byDuration(duration));
-        assertEquals(10L, custom.duration().get().toSeconds(), "Duration should match the specified value in milliseconds.");
+        assertEquals(10L, custom.duration().toSeconds(), "Duration should match the specified value in milliseconds.");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -62,6 +62,7 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilder;
@@ -187,7 +188,7 @@ public class StreamThreadTest {
     private final MockTime mockTime = new MockTime();
     private final String stateDir = TestUtils.tempDirectory().getPath();
     private final MockClientSupplier clientSupplier = new MockClientSupplier();
-    private final ConsumedInternal<Object, Object> consumed = new ConsumedInternal<>();
+    private final ConsumedInternal<Object, Object> consumed = new ConsumedInternal<>(Consumed.with(null, null));
     private final ChangelogReader changelogReader = new MockChangelogReader();
     private StateDirectory stateDirectory = null;
     private final InternalTopologyBuilder internalTopologyBuilder = new InternalTopologyBuilder();
@@ -2087,7 +2088,7 @@ public class StreamThreadTest {
             .count(Materialized.as(storeName1));
         final MaterializedInternal<Object, Object, KeyValueStore<Bytes, byte[]>> materialized
             = new MaterializedInternal<>(Materialized.as(storeName2), internalStreamsBuilder, "");
-        internalStreamsBuilder.table(topic2, new ConsumedInternal<>(), materialized);
+        internalStreamsBuilder.table(topic2, new ConsumedInternal<>(Consumed.with(null, null)), materialized);
 
         internalStreamsBuilder.buildAndOptimizeTopology();
         restoreConsumer.updatePartitions(changelogName1,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -44,6 +44,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -2702,8 +2703,8 @@ public class StreamsPartitionAssignorTest {
 
         final InternalStreamsBuilder streamsBuilder = new InternalStreamsBuilder(builder);
 
-        final KStream<String, String> inputTopic = streamsBuilder.stream(singleton("topic1"), new ConsumedInternal<>());
-        final KTable<String, String> inputTable = streamsBuilder.table("topic2", new ConsumedInternal<>(), new MaterializedInternal<>(Materialized.as("store")));
+        final KStream<String, String> inputTopic = streamsBuilder.stream(singleton("topic1"), new ConsumedInternal<>(Consumed.with(null, null)));
+        final KTable<String, String> inputTable = streamsBuilder.table("topic2", new ConsumedInternal<>(Consumed.with(null, null)), new MaterializedInternal<>(Materialized.as("store")));
         inputTopic
             .groupBy(
                 (k, v) -> k,


### PR DESCRIPTION
Part of KIP-1106.

Adds support for "by_duration" and "none" reset strategy to the Kafka Streams runtime.