### PR TITLE
KAFKA-18242: The java code in core module is NOT configured with suitable release version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -801,6 +801,11 @@ subprojects {
     scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
     scalaCompileOptions.additionalParameters += ["--release", String.valueOf(releaseVersion)]
 
+    // Gradle does not support the `release` configuration when performing joint Java-Scala compilation.
+    // For more details, refer to https://github.com/gradle/gradle/issues/13762.
+    // As a result, we need to explicitly configure the Scala compiler with this setting.
+    options.compilerArgs += ["--release", String.valueOf(releaseVersion)]
+
     configureJavaCompiler(name, options, project.path)
 
     configure(scalaCompileOptions.forkOptions) {


### PR DESCRIPTION
JIRA: KAFKA-18242

> gradle does not support the `release` in joint compilation (see https://github.com/gradle/gradle/issues/13762)
> hence, we have to add `options.compilerArgs += ["--release", String.valueOf(releaseVersion)]` back to scala compiler

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
