### PR TITLE
KAFKA-18200: Handle empty batches in coordinator runtime

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -767,6 +767,18 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private void flushCurrentBatch() {
             if (currentBatch != null) {
                 try {
+                    int numRecords = currentBatch.builder.numRecords();
+                    if (numRecords == 0) {
+                        // The only way we can get here is if append() has failed in an unexpected
+                        // way and left an empty batch. Try to clean it up.
+                        log.warn("Tried to flush an empty batch for {}.", tp);
+                        // There should not be any deferred events attached to the batch. We fail
+                        // the batch just in case. As a side effect, coordinator state is also
+                        // reverted, but there should be no changes since the batch was empty.
+                        failCurrentBatch(new IllegalStateException("Record batch was empty"));
+                        return;
+                    }
+
                     long flushStartMs = time.milliseconds();
                     // Write the records to the log and update the last written offset.
                     long offset = partitionWriter.append(
@@ -925,7 +937,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 // If the records are empty, it was a read operation after all. In this case,
                 // the response can be returned directly iff there are no pending write operations;
                 // otherwise, the read needs to wait on the last write operation to be completed.
-                if (currentBatch != null) {
+                if (currentBatch != null && currentBatch.builder.numRecords() > 0) {
                     currentBatch.deferredEvents.add(event);
                 } else {
                     if (coordinator.lastCommittedOffset() < coordinator.lastWrittenOffset()) {

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -767,8 +767,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private void flushCurrentBatch() {
             if (currentBatch != null) {
                 try {
-                    int numRecords = currentBatch.builder.numRecords();
-                    if (numRecords == 0) {
+                    if (currentBatch.builder.numRecords() == 0) {
                         // The only way we can get here is if append() has failed in an unexpected
                         // way and left an empty batch. Try to clean it up.
                         log.warn("Tried to flush an empty batch for {}.", tp);

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -767,6 +767,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private void flushCurrentBatch() {
             if (currentBatch != null) {
                 try {
+                    int numRecords = currentBatch.builder.numRecords();
                     long flushStartMs = time.milliseconds();
                     // Write the records to the log and update the last written offset.
                     long offset = partitionWriter.append(
@@ -775,6 +776,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         currentBatch.builder.build()
                     );
                     runtimeMetrics.recordFlushTime(time.milliseconds() - flushStartMs);
+                    if (numRecords == 0) {
+                        // append returns 0 if no records were written.
+                        offset = currentBatch.nextOffset;
+                    }
                     coordinator.updateLastWrittenOffset(offset);
 
                     if (offset != currentBatch.nextOffset) {
@@ -794,8 +799,17 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     }
 
                     // Add all the pending deferred events to the deferred event queue.
-                    for (DeferredEvent event : currentBatch.deferredEvents) {
-                        deferredEventQueue.add(offset, event);
+                    if (coordinator.lastCommittedOffset() < offset) {
+                        for (DeferredEvent event : currentBatch.deferredEvents) {
+                            deferredEventQueue.add(offset, event);
+                        }
+                    } else {
+                        // We shouldn't ever have an empty batch with deferredEvents attached. But
+                        // if we do, and the last committed offset is caught up, we can complete
+                        // them immediately.
+                        for (DeferredEvent event : currentBatch.deferredEvents) {
+                            event.complete(null);
+                        }
                     }
 
                     // Free up the current batch.
@@ -935,86 +949,58 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     }
                 }
             } else {
-                // If the records are not empty, first, they are applied to the state machine,
-                // second, they are appended to the opened batch.
-                long currentTimeMs = time.milliseconds();
+                try {
+                    // If the records are not empty, first, they are applied to the state machine,
+                    // second, they are appended to the opened batch.
+                    long currentTimeMs = time.milliseconds();
 
-                // If the current write operation is transactional, the current batch
-                // is written before proceeding with it.
-                if (producerId != RecordBatch.NO_PRODUCER_ID) {
-                    isAtomic = true;
-                    // If flushing fails, we don't catch the exception in order to let
-                    // the caller fail the current operation.
-                    flushCurrentBatch();
-                }
-
-                // Allocate a new batch if none exists.
-                maybeAllocateNewBatch(
-                    producerId,
-                    producerEpoch,
-                    verificationGuard,
-                    currentTimeMs
-                );
-
-                // Prepare the records.
-                List<SimpleRecord> recordsToAppend = new ArrayList<>(records.size());
-                for (U record : records) {
-                    recordsToAppend.add(new SimpleRecord(
-                        currentTimeMs,
-                        serializer.serializeKey(record),
-                        serializer.serializeValue(record)
-                    ));
-                }
-
-                if (isAtomic) {
-                    // Compute the estimated size of the records.
-                    int estimatedSize = AbstractRecords.estimateSizeInBytes(
-                        currentBatch.builder.magic(),
-                        compression.type(),
-                        recordsToAppend
-                    );
-
-                    // Check if the current batch has enough space. We check this before
-                    // replaying the records in order to avoid having to revert back
-                    // changes if the records do not fit within a batch.
-                    if (estimatedSize > currentBatch.builder.maxAllowedBytes()) {
-                        throw new RecordTooLargeException("Message batch size is " + estimatedSize +
-                            " bytes in append to partition " + tp + " which exceeds the maximum " +
-                            "configured size of " + currentBatch.maxBatchSize + ".");
-                    }
-
-                    if (!currentBatch.builder.hasRoomFor(estimatedSize)) {
-                        // Otherwise, we write the current batch, allocate a new one and re-verify
-                        // whether the records fit in it.
+                    // If the current write operation is transactional, the current batch
+                    // is written before proceeding with it.
+                    if (producerId != RecordBatch.NO_PRODUCER_ID) {
+                        isAtomic = true;
                         // If flushing fails, we don't catch the exception in order to let
                         // the caller fail the current operation.
                         flushCurrentBatch();
-                        maybeAllocateNewBatch(
-                            producerId,
-                            producerEpoch,
-                            verificationGuard,
-                            currentTimeMs
-                        );
                     }
-                }
 
+                    // Allocate a new batch if none exists.
+                    maybeAllocateNewBatch(
+                        producerId,
+                        producerEpoch,
+                        verificationGuard,
+                        currentTimeMs
+                    );
 
-                for (int i = 0; i < records.size(); i++) {
-                    U recordToReplay = records.get(i);
-                    SimpleRecord recordToAppend = recordsToAppend.get(i);
+                    // Prepare the records.
+                    List<SimpleRecord> recordsToAppend = new ArrayList<>(records.size());
+                    for (U record : records) {
+                        recordsToAppend.add(new SimpleRecord(
+                            currentTimeMs,
+                            serializer.serializeKey(record),
+                            serializer.serializeValue(record)
+                        ));
+                    }
 
-                    if (!isAtomic) {
-                        // Check if the current batch has enough space. We check this before
-                        // replaying the record in order to avoid having to revert back
-                        // changes if the record do not fit within a batch.
-                        boolean hasRoomFor = currentBatch.builder.hasRoomFor(
-                            recordToAppend.timestamp(),
-                            recordToAppend.key(),
-                            recordToAppend.value(),
-                            recordToAppend.headers()
+                    if (isAtomic) {
+                        // Compute the estimated size of the records.
+                        int estimatedSize = AbstractRecords.estimateSizeInBytes(
+                            currentBatch.builder.magic(),
+                            compression.type(),
+                            recordsToAppend
                         );
 
-                        if (!hasRoomFor) {
+                        // Check if the current batch has enough space. We check this before
+                        // replaying the records in order to avoid having to revert back
+                        // changes if the records do not fit within a batch.
+                        if (estimatedSize > currentBatch.builder.maxAllowedBytes()) {
+                            throw new RecordTooLargeException("Message batch size is " + estimatedSize +
+                                " bytes in append to partition " + tp + " which exceeds the maximum " +
+                                "configured size of " + currentBatch.maxBatchSize + ".");
+                        }
+
+                        if (!currentBatch.builder.hasRoomFor(estimatedSize)) {
+                            // Otherwise, we write the current batch, allocate a new one and re-verify
+                            // whether the records fit in it.
                             // If flushing fails, we don't catch the exception in order to let
                             // the caller fail the current operation.
                             flushCurrentBatch();
@@ -1027,42 +1013,78 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         }
                     }
 
-                    try {
-                        if (replay) {
-                            coordinator.replay(
-                                currentBatch.nextOffset,
-                                producerId,
-                                producerEpoch,
-                                recordToReplay
+                    for (int i = 0; i < records.size(); i++) {
+                        U recordToReplay = records.get(i);
+                        SimpleRecord recordToAppend = recordsToAppend.get(i);
+
+                        if (!isAtomic) {
+                            // Check if the current batch has enough space. We check this before
+                            // replaying the record in order to avoid having to revert back
+                            // changes if the record do not fit within a batch.
+                            boolean hasRoomFor = currentBatch.builder.hasRoomFor(
+                                recordToAppend.timestamp(),
+                                recordToAppend.key(),
+                                recordToAppend.value(),
+                                recordToAppend.headers()
                             );
+
+                            if (!hasRoomFor) {
+                                // If flushing fails, we don't catch the exception in order to let
+                                // the caller fail the current operation.
+                                flushCurrentBatch();
+                                maybeAllocateNewBatch(
+                                    producerId,
+                                    producerEpoch,
+                                    verificationGuard,
+                                    currentTimeMs
+                                );
+                            }
                         }
 
-                        currentBatch.builder.append(recordToAppend);
-                        currentBatch.nextOffset++;
-                    } catch (Throwable t) {
-                        log.error("Replaying record {} to {} failed due to: {}.", recordToReplay, tp, t.getMessage());
+                        try {
+                            if (replay) {
+                                coordinator.replay(
+                                    currentBatch.nextOffset,
+                                    producerId,
+                                    producerEpoch,
+                                    recordToReplay
+                                );
+                            }
 
-                        // Add the event to the list of pending events associated with the last
-                        // batch in order to fail it too.
-                        currentBatch.deferredEvents.add(event);
+                            currentBatch.builder.append(recordToAppend);
+                            currentBatch.nextOffset++;
+                        } catch (Throwable t) {
+                            log.error("Replaying record {} to {} failed due to: {}.", recordToReplay, tp, t.getMessage());
 
-                        // If an exception is thrown, we fail the entire batch. Exceptions should be
-                        // really exceptional in this code path and they would usually be the results
-                        // of bugs preventing records to be replayed.
-                        failCurrentBatch(t);
+                            // Add the event to the list of pending events associated with the last
+                            // batch in order to fail it too.
+                            currentBatch.deferredEvents.add(event);
 
-                        return;
+                            // If an exception is thrown, we fail the entire batch. Exceptions should be
+                            // really exceptional in this code path and they would usually be the results
+                            // of bugs preventing records to be replayed.
+                            failCurrentBatch(t);
+
+                            return;
+                        }
                     }
+
+                    // Add the event to the list of pending events associated with the batch.
+                    currentBatch.deferredEvents.add(event);
+
+                    // Write the current batch if it is transactional or if the linger timeout
+                    // has expired.
+                    // If flushing fails, we don't catch the exception in order to let
+                    // the caller fail the current operation.
+                    maybeFlushCurrentBatch(currentTimeMs);
+                } catch (Throwable t) {
+                    log.error("Appending records {} to {} failed due to: {}.", records, tp, t.getMessage());
+
+                    // It's not clear what state the current batch is in, so fail it.
+                    failCurrentBatch(t);
+
+                    event.complete(t);
                 }
-
-                // Add the event to the list of pending events associated with the batch.
-                currentBatch.deferredEvents.add(event);
-
-                // Write the current batch if it is transactional or if the linger timeout
-                // has expired.
-                // If flushing fails, we don't catch the exception in order to let
-                // the caller fail the current operation.
-                maybeFlushCurrentBatch(currentTimeMs);
             }
         }
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -770,7 +770,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     if (currentBatch.builder.numRecords() == 0) {
                         // The only way we can get here is if append() has failed in an unexpected
                         // way and left an empty batch. Try to clean it up.
-                        log.warn("Tried to flush an empty batch for {}.", tp);
+                        log.debug("Tried to flush an empty batch for {}.", tp);
                         // There should not be any deferred events attached to the batch. We fail
                         // the batch just in case. As a side effect, coordinator state is also
                         // reverted, but there should be no changes since the batch was empty.

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatcher;
 
 import java.nio.ByteBuffer;
+import java.nio.BufferOverflowException;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -101,7 +102,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("checkstyle:JavaNCSS")
+@SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:ClassDataAbstractionCoupling"})
 public class CoordinatorRuntimeTest {
     private static final TopicPartition TP = new TopicPartition("__consumer_offsets", 0);
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMillis(5);
@@ -117,6 +118,34 @@ public class CoordinatorRuntimeTest {
         @Override
         public byte[] serializeValue(String record) {
             return record.getBytes(Charset.defaultCharset());
+        }
+    }
+
+    private static class ThrowingSerializer<T> implements Serializer<T> {
+        private final Serializer<T> serializer;
+        private boolean throwOnNextOperation;
+
+        public ThrowingSerializer(Serializer<T> serializer) {
+            this.serializer = serializer;
+            this.throwOnNextOperation = false;
+        }
+
+        public void throwOnNextOperation() {
+            throwOnNextOperation = true;
+        }
+
+        @Override
+        public byte[] serializeKey(T record) {
+            return serializer.serializeKey(record);
+        }
+
+        @Override
+        public byte[] serializeValue(T record) {
+            if (throwOnNextOperation) {
+                throwOnNextOperation = false;
+                throw new BufferOverflowException();
+            }
+            return serializer.serializeValue(record);
         }
     }
 
@@ -269,6 +298,10 @@ public class CoordinatorRuntimeTest {
         ) {
             if (batch.sizeInBytes() > config(tp).maxMessageSize())
                 throw new RecordTooLargeException("Batch is larger than the max message size");
+
+            // We don't want the coordinator to write empty batches.
+            if (batch.validBytes() <= 0)
+                throw new KafkaException("Coordinator tried to write an empty batch");
 
             if (writeCount.incrementAndGet() > maxWrites)
                 throw new KafkaException("Maximum number of writes reached");
@@ -4211,6 +4244,73 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(0L), ctx.coordinator.snapshotRegistry().epochsList());
         assertEquals(Collections.emptyList(), ctx.coordinator.coordinator().fullRecords());
         assertEquals(Collections.emptyList(), writer.entries(TP));
+    }
+
+    @Test
+    public void testEmptyBatch() throws Exception {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = new MockPartitionWriter();
+        ThrowingSerializer<String> serializer = new ThrowingSerializer<String>(new StringSerializer());
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
+                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(serializer)
+                .withAppendLingerMs(10)
+                .withExecutorService(mock(ExecutorService.class))
+                .build();
+
+        // Schedule the loading.
+        runtime.scheduleLoadOperation(TP, 10);
+
+        // Verify the initial state.
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        assertNull(ctx.currentBatch);
+
+        // Write #1, which fails.
+        serializer.throwOnNextOperation();
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+            state -> new CoordinatorResult<>(List.of("1"), "response1"));
+
+        // Write #1 should fail and leave an empty batch.
+        assertFutureThrows(write1, BufferOverflowException.class);
+        assertNotNull(ctx.currentBatch);
+
+        // Write #2, with no records.
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+            state -> new CoordinatorResult<>(Collections.emptyList(), "response2"));
+
+        // Write #2 should not be attached to the empty batch.
+        assertTrue(write2.isDone());
+        assertEquals("response2", write2.get(5, TimeUnit.SECONDS));
+
+        // Complete transaction #1. It will flush the current empty batch.
+        // The coordinator must not try to write an empty batch, otherwise the mock partition writer
+        // will throw an exception.
+        CompletableFuture<Void> complete1 = runtime.scheduleTransactionCompletion(
+            "complete#1",
+            TP,
+            100L,
+            (short) 50,
+            10,
+            TransactionResult.COMMIT,
+            DEFAULT_WRITE_TIMEOUT
+        );
+
+        // Verify that the completion is not committed yet.
+        assertFalse(complete1.isDone());
+
+        // Commit and verify that writes are completed.
+        writer.commit(TP);
+        assertNull(complete1.get(5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -54,8 +54,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatcher;
 
-import java.nio.ByteBuffer;
 import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;


### PR DESCRIPTION
* Avoid attaching empty writes to empty batches.
* Handle flushes of empty batches, which would return a 0 offset otherwise.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
