### PR TITLE
MINOR: Only look for the CI workflow pending approval

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -44,10 +44,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
+        # Find the CI workflow run that is pending approval and approve it
         run: |
           set +e
           echo "Found 'ci-approved' label on PR #$PR_NUMBER."
-          RUN_ID=$(gh run list -L 1 -c $SHA -s action_required --json databaseId --jq '.[].databaseId')
+          RUN_ID=$(gh run list -L 1 -c $SHA -s action_required -w CI --json databaseId --jq '.[].databaseId')
           if [ -z "$RUN_ID" ]; then
             echo "No workflow run found for SHA $SHA";
             exit 0;


### PR DESCRIPTION
When finding the workflow to approve using `ci-approved`, filter the workflows to only include the "CI" workflow.