### PR TITLE
MINOR: improvement MetadataShell to use System.out.println

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -36,9 +36,6 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -57,7 +57,6 @@ import java.util.concurrent.TimeUnit;
  * The Kafka metadata shell entry point.
  */
 public final class MetadataShell {
-    private static final Logger log = LoggerFactory.getLogger(MetadataShell.class);
 
     public static class Builder {
         private KafkaRaftManager<ApiMessageAndVersion> raftManager = null;
@@ -226,7 +225,7 @@ public final class MetadataShell {
             try {
                 raftManager.shutdown();
             } catch (Exception e) {
-                log.error("Error shutting down RaftManager", e);
+                System.out.println("Error shutting down RaftManager, " + e);
             }
         }
         Utils.closeQuietly(snapshotFileReader, "raftManager");
@@ -234,7 +233,7 @@ public final class MetadataShell {
             try {
                 fileLock.destroy();
             } catch (Exception e) {
-                log.error("Error destroying fileLock", e);
+                System.out.println("Error destroying fileLock, " + e);
             } finally {
                 fileLock = null;
             }
@@ -258,11 +257,11 @@ public final class MetadataShell {
             builder.setSnapshotPath(res.getString("snapshot"));
             Path tempDir = Files.createTempDirectory("MetadataShell");
             Exit.addShutdownHook("agent-shutdown-hook", () -> {
-                log.debug("Removing temporary directory " + tempDir.toAbsolutePath());
+                System.out.println("Removing temporary directory " + tempDir.toAbsolutePath());
                 try {
                     Utils.delete(tempDir.toFile());
                 } catch (Exception e) {
-                    log.error("Got exception while removing temporary directory " +
+                    System.out.println("Got exception while removing temporary directory " +
                         tempDir.toAbsolutePath());
                 }
             });

--- a/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
@@ -96,7 +96,7 @@ public final class TreeCommandHandler implements Commands.Handler {
         PrintWriter writer,
         MetadataShellState state
     ) throws Exception {
-        log.trace("tree " + targets);
+        log.trace("tree {}", targets);
         for (String target : targets) {
             state.visit(new GlobVisitor(target, entryOption -> {
                 if (entryOption.isPresent()) {


### PR DESCRIPTION
When user use the shell tools, The system print should show on the console, we should not use the logging.
Also improvement logging should use {} instead of + 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
