### PR TITLE
MINOR Ignore missing label after review

### DIFF
--- a/.github/workflows/pr-reviewed.yml
+++ b/.github/workflows/pr-reviewed.yml
@@ -40,6 +40,7 @@ jobs:
           name: pr-number.txt
       - name: Remove label
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Follow up for #17881, ignores missing "triage" label in the pr-reviewed workflow