### PR TITLE
KAFKA-17554: Flaky testFutureCompletionOutsidePoll in ConsumerNetworkClientTest add disable annotation

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -265,6 +266,7 @@ public class ConsumerNetworkClientTest {
         assertEquals(metadataException, exc);
     }
 
+    @Disabled("KAFKA-17554")
     @Test
     public void testFutureCompletionOutsidePoll() throws Exception {
         // Tests the scenario in which the request that is being awaited in one thread


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17554
as title

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
