### PR TITLE
KAFKA-18240: Remove nonexistent `LOG4J_CONFIG` from transactional_message_copier.py

### DIFF
--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -79,7 +79,7 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
         # Create and upload log properties
         log_config = self.render(get_log4j_config_for_tools(node),
                                  log_file=TransactionalMessageCopier.LOG_FILE)
-        node.account.create_file(get_log4j_config_for_tools(node).LOG4J_CONFIG, log_config)
+        node.account.create_file(get_log4j_config_for_tools(node), log_config)
         # Configure security
         self.security_config = self.kafka.security_config.client_config(node=node)
         self.security_config.setup_node(node)


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-18240
As title.
<img width="1155" alt="jekins1" src="https://github.com/user-attachments/assets/8b5d2b0f-7bde-416c-870c-c36dca0af0c7" />
<img width="1027" alt="jenkins2" src="https://github.com/user-attachments/assets/cd98ce22-f3d2-4d65-b9d6-cfeba74e154e" />



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
