### PR TITLE
KAFKA-18246: Fix ConnectRestApiTest.test_rest_api by adding multiversioning configs

### DIFF
--- a/tests/kafkatest/tests/connect/connect_rest_test.py
+++ b/tests/kafkatest/tests/connect/connect_rest_test.py
@@ -37,12 +37,14 @@ class ConnectRestApiTest(KafkaTest):
                            'topic', 'file', 'transforms', 'config.action.reload', 'errors.retry.timeout', 'errors.retry.delay.max.ms',
                            'errors.tolerance', 'errors.log.enable', 'errors.log.include.messages', 'predicates', 'topic.creation.groups',
                            'exactly.once.support', 'transaction.boundary', 'transaction.boundary.interval.ms', 'offsets.storage.topic',
-                           'tasks.max.enforce'}
+                           'tasks.max.enforce', 'connector.plugin.version', 'key.converter.plugin.version', 'value.converter.plugin.version', 
+                           'header.converter.plugin.version'}
     FILE_SINK_CONFIGS = {'name', 'connector.class', 'tasks.max', 'key.converter', 'value.converter', 'header.converter', 'topics',
                          'file', 'transforms', 'topics.regex', 'config.action.reload', 'errors.retry.timeout', 'errors.retry.delay.max.ms',
                          'errors.tolerance', 'errors.log.enable', 'errors.log.include.messages', 'errors.deadletterqueue.topic.name',
                          'errors.deadletterqueue.topic.replication.factor', 'errors.deadletterqueue.context.headers.enable', 'predicates',
-                         'tasks.max.enforce'}
+                         'tasks.max.enforce', 'connector.plugin.version', 'key.converter.plugin.version', 'value.converter.plugin.version', 
+                           'header.converter.plugin.version'}
 
     INPUT_FILE = "/mnt/connect.input"
     INPUT_FILE2 = "/mnt/connect.input2"


### PR DESCRIPTION
The test rest api is missing some configs, causing e2e error in the connect protocol.

Connect protocol in compatible.metadata_quorum=ISOLATED_KRAFT
![Screenshot 2024-12-15 122900](https://github.com/user-attachments/assets/0be74d03-463e-44e0-a66a-eb938f9e2f70)
![Screenshot 2024-12-15 122922](https://github.com/user-attachments/assets/2dd58524-74f8-4e85-88cb-f6f120b49aa0)

Connect protocol in eager.metadata_quorum=ISOLATED_KRAFT
![Screenshot 2024-12-15 122845](https://github.com/user-attachments/assets/bc60a6f3-b09e-4196-a300-9876aa79a513)
![Screenshot 2024-12-15 122913](https://github.com/user-attachments/assets/3ccfc15d-ac07-4940-bd0f-299ace86c089)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
