### PR TITLE
MINOR: Remove waitUntilTrue from TestUtils.scala.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -383,6 +383,10 @@ public class TestUtils {
         waitForCondition(testCondition, maxWaitMs, () -> conditionDetails);
     }
 
+    public static void waitForCondition(final TestCondition testCondition, String conditionDetails, final long maxWaitMs) throws InterruptedException {
+        waitForCondition(testCondition, maxWaitMs, conditionDetails);
+    }
+
     /**
      * Wait for condition to be met for at most {@code maxWaitMs} and throw assertion failure otherwise.
      * This should be used instead of {@code Thread.sleep} whenever possible as it allows a longer timeout to be used
@@ -392,6 +396,16 @@ public class TestUtils {
     public static void waitForCondition(final TestCondition testCondition, final long maxWaitMs, Supplier<String> conditionDetailsSupplier) throws InterruptedException {
         waitForCondition(testCondition, maxWaitMs, DEFAULT_POLL_INTERVAL_MS, conditionDetailsSupplier);
     }
+
+    public static void waitForCondition(
+            final TestCondition testCondition,
+            String conditionDetails,
+            final long maxWaitMs,
+            final long pollIntervalMs
+    ) throws InterruptedException {
+        waitForCondition(testCondition, maxWaitMs, pollIntervalMs, () -> conditionDetails);
+    }
+
 
     /**
      * Wait for condition to be met for at most {@code maxWaitMs} with a polling interval of {@code pollIntervalMs}

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -383,10 +383,6 @@ public class TestUtils {
         waitForCondition(testCondition, maxWaitMs, () -> conditionDetails);
     }
 
-    public static void waitForCondition(final TestCondition testCondition, String conditionDetails, final long maxWaitMs) throws InterruptedException {
-        waitForCondition(testCondition, maxWaitMs, conditionDetails);
-    }
-
     /**
      * Wait for condition to be met for at most {@code maxWaitMs} and throw assertion failure otherwise.
      * This should be used instead of {@code Thread.sleep} whenever possible as it allows a longer timeout to be used
@@ -396,16 +392,6 @@ public class TestUtils {
     public static void waitForCondition(final TestCondition testCondition, final long maxWaitMs, Supplier<String> conditionDetailsSupplier) throws InterruptedException {
         waitForCondition(testCondition, maxWaitMs, DEFAULT_POLL_INTERVAL_MS, conditionDetailsSupplier);
     }
-
-    public static void waitForCondition(
-            final TestCondition testCondition,
-            String conditionDetails,
-            final long maxWaitMs,
-            final long pollIntervalMs
-    ) throws InterruptedException {
-        waitForCondition(testCondition, maxWaitMs, pollIntervalMs, () -> conditionDetails);
-    }
-
 
     /**
      * Wait for condition to be met for at most {@code maxWaitMs} with a polling interval of {@code pollIntervalMs}

--- a/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
@@ -20,7 +20,8 @@ package kafka.admin
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
-import kafka.utils.TestUtils.{createProducer, plaintextBootstrapServers, tempDir, waitUntilTrue}
+import kafka.utils.TestUtils.{createProducer, plaintextBootstrapServers, tempDir}
+
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
@@ -28,6 +29,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.requests.ListOffsetsResponse
 import org.apache.kafka.common.utils.{MockTime, Time, Utils}
 import org.apache.kafka.server.config.ServerLogConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -187,11 +189,11 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
     adminClient.alterPartitionReassignments(java.util.Collections.singletonMap(new TopicPartition(topic, 0),
       Optional.of(new NewPartitionReassignment(java.util.Arrays.asList(newLeader))))).all().get()
     // wait for all reassignments get completed
-    waitUntilTrue(() => adminClient.listPartitionReassignments().reassignments().get().isEmpty,
+    JTestUtils.waitForCondition(() => adminClient.listPartitionReassignments().reassignments().get().isEmpty,
       s"There still are ongoing reassignments")
     // make sure we are able to see the new leader
     var lastLeader = -1
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       lastLeader = leader()
       lastLeader == newLeader
     }, s"expected leader: $newLeader but actual: $lastLeader")

--- a/core/src/test/scala/integration/kafka/admin/RemoteTopicCrudTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/RemoteTopicCrudTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.errors.{InvalidConfigurationException, UnknownTop
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteLogSegmentState}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.{BeforeEach, Tag, TestInfo}
@@ -458,7 +459,7 @@ class RemoteTopicCrudTest extends IntegrationTestHarness {
     TestUtils.deleteTopicWithAdmin(createAdminClient(), testTopicName, brokers, controllerServers)
     assertThrowsException(classOf[UnknownTopicOrPartitionException],
       () => TestUtils.describeTopic(createAdminClient(), testTopicName), "Topic should be deleted")
-    TestUtils.waitUntilTrue(() =>
+    JTestUtils.waitForCondition(() =>
       numPartitions * MyRemoteLogMetadataManager.segmentCountPerPartition == MyRemoteStorageManager.deleteSegmentEventCounter.get(),
       "Remote log segments should be deleted only once by the leader")
   }
@@ -509,7 +510,7 @@ class RemoteTopicCrudTest extends IntegrationTestHarness {
   }
 
   private def verifyRemoteLogTopicConfigs(topicConfig: Properties): Unit = {
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val logBuffer = brokers.flatMap(_.logManager.getLog(new TopicPartition(testTopicName, 0)))
       var result = logBuffer.nonEmpty
       if (result) {

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -152,7 +152,7 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
 
     // since subscribe call to poller does not actually call consumer subscribe right away, wait
     // until subscribe is called on all consumers
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumerPollers.forall { poller => poller.isSubscribeRequestProcessed }
     }, s"Failed to call subscribe on all consumers in the group for subscription $subscriptions", 1000L)
 
@@ -371,7 +371,7 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
                               waitTime: Long = 10000L,
                               expectedAssignment: mutable.Buffer[Set[TopicPartition]] = mutable.Buffer()): Unit = {
     val assignments = mutable.Buffer[Set[TopicPartition]]()
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       assignments.clear()
       consumerPollers.foreach(assignments += _.consumerAssignment())
       isPartitionAssignmentValid(assignments, subscriptions, expectedAssignment)

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -154,7 +154,7 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
     // until subscribe is called on all consumers
     JTestUtils.waitForCondition(() => {
       consumerPollers.forall { poller => poller.isSubscribeRequestProcessed }
-    }, s"Failed to call subscribe on all consumers in the group for subscription $subscriptions", 1000L)
+    }, 1000L, s"Failed to call subscribe on all consumers in the group for subscription $subscriptions")
 
     validateGroupAssignment(consumerPollers, subscriptions,
       Some(s"Did not get valid assignment for partitions ${subscriptions.asJava} after we changed subscription"))
@@ -375,7 +375,7 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
       assignments.clear()
       consumerPollers.foreach(assignments += _.consumerAssignment())
       isPartitionAssignmentValid(assignments, subscriptions, expectedAssignment)
-    }, msg.getOrElse(s"Did not get valid assignment for partitions $subscriptions. Instead, got $assignments"), waitTime)
+    }, waitTime, msg.getOrElse(s"Did not get valid assignment for partitions $subscriptions. Instead, got $assignments"))
   }
 
   /**

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.{ExecutionException, Semaphore}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
 import kafka.utils.{TestInfoUtils, TestUtils}
-import kafka.utils.TestUtils.waitUntilTrue
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, NewTopic}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer._
@@ -1068,7 +1067,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
       }
       def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
       }})
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumer.poll(Duration.ofMillis(500))
       assignSemaphore.tryAcquire()
     }, "Assignment did not complete on time")
@@ -1126,7 +1125,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
       }
       def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
       }})
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumer.poll(Duration.ofMillis(500))
       assignSemaphore.tryAcquire()
     }, "Assignment did not complete on time")
@@ -1239,7 +1238,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
     val resource = if (resType == TOPIC) newTopicResource else clusterResource
     addAndVerifyAcls(acls, resource)
 
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumer.poll(Duration.ofMillis(50L))
       brokers.forall { broker =>
         broker.metadataCache.getPartitionInfo(newTopic, 0) match {

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.test.TestUtils.assertFutureThrows
 import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
@@ -242,7 +243,7 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
   }
 
   def waitForTopics(client: Admin, expectedPresent: Seq[String], expectedMissing: Seq[String]): Unit = {
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val topics = client.listTopics.names.get()
       expectedPresent.forall(topicName => topics.contains(topicName)) &&
         expectedMissing.forall(topicName => !topics.contains(topicName))
@@ -254,7 +255,7 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
                        describeOptions: DescribeTopicsOptions = new DescribeTopicsOptions,
                        expectedNumPartitionsOpt: Option[Int] = None): TopicDescription = {
     var result: TopicDescription = null
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val topicResult = client.describeTopics(Set(topic).asJava, describeOptions).topicNameValues().get(topic)
       try {
         result = topicResult.get

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.config.{QuotaConfig, ServerConfigs}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.quota.QuotaType
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -330,7 +331,7 @@ abstract class QuotaTestClients(topic: String,
     val maxMetric = producer.metrics.get(new MetricName("produce-throttle-time-max", "producer-metrics", "", tags))
 
     if (expectThrottle) {
-      TestUtils.waitUntilTrue(() => metricValue(avgMetric) > 0.0 && metricValue(maxMetric) > 0.0,
+      JTestUtils.waitForCondition(() => metricValue(avgMetric) > 0.0 && metricValue(maxMetric) > 0.0,
         s"Producer throttle metric not updated: avg=${metricValue(avgMetric)} max=${metricValue(maxMetric)}")
     } else
       assertEquals(0.0, metricValue(maxMetric), 0.0, "Should not have been throttled")
@@ -343,7 +344,7 @@ abstract class QuotaTestClients(topic: String,
     val maxMetric = consumer.metrics.get(new MetricName("fetch-throttle-time-max", "consumer-fetch-manager-metrics", "", tags))
 
     if (expectThrottle) {
-      TestUtils.waitUntilTrue(() => metricValue(avgMetric) > 0.0 && metricValue(maxMetric) > 0.0,
+      JTestUtils.waitForCondition(() => metricValue(avgMetric) > 0.0 && metricValue(maxMetric) > 0.0,
         s"Consumer throttle metric not updated: avg=${metricValue(avgMetric)} max=${metricValue(maxMetric)}")
       maxThrottleTime.foreach(max => assertTrue(metricValue(maxMetric) <= max,
         s"Maximum consumer throttle too high: ${metricValue(maxMetric)}"))

--- a/core/src/test/scala/integration/kafka/api/ConsumerRebootstrapTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerRebootstrapTest.scala
@@ -18,9 +18,10 @@ package kafka.api
 
 import kafka.api.ConsumerRebootstrapTest._
 import kafka.server.QuorumTestHarness.getTestQuorumAndGroupProtocolParametersClassicGroupProtocolOnly_ZK_implicit
-import kafka.utils.{TestInfoUtils, TestUtils}
+import kafka.utils.TestInfoUtils
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -36,7 +37,7 @@ class ConsumerRebootstrapTest extends RebootstrapTest {
   def testRebootstrap(quorum: String, groupProtocol: String, useRebootstrapTriggerMs: Boolean): Unit = {
     sendRecords(10, 0)
 
-    TestUtils.waitUntilTrue(
+    TestUtils.waitForCondition(
       () => server0.logManager.logsByTopic(tp.topic()).head.logEndOffset == server1.logManager.logsByTopic(tp.topic()).head.logEndOffset,
       "Timeout waiting for records to be replicated"
     )
@@ -54,7 +55,7 @@ class ConsumerRebootstrapTest extends RebootstrapTest {
     // Bring back the server 1 and shut down 0.
     server1.startup()
 
-    TestUtils.waitUntilTrue(
+    TestUtils.waitForCondition(
       () => server0.logManager.logsByTopic(tp.topic()).head.logEndOffset == server1.logManager.logsByTopic(tp.topic()).head.logEndOffset,
       "Timeout waiting for records to be replicated"
     )
@@ -71,7 +72,7 @@ class ConsumerRebootstrapTest extends RebootstrapTest {
     // Bring back the server 0 and shut down 1.
     server0.startup()
 
-    TestUtils.waitUntilTrue(
+    TestUtils.waitForCondition(
       () => server0.logManager.logsByTopic(tp.topic()).head.logEndOffset == server1.logManager.logsByTopic(tp.topic()).head.logEndOffset,
       "Timeout waiting for records to be replicated"
     )

--- a/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
@@ -21,11 +21,12 @@ import java.lang.{Boolean => JBoolean}
 import java.time.Duration
 import java.util
 import java.util.{Collections, Locale}
-import kafka.utils.{EmptyTestInfo, TestUtils}
+import kafka.utils.EmptyTestInfo
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.{ConsumerConfig, GroupProtocol}
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.server.config.{ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -85,7 +86,7 @@ object ConsumerTopicCreationTest {
 
       // Wait until the produced record was consumed. This guarantees that metadata request for `topic_2` was sent to the
       // broker.
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         consumer.poll(Duration.ofMillis(100)).count > 0
       }, "Timed out waiting to consume")
 

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.DelegationToken
 import org.apache.kafka.metadata.storage.Formatter
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -154,7 +155,7 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
         }
         val privilegedToken = privilegedAdminClient.createDelegationToken().delegationToken().get()
         //wait for tokens to reach all the brokers
-        TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),
+        JTestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),
           "Timed out waiting for token to propagate to all servers")
         (token, privilegedToken)
       } finally {

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteStorageMetrics}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -194,7 +195,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
 
   private def verifyBrokerAuthenticationMetrics(server: KafkaBroker): Unit = {
     val metrics = server.metrics.metrics
-    TestUtils.waitUntilTrue(() =>
+    JTestUtils.waitForCondition(() =>
       maxKafkaMetricValue("failed-authentication-total", metrics, "Broker", Some("socket-server-metrics")) > 0,
       "failed-authentication-total not updated")
     verifyKafkaMetricRecorded("successful-authentication-rate", metrics, "Broker", Some("socket-server-metrics"))

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -3289,7 +3289,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         all().get().get(broker0Resource).entries().asScala.map(entry => (entry.name, entry.value)).toMap
       ("123".equals(broker0Configs.getOrElse(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "456".equals(broker0Configs.getOrElse(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "")))
-    }, "Expected to see the broker properties we just set", DEFAULT_MAX_WAIT_MS, 25)
+    }, DEFAULT_MAX_WAIT_MS, 25, () => "Expected to see the broker properties we just set")
     client.incrementalAlterConfigs(Map(broker0Resource ->
       Seq(new AlterConfigOp(new ConfigEntry(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, ""),
         AlterConfigOp.OpType.DELETE),
@@ -3304,7 +3304,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       ("".equals(broker0Configs.getOrElse(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "654".equals(broker0Configs.getOrElse(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "987".equals(broker0Configs.getOrElse(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, "")))
-    }, "Expected to see the broker properties we just modified", DEFAULT_MAX_WAIT_MS, 25)
+    }, DEFAULT_MAX_WAIT_MS, 25, () => "Expected to see the broker properties we just modified")
   }
 
   @ParameterizedTest
@@ -3326,7 +3326,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       ("123".equals(broker0Configs.getOrElse(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "456".equals(broker0Configs.getOrElse(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "789".equals(broker0Configs.getOrElse(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, "")))
-    }, "Expected to see the broker properties we just set", DEFAULT_MAX_WAIT_MS, 25)
+    }, DEFAULT_MAX_WAIT_MS, 25, () => "Expected to see the broker properties we just set")
     client.incrementalAlterConfigs(Map(broker0Resource ->
       Seq(new AlterConfigOp(new ConfigEntry(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, ""),
         AlterConfigOp.OpType.DELETE),
@@ -3341,7 +3341,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       ("".equals(broker0Configs.getOrElse(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "".equals(broker0Configs.getOrElse(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG, "")) &&
         "".equals(broker0Configs.getOrElse(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, "")))
-    }, "Expected to see the broker properties we just removed to be deleted", DEFAULT_MAX_WAIT_MS, 25)
+    }, DEFAULT_MAX_WAIT_MS, 25, () => "Expected to see the broker properties we just removed to be deleted")
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerAssignorsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerAssignorsTest.scala
@@ -12,10 +12,11 @@
   */
 package kafka.api
 
-import kafka.utils.{TestInfoUtils, TestUtils}
+import kafka.utils.TestInfoUtils
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.UnsupportedAssignorException
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -351,7 +352,7 @@ class PlaintextConsumerAssignorsTest extends AbstractConsumerTest {
     }
     val consumerPoller1 = new ConsumerAssignmentPoller(consumer1, List(topic), Set.empty, customRebalanceListener)
     consumerPoller1.start()
-    TestUtils.waitUntilTrue(() => consumerPoller1.consumerAssignment() == expectedAssignment,
+    TestUtils.waitForCondition(() => consumerPoller1.consumerAssignment() == expectedAssignment,
       s"Timed out while awaiting expected assignment change to $expectedAssignment.")
 
     // Since the consumer1 already completed the rebalance,
@@ -369,9 +370,9 @@ class PlaintextConsumerAssignorsTest extends AbstractConsumerTest {
     }
 
     val consumerPoller2 = subscribeConsumerAndStartPolling(consumer2, List(topic))
-    TestUtils.waitUntilTrue(() => consumerPoller1.consumerAssignment().size == 1,
+    TestUtils.waitForCondition(() => consumerPoller1.consumerAssignment().size == 1,
       s"Timed out while awaiting expected assignment size change to 1.")
-    TestUtils.waitUntilTrue(() => consumerPoller2.consumerAssignment().size == 1,
+    TestUtils.waitForCondition(() => consumerPoller2.consumerAssignment().size == 1,
       s"Timed out while awaiting expected assignment size change to 1.")
 
     if (!lock.tryLock(3000, TimeUnit.MILLISECONDS)) {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerSubscriptionTest.scala
@@ -16,6 +16,7 @@ import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{InvalidRegularExpression, InvalidTopicException}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.function.Executable
@@ -278,8 +279,8 @@ class PlaintextConsumerSubscriptionTest extends AbstractConsumerTest {
     setupSubscribeInvalidTopic(consumer)
     if(groupProtocol == "consumer") {
       // Must ensure memberId is not empty before sending leave group heartbeat. This is a temporary solution before KIP-1082.
-      TestUtils.waitUntilTrue(() => consumer.groupMetadata().memberId().nonEmpty,
-        waitTimeMs = 30000, msg = "Timeout waiting for first consumer group heartbeat response")
+      JTestUtils.waitForCondition(() => consumer.groupMetadata().memberId().nonEmpty,
+        30000, "Timeout waiting for first consumer group heartbeat response")
     }
     assertDoesNotThrow(new Executable {
       override def execute(): Unit = consumer.unsubscribe()
@@ -303,13 +304,13 @@ class PlaintextConsumerSubscriptionTest extends AbstractConsumerTest {
     consumer.subscribe(List(invalidTopicName).asJava)
 
     var exception : InvalidTopicException = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       try consumer.poll(Duration.ofMillis(500)) catch {
         case e : InvalidTopicException => exception = e
         case e : Throwable => fail(s"An InvalidTopicException should be thrown. But ${e.getClass} is thrown")
       }
       exception != null
-    }, waitTimeMs = 5000, msg = "An InvalidTopicException should be thrown.")
+    }, 5000, "An InvalidTopicException should be thrown.")
 
     assertEquals(s"Invalid topics: [${invalidTopicName}]", exception.getMessage)
   }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -19,7 +19,7 @@ import java.util
 import java.util.Arrays.asList
 import java.util.{Collections, Locale, Optional, Properties}
 import kafka.server.KafkaBroker
-import kafka.utils.{TestInfoUtils, TestUtils}
+import kafka.utils.TestInfoUtils
 import org.apache.kafka.clients.admin.{NewPartitions, NewTopic}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
@@ -31,6 +31,7 @@ import org.apache.kafka.common.test.api.Flaky
 import org.apache.kafka.common.{MetricName, TopicPartition}
 import org.apache.kafka.server.quota.QuotaType
 import org.apache.kafka.test.{MockConsumerInterceptor, MockProducerInterceptor}
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -143,7 +144,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val consumer = createConsumer()
     // First call would create the topic
     consumer.partitionsFor("non-exist-topic")
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       !consumer.partitionsFor("non-exist-topic").isEmpty
     }, s"Timed out while awaiting non empty partitions.")
   }
@@ -858,7 +859,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // consumer explicitly left the group as opposed to being kicked out by the broker.
     val leaveGroupTimeoutMs = config.getInt(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG) / 2
 
-    TestUtils.waitUntilTrue(
+    TestUtils.waitForCondition(
       () => {
         try {
           val groupId = config.getString(ConsumerConfig.GROUP_ID_CONFIG)
@@ -869,8 +870,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
             false
         }
       },
-      msg=s"Consumer did not leave the consumer group within $leaveGroupTimeoutMs ms of close",
-      waitTimeMs=leaveGroupTimeoutMs
+      String.format("Consumer did not leave the consumer group within %s ms of close", leaveGroupTimeoutMs),
+      leaveGroupTimeoutMs
     )
   }
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -870,8 +870,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
             false
         }
       },
-      String.format("Consumer did not leave the consumer group within %s ms of close", leaveGroupTimeoutMs),
-      leaveGroupTimeoutMs
+      leaveGroupTimeoutMs,
+      String.format("Consumer did not leave the consumer group within %s ms of close", leaveGroupTimeoutMs)
     )
   }
 }

--- a/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
@@ -189,7 +189,7 @@ class ProducerIdExpirationTest extends KafkaServerTestHarness {
 
     // Ensure producer ID does not expire within 4 seconds.
     assertThrows(classOf[AssertionFailedError], () =>
-      JTestUtils.waitForCondition(() => producerState.isEmpty, "Producer ID did not expire.", 4000)
+      JTestUtils.waitForCondition(() => producerState.isEmpty, 4000L, "Producer ID did not expire.")
     )
 
     // Update the expiration time to a low value again.

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.metadata.storage.Formatter
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{MethodSource, ValueSource}
 
@@ -211,7 +212,7 @@ class SaslClientsWithInvalidCredentialsTest extends AbstractSaslTest {
 
   private def verifyWithRetry(action: => Unit): Unit = {
     var attempts = 0
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       try {
         attempts += 1
         action

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -734,9 +734,10 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
     val filter = new AclBindingFilter(resource.toFilter, accessControlEntryFilter)
     JTestUtils.waitForCondition(() => !authorizer.acls(filter).asScala.map(_.entry).toSet.contains(expectedToRemoved),
+      45000,
       s"expected acl to be removed : $expectedToRemoved" +
         s"but got:${authorizer.acls(filter).asScala.map(_.entry).mkString(newLine + "\t", newLine + "\t", newLine)}",
-      45000)
+    )
   }
 
   def waitAndVerifyAcl(expected: AccessControlEntry,
@@ -747,8 +748,9 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
     val filter = new AclBindingFilter(resource.toFilter, accessControlEntryFilter)
     JTestUtils.waitForCondition(() => authorizer.acls(filter).asScala.map(_.entry).toSet.contains(expected),
+      45000L,
       s"expected to contain acl: $expected" +
         s"but got:${authorizer.acls(filter).asScala.map(_.entry).mkString(newLine + "\t", newLine + "\t", newLine)}",
-      45000)
+    )
   }
 }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -853,7 +853,7 @@ class TransactionsTest extends IntegrationTestHarness {
           val producerStateEntry = log.producerStateManager.activeProducers.get(producerId)
           producerStateEntry != null && producerStateEntry.producerEpoch > previousProducerEpoch
         }
-      }, "Timed out waiting for producer epoch to be incremented after second commit", 10000)
+      }, 10000L, "Timed out waiting for producer epoch to be incremented after second commit")
 
       // Now that we've verified that the producer epoch has increased,
       // update the previous producer epoch.
@@ -944,7 +944,7 @@ class TransactionsTest extends IntegrationTestHarness {
       // Wait until the producer epoch has been updated on the broker.
       JTestUtils.waitForCondition(() => {
           producerStateEntry != null && producerStateEntry.producerEpoch == initialProducerEpoch + 3
-      }, "Timed out waiting for producer epoch to be incremented after second commit", 10000)
+      }, 10000L, "Timed out waiting for producer epoch to be incremented after second commit")
     }
   }
 

--- a/core/src/test/scala/integration/kafka/server/DelayedFutureTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFutureTest.scala
@@ -17,8 +17,8 @@
 package integration.kafka.server
 
 import kafka.server.DelayedFuturePurgatory
-import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
 
@@ -60,8 +60,8 @@ class DelayedFutureTest {
       assertFalse(r2.isCompleted)
       assertEquals(-1, result.get())
       futures2(1).complete(21)
-      TestUtils.waitUntilTrue(() => r2.isCompleted, "r2 not completed")
-      TestUtils.waitUntilTrue(() => result.get == 41, "callback not invoked")
+      TestUtils.waitForCondition(() => r2.isCompleted, "r2 not completed")
+      TestUtils.waitForCondition(() => result.get == 41, "callback not invoked")
       assertTrue(hasExecutorThread, "Thread not created for executing delayed task")
 
       // One immediate and one delayed future: callback should wait for delayed task to complete
@@ -71,8 +71,8 @@ class DelayedFutureTest {
       assertFalse(r3.isCompleted, "r3 should be incomplete")
       assertEquals(-1, result.get())
       futures3.head.complete(30)
-      TestUtils.waitUntilTrue(() => r3.isCompleted, "r3 not completed")
-      TestUtils.waitUntilTrue(() => result.get == 61, "callback not invoked")
+      TestUtils.waitForCondition(() => r3.isCompleted, "r3 not completed")
+      TestUtils.waitForCondition(() => result.get == 61, "callback not invoked")
 
       // One future doesn't complete within timeout. Should expire and invoke callback after timeout.
       result.set(-1)
@@ -81,7 +81,7 @@ class DelayedFutureTest {
       val futures4 = List(new CompletableFuture[Integer], new CompletableFuture[Integer])
       val r4 = purgatory.tryCompleteElseWatch[Integer](expirationMs, futures4, () => updateResult(futures4))
       futures4.head.complete(40)
-      TestUtils.waitUntilTrue(() => futures4(1).isDone, "r4 futures not expired")
+      TestUtils.waitForCondition(() => futures4(1).isDone, "r4 futures not expired")
       assertTrue(r4.isCompleted, "r4 not completed after timeout")
       val elapsed = Time.SYSTEM.hiResClockMs - start
       assertTrue(elapsed >= expirationMs, s"Time for expiration $elapsed should at least $expirationMs")

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.config.ServerLogConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{Disabled, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
@@ -121,7 +122,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
     // Shutdown follower broker.
     brokers(followerBrokerId).shutdown()
     val topicPartition = new TopicPartition(topic, 0)
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val endpoints = brokers(leaderBrokerId).metadataCache.getPartitionReplicaEndpoints(topicPartition, listenerName)
       !endpoints.contains(followerBrokerId)
     }, "follower is still reachable.")
@@ -154,7 +155,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
       consumer.subscribe(List(topic).asJava)
 
       // Wait until preferred replica is set to follower.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         getPreferredReplica == 1
       }, "Preferred replica is not set")
 
@@ -169,7 +170,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
 
       // Start the follower and wait until preferred replica is set to follower.
       brokers(followerBrokerId).startup()
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         getPreferredReplica == 1
       }, "Preferred replica is not set")
 

--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -37,6 +37,8 @@ import org.apache.kafka.common.security.auth.{Login, SecurityProtocol}
 import org.apache.kafka.common.security.kerberos.KerberosLogin
 import org.apache.kafka.common.utils.{LogContext, MockTime}
 import org.apache.kafka.network.SocketServerConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -223,7 +225,7 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
   }
 
   private def pollUntilReadyOrDisconnected(selector: Selector, nodeId: String): Boolean = {
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       selector.poll(100)
       val disconnectState = selector.disconnected().get(nodeId)
       // Verify that disconnect state is not AUTHENTICATION_FAILED
@@ -248,7 +250,7 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
     val selector = createSelector()
     val nodeId = "1"
     selector.connect(nodeId, serverAddr, 1024, 1024)
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       selector.poll(100)
       val disconnectState = selector.disconnected().get(nodeId)
       if (disconnectState != null)

--- a/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
@@ -20,10 +20,10 @@ package kafka.server
 import org.apache.kafka.common.test.api.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterTest, ClusterTests, Type}
 import org.apache.kafka.common.test.api.ClusterTestExtensions
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.FeatureUpdate.UpgradeType
 import org.apache.kafka.clients.admin.{FeatureUpdate, UpdateFeaturesOptions}
 import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -54,7 +54,7 @@ class MetadataVersionIntegrationTest {
       updateResult.all().get()
 
       // Verify that new version is visible on broker
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         val describeResult2 = admin.describeFeatures()
         val ff2 = describeResult2.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
         ff2.minVersionLevel() == updateVersion && ff2.maxVersionLevel() == updateVersion

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -19,11 +19,11 @@ package kafka.server
 
 import org.apache.kafka.common.test.KafkaClusterTestKit
 import org.apache.kafka.common.test.TestKitNodes
-import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.BufferSupplier
 import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.server.config.KRaftConfigs
 import org.apache.kafka.snapshot.RecordsSnapshotReader
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -57,7 +57,7 @@ class RaftClusterSnapshotTest {
       cluster.startup()
 
       // Check that every controller and broker has a snapshot
-      TestUtils.waitUntilTrue(
+      TestUtils.waitForCondition(
         () => {
           cluster.raftManagers().asScala.forall { case (_, raftManager) =>
             raftManager.replicatedLog.latestSnapshotId.isPresent

--- a/core/src/test/scala/kafka/tools/LogCompactionTester.scala
+++ b/core/src/test/scala/kafka/tools/LogCompactionTester.scala
@@ -23,17 +23,16 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path}
 import java.time.Duration
 import java.util.{Properties, Random}
-
 import joptsimple.OptionParser
-import kafka.utils._
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringDeserializer}
-import org.apache.kafka.common.utils.{Exit, AbstractIterator, Utils}
+import org.apache.kafka.common.utils.{AbstractIterator, Exit, Utils}
 import org.apache.kafka.server.util.CommandLineUtils
+import org.apache.kafka.test.TestUtils
 
 import scala.jdk.CollectionConverters._
 
@@ -147,7 +146,7 @@ object LogCompactionTester {
       adminClient.createTopics(newTopics).all.get
 
       var pendingTopics: Seq[String] = Seq()
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         val allTopics = adminClient.listTopics.names.get.asScala.toSeq
         pendingTopics = topics.filter(topicName => !allTopics.contains(topicName))
         pendingTopics.isEmpty

--- a/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
@@ -13,16 +13,16 @@
 package kafka.admin
 
 import kafka.server.KafkaServer
-import kafka.utils.TestUtils
 import kafka.zk.AdminZkClient
 import org.apache.kafka.server.config.{ConfigType, QuotaConfig}
+import org.apache.kafka.test.TestUtils
 
 import scala.collection.Seq
 
 object ReplicationQuotaUtils {
 
   def checkThrottleConfigRemovedFromZK(adminZkClient: AdminZkClient, topic: String, servers: Seq[KafkaServer]): Unit = {
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val hasRateProp = servers.forall { server =>
         val brokerConfig = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)
         brokerConfig.contains(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG) ||
@@ -36,7 +36,7 @@ object ReplicationQuotaUtils {
   }
 
   def checkThrottleConfigAddedToZK(adminZkClient: AdminZkClient, expectedThrottleRate: Long, servers: Seq[KafkaServer], topic: String, throttledLeaders: Set[String], throttledFollowers: Set[String]): Unit = {
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       //Check for limit in ZK
       val brokerConfigAvailable = servers.forall { server =>
         val configInZk = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.storage.internals.checkpoint.OffsetCheckpoints
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
 import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, LocalLog, LogAppendInfo, LogConfig, LogDirFailureChannel, LogLoader, LogSegments, ProducerStateManager, ProducerStateManagerConfig, VerificationGuard}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers
@@ -128,7 +129,7 @@ class PartitionLockTest extends Logging {
     val active = new AtomicBoolean(true)
 
     val future = scheduleShrinkIsr(active, mockTimeSleepMs = 10000)
-    TestUtils.waitUntilTrue(() => shrinkIsrSemaphore.hasQueuedThreads, "shrinkIsr not invoked")
+    JTestUtils.waitForCondition(() => shrinkIsrSemaphore.hasQueuedThreads, "shrinkIsr not invoked")
     concurrentProduceFetchWithWriteLock()
     active.set(false)
     future.get(15, TimeUnit.SECONDS)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2755,7 +2755,7 @@ class PartitionTest extends AbstractPartitionTest {
     fetchFollower(partition, replicaId = follower3, fetchOffset = 10L)
 
     // Try avoiding a race
-    JTestUtils.waitForCondition(() => !partition.partitionState.isInflight, "Expected ISR state to be committed", 100)
+    JTestUtils.waitForCondition(() => !partition.partitionState.isInflight, 100L, "Expected ISR state to be committed")
 
     partition.partitionState match {
       case CommittedPartitionState(isr, _) => assertEquals(Set(brokerId, follower1, follower2, follower3), isr)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -33,6 +33,8 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, TopicPartition, Uuid}
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.metadata.LeaderRecoveryState
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
@@ -492,7 +494,7 @@ class PartitionTest extends AbstractPartitionTest {
       }
     }
     appendThread.start()
-    TestUtils.waitUntilTrue(() => appendSemaphore.hasQueuedThreads, "follower log append is not called.")
+    JTestUtils.waitForCondition(() => appendSemaphore.hasQueuedThreads, "follower log append is not called.")
 
     val partitionState = new LeaderAndIsrPartitionState()
       .setControllerEpoch(0)
@@ -2753,7 +2755,7 @@ class PartitionTest extends AbstractPartitionTest {
     fetchFollower(partition, replicaId = follower3, fetchOffset = 10L)
 
     // Try avoiding a race
-    TestUtils.waitUntilTrue(() => !partition.partitionState.isInflight, "Expected ISR state to be committed", 100)
+    JTestUtils.waitForCondition(() => !partition.partitionState.isInflight, "Expected ISR state to be committed", 100)
 
     partition.partitionState match {
       case CommittedPartitionState(isr, _) => assertEquals(Set(brokerId, follower1, follower2, follower3), isr)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -31,6 +31,8 @@ import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.server.common.{MetadataVersion, TransactionVersion}
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.util.RequestAndCompletionHandler
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -158,7 +160,7 @@ class TransactionMarkerChannelManagerTest {
         time.milliseconds(), time.milliseconds(), false, null, null,
         response)
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         val requests = channelManager.generateRequests().asScala
         if (requests.nonEmpty) {
           assertEquals(1, requests.size)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -207,7 +207,7 @@ class TransactionStateManagerTest {
     })
     loadingThread.start()
     TestUtils.waitForCondition(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
-      "Timed out waiting for loading partition", TestUtils.DEFAULT_MAX_WAIT_MS, 10)
+      TestUtils.DEFAULT_MAX_WAIT_MS, 10, () => "Timed out waiting for loading partition")
 
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId)
     assertFalse(transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch))
@@ -266,7 +266,7 @@ class TransactionStateManagerTest {
     })
     loadingThread.start()
     TestUtils.waitForCondition(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
-      "Timed out waiting for loading partition", TestUtils.DEFAULT_MAX_WAIT_MS, 10)
+      TestUtils.DEFAULT_MAX_WAIT_MS, 10, () => "Timed out waiting for loading partition")
 
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch + 1)
     assertFalse(transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch))

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.ReentrantLock
 import javax.management.ObjectName
 import kafka.log.UnifiedLog
 import kafka.server.{MetadataCache, ReplicaManager}
-import kafka.utils.{Pool, TestUtils}
+import kafka.utils.Pool
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.compress.Compression
@@ -40,6 +40,7 @@ import org.apache.kafka.coordinator.transaction.generated.TransactionLogKey
 import org.apache.kafka.server.storage.log.FetchIsolation
 import org.apache.kafka.server.util.MockScheduler
 import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, LogConfig, LogOffsetMetadata}
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -205,8 +206,8 @@ class TransactionStateManagerTest {
       transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch, (_, _, _, _) => ())
     })
     loadingThread.start()
-    TestUtils.waitUntilTrue(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
-      "Timed out waiting for loading partition", pause = 10)
+    TestUtils.waitForCondition(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
+      "Timed out waiting for loading partition", TestUtils.DEFAULT_MAX_WAIT_MS, 10)
 
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId)
     assertFalse(transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch))
@@ -264,8 +265,8 @@ class TransactionStateManagerTest {
       transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch, (_, _, _, _) => ())
     })
     loadingThread.start()
-    TestUtils.waitUntilTrue(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
-      "Timed out waiting for loading partition", pause = 10)
+    TestUtils.waitForCondition(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
+      "Timed out waiting for loading partition", TestUtils.DEFAULT_MAX_WAIT_MS, 10)
 
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch + 1)
     assertFalse(transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch))

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{KafkaException, Uuid}
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 
 import java.io.File
@@ -341,7 +342,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
   def waitForUserScramCredentialToAppearOnAllBrokers(clientPrincipal: String, mechanismName: String): Unit = {
     _brokers.foreach { server =>
       val cache = server.credentialProvider.credentialCache.cache(mechanismName, classOf[ScramCredential])
-      TestUtils.waitUntilTrue(() => cache.get(clientPrincipal) != null, s"SCRAM credentials not created for $clientPrincipal")
+      JTestUtils.waitForCondition(() => cache.get(clientPrincipal) != null, s"SCRAM credentials not created for $clientPrincipal")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigOp, AlterConfigsResult, ConfigEntry}
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.apache.log4j.{Level, Logger}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
@@ -282,7 +283,7 @@ class UncleanLeaderElectionTest extends QuorumTestHarness {
 
     produceMessage(brokers, topic, "third")
     //make sure follower server joins the ISR
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val partitionInfoOpt = followerServer.metadataCache.getPartitionInfo(topic, partitionId)
       partitionInfoOpt.isDefined && partitionInfoOpt.get.isr.contains(followerId)
     }, "Inconsistent metadata after first server startup")
@@ -425,7 +426,7 @@ class UncleanLeaderElectionTest extends QuorumTestHarness {
   }
 
   private def waitForNoLeaderAndIsrHasOldLeaderId(metadataCache: MetadataCache, leaderId: Int): Unit = {
-    waitUntilTrue(() => metadataCache.getPartitionInfo(topic, partitionId).isDefined &&
+    JTestUtils.waitForCondition(() => metadataCache.getPartitionInfo(topic, partitionId).isDefined &&
       metadataCache.getPartitionInfo(topic, partitionId).get.leader() == LeaderConstants.NO_LEADER &&
       java.util.Arrays.asList(leaderId).equals(metadataCache.getPartitionInfo(topic, partitionId).get.isr()),
       "Timed out waiting for broker metadata cache updates the info for topic partition:" + topicPartition)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -77,11 +77,11 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest {
     val uncleanablePartitionsCountGauge = getGauge[Int]("uncleanable-partitions-count", uncleanableDirectory)
     val uncleanableBytesGauge = getGauge[Long]("uncleanable-bytes", uncleanableDirectory)
 
-    JTestUtils.waitForCondition(() => uncleanablePartitionsCountGauge.value() == 2, "There should be 2 uncleanable partitions", 2000L)
+    JTestUtils.waitForCondition(() => uncleanablePartitionsCountGauge.value() == 2, 2000L,"There should be 2 uncleanable partitions")
     val expectedTotalUncleanableBytes = LogCleanerManager.calculateCleanableBytes(log, 0, log.logSegments.asScala.last.baseOffset)._2 +
       LogCleanerManager.calculateCleanableBytes(log2, 0, log2.logSegments.asScala.last.baseOffset)._2
     JTestUtils.waitForCondition(() => uncleanableBytesGauge.value() == expectedTotalUncleanableBytes,
-      s"There should be $expectedTotalUncleanableBytes uncleanable bytes", 1000L)
+      1000L, s"There should be $expectedTotalUncleanableBytes uncleanable bytes")
 
     val uncleanablePartitions = cleaner.cleanerManager.uncleanablePartitions(uncleanableDirectory)
     assertTrue(uncleanablePartitions.contains(topicPartitions(0)))
@@ -95,8 +95,9 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest {
         time.sleep(1000)
         uncleanablePartitionsCountGauge.value() == 1
       },
+      2000L,
       "There should be 1 uncleanable partitions",
-      2000L)
+    )
 
     val uncleanablePartitions2 = cleaner.cleanerManager.uncleanablePartitions(uncleanableDirectory)
     assertFalse(uncleanablePartitions2.contains(topicPartitions(0)))

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -30,6 +30,8 @@ import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.storage.internals.checkpoint.OffsetCheckpointFile
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
@@ -124,7 +126,7 @@ class LogCleanerParameterizedIntegrationTest extends AbstractLogCleanerIntegrati
     // Set the last modified time to an old value to force deletion of old segments
     val endOffset = log.logEndOffset
     log.logSegments.forEach(_.setLastModified(time.milliseconds - (2 * retentionMs)))
-    TestUtils.waitUntilTrue(() => log.logStartOffset == endOffset && log.numberOfSegments == 1,
+    JTestUtils.waitForCondition(() => log.logStartOffset == endOffset && log.numberOfSegments == 1,
       "Timed out waiting for deletion of old segments")
 
     cleaner.shutdown()

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -33,6 +33,8 @@ import org.apache.kafka.image.{TopicImage, TopicsImage}
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
@@ -274,7 +276,7 @@ class LogManagerTest {
     t.start()
 
     // 4. shutdown LogManager after the first log is loaded but before the second log is loaded
-    TestUtils.waitUntilTrue(() => loadLogCalled == 1,
+    JTestUtils.waitForCondition(() => loadLogCalled == 1,
       "Timed out waiting for only the first log to be loaded")
     logManager.shutdown()
     logManager = null

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1858,7 +1858,7 @@ class SocketServerTest {
       testableSelector.operationCounts.clear()
       val sockets = (1 to numConnections).map(_ => connect(testableServer))
       JTestUtils.waitForCondition(() => errors.nonEmpty || registeredConnectionCount == numConnections,
-        "Connections not registered", 15000)
+        15000L, "Connections not registered")
       assertEquals(Set.empty, errors)
       testableSelector.waitForOperations(SelectorOperation.Register, numConnections)
 
@@ -1985,7 +1985,7 @@ class SocketServerTest {
 
       // force all data to be transferred to the kafka broker by closing the client connection to proxy server
       sslSocket.close()
-      JTestUtils.waitForCondition(() => proxyServer.clientConnSocket.isClosed, "proxyServer.clientConnSocket is still not closed after 60000 ms", 60000)
+      JTestUtils.waitForCondition(() => proxyServer.clientConnSocket.isClosed, 60000, "proxyServer.clientConnSocket is still not closed after 60000 ms")
 
       // process the request and send the response
       processRequest(testableServer.dataPlaneRequestChannel, req1)

--- a/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
@@ -36,6 +36,8 @@ import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.AuthorizerTestServerInfo
 import org.apache.kafka.security.authorizer.AclEntry.{WILDCARD_HOST, WILDCARD_PRINCIPAL_STRING}
 import org.apache.kafka.server.authorizer._
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Test
@@ -343,9 +345,9 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     acls = changeAclAndVerify(acls, Set(acl5), Set.empty)
 
     //test get by principal name.
-    TestUtils.waitUntilTrue(() => Set(acl1, acl2).map(acl => new AclBinding(resource, acl)) == getAcls(authorizer1, user1),
+    JTestUtils.waitForCondition(() => Set(acl1, acl2).map(acl => new AclBinding(resource, acl)) == getAcls(authorizer1, user1),
       "changes not propagated in timeout period")
-    TestUtils.waitUntilTrue(() => Set(acl3, acl4, acl5).map(acl => new AclBinding(resource, acl)) == getAcls(authorizer1, user2),
+    JTestUtils.waitForCondition(() => Set(acl3, acl4, acl5).map(acl => new AclBinding(resource, acl)) == getAcls(authorizer1, user2),
       "changes not propagated in timeout period")
 
     val resourceToAcls = Map[ResourcePattern, Set[AccessControlEntry]](
@@ -359,7 +361,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val expectedAcls = (resourceToAcls + (resource -> acls)).flatMap {
       case (res, resAcls) => resAcls.map { acl => new AclBinding(res, acl) }
     }.toSet
-    TestUtils.waitUntilTrue(() => expectedAcls == getAcls(authorizer1), "changes not propagated in timeout period.")
+    JTestUtils.waitForCondition(() => expectedAcls == getAcls(authorizer1), "changes not propagated in timeout period.")
 
     //test remove acl from existing acls.
     acls = changeAclAndVerify(acls, Set.empty, Set(acl1, acl5))

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.storage.internals.log.LogAppendInfo
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.{BeforeEach, Test}
@@ -72,7 +73,7 @@ class AbstractFetcherThreadTest {
     val fetcherMetrics = Set(FetcherMetrics.BytesPerSec, FetcherMetrics.RequestsPerSec, FetcherMetrics.ConsumerLag)
 
     // wait until all fetcher metrics are present
-    TestUtils.waitUntilTrue(() => allMetricsNames == brokerTopicStatsMetrics ++ fetcherMetrics,
+    JTestUtils.waitForCondition(() => allMetricsNames == brokerTopicStatsMetrics ++ fetcherMetrics,
       "Failed waiting for all fetcher metrics to be registered")
 
     fetcher.shutdown()
@@ -380,7 +381,7 @@ class AbstractFetcherThreadTest {
     fetcher.mockLeader.setLeaderState(partition, leaderState)
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       fetcher.doWork()
       fetcher.replicaPartitionState(partition).log == fetcher.mockLeader.leaderPartitionState(partition).log
     }, "Failed to reconcile leader and follower logs")
@@ -699,7 +700,7 @@ class AbstractFetcherThreadTest {
     assertEquals(2, replicaState.logStartOffset)
     assertEquals(List(), replicaState.log.toList)
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       fetcher.doWork()
       fetcher.replicaPartitionState(partition).log == fetcher.mockLeader.leaderPartitionState(partition).log
     }, "Failed to reconcile leader and follower logs")
@@ -742,7 +743,7 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(Fetching), fetcher.fetchState(partition).map(_.state))
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       fetcher.doWork()
       fetcher.replicaPartitionState(partition).log == fetcher.mockLeader.leaderPartitionState(partition).log
     }, "Failed to reconcile leader and follower logs")
@@ -1032,7 +1033,7 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     fetcher.verifyLastFetchedEpoch(partition, Some(2))
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       fetcher.doWork()
       fetcher.replicaPartitionState(partition).log == fetcher.mockLeader.leaderPartitionState(partition).log
     }, "Failed to reconcile leader and follower logs")
@@ -1100,7 +1101,7 @@ class AbstractFetcherThreadTest {
     // Truncate should have been called only once and process partition data
     // should have been called at least once. The log end offset and the high
     // watermark are updated.
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       fetcher.doWork()
       fetcher.replicaPartitionState(partition).log == fetcher.mockLeader.leaderPartitionState(partition).log
     }, "Failed to reconcile leader and follower logs")

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
 import org.apache.kafka.common.requests.{AddPartitionsToTxnRequest, AddPartitionsToTxnResponse, FindCoordinatorRequest, FindCoordinatorResponse, InitProducerIdRequest, InitProducerIdResponse}
 import org.apache.kafka.server.config.ServerLogConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -180,7 +181,7 @@ class AddPartitionsToTxnRequestServerTest extends BaseRequestTest {
 
     var initPidResponse: InitProducerIdResponse = null
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val initPidRequest = new InitProducerIdRequest.Builder(new InitProducerIdRequestData().setTransactionalId(transactionalId).setTransactionTimeoutMs(10000)).build()
       initPidResponse = connectAndReceive[InitProducerIdResponse](initPidRequest, brokerSocketServer(coordinatorId))
       initPidResponse.error() != Errors.COORDINATOR_LOAD_IN_PROGRESS

--- a/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.nio.charset.StandardCharsets
 import java.util
-import kafka.utils.TestUtils
 import kafka.network.SocketServer
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.apache.kafka.clients.admin.ScramMechanism
@@ -34,6 +33,7 @@ import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuild
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -285,7 +285,7 @@ class AlterUserScramCredentialsRequestTest extends BaseRequestTest {
 
     // KRaft is eventually consistent so it is possible to call describe before
     // the credential is propagated from the controller to the broker.
-    TestUtils.waitUntilTrue(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 3,
+    TestUtils.waitForCondition(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 3,
                                "describeAllWithNoTopLevelErrorConfirmed does not see 3 users")
 
     // now describe them all
@@ -346,7 +346,7 @@ class AlterUserScramCredentialsRequestTest extends BaseRequestTest {
     checkUserAppearsInAlterResults(results4, user1)
     checkUserAppearsInAlterResults(results4, user2)
 
-    TestUtils.waitUntilTrue(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 2,
+    TestUtils.waitForCondition(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 2,
                                "describeAllWithNoTopLevelErrorConfirmed does not see only 2 users")
 
     // now describe them all, which should just yield 2 credentials
@@ -370,7 +370,7 @@ class AlterUserScramCredentialsRequestTest extends BaseRequestTest {
     checkUserAppearsInAlterResults(results6, user1)
     checkUserAppearsInAlterResults(results6, user3)
 
-    TestUtils.waitUntilTrue(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 0,
+    TestUtils.waitForCondition(() => describeAllWithNoTopLevelErrorConfirmed().data.results.size == 0,
                                "describeAllWithNoTopLevelErrorConfirmed does not see empty user")
 
     // now describe them all, which should yield 0 credentials

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
@@ -32,6 +32,8 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.common.Feature
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -103,7 +105,7 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
 
       // Add first group with one member.
       var grp1Member1Response: ConsumerGroupHeartbeatResponseData = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         grp1Member1Response = consumerGroupHeartbeat(
           groupId = "grp-1",
           memberId = Uuid.randomUuid().toString,
@@ -112,13 +114,13 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
           topicPartitions = List.empty
         )
         grp1Member1Response.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $grp1Member1Response.")
+      },  s"Could not join the group successfully. Last response $grp1Member1Response.")
 
       // Add second group with two members. For the first member, we
       // wait until it receives an assignment. We use 'range` in this
       // case to validate the assignor selection logic.
       var grp2Member1Response: ConsumerGroupHeartbeatResponseData = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         grp2Member1Response = consumerGroupHeartbeat(
           memberId = "member-1",
           groupId = "grp-2",
@@ -128,7 +130,7 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
           topicPartitions = List.empty
         )
         grp2Member1Response.assignment != null && !grp2Member1Response.assignment.topicPartitions.isEmpty
-      }, msg = s"Could not join the group successfully. Last response $grp2Member1Response.")
+      }, s"Could not join the group successfully. Last response $grp2Member1Response.")
 
       val grp2Member2Response = consumerGroupHeartbeat(
         memberId = "member-2",

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse}
 import org.apache.kafka.coordinator.group.{GroupConfig, GroupCoordinatorConfig}
 import org.apache.kafka.server.common.Feature
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull}
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -101,10 +102,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -134,11 +135,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned.
       consumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(2, consumerGroupHeartbeatResponse.data.memberEpoch)
@@ -189,10 +190,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -222,11 +223,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned.
       consumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(2, consumerGroupHeartbeatResponse.data.memberEpoch)
@@ -264,10 +265,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.INVALID_REGULAR_EXPRESSION.code
-      }, msg = s"Did not receive the expected error. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Did not receive the expected error. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(Errors.INVALID_REGULAR_EXPRESSION.code, consumerGroupHeartbeatResponse.data.errorCode)
@@ -303,10 +304,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Did not receive the expected successful response. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Did not receive the expected successful response. Last response $consumerGroupHeartbeatResponse.")
 
       // Heartbeat request to join the group.
       consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequest.Builder(
@@ -322,10 +323,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       consumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Did not receive the expected successful response. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Did not receive the expected successful response. Last response $consumerGroupHeartbeatResponse.")
     } finally {
       admin.close()
     }
@@ -360,10 +361,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Static member could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Static member could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -394,11 +395,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned.
       consumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Static member could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Static member could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -481,10 +482,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -515,11 +516,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned.
       consumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(2, consumerGroupHeartbeatResponse.data.memberEpoch)
@@ -544,11 +545,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // The new static member join group will keep failing with an UnreleasedInstanceIdException
       // until eventually it gets through because the existing member will be kicked out
       // because of not sending a heartbeat till session timeout expiry.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not re-join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not re-join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response. The group epoch bumps upto 4 which eventually reflects in the new member epoch.
       assertEquals(4, consumerGroupHeartbeatResponse.data.memberEpoch)
@@ -594,10 +595,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(consumerGroupHeartbeatResponse.data.memberId)
@@ -622,11 +623,11 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       ).build()
 
       // Verify the response. The heartbeat interval was updated.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           newHeartbeatIntervalMs == consumerGroupHeartbeatResponse.data.heartbeatIntervalMs
-      }, msg = s"Dynamic update consumer group config failed. Last response $consumerGroupHeartbeatResponse.")
+      }, s"Dynamic update consumer group config failed. Last response $consumerGroupHeartbeatResponse.")
     } finally {
       admin.close()
     }
@@ -655,10 +656,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       ).build()
 
       var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
         consumerGroupHeartbeatResponse.data.errorCode == Errors.INVALID_REQUEST.code
-      }, msg = "Should fail due to invalid member id.")
+      }, "Should fail due to invalid member id.")
     } finally {
       admin.close()
     }
@@ -686,10 +687,10 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
     ).build(0)
 
     var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
       consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-    }, msg = s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
+    }, s"Could not join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
     val memberId = consumerGroupHeartbeatResponse.data().memberId()
     assertNotNull(memberId)

--- a/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
@@ -183,7 +183,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
       // throttle time should be zero.
       val rejectedTopicName = errors1.filter(_._2 == Errors.THROTTLING_QUOTA_EXCEEDED).keys.head
       val rejectedTopicSpec = TopicsWith30Partitions.filter(_._1 == rejectedTopicName)
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         val (throttleTimeMs2, errors2) = createTopics(rejectedTopicSpec, StrictCreateTopicsRequestVersion)
         throttleTimeMs2 == 0 && errors2 == Map(rejectedTopicName -> Errors.NONE)
       }, "Failed to create topics after having been throttled")
@@ -237,7 +237,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
       // throttle time should be zero.
       val rejectedTopicName = errors1.filter(_._2 == Errors.THROTTLING_QUOTA_EXCEEDED).keys.head
       val rejectedTopicSpec = TopicsWith30Partitions.filter(_._1 == rejectedTopicName)
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         val (throttleTimeMs2, errors2) = deleteTopics(rejectedTopicSpec, StrictDeleteTopicsRequestVersion)
         throttleTimeMs2 == 0 && errors2 == Map(rejectedTopicName -> Errors.NONE)
       }, "Failed to delete topics after having been throttled")
@@ -297,7 +297,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
       // throttle time should be zero.
       val rejectedTopicName = errors1.filter(_._2 == Errors.THROTTLING_QUOTA_EXCEEDED).keys.head
       val rejectedTopicSpec = TopicsWith30Partitions.filter(_._1 == rejectedTopicName)
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         val (throttleTimeMs2, errors2) = createPartitions(rejectedTopicSpec, StrictCreatePartitionsRequestVersion)
         throttleTimeMs2 == 0 && errors2 == Map(rejectedTopicName -> Errors.NONE)
       }, "Failed to create partitions after having been throttled")
@@ -390,7 +390,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
     val controllerQuotaManager = controllerServers.head.quotaManagers.controllerMutation
     var actualQuota = Double.MinValue
 
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       actualQuota = quotaManager.quota(user, "").bound()
       expectedQuota == actualQuota && expectedQuota == controllerQuotaManager.quota(user, "").bound()
     }, s"Quota of $user is not $expectedQuota but $actualQuota")

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -18,12 +18,12 @@ package kafka.server
 
 import kafka.api.{IntegrationTestHarness, KafkaSasl, SaslSetup}
 import kafka.security.JaasTestUtils
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
 import org.apache.kafka.common.errors.{DelegationTokenNotFoundException, InvalidPrincipalTypeException}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.SecurityUtils
 import org.apache.kafka.server.config.DelegationTokenManagerConfigs
+import org.apache.kafka.test.TestUtils 
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -75,7 +75,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val createResult1 = adminClient.createDelegationToken(new CreateDelegationTokenOptions().renewers(renewer1))
     val tokenCreated = createResult1.delegationToken().get()
 
-    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 1),
+    TestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 1),
           "Timed out waiting for token to propagate to all servers")
 
     //test describe token
@@ -89,7 +89,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val createResult2 = adminClient.createDelegationToken(new CreateDelegationTokenOptions().renewers(renewer2))
     val token2 = createResult2.delegationToken().get()
 
-    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),
+    TestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),
           "Timed out waiting for token to propagate to all servers")
 
     //get all tokens
@@ -112,7 +112,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val createResult3 = adminClient.createDelegationToken(new CreateDelegationTokenOptions().renewers(renewer3))
     val token3 = createResult3.delegationToken().get()
 
-    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 3),
+    TestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 3),
           "Timed out waiting for token to propagate to all servers")
 
     val describeResult = adminClient.describeDelegationToken()
@@ -131,7 +131,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val expireResult3 = adminClient.expireDelegationToken(token3.hmac())
     expiryTimestamp = expireResult3.expiryTimestamp().get()
 
-    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 0),
+    TestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 0),
           "Timed out waiting for token to propagate to all servers")
 
     tokens = adminClient.describeDelegationToken().delegationTokens().get()
@@ -154,7 +154,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
       .maxLifetimeMs(1 * 1000))
     val token5 = createResult5.delegationToken().get()
 
-    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 1),
+    TestUtils.waitForCondition(() => brokers.forall(server => server.tokenCache.tokens().size() == 1),
           "Timed out waiting for token to propagate to all servers")
 
     Thread.sleep(2 * 5 * 1000)

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.network.metrics.RequestMetrics
 import org.apache.kafka.server.config.ServerLogConfigs.LOG_MESSAGE_DOWNCONVERSION_ENABLE_CONFIG
 import org.apache.kafka.storage.log.metrics.BrokerTopicMetrics
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -228,15 +229,15 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
     }
 
     def verifyMetrics(): Unit = {
-      TestUtils.waitUntilTrue(() => TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC) > initialFetchMessageConversionsPerSec,
+      JTestUtils.waitForCondition(() => TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC) > initialFetchMessageConversionsPerSec,
         s"The `FetchMessageConversionsPerSec` metric count is not incremented after 5 seconds. " +
           s"init: $initialFetchMessageConversionsPerSec final: ${TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC)}", 5000)
 
-      TestUtils.waitUntilTrue(() => TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName) > initialFetchMessageConversionsTimeMs,
+      JTestUtils.waitForCondition(() => TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName) > initialFetchMessageConversionsTimeMs,
         s"The `MessageConversionsTimeMs` in fetch request metric count is not incremented after 5 seconds. " +
           s"init: $initialFetchMessageConversionsTimeMs final: ${TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName)}", 5000)
 
-      TestUtils.waitUntilTrue(() => TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName) > initialFetchTemporaryMemoryBytes,
+      JTestUtils.waitForCondition(() => TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName) > initialFetchTemporaryMemoryBytes,
         s"The `TemporaryMemoryBytes` in fetch request metric count is not incremented after 5 seconds. " +
           s"init: $initialFetchTemporaryMemoryBytes final: ${TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName)}", 5000)
     }

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -230,16 +230,19 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
 
     def verifyMetrics(): Unit = {
       JTestUtils.waitForCondition(() => TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC) > initialFetchMessageConversionsPerSec,
+        5000L,
         s"The `FetchMessageConversionsPerSec` metric count is not incremented after 5 seconds. " +
-          s"init: $initialFetchMessageConversionsPerSec final: ${TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC)}", 5000)
+          s"init: $initialFetchMessageConversionsPerSec final: ${TestUtils.metersCount(BrokerTopicMetrics.FETCH_MESSAGE_CONVERSIONS_PER_SEC)}")
 
       JTestUtils.waitForCondition(() => TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName) > initialFetchMessageConversionsTimeMs,
+        5000L,
         s"The `MessageConversionsTimeMs` in fetch request metric count is not incremented after 5 seconds. " +
-          s"init: $initialFetchMessageConversionsTimeMs final: ${TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName)}", 5000)
+          s"init: $initialFetchMessageConversionsTimeMs final: ${TestUtils.metersCount(fetchMessageConversionsTimeMsMetricName)}")
 
       JTestUtils.waitForCondition(() => TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName) > initialFetchTemporaryMemoryBytes,
+        5000L,
         s"The `TemporaryMemoryBytes` in fetch request metric count is not incremented after 5 seconds. " +
-          s"init: $initialFetchTemporaryMemoryBytes final: ${TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName)}", 5000)
+          s"init: $initialFetchTemporaryMemoryBytes final: ${TestUtils.metersCount(fetchTemporaryMemoryBytesMetricName)}")
     }
 
     assertEquals(Errors.NONE, error(partitionWithDownConversionEnabled))

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, AddO
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, fail}
 
 import java.util.{Comparator, Properties}
@@ -527,10 +528,10 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     // here because the group coordinator is loaded in the background.
     val joinGroupRequest = new JoinGroupRequest.Builder(joinGroupRequestData).build(version)
     var joinGroupResponse: JoinGroupResponse = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       joinGroupResponse = connectAndReceive[JoinGroupResponse](joinGroupRequest)
       joinGroupResponse != null
-    }, msg = s"Could not join the group successfully. Last response $joinGroupResponse.")
+    }, s"Could not join the group successfully. Last response $joinGroupResponse.")
 
     joinGroupResponse.data
   }
@@ -734,10 +735,10 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     // Send the request until receiving a successful response. There is a delay
     // here because the group coordinator is loaded in the background.
     var consumerGroupHeartbeatResponse: ConsumerGroupHeartbeatResponse = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       consumerGroupHeartbeatResponse = connectAndReceive[ConsumerGroupHeartbeatResponse](consumerGroupHeartbeatRequest)
       consumerGroupHeartbeatResponse.data.errorCode == expectedError.code
-    }, msg = s"Could not heartbeat successfully. Last response $consumerGroupHeartbeatResponse.")
+    }, s"Could not heartbeat successfully. Last response $consumerGroupHeartbeatResponse.")
 
     consumerGroupHeartbeatResponse.data
   }
@@ -763,10 +764,10 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     // Send the request until receiving a successful response. There is a delay
     // here because the group coordinator is loaded in the background.
     var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       shareGroupHeartbeatResponse = connectAndReceive[ShareGroupHeartbeatResponse](shareGroupHeartbeatRequest)
       shareGroupHeartbeatResponse.data.errorCode == expectedError.code
-    }, msg = s"Could not heartbeat successfully. Last response $shareGroupHeartbeatResponse.")
+    }, s"Could not heartbeat successfully. Last response $shareGroupHeartbeatResponse.")
 
     shareGroupHeartbeatResponse.data
   }

--- a/core/src/test/scala/unit/kafka/server/HeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HeartbeatRequestTest.scala
@@ -19,13 +19,13 @@ package kafka.server
 import org.apache.kafka.common.test.api.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, ClusterTestDefaults, Type}
 import org.apache.kafka.common.test.api.ClusterTestExtensions
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.message.SyncGroupRequestData
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util.Collections
@@ -152,10 +152,10 @@ class HeartbeatRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBas
         )
       }
 
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         val described = describeGroups(groupIds = List("grp"))
         ClassicGroupState.PREPARING_REBALANCE.toString == described.head.groupState
-      }, msg = s"The group is not in PREPARING_REBALANCE state.")
+      }, s"The group is not in PREPARING_REBALANCE state.")
 
       // Heartbeat PREPARING_REBALANCE group.
       heartbeat(

--- a/core/src/test/scala/unit/kafka/server/JoinGroupRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/JoinGroupRequestTest.scala
@@ -19,7 +19,6 @@ package kafka.server
 import org.apache.kafka.common.test.api.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, Type}
 import org.apache.kafka.common.test.api.ClusterTestExtensions
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember
@@ -27,6 +26,7 @@ import org.apache.kafka.common.message.{JoinGroupResponseData, SyncGroupRequestD
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -186,10 +186,10 @@ class JoinGroupRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBas
         )
       }
 
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         val described = describeGroups(groupIds = List("grp"))
         ClassicGroupState.PREPARING_REBALANCE.toString == described.head.groupState
-      }, msg = s"The group is not in PREPARING_REBALANCE state.")
+      }, s"The group is not in PREPARING_REBALANCE state.")
 
       // The leader rejoins.
       val rejoinLeaderResponseData = sendJoinRequest(
@@ -312,10 +312,10 @@ class JoinGroupRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBas
       )
     }
 
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val described = describeGroups(groupIds = List("grp"))
       ClassicGroupState.PREPARING_REBALANCE.toString == described.head.groupState
-    }, msg = s"The group is not in PREPARING_REBALANCE state.")
+    }, s"The group is not in PREPARING_REBALANCE state.")
 
     // A new follower with duplicated group instance id joins.
     val joinNewFollowerResponseData = sendJoinRequest(
@@ -325,10 +325,10 @@ class JoinGroupRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBas
       version = version.toShort
     )
 
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val described = describeGroups(groupIds = List("grp"))
       ClassicGroupState.COMPLETING_REBALANCE.toString == described.head.groupState
-    }, msg = s"The group is not in COMPLETING_REBALANCE state.")
+    }, s"The group is not in COMPLETING_REBALANCE state.")
 
     // The old follower rejoin request should be fenced.
     val rejoinFollowerResponseData = sendJoinRequest(

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse}
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -196,7 +197,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     killBroker(firstLeaderId)
     val secondLeaderId = TestUtils.awaitLeaderChange(brokers, partition, oldLeaderOpt = Some(firstLeaderId))
     // make sure high watermark of new leader has caught up
-    TestUtils.waitUntilTrue(() => sendRequest(secondLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, -1).errorCode != Errors.OFFSET_NOT_AVAILABLE.code,
+    JTestUtils.waitForCondition(() => sendRequest(secondLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, -1).errorCode != Errors.OFFSET_NOT_AVAILABLE.code,
       "the second leader does not sync to follower")
     val secondLeaderEpoch = TestUtils.findLeaderEpoch(secondLeaderId, partition, brokers)
 

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -239,7 +239,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
     }
 
     // Wait for ReplicaHighWatermarkCheckpoint to happen so that the log directory of the topic will be offline
-    JTestUtils.waitForCondition(() => !leaderBroker.logManager.isLogDirOnline(logDir.getAbsolutePath), "Expected log directory offline", 3000L)
+    JTestUtils.waitForCondition(() => !leaderBroker.logManager.isLogDirOnline(logDir.getAbsolutePath), 3000L, "Expected log directory offline")
     assertTrue(leaderBroker.replicaManager.localLog(partition).isEmpty)
     logDir
   }

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.apache.kafka.storage.internals.log.{LogSegment, LogStartOffsetIncrementReason}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
@@ -85,7 +86,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.LATEST_TIMESTAMP, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 3L), offsets)
 
-    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+    JTestUtils.waitForCondition(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 15).asJava).build()
@@ -152,7 +153,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.LATEST_TIMESTAMP, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)
 
-    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, 0, broker),
+    JTestUtils.waitForCondition(() => isLeaderLocalOnBroker(topic, 0, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 15).asJava).build()
@@ -226,7 +227,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(now, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)
 
-    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+    JTestUtils.waitForCondition(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, now, 15).asJava).build()
@@ -253,7 +254,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.EARLIEST_TIMESTAMP, 10)
     assertEquals(Seq(0L), offsets)
 
-    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+    JTestUtils.waitForCondition(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.EARLIEST_TIMESTAMP, 10).asJava).build()
@@ -322,7 +323,7 @@ class LogOffsetTest extends BaseRequestTest {
     createTopic(topic)
 
     val logManager = broker.logManager
-    TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
+    JTestUtils.waitForCondition(() => logManager.getLog(topicPartition).isDefined,
       "Log for partition [topic,0] should be created")
     logManager.getLog(topicPartition).get
   }

--- a/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
@@ -265,7 +265,7 @@ class LogRecoveryTest extends QuorumTestHarness {
     }
 
     JTestUtils.waitForCondition(() => leaderExists.isDefined,
-      s"Did not find a leader for partition $tp after $timeout ms", timeout)
+      timeout, s"Did not find a leader for partition $tp after $timeout ms")
 
     leaderExists.get
   }

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -241,7 +241,7 @@ class MetadataRequestTest extends AbstractMetadataRequestTest {
     TestUtils.waitForCondition(() => {
       val response = sendMetadataRequest(new MetadataRequest.Builder(List(replicaDownTopic).asJava, true).build())
       !response.brokers.asScala.exists(_.id == downNode.dataPlaneRequestProcessor.brokerId)
-    }, "Replica was not found down", 50000)
+    }, 50000L, "Replica was not found down")
 
     // Validate version 0 still filters unavailable replicas and contains error
     val v0MetadataResponse = sendMetadataRequest(new MetadataRequest(requestData(List(replicaDownTopic), allowAutoTopicCreation = true), 0.toShort))

--- a/core/src/test/scala/unit/kafka/server/ProduceRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ProduceRequestTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.requests.{ProduceRequest, ProduceResponse}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.storage.log.metrics.BrokerTopicMetrics
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -91,7 +92,7 @@ class ProduceRequestTest extends BaseRequestTest {
     topic: String
   ): Map[Int, Int] = {
     var topicDescription: TopicDescription = null
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       val topicMap = admin.
         describeTopics(java.util.Arrays.asList(topic)).
           allTopicNames().get(10, TimeUnit.MINUTES)

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
@@ -19,11 +19,11 @@ package kafka.server
 
 import org.junit.jupiter.api.AfterEach
 import kafka.utils.TestUtils
-import TestUtils._
 import kafka.api.IntegrationTestHarness
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -71,6 +71,6 @@ class ReplicaFetchTest extends IntegrationTestHarness {
       }
       result
     }
-    waitUntilTrue(logsMatch _, "Broker logs should be identical")
+    JTestUtils.waitForCondition(logsMatch _, "Broker logs should be identical")
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -23,7 +23,6 @@ import java.util.{Optional, Properties}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.metadata.MockConfigRepository
-import kafka.utils.TestUtils.waitUntilTrue
 import kafka.utils.{CoreUtils, Logging, TestUtils}
 import org.apache.kafka.common.metadata.RegisterBrokerRecord
 import org.apache.kafka.common.metadata.{PartitionChangeRecord, PartitionRecord, TopicRecord}
@@ -45,6 +44,7 @@ import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerL
 import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams, FetchPartitionData}
 import org.apache.kafka.server.util.{MockTime, ShutdownableThread}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, LogConfig, LogDirFailureChannel}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.mockito.Mockito
@@ -107,7 +107,7 @@ class ReplicaManagerConcurrencyTest extends Logging {
     submit(controller)
     controller.initialize()
 
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       replicaManager.getPartition(topicPartition) match {
         case HostedPartition.Online(partition) => partition.isLeader
         case _ => false
@@ -134,13 +134,13 @@ class ReplicaManagerConcurrencyTest extends Logging {
     )
 
     submit(fetcher)
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       partition.inSyncReplicaIds == Set(localId, remoteId)
     }, "Test timed out before ISR was expanded")
 
     // Stop the fetcher so that the replica is removed from the ISR
     fetcher.shutdown()
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       partition.inSyncReplicaIds == Set(localId)
     }, "Test timed out before ISR was shrunk")
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -255,7 +255,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
     JTestUtils.waitForCondition(() => {
       offset == brokerFor(brokerId).logManager.getLog(new TopicPartition(topic, partitionId))
         .map(_.logEndOffset).getOrElse(0)
-    }, s"Offsets did not match for partition $partitionId on broker $brokerId", 60000)
+    }, 60000, s"Offsets did not match for partition $partitionId on broker $brokerId")
   }
 
   private def brokerFor(id: Int): KafkaBroker = brokers.filter(_.config.brokerId == id).head

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.controller.ControllerRequestContextUtil
 import org.apache.kafka.server.common.{Feature, MetadataVersion}
 import org.apache.kafka.server.config.QuotaConfig
 import org.apache.kafka.server.quota.QuotaType
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.params.ParameterizedTest
@@ -251,7 +252,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
   }
 
   private def waitForOffsetsToMatch(offset: Int, partitionId: Int, brokerId: Int): Unit = {
-    waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       offset == brokerFor(brokerId).logManager.getLog(new TopicPartition(topic, partitionId))
         .map(_.logEndOffset).getOrElse(0)
     }, s"Offsets did not match for partition $partitionId on broker $brokerId", 60000)

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerial
 import org.apache.kafka.common.utils.Exit
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.config.{KRaftConfigs, ServerLogConfigs}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.{BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.function.Executable
@@ -166,7 +167,7 @@ class ServerShutdownTest extends KafkaServerTestHarness {
       // this startup should fail with no online log dir (due to corrupted log), and exit directly without throwing exception
       assertDoesNotThrow(recreateBrokerExec)
       // JVM should exit with status code 1
-      TestUtils.waitUntilTrue(() => hasHaltProcedureCalled == true && expectedStatusCode == receivedStatusCode,
+      JTestUtils.waitForCondition(() => hasHaltProcedureCalled == true && expectedStatusCode == receivedStatusCode,
         s"Expected to halt directly with the expected status code:${expectedStatusCode.get}, " +
           s"but got hasHaltProcedureCalled: $hasHaltProcedureCalled and received status code: ${receivedStatusCode.orNull}")
     } finally {

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -16,13 +16,13 @@
  */
 package kafka.server
 
-import kafka.utils.TestUtils
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterInstance, ClusterTest, ClusterTestDefaults, ClusterTestExtensions, ClusterTests, Type}
 import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords
 import org.apache.kafka.common.message.{ShareAcknowledgeRequestData, ShareAcknowledgeResponseData, ShareFetchRequestData, ShareFetchResponseData}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.requests.{ShareAcknowledgeRequest, ShareAcknowledgeResponse, ShareFetchRequest, ShareFetchResponse, ShareRequestMetadata}
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Tag, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
@@ -258,7 +258,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     // For the multi partition fetch request, the response may not be available in the first attempt
     // as the share partitions might not be initialized yet. So, we retry until we get the response.
     var responses = Seq[ShareFetchResponseData.PartitionData]()
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val shareFetchResponse = connectAndReceive[ShareFetchResponse](shareFetchRequest)
       val shareFetchResponseData = shareFetchResponse.data()
       assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
@@ -850,7 +850,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val acquiredRecords : util.List[AcquiredRecords] = new util.ArrayList[AcquiredRecords]()
     var releaseAcknowledgementSent = false
 
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       shareSessionEpoch = ShareRequestMetadata.nextEpoch(shareSessionEpoch)
       metadata = new ShareRequestMetadata(memberId, shareSessionEpoch)
       if (releaseAcknowledgementSent) {
@@ -2267,7 +2267,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     // For the multi partition fetch request, the response may not be available in the first attempt
     // as the share partitions might not be initialized yet. So, we retry until we get the response.
     var responses = Seq[ShareFetchResponseData.PartitionData]()
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val shareFetchResponse = connectAndReceive[ShareFetchResponse](shareFetchRequest)
       val shareFetchResponseData = shareFetchResponse.data()
       assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
@@ -2315,7 +2315,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
   // partition is not initialized yet. Hence, wait for response from all partitions before proceeding.
   private def sendFirstShareFetchRequest(memberId: Uuid, groupId: String, topicIdPartitions: Seq[TopicIdPartition]): Unit = {
     val partitions: util.Set[Integer] = new util.HashSet()
-    TestUtils.waitUntilTrue(() => {
+    TestUtils.waitForCondition(() => {
       val metadata = new ShareRequestMetadata(memberId, ShareRequestMetadata.INITIAL_EPOCH)
       val shareFetchRequest = createShareFetchRequest(groupId, metadata, MAX_PARTITION_BYTES, topicIdPartitions, Seq.empty, Map.empty)
       val shareFetchResponse = connectAndReceive[ShareFetchResponse](shareFetchRequest)

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -273,7 +273,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
         })
       }
       responses.size == 3
-    }, "Share fetch request failed", 5000)
+    }, 5000L, "Share fetch request failed")
 
     val expectedPartitionData1 = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(0)
@@ -880,7 +880,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       // 2. batch containing 10-19 offsets which were produced in the second produceData function call.
       acquiredRecords.size() == 2
 
-    }, "Share fetch request failed", 5000)
+    },  5000L, "Share fetch request failed")
 
     // All the records from offsets 0 to 19 will be fetched. Records from 0 to 9 will have delivery count as 2 because
     // they are re delivered, and records from 10 to 19 will have delivery count as 1 because they are newly acquired
@@ -2282,7 +2282,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
         })
       }
       responses.size == 2
-    }, "Share fetch request failed", 5000)
+    },  5000L, "Share fetch request failed")
 
     // Producing 10 more records to the topic partitions created above
     produceData(topicIdPartition1, 10)
@@ -2329,7 +2329,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       })
 
       partitions.size() == topicIdPartitions.size
-    }, "Share fetch request failed", 5000)
+    }, 5000L, "Share fetch request failed")
   }
 
   private def expectedAcquiredRecords(firstOffsets: util.List[Long], lastOffsets: util.List[Long], deliveryCounts: util.List[Int]): util.List[AcquiredRecords] = {

--- a/core/src/test/scala/unit/kafka/server/ShareGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupDescribeRequestTest.scala
@@ -31,6 +31,8 @@ import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{Tag, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
@@ -102,13 +104,13 @@ class ShareGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCoord
 
       // Add first group with one member.
       var grp1Member1Response: ShareGroupHeartbeatResponseData = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         grp1Member1Response = shareGroupHeartbeat(
           groupId = "grp-1",
           subscribedTopicNames = List("bar"),
         )
         grp1Member1Response.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $grp1Member1Response.")
+      }, s"Could not join the group successfully. Last response $grp1Member1Response.")
 
       for (version <- ApiKeys.SHARE_GROUP_DESCRIBE.oldestVersion() to ApiKeys.SHARE_GROUP_DESCRIBE.latestVersion(isUnstableApiEnabled)) {
         val expected = List(

--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.message.{ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertNotNull, assertNull, assertTrue}
 import org.junit.jupiter.api.{Tag, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
@@ -85,10 +86,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertNotNull(shareGroupHeartbeatResponse.data.memberId)
@@ -119,11 +120,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned.
       shareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -181,10 +182,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member 1.
       val memberId1 = shareGroupHeartbeatResponse.data.memberId
@@ -203,10 +204,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       ).build()
 
       // Send the second member request until receiving a successful response.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member 2.
       val memberId2 = shareGroupHeartbeatResponse.data.memberId
@@ -240,11 +241,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned for member 1.
       shareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -260,11 +261,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the partitions are assigned for member 2.
       shareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -281,11 +282,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Heartbeats until the response for no change of assignment occurs for member 1 with same epoch.
       shareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == null
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -328,10 +329,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
@@ -361,11 +362,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
       assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -380,10 +381,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       ).build()
 
       // Send the member request until receiving a successful response.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not leave the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not leave the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member.
       assertEquals(-1, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -441,10 +442,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
       assertNotNull(memberId)
@@ -483,13 +484,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       cluster.waitForTopic("foo", 2)
       cluster.waitForTopic("bar", 3)
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not get partitions for topic foo and bar assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions for topic foo and bar assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
       assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
       // Create the topic baz.
@@ -519,13 +520,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not get partitions for topic baz assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions for topic baz assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
       // Increasing the partitions of topic bar which is already being consumed in the share group.
@@ -551,13 +552,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not update partitions assignment for topic bar. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not update partitions assignment for topic bar. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
       assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
       // Delete the topic foo.
@@ -585,13 +586,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
       assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
     } finally {
@@ -637,10 +638,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
@@ -671,11 +672,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get foo partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get foo partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response, the epoch should have been bumped.
       assertTrue(shareGroupHeartbeatResponse.data.memberEpoch > memberEpoch)
@@ -705,13 +706,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
             .setTopicId(barId)
             .setPartitions(List[Integer](0).asJava)).asJava)
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not get bar partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get bar partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response, the epoch should have been bumped.
       assertTrue(shareGroupHeartbeatResponse.data.memberEpoch > memberEpoch)
@@ -726,10 +727,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not get empty heartbeat response. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get empty heartbeat response. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response, the epoch should be same.
       assertEquals(memberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -746,10 +747,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.UNKNOWN_MEMBER_ID.code
-      }, msg = s"Member should have been expired because of the timeout . Last response $shareGroupHeartbeatResponse.")
+      }, s"Member should have been expired because of the timeout . Last response $shareGroupHeartbeatResponse.")
 
       // Member sends a request again to join the share group
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
@@ -761,13 +762,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment != null &&
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
-      }, msg = s"Could not get bar partitions assigned upon rejoining. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get bar partitions assigned upon rejoining. Last response $shareGroupHeartbeatResponse.")
 
       // Epoch should have been bumped when a member is removed and again when it joins back.
       assertTrue(shareGroupHeartbeatResponse.data.memberEpoch > memberEpoch)
@@ -807,10 +808,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the request until receiving a successful response. There is a delay
       // here because the group coordinator is loaded in the background.
       var shareGroupHeartbeatResponse: ShareGroupHeartbeatResponse = null
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
       assertNotNull(memberId)
@@ -836,11 +837,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         true
       ).build()
 
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
       assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
 
@@ -859,10 +860,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       ).build()
 
       // Should receive no error and no assignment changes.
-      TestUtils.waitUntilTrue(() => {
+      JTestUtils.waitForCondition(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
-      }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      }, s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response. Epoch should not have changed and null assignments determines that no
       // change in old assignment.

--- a/core/src/test/scala/unit/kafka/server/SyncGroupRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SyncGroupRequestTest.scala
@@ -19,13 +19,13 @@ package kafka.server
 import org.apache.kafka.common.test.api.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, ClusterTestDefaults, Type}
 import org.apache.kafka.common.test.api.ClusterTestExtensions
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.message.SyncGroupRequestData
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util.Collections
@@ -180,10 +180,10 @@ class SyncGroupRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBas
         )
       }
 
-      TestUtils.waitUntilTrue(() => {
+      TestUtils.waitForCondition(() => {
         val described = describeGroups(groupIds = List("grp"))
         ClassicGroupState.PREPARING_REBALANCE.toString == described.head.groupState
-      }, msg = s"The group is not in PREPARING_REBALANCE state.")
+      }, s"The group is not in PREPARING_REBALANCE state.")
 
       // The leader rejoins.
       val rejoinLeaderResponseData = sendJoinRequest(

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -17,7 +17,6 @@
 package kafka.server
 
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterInstance, ClusterTest, ClusterTestDefaults, ClusterTestExtensions, Type}
-import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -25,6 +24,7 @@ import org.apache.kafka.common.requests.JoinGroupRequest
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertThrows, assertTrue, fail}
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -171,7 +171,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
   ): Unit = {
     var producerIdAndEpoch: ProducerIdAndEpoch = null
     // Wait until the coordinator finishes loading.
-    TestUtils.waitUntilTrue(() =>
+    TestUtils.waitForCondition(() =>
       try {
         producerIdAndEpoch = initProducerId(
           transactionalId = transactionalId,
@@ -218,7 +218,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     val expectedOffset = if (expectedTxnCommitError == Errors.NONE) offset else originalOffset
 
-    TestUtils.waitUntilTrue(() =>
+    TestUtils.waitForCondition(() =>
       try {
         fetchOffset(topic, partition, groupId) == expectedOffset
       } catch {

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -80,7 +80,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
 
     //Then they should be stamped with Leader Epoch 0
     var expectedLeaderEpoch = 0
-    waitUntilTrue(() => messagesHaveLeaderEpoch(brokers(0), expectedLeaderEpoch, 0), "Leader epoch should be 0")
+    JTestUtils.waitForCondition(() => messagesHaveLeaderEpoch(brokers(0), expectedLeaderEpoch, 0), "Leader epoch should be 0")
 
     //Given we then bounce the leader
     brokers(0).shutdown()
@@ -95,7 +95,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
     sendFourMessagesToEachTopic()
 
     //The new messages should be stamped with LeaderEpoch = 1
-    waitUntilTrue(() => messagesHaveLeaderEpoch(brokers(0), expectedLeaderEpoch, 4), "Leader epoch should be 1")
+    JTestUtils.waitForCondition(() => messagesHaveLeaderEpoch(brokers(0), expectedLeaderEpoch, 4), "Leader epoch should be 1")
   }
 
   @ParameterizedTest
@@ -245,7 +245,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
   }
 
   private def waitForEpochChangeTo(topic: String, partition: Int, epoch: Int): Unit = {
-    TestUtils.waitUntilTrue(() => {
+    JTestUtils.waitForCondition(() => {
       brokers(0).metadataCache.getPartitionInfo(topic, partition).exists(_.leaderEpoch == epoch)
     }, "Epoch didn't change")
   }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -39,6 +39,7 @@ import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.LeaderAndEpoch
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion}
 import org.apache.kafka.server.fault.FaultHandler
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
@@ -123,7 +124,7 @@ class BrokerMetadataPublisherTest {
         admin.incrementalAlterConfigs(singletonMap(
           new ConfigResource(BROKER, ""),
           singleton(new AlterConfigOp(new ConfigEntry(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, "123"), SET)))).all().get()
-        TestUtils.waitUntilTrue(() => numTimesReloadCalled.get() == 0,
+        JTestUtils.waitForCondition(() => numTimesReloadCalled.get() == 0,
           "numTimesConfigured never reached desired value")
 
         // Setting the foo.bar.test.configuration to 1 will still trigger reconfiguration because
@@ -131,7 +132,7 @@ class BrokerMetadataPublisherTest {
         admin.incrementalAlterConfigs(singletonMap(
           new ConfigResource(BROKER, broker.config.nodeId.toString),
           singleton(new AlterConfigOp(new ConfigEntry(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, "123"), SET)))).all().get()
-        TestUtils.waitUntilTrue(() => numTimesReloadCalled.get() == 1,
+        JTestUtils.waitForCondition(() => numTimesReloadCalled.get() == 1,
           "numTimesConfigured never reached desired value")
       } finally {
         admin.close()

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -840,7 +840,7 @@ object TestUtils extends Logging {
     JTestUtils.waitForCondition(() => {
       consumer.poll(Duration.ofMillis(100))
       action()
-    }, msg, 0L, waitTimeMs)
+    }, 0L, waitTimeMs, () => msg)
   }
 
   def pollRecordsUntilTrue[K, V](consumer: Consumer[K, V],
@@ -851,7 +851,7 @@ object TestUtils extends Logging {
     JTestUtils.waitForCondition(() => {
       val records = consumer.poll(Duration.ofMillis(pollTimeoutMs))
       action(records)
-    }, msg, waitTimeMs, 0L)
+    }, waitTimeMs, 0L, () => msg)
   }
 
 


### PR DESCRIPTION
Removed the waitUntilTrue function from TestUtils.scala and replaced it with waitForCondition.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
