### PR TITLE
KAFKA-18231: fix e2e reassign_partitions_test

### DIFF
--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -44,6 +44,8 @@ LOG_SEGMENT_BYTES = "log.segment.bytes"
 LOG_RETENTION_CHECK_INTERVAL_MS = "log.retention.check.interval.ms"
 LOG_RETENTION_MS = "log.retention.ms"
 LOG_CLEANER_ENABLE = "log.cleaner.enable"
+LOG_DELETE_DELAY_MS = "log.segment.delete.delay.ms"
+LOG_INITIAL_TASK_DELAY_MS = "log.initial.task.delay.ms"
 
 METADATA_LOG_DIR = "metadata.log.dir"
 METADATA_LOG_SEGMENT_BYTES = "metadata.log.segment.bytes"

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -44,8 +44,6 @@ LOG_SEGMENT_BYTES = "log.segment.bytes"
 LOG_RETENTION_CHECK_INTERVAL_MS = "log.retention.check.interval.ms"
 LOG_RETENTION_MS = "log.retention.ms"
 LOG_CLEANER_ENABLE = "log.cleaner.enable"
-LOG_DELETE_DELAY_MS = "log.segment.delete.delay.ms"
-LOG_INITIAL_TASK_DELAY_MS = "log.initial.task.delay.ms"
 
 METADATA_LOG_DIR = "metadata.log.dir"
 METADATA_LOG_SEGMENT_BYTES = "metadata.log.segment.bytes"

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -47,6 +47,8 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         self.kafka = KafkaService(test_context, num_nodes=4, zk=None,
                                   server_prop_overrides=[
                                       [config_property.LOG_ROLL_TIME_MS, "5000"],
+                                      [config_property.LOG_INITIAL_TASK_DELAY_MS, "100"],
+                                      [config_property.LOG_DELETE_DELAY_MS, "1000"],
                                       [config_property.LOG_RETENTION_CHECK_INTERVAL_MS, "5000"]
                                   ],
                                   topics={self.topic: {

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -47,8 +47,6 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         self.kafka = KafkaService(test_context, num_nodes=4, zk=None,
                                   server_prop_overrides=[
                                       [config_property.LOG_ROLL_TIME_MS, "5000"],
-                                      [config_property.LOG_INITIAL_TASK_DELAY_MS, "100"],
-                                      [config_property.LOG_DELETE_DELAY_MS, "1000"],
                                       [config_property.LOG_RETENTION_CHECK_INTERVAL_MS, "5000"]
                                   ],
                                   topics={self.topic: {

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -136,7 +136,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         # segment is deleted. An altenate to using timeouts is to poll each
         # partition until the log start offset matches the end offset. The
         # latter is more robust.
-        time.sleep(6)
+        time.sleep(15)
 
     @cluster(num_nodes=8)
     @matrix(


### PR DESCRIPTION
When `reassign_from_offset_zero` is set `False`, the system test will become fail.

if reassign_from_offset_zero is `False`, this test create a producer in order to sending some records for simulating start offset is not from zero.

Base on follow comments, this record should be deleted but it is not done. So I set some configs to trigger this event.
```
# Since the configured check interval is 5 seconds, we wait another
# 6 seconds to ensure that at least one more cleaning so that the last
# segment is deleted. An altenate to using timeouts is to poll each
# partition until the log start offset matches the end offset. The
# latter is more robust.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
