### PR TITLE
MINOR: Distribute batch combining among read and write state.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombiner.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombiner.java
@@ -86,8 +86,11 @@ public class PersisterStateBatchCombiner {
      *
      * @return list of {@link PersisterStateBatch} representing non-overlapping combined batches
      */
-    public List<PersisterStateBatch> combineStateBatches() {
+    public List<PersisterStateBatch> combineStateBatches(boolean pruneOnly) {
         pruneBatches();
+        if (pruneOnly) {
+            return combinedBatchList;
+        }
         mergeBatches();
         return finalBatchList;
     }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -315,9 +315,14 @@ class ShareCoordinatorShardTest {
         assertEquals(incrementalUpdate.snapshotEpoch(), combinedState.snapshotEpoch());
         assertEquals(incrementalUpdate.leaderEpoch(), combinedState.leaderEpoch());
         assertEquals(incrementalUpdate.startOffset(), combinedState.startOffset());
-        // The batches should have combined to 1 since same state.
-        assertEquals(Collections.singletonList(new PersisterStateBatch(0, 20, (byte) 0, (short) 1)),
-            combinedState.stateBatches());
+        // The batches should only be pruned, based on start offset. Not combined.
+        assertEquals(
+            List.of(
+                new PersisterStateBatch(0, 10, (byte) 0, (short) 1),
+                new PersisterStateBatch(11, 20, (byte) 0, (short) 1)
+            ),
+            combinedState.stateBatches()
+        );
         assertEquals(0, shard.getLeaderMapValue(shareCoordinatorKey));
     }
 


### PR DESCRIPTION
* We have implemented the share state batch combining logic in `PersisterStateBatchCombiner` and it can be broken into 2 parts - batch pruning (based on start offset) and overlapping batch combination.
* While batch pruning is a simple `O(n)` operation, combination is `O(nlogn)` with additional overhead of `TreeSet`.
* It can be observed that the read and write RPC caller will only receive batches from the coordinator when they issue a read state call. Additionally, writes are very frequent compared to reads which happen only on share partition initialization.
* In light of above points, we can trade memory for better running time.
* In this PR we have done some tuning to the combine logic which is as follows:
  * Allow `PersisterStateBatchCombiner` to combine batches with only pruning (using a boolean argument as flag).
  * For share update calls (much more frequent than share snapshot - default 500 per snapshot), batch combining happens with prune only.
  * For share snapshot calls combining happens with deep merging.
  * For read calls combining happens with deep merging.
  * For replay calls for share update, merging is prune only while for snapshot, no merging is required
  * There is a corner case when we receive a write RPC for the first time for a new share partition. In this we have chosen to go with prune only merging.
* So, in light of these our compute is distributed such that frequent operations are fast while infrequent ones bear the burden of heavy lifting while minor pruning is done in all operations to optimize for memory. Overall we are saved from Frequent `TreeSet` initialization for sure.

### Observed benefits (over 1 million records)
* Without the change each write RPC averages ~13.44ms.
* After change the avg time is ~13ms.
* It might seem like a small win but considering that write RPCs will run in 1000s, the numbers will add up.