### PR TITLE
KAFKA-18244: "Pull Request Labeled" always pass empty commit sha

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -64,4 +64,4 @@ jobs:
           repository: ${{ github.repository }}
           run_id: ${{ env.RUN_ID }}
           pr_number: ${{ env.PR_NUMBER }}
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
jira:https://issues.apache.org/jira/browse/KAFKA-18244

When the `Pull Request Labeled` is triggered, it passes the `commit SHA` via [`github.event.workflow_run.head_sha`](https://github.com/apache/kafka/blob/trunk/.github/workflows/pr-labeled.yml#L67). 

However, this value can be empty in the logs. 

![image](https://github.com/user-attachments/assets/d5334f8b-3c8d-4256-98dc-089db2cccfae)


To resolve this, we replaced it with `github.event.pull_request.head.sha`

![image](https://github.com/user-attachments/assets/515a24bc-2ea4-477d-bba4-b2643af560af)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
