### PR TITLE
HOTFIX: RocksDBMetricsRecorder#init should null check taskId

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -135,7 +135,7 @@ public class RocksDBMetricsRecorder {
     public void init(final StreamsMetricsImpl streamsMetrics,
                      final TaskId taskId) {
         Objects.requireNonNull(streamsMetrics, "Streams metrics must not be null");
-        Objects.requireNonNull(streamsMetrics, "task ID must not be null");
+        Objects.requireNonNull(taskId, "task ID must not be null");
         if (this.taskId != null && !this.taskId.equals(taskId)) {
             throw new IllegalStateException("Metrics recorder is re-initialised with different task: previous task is " +
                 this.taskId + " whereas current task is " + taskId + ". This is a bug in Kafka Streams. " +

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -176,7 +176,7 @@ public class RocksDBMetricsRecorderTest {
     @Test
     public void shouldThrowIfMetricRecorderIsInitialisedWithNullMetrics() {
         assertThrows(
-            IllegalStateException.class,
+            NullPointerException.class,
             () -> recorder.init(null, TASK_ID1)
         );
     }
@@ -184,7 +184,7 @@ public class RocksDBMetricsRecorderTest {
     @Test
     public void shouldThrowIfMetricRecorderIsInitialisedWithNullTaskId() {
         assertThrows(
-            IllegalStateException.class,
+            NullPointerException.class,
             () -> recorder.init(streamsMetrics, null)
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -174,6 +174,22 @@ public class RocksDBMetricsRecorderTest {
     }
 
     @Test
+    public void shouldThrowIfMetricRecorderIsInitialisedWithNullMetrics() {
+        assertThrows(
+            IllegalStateException.class,
+            () -> recorder.init(null, TASK_ID1)
+        );
+    }
+
+    @Test
+    public void shouldThrowIfMetricRecorderIsInitialisedWithNullTaskId() {
+        assertThrows(
+            IllegalStateException.class,
+            () -> recorder.init(streamsMetrics, null)
+        );
+    }
+
+    @Test
     public void shouldThrowIfMetricRecorderIsReInitialisedWithDifferentStreamsMetrics() {
         assertThrows(
             IllegalStateException.class,


### PR DESCRIPTION
Appears to be a typo in the code, since the error message indicates this check is for taskId being null, but instead we accidentally check the streams metrics twice