### PR TITLE
KAFKA-18228: The MetricsDuringTopicCreationDeletionTest should delete topics to ensure that the metrics are recreated.

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
@@ -145,8 +145,8 @@ class MetricsDuringTopicCreationDeletionTest extends KafkaServerTestHarness with
       // Delete topics
       for (t <- topics if running) {
           try {
-            adminZkClient.deleteTopic(t)
-            TestUtils.verifyTopicDeletion(zkClient, t, partitionNum, servers)
+            deleteTopic(t)
+            TestUtils.verifyTopicDeletion(null, t, partitionNum, servers)
           } catch {
           case e: Exception => e.printStackTrace()
           }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18228

as title

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
