### PR TITLE
KAFKA-15474: Disable flaky testWakeupAfterSyncGroupReceivedExternalCompletion

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -59,6 +59,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -1504,6 +1505,7 @@ public class AbstractCoordinatorTest {
     }
 
     @Test
+    @Disabled("KAFKA-15474")
     public void testWakeupAfterSyncGroupReceivedExternalCompletion() throws Exception {
         setupCoordinator();
 


### PR DESCRIPTION
JIRA: KAFKA-15474

as title, since `test-common:test-common-api` requires Java 17, we use `@Disable` instead.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
