### PR TITLE
[DO NOT MERGE] Experimentally change consumer topic auto-create default

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -372,7 +372,7 @@ public class ConsumerConfig extends AbstractConfig {
             " subscribing to or assigning a topic. A topic being subscribed to will be automatically created only if the" +
             " broker allows for it using `auto.create.topics.enable` broker configuration. This configuration must" +
             " be set to `true` when using brokers older than 0.11.0";
-    public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = true;
+    public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
     /**
      * <code>security.providers</code>


### PR DESCRIPTION
KIP-361 introduced a consumer config `allow.auto.create.topics` which enables a consumer subscribing to a non-existent topic to create it automatically. Initially, it defaulted to `true`, but the eventual plan was to change the default to `false`. This PR changes the default.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
