### PR TITLE
KAFKA-18218: Trogdor system test can't find coordinator

### DIFF
--- a/tests/kafkatest/services/trogdor/trogdor.py
+++ b/tests/kafkatest/services/trogdor/trogdor.py
@@ -170,7 +170,7 @@ class TrogdorService(KafkaPathResolverMixin, Service):
                 stdout_stderr_capture_path,
                 stdout_stderr_capture_path)
         node.account.ssh(cmd)
-        with node.account.monitor_log(log_path) as monitor:
+        with node.account.monitor_log(stdout_stderr_capture_path) as monitor:
             monitor.wait_until("Starting %s process." % daemon_name, timeout_sec=60, backoff_sec=.10,
                                err_msg=("%s on %s didn't finish startup" % (daemon_name, node.name)))
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-18218

https://github.com/apache/kafka/pull/18000 make output as console instead of log so we need to update e2e.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
