### PR TITLE
KAFKA-18224: Explicit group protocol setting in streams resetter

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -1189,7 +1190,8 @@ public class IntegrationTestUtils {
     /**
      * Sets up a {@link KafkaConsumer} from a copy of the given configuration that has
      * {@link ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} set to "earliest" and {@link ConsumerConfig#ENABLE_AUTO_COMMIT_CONFIG}
-     * set to "true" to prevent missing events as well as repeat consumption.
+     * set to "true" to prevent missing events as well as repeat consumption. This also sets
+     * {@link ConsumerConfig#GROUP_PROTOCOL_CONFIG} to "classic".
      * @param consumerConfig Consumer configuration
      * @return Consumer
      */
@@ -1198,6 +1200,7 @@ public class IntegrationTestUtils {
         filtered.putAll(consumerConfig);
         filtered.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         filtered.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        filtered.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.CLASSIC.name);
         return new KafkaConsumer<>(filtered);
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.KafkaFuture;
@@ -59,6 +60,8 @@ import java.util.stream.Collectors;
 import joptsimple.OptionException;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_PROTOCOL_CONFIG;
 
 
 /**
@@ -152,6 +155,12 @@ public class StreamsResetter {
                 }
 
                 final HashMap<Object, Object> consumerConfig = new HashMap<>(config);
+                if (consumerConfig.containsKey(GROUP_PROTOCOL_CONFIG) &&
+                    !consumerConfig.get(GROUP_PROTOCOL_CONFIG).toString().equalsIgnoreCase(GroupProtocol.CLASSIC.name())
+                ) {
+                    System.out.println("WARNING: provided group protocol will be ignored. Using supported " + GroupProtocol.CLASSIC.name() + " protocol instead");
+                }
+                consumerConfig.put(GROUP_PROTOCOL_CONFIG, GroupProtocol.CLASSIC.name());
                 consumerConfig.putAll(properties);
                 int exitCode = maybeResetInputAndSeekToEndIntermediateTopicOffsets(consumerConfig, options);
                 exitCode |= maybeDeleteInternalTopics(adminClient, options);

--- a/tools/src/test/java/org/apache/kafka/tools/AbstractResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/AbstractResetIntegrationTest.java
@@ -408,7 +408,6 @@ public abstract class AbstractResetIntegrationTest {
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
-        cleanUpConfig.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.CLASSIC.name);
 
         return new StreamsResetter().execute(parameters, cleanUpConfig) == 0;
     }


### PR DESCRIPTION
Ensure the streams resetter sets protocol to classic, to avoid relying on the default value that will eventually change.
