### PR TITLE
flaky test report improvements

### DIFF
--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -822,13 +822,13 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
     
     # Print table with class and method information
     print("\n<table>")
-    print("<tr><td>Class</td><td>Test Case</td><td>Failure Rate</td><td>Build Scans</td></tr>")
+    print("<tr><td>Class</td><td>Test Case</td><td>Failure Rate</td><td>Build Scans</td><td>Link</td></tr>")
     
     for test_name, details in sorted(problematic_tests.items(), 
                                    key=lambda x: x[1]['failure_rate'],
                                    reverse=True):
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"4\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
+        print(f"<tr><td colspan=\"4\">{test_name}</td><td><a href=\"{class_link}\">↗️</a></td></tr>")
         
         for test_case in sorted(details['test_cases'],
                               key=lambda x: (x.outcome_distribution.failed + x.outcome_distribution.flaky) / x.outcome_distribution.total 
@@ -839,8 +839,9 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
                 method_link = get_develocity_method_link(test_name, test_case.name, threshold_days)
                 total_runs = test_case.outcome_distribution.total
                 failure_rate = (test_case.outcome_distribution.failed + test_case.outcome_distribution.flaky) / total_runs if total_runs > 0 else 0
-                print(f"<tr><td></td><td>{method_name} <a href=\"{method_link}\">↗️</a></td>"
-                      f"<td>{failure_rate:.2%}</td><td>{total_runs}</td></tr>")
+                print(f"<tr><td></td><td>{method_name}</td>"
+                      f"<td>{failure_rate:.2%}</td><td>{total_runs}</td>"
+                      f"<td><a href=\"{method_link}\">↗️</a></td></tr>")
     print("</table>")
     
     # Print detailed execution history
@@ -887,20 +888,20 @@ def print_flaky_regressions(flaky_regressions: Dict[str, Dict], threshold_days: 
     
     # Print table with test details
     print("\n<table>")
-    print("<tr><td>Test Class</td><td>Recent Flaky Rate</td><td>Historical Rate</td><td>Recent Executions</td></tr>")
+    print("<tr><td>Test Class</td><td>Recent Flaky Rate</td><td>Historical Rate</td><td>Recent Executions</td><td>Link</td></tr>")
     
     for test_name, details in flaky_regressions.items():
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"4\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
+        print(f"<tr><td colspan=\"4\">{test_name}</td><td><a href=\"{class_link}\">↗️</a></td></tr>")
         print(f"<tr><td></td><td>{details['recent_flaky_rate']:.2%}</td>"
               f"<td>{details['historical_flaky_rate']:.2%}</td>"
-              f"<td>{len(details['recent_executions'])}</td></tr>")
+              f"<td>{len(details['recent_executions'])}</td><td></td></tr>")
         
         # Add recent execution details in sub-rows
-        print("<tr><td colspan=\"4\">Recent Executions:</td></tr>")
+        print("<tr><td colspan=\"5\">Recent Executions:</td></tr>")
         for entry in sorted(details['recent_executions'], key=lambda x: x.timestamp)[-5:]:
             date_str = entry.timestamp.strftime('%Y-%m-%d %H:%M')
-            print(f"<tr><td></td><td colspan=\"3\">{date_str} - {entry.outcome}</td></tr>")
+            print(f"<tr><td></td><td colspan=\"4\">{date_str} - {entry.outcome}</td></tr>")
     print("</table>")
     
     # Print detailed history
@@ -939,17 +940,17 @@ def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
     
     # Print table with class and method information
     print("\n<table>")
-    print("<tr><td>Test Class</td><td>Test Method</td><td>Success Rate</td><td>Total Runs</td><td>Recent Status</td></tr>")
+    print("<tr><td>Test Class</td><td>Test Method</td><td>Success Rate</td><td>Total Runs</td><td>Recent Status</td><td>Link</td></tr>")
     
     for test_name, details in sorted(cleared_tests.items(),
                                    key=lambda x: x[1]['success_rate'],
                                    reverse=True):
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"5\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
+        print(f"<tr><td colspan=\"5\">{test_name}</td><td><a href=\"{class_link}\">↗️</a></td></tr>")
         print(f"<tr><td></td><td>Class Overall</td>"
               f"<td>{details['success_rate']:.2%}</td>"
               f"<td>{details['total_executions']}</td>"
-              f"<td>{details['successful_runs']} passed</td></tr>")
+              f"<td>{details['successful_runs']} passed</td><td></td></tr>")
         
         for test_case in details['test_cases']:
             method_name = test_case['name'].split('.')[-1]
@@ -958,11 +959,12 @@ def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
             if test_case['recent_executions']:
                 recent_status = test_case['recent_executions'][-1].outcome
             
-            print(f"<tr><td></td><td>{method_name} <a href=\"{method_link}\">↗️</a></td>"
+            print(f"<tr><td></td><td>{method_name}</td>"
                   f"<td>{test_case['success_rate']:.2%}</td>"
                   f"<td>{test_case['total_executions']}</td>"
-                  f"<td>{recent_status}</td></tr>")
-        print("<tr><td colspan=\"5\">&nbsp;</td></tr>")
+                  f"<td>{recent_status}</td>"
+                  f"<td><a href=\"{method_link}\">↗️</a></td></tr>")
+        print("<tr><td colspan=\"6\">&nbsp;</td></tr>")
     print("</table>")
     
     # Print detailed history

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -828,7 +828,7 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
                                    key=lambda x: x[1]['failure_rate'],
                                    reverse=True):
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"4\"><a href=\"{class_link}\">{test_name}</a></td></tr>")
+        print(f"<tr><td colspan=\"4\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
         
         for test_case in sorted(details['test_cases'],
                               key=lambda x: (x.outcome_distribution.failed + x.outcome_distribution.flaky) / x.outcome_distribution.total 
@@ -839,7 +839,7 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
                 method_link = get_develocity_method_link(test_name, test_case.name, threshold_days)
                 total_runs = test_case.outcome_distribution.total
                 failure_rate = (test_case.outcome_distribution.failed + test_case.outcome_distribution.flaky) / total_runs if total_runs > 0 else 0
-                print(f"<tr><td></td><td><a href=\"{method_link}\">{method_name}</a></td>"
+                print(f"<tr><td></td><td>{method_name} <a href=\"{method_link}\">↗️</a></td>"
                       f"<td>{failure_rate:.2%}</td><td>{total_runs}</td></tr>")
     print("</table>")
     
@@ -891,7 +891,7 @@ def print_flaky_regressions(flaky_regressions: Dict[str, Dict], threshold_days: 
     
     for test_name, details in flaky_regressions.items():
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"4\"><a href=\"{class_link}\">{test_name}</a></td></tr>")
+        print(f"<tr><td colspan=\"4\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
         print(f"<tr><td></td><td>{details['recent_flaky_rate']:.2%}</td>"
               f"<td>{details['historical_flaky_rate']:.2%}</td>"
               f"<td>{len(details['recent_executions'])}</td></tr>")
@@ -945,7 +945,7 @@ def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
                                    key=lambda x: x[1]['success_rate'],
                                    reverse=True):
         class_link = get_develocity_class_link(test_name, threshold_days)
-        print(f"<tr><td colspan=\"5\"><a href=\"{class_link}\">{test_name}</a></td></tr>")
+        print(f"<tr><td colspan=\"5\">{test_name} <a href=\"{class_link}\">↗️</a></td></tr>")
         print(f"<tr><td></td><td>Class Overall</td>"
               f"<td>{details['success_rate']:.2%}</td>"
               f"<td>{details['total_executions']}</td>"
@@ -958,7 +958,7 @@ def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
             if test_case['recent_executions']:
                 recent_status = test_case['recent_executions'][-1].outcome
             
-            print(f"<tr><td></td><td><a href=\"{method_link}\">{method_name}</a></td>"
+            print(f"<tr><td></td><td>{method_name} <a href=\"{method_link}\">↗️</a></td>"
                   f"<td>{test_case['success_rate']:.2%}</td>"
                   f"<td>{test_case['total_executions']}</td>"
                   f"<td>{recent_status}</td></tr>")


### PR DESCRIPTION
- Added test cases to cleared test reports
- Added table view to all the remaining reports

### Testing

# Flaky Test Report for 2024-12-17
This report was run on 2024-12-17 08:45:18 UTC

## Most Problematic Tests
Found 8 tests that have been quarantined for 7 days and are still failing frequently.

<table>
<tr><td>Class</td><td>Test Case</td><td>Failure Rate</td><td>Build Scans</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.OffloadAndTxnConsumeFromLeaderTest">org.apache.kafka.tiered.storage.integration.OffloadAndTxnConsumeFromLeaderTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.OffloadAndTxnConsumeFromLeaderTest&tests.test=executeTieredStorageTest%28String%2C%20String%29%5B1%5D">executeTieredStorageTest(String, String)[1]</a></td><td>100.00%</td><td>2</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.OffloadAndTxnConsumeFromLeaderTest&tests.test=executeTieredStorageTest%28String%2C%20String%29%5B2%5D">executeTieredStorageTest(String, String)[2]</a></td><td>100.00%</td><td>2</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.CustomQuotaCallbackTest">kafka.api.CustomQuotaCallbackTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.CustomQuotaCallbackTest&tests.test=testExecuteUpdateClusterMetadataMethodCallback%28String%2C%20String%29%5B1%5D">testExecuteUpdateClusterMetadataMethodCallback(String, String)[1]</a></td><td>100.00%</td><td>2</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest">org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest&tests.test=testReadCommittedConsumerShouldNotSeeUndecidedData%28String%2C%20String%29%5B2%5D">testReadCommittedConsumerShouldNotSeeUndecidedData(String, String)[2]</a></td><td>16.10%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest&tests.test=testBumpTransactionalEpochWithTV2Enabled%28String%2C%20String%2C%20boolean%29%5B2%5D">testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[2]</a></td><td>15.24%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest&tests.test=testBumpTransactionalEpochWithTV2Enabled%28String%2C%20String%2C%20boolean%29%5B1%5D">testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[1]</a></td><td>14.73%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest&tests.test=testBumpTransactionalEpochWithTV2Disabled%28String%2C%20String%2C%20boolean%29%5B1%5D">testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[1]</a></td><td>7.88%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest&tests.test=testBumpTransactionalEpochWithTV2Disabled%28String%2C%20String%2C%20boolean%29%5B2%5D">testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[2]</a></td><td>5.65%</td><td>584</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.common.network.Tls13SelectorTest">org.apache.kafka.common.network.Tls13SelectorTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.common.network.Tls13SelectorTest&tests.test=testCloseOldestConnection%28%29">testCloseOldestConnection()</a></td><td>25.00%</td><td>4</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.common.network.SslTransportLayerTest">org.apache.kafka.common.network.SslTransportLayerTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.common.network.SslTransportLayerTest&tests.test=testSelectorPollReadSize%28Args%29%5B1%5D">testSelectorPollReadSize(Args)[1]</a></td><td>25.00%</td><td>4</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.TransactionsTest">kafka.api.TransactionsTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.TransactionsTest&tests.test=testBumpTransactionalEpochWithTV2Enabled%28String%2C%20String%2C%20boolean%29%5B1%5D">testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[1]</a></td><td>10.14%</td><td>582</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.TransactionsTest&tests.test=testBumpTransactionalEpochWithTV2Enabled%28String%2C%20String%2C%20boolean%29%5B2%5D">testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[2]</a></td><td>8.08%</td><td>582</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.TransactionsTest&tests.test=testBumpTransactionalEpochWithTV2Disabled%28String%2C%20String%2C%20boolean%29%5B1%5D">testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[1]</a></td><td>5.84%</td><td>582</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.TransactionsTest&tests.test=testBumpTransactionalEpochWithTV2Disabled%28String%2C%20String%2C%20boolean%29%5B2%5D">testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[2]</a></td><td>5.50%</td><td>582</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest">kafka.api.PlaintextConsumerTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCloseLeavesGroupOnInterrupt%28String%2C%20String%29%5B2%5D">testCloseLeavesGroupOnInterrupt(String, String)[2]</a></td><td>9.59%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>3.08%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCloseLeavesGroupOnInterrupt%28String%2C%20String%29%5B1%5D">testCloseLeavesGroupOnInterrupt(String, String)[1]</a></td><td>2.40%</td><td>584</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>2.23%</td><td>584</td></tr>
<tr><td colspan="4"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest">org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest</a></td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest&tests.test=testWakeupAfterSyncGroupReceived%28%29">testWakeupAfterSyncGroupReceived()</a></td><td>25.00%</td><td>4</td></tr>
</table>

<details>
<summary>Detailed Execution History</summary>


### org.apache.kafka.tiered.storage.integration.OffloadAndTxnConsumeFromLeaderTest
* Days Quarantined: 7
* Recent Failure Rate: 100.00%
* Total Runs: 2
* Build Outcomes: Passed: 0 | Failed: 2 | Flaky: 0

#### executeTieredStorageTest(String, String)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-15 08:00  failed     lkhdsxpqn3mpa
2024-12-15 08:01  flaky      sqgdbmoepagkq
```

#### executeTieredStorageTest(String, String)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-15 08:00  flaky      lkhdsxpqn3mpa
2024-12-15 08:01  flaky      sqgdbmoepagkq
```

### kafka.api.CustomQuotaCallbackTest
* Days Quarantined: 7
* Recent Failure Rate: 50.00%
* Total Runs: 4
* Build Outcomes: Passed: 2 | Failed: 2 | Flaky: 0

#### testExecuteUpdateClusterMetadataMethodCallback(String, String)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-16 17:09  failed     sbnxnoxopk3lw
2024-12-16 17:10  failed     jwr5anuivvwsw
```

### org.apache.kafka.tiered.storage.integration.TransactionsWithTieredStoreTest
* Days Quarantined: 7
* Recent Failure Rate: 44.85%
* Total Runs: 584
* Build Outcomes: Passed: 320 | Failed: 8 | Flaky: 256

#### testReadCommittedConsumerShouldNotSeeUndecidedData(String, String)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  flaky      tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  flaky      dmojogsx5lrb4
```

### org.apache.kafka.common.network.Tls13SelectorTest
* Days Quarantined: 7
* Recent Failure Rate: 25.00%
* Total Runs: 4
* Build Outcomes: Passed: 3 | Failed: 0 | Flaky: 1

#### testCloseOldestConnection()
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-12 20:45  flaky      hhdqo5lixoioi
2024-12-12 20:45  passed     4gllln4top7n6
2024-12-12 22:22  passed     ct6a5b7wnnosw
2024-12-12 22:22  passed     igseo3kh3m2z6
```

### org.apache.kafka.common.network.SslTransportLayerTest
* Days Quarantined: 7
* Recent Failure Rate: 25.00%
* Total Runs: 4
* Build Outcomes: Passed: 3 | Failed: 0 | Flaky: 1

#### testSelectorPollReadSize(Args)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-12 20:45  passed     hhdqo5lixoioi
2024-12-12 20:45  passed     4gllln4top7n6
2024-12-12 22:22  flaky      ct6a5b7wnnosw
2024-12-12 22:22  passed     igseo3kh3m2z6
```

### kafka.api.TransactionsTest
* Days Quarantined: 7
* Recent Failure Rate: 23.95%
* Total Runs: 582
* Build Outcomes: Passed: 449 | Failed: 8 | Flaky: 125

#### testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  flaky      ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Enabled(String, String, boolean)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testBumpTransactionalEpochWithTV2Disabled(String, String, boolean)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.PlaintextConsumerTest
* Days Quarantined: 7
* Recent Failure Rate: 15.84%
* Total Runs: 584
* Build Outcomes: Passed: 495 | Failed: 0 | Flaky: 89

#### testCloseLeavesGroupOnInterrupt(String, String)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[2]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCloseLeavesGroupOnInterrupt(String, String)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[1]
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest
* Days Quarantined: 7
* Recent Failure Rate: 25.00%
* Total Runs: 8
* Build Outcomes: Passed: 7 | Failed: 0 | Flaky: 1

#### testWakeupAfterSyncGroupReceived()
Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-12 20:45  passed     hhdqo5lixoioi
2024-12-12 20:45  flaky      4gllln4top7n6
2024-12-12 22:22  passed     ct6a5b7wnnosw
2024-12-12 22:22  passed     igseo3kh3m2z6
```
</details>

## Flaky Test Regressions
No flaky test regressions found.

## Cleared Tests (Ready for Unquarantine)
Found 20 test classes with 42 test methods that have been consistently passing. These tests could be candidates for removing quarantine annotations at either class or method level.

<table>
<tr><td>Test Class</td><td>Test Method</td><td>Success Rate</td><td>Total Runs</td><td>Recent Status</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.integration.MetricsDuringTopicCreationDeletionTest">kafka.integration.MetricsDuringTopicCreationDeletionTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>100.00%</td><td>77</td><td>77 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.integration.MetricsDuringTopicCreationDeletionTest&tests.test=testMetricsDuringTopicCreateDelete%28String%29%5B1%5D">testMetricsDuringTopicCreateDelete(String)[1]</a></td><td>99.22%</td><td>129</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerSubscriptionTest">kafka.api.PlaintextConsumerSubscriptionTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.80%</td><td>509</td><td>508 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerSubscriptionTest&tests.test=testRe2JPatternExpandSubscription%28String%2C%20String%29%5B1%5D">testRe2JPatternExpandSubscription(String, String)[1]</a></td><td>99.82%</td><td>569</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextAdminIntegrationTest">kafka.api.PlaintextAdminIntegrationTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.61%</td><td>517</td><td>515 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextAdminIntegrationTest&tests.test=testConsumerGroupWithMemberMigration%28String%29%5B1%5D">testConsumerGroupWithMemberMigration(String)[1]</a></td><td>99.65%</td><td>575</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SslAdminIntegrationTest">kafka.api.SslAdminIntegrationTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.60%</td><td>251</td><td>250 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SslAdminIntegrationTest&tests.test=testListNodesFromControllersIncludingFencedBrokers%28String%29%5B1%5D">testListNodesFromControllersIncludingFencedBrokers(String)[1]</a></td><td>99.67%</td><td>301</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.AutoOffsetResetTest">org.apache.kafka.streams.AutoOffsetResetTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.48%</td><td>382</td><td>380 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.AutoOffsetResetTest&tests.test=shouldThrowExceptionOnDurationForEarliestReset%28%29">shouldThrowExceptionOnDurationForEarliestReset()</a></td><td>99.51%</td><td>410</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.AutoOffsetResetTest&tests.test=shouldThrowExceptionOnDurationForLastetReset%28%29">shouldThrowExceptionOnDurationForLastetReset()</a></td><td>99.51%</td><td>410</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.AutoOffsetResetTest&tests.test=shouldThrowExceptionOnDurationForNoneReset%28%29">shouldThrowExceptionOnDurationForNoneReset()</a></td><td>99.51%</td><td>410</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.kstream.internals.KStreamImplTest">org.apache.kafka.streams.kstream.internals.KStreamImplTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.45%</td><td>362</td><td>360 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.kstream.internals.KStreamImplTest&tests.test=shouldProcessWithProcessorAndState%28%29">shouldProcessWithProcessorAndState()</a></td><td>99.51%</td><td>410</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.producer.internals.TransactionManagerTest">org.apache.kafka.clients.producer.internals.TransactionManagerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.43%</td><td>352</td><td>350 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.producer.internals.TransactionManagerTest&tests.test=testTransactionV2AddPartitionAndOffsets%28%29">testTransactionV2AddPartitionAndOffsets()</a></td><td>99.44%</td><td>358</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.producer.internals.TransactionManagerTest&tests.test=testMaybeAddPartitionToTransactionInTransactionV2%28%29">testMaybeAddPartitionToTransactionInTransactionV2()</a></td><td>99.44%</td><td>358</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.producer.internals.TransactionManagerTest&tests.test=testFatalErrorWhenProduceResponseWithInvalidPidMapping%28%29">testFatalErrorWhenProduceResponseWithInvalidPidMapping()</a></td><td>99.44%</td><td>358</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SslConsumerTest">kafka.api.SslConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.43%</td><td>522</td><td>519 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SslConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>99.83%</td><td>582</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SslConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>99.66%</td><td>582</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.StreamsBuilderTest">org.apache.kafka.streams.StreamsBuilderTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>99.24%</td><td>524</td><td>520 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.StreamsBuilderTest&tests.test=shouldWrapProcessorsForStreamStreamSelfJoinWithSharedStoreOptimization%28%29">shouldWrapProcessorsForStreamStreamSelfJoinWithSharedStoreOptimization()</a></td><td>99.39%</td><td>327</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslSslConsumerTest">kafka.api.SaslSslConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>98.85%</td><td>524</td><td>518 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslSslConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>98.97%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslSslConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>99.83%</td><td>584</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.consumer.internals.ApplicationEventHandlerTest">org.apache.kafka.clients.consumer.internals.ApplicationEventHandlerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>98.64%</td><td>221</td><td>218 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.clients.consumer.internals.ApplicationEventHandlerTest&tests.test=testRecordApplicationEventQueueSize%28%29">testRecordApplicationEventQueueSize()</a></td><td>98.53%</td><td>273</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorderTest">org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorderTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>98.54%</td><td>137</td><td>135 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorderTest&tests.test=shouldThrowIfMetricRecorderIsInitialisedWithNullTaskId%28%29">shouldThrowIfMetricRecorderIsInitialisedWithNullTaskId()</a></td><td>98.94%</td><td>189</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorderTest&tests.test=shouldThrowIfMetricRecorderIsInitialisedWithNullMetrics%28%29">shouldThrowIfMetricRecorderIsInitialisedWithNullMetrics()</a></td><td>98.94%</td><td>189</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.controller.QuorumControllerTest">org.apache.kafka.controller.QuorumControllerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>98.53%</td><td>273</td><td>269 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.controller.QuorumControllerTest&tests.test=testUncleanShutdownElrDisabled%28%29">testUncleanShutdownElrDisabled()</a></td><td>99.64%</td><td>277</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.controller.QuorumControllerTest&tests.test=testUncleanShutdownBrokerElrEnabled%28%29">testUncleanShutdownBrokerElrEnabled()</a></td><td>98.92%</td><td>277</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest">kafka.test.api.ShareConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>98.47%</td><td>522</td><td>514 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest&tests.test=testAcknowledgementCommitCallbackCallsShareConsumerWakeup%28String%29%5B1%5D">testAcknowledgementCommitCallbackCallsShareConsumerWakeup(String)[1]</a></td><td>99.83%</td><td>582</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest&tests.test=testAcknowledgementCommitCallbackCallsShareConsumerWakeup%28String%29%5B2%5D">testAcknowledgementCommitCallbackCallsShareConsumerWakeup(String)[2]</a></td><td>99.66%</td><td>582</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest&tests.test=testAcknowledgementCommitCallbackInvalidRecordStateException%28String%29%5B1%5D">testAcknowledgementCommitCallbackInvalidRecordStateException(String)[1]</a></td><td>99.14%</td><td>582</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest&tests.test=testMultipleConsumersInGroupConcurrentConsumption%28String%29%5B1%5D">testMultipleConsumersInGroupConcurrentConsumption(String)[1]</a></td><td>99.83%</td><td>582</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.test.api.ShareConsumerTest&tests.test=testExplicitAcknowledgementCommitAsync%28String%29%5B1%5D">testExplicitAcknowledgementCommitAsync(String)[1]</a></td><td>99.83%</td><td>582</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.integration.FineGrainedAutoResetIntegrationTest">org.apache.kafka.streams.integration.FineGrainedAutoResetIntegrationTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>97.75%</td><td>356</td><td>348 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.integration.FineGrainedAutoResetIntegrationTest&tests.test=shouldResetByDuration%28%29">shouldResetByDuration()</a></td><td>99.03%</td><td>412</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.streams.integration.FineGrainedAutoResetIntegrationTest&tests.test=shouldFailForResetNone%28%29">shouldFailForResetNone()</a></td><td>99.03%</td><td>412</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslMultiMechanismConsumerTest">kafka.api.SaslMultiMechanismConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>96.95%</td><td>524</td><td>508 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslMultiMechanismConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>97.77%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslMultiMechanismConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>98.97%</td><td>584</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest">org.apache.kafka.connect.integration.OffsetsApiIntegrationTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>96.37%</td><td>524</td><td>505 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.test=testResetSinkConnectorOffsetsOverriddenConsumerGroupId%28%29">testResetSinkConnectorOffsetsOverriddenConsumerGroupId()</a></td><td>98.80%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.test=testResetSinkConnectorOffsets%28%29">testResetSinkConnectorOffsets()</a></td><td>98.80%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.test=testAlterSinkConnectorOffsetsOverriddenConsumerGroupId%28%29">testAlterSinkConnectorOffsetsOverriddenConsumerGroupId()</a></td><td>99.32%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.test=testGetSinkConnectorOffsetsDifferentKafkaClusterTargeted%28%29">testGetSinkConnectorOffsetsDifferentKafkaClusterTargeted()</a></td><td>98.29%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=org.apache.kafka.connect.integration.OffsetsApiIntegrationTest&tests.test=testAlterSinkConnectorOffsetsDifferentKafkaClusterTargeted%28%29">testAlterSinkConnectorOffsetsDifferentKafkaClusterTargeted()</a></td><td>97.60%</td><td>584</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.network.DynamicConnectionQuotaTest">kafka.network.DynamicConnectionQuotaTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>95.59%</td><td>522</td><td>499 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.network.DynamicConnectionQuotaTest&tests.test=testDynamicConnectionQuota%28String%29%5B1%5D">testDynamicConnectionQuota(String)[1]</a></td><td>95.53%</td><td>582</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslPlaintextConsumerTest">kafka.api.SaslPlaintextConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>94.65%</td><td>523</td><td>495 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslPlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>99.83%</td><td>583</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.SaslPlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>94.51%</td><td>583</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
<tr><td colspan="5"><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest">kafka.api.PlaintextConsumerTest</a></td></tr>
<tr><td></td><td>Class Overall</td><td>84.16%</td><td>524</td><td>441 passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B2%5D">testCoordinatorFailover(String, String)[2]</a></td><td>96.92%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCoordinatorFailover%28String%2C%20String%29%5B1%5D">testCoordinatorFailover(String, String)[1]</a></td><td>97.77%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCloseLeavesGroupOnInterrupt%28String%2C%20String%29%5B1%5D">testCloseLeavesGroupOnInterrupt(String, String)[1]</a></td><td>97.60%</td><td>584</td><td>passed</td></tr>
<tr><td></td><td><a href="https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.timeZoneId=America/New_York&search.relativeStartTime=P7D&tests.container=kafka.api.PlaintextConsumerTest&tests.test=testCloseLeavesGroupOnInterrupt%28String%2C%20String%29%5B2%5D">testCloseLeavesGroupOnInterrupt(String, String)[2]</a></td><td>90.41%</td><td>584</td><td>passed</td></tr>
<tr><td colspan="5">&nbsp;</td></tr>
</table>

<details>
<summary>Detailed Test Method History</summary>


### kafka.integration.MetricsDuringTopicCreationDeletionTest
* Overall Success Rate: 100.00%
* Total Executions: 77
* Consecutive Successful Runs: 77

#### testMetricsDuringTopicCreateDelete(String)[1]
* Success Rate: 99.22%
* Total Runs: 129

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 01:56  passed     jftbd3tqqv23e
2024-12-17 02:41  passed     kbajkeckvufya
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
```

### kafka.api.PlaintextConsumerSubscriptionTest
* Overall Success Rate: 99.80%
* Total Executions: 509
* Consecutive Successful Runs: 508

#### testRe2JPatternExpandSubscription(String, String)[1]
* Success Rate: 99.82%
* Total Runs: 569

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.PlaintextAdminIntegrationTest
* Overall Success Rate: 99.61%
* Total Executions: 517
* Consecutive Successful Runs: 515

#### testConsumerGroupWithMemberMigration(String)[1]
* Success Rate: 99.65%
* Total Runs: 575

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.SslAdminIntegrationTest
* Overall Success Rate: 99.60%
* Total Executions: 251
* Consecutive Successful Runs: 250

#### testListNodesFromControllersIncludingFencedBrokers(String)[1]
* Success Rate: 99.67%
* Total Runs: 301

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.streams.AutoOffsetResetTest
* Overall Success Rate: 99.48%
* Total Executions: 382
* Consecutive Successful Runs: 380

#### shouldThrowExceptionOnDurationForEarliestReset()
* Success Rate: 99.51%
* Total Runs: 410

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### shouldThrowExceptionOnDurationForLastetReset()
* Success Rate: 99.51%
* Total Runs: 410

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### shouldThrowExceptionOnDurationForNoneReset()
* Success Rate: 99.51%
* Total Runs: 410

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.streams.kstream.internals.KStreamImplTest
* Overall Success Rate: 99.45%
* Total Executions: 362
* Consecutive Successful Runs: 360

#### shouldProcessWithProcessorAndState()
* Success Rate: 99.51%
* Total Runs: 410

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.clients.producer.internals.TransactionManagerTest
* Overall Success Rate: 99.43%
* Total Executions: 352
* Consecutive Successful Runs: 350

#### testTransactionV2AddPartitionAndOffsets()
* Success Rate: 99.44%
* Total Runs: 358

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-14 03:24  passed     kxmtr5vf6jjos
2024-12-14 03:24  passed     2uthfvry5onu2
2024-12-14 14:27  passed     673h4uvqqp43i
2024-12-15 01:15  passed     657l6cmibrueo
2024-12-15 01:15  passed     sfttfmn2pt6am
```

#### testMaybeAddPartitionToTransactionInTransactionV2()
* Success Rate: 99.44%
* Total Runs: 358

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-14 03:24  passed     kxmtr5vf6jjos
2024-12-14 03:24  passed     2uthfvry5onu2
2024-12-14 14:27  passed     673h4uvqqp43i
2024-12-15 01:15  passed     657l6cmibrueo
2024-12-15 01:15  passed     sfttfmn2pt6am
```

#### testFatalErrorWhenProduceResponseWithInvalidPidMapping()
* Success Rate: 99.44%
* Total Runs: 358

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-14 03:24  passed     kxmtr5vf6jjos
2024-12-14 03:24  passed     2uthfvry5onu2
2024-12-14 14:27  passed     673h4uvqqp43i
2024-12-15 01:15  passed     657l6cmibrueo
2024-12-15 01:15  passed     sfttfmn2pt6am
```

### kafka.api.SslConsumerTest
* Overall Success Rate: 99.43%
* Total Executions: 522
* Consecutive Successful Runs: 519

#### testCoordinatorFailover(String, String)[1]
* Success Rate: 99.83%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[2]
* Success Rate: 99.66%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.streams.StreamsBuilderTest
* Overall Success Rate: 99.24%
* Total Executions: 524
* Consecutive Successful Runs: 520

#### shouldWrapProcessorsForStreamStreamSelfJoinWithSharedStoreOptimization()
* Success Rate: 99.39%
* Total Runs: 327

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.SaslSslConsumerTest
* Overall Success Rate: 98.85%
* Total Executions: 524
* Consecutive Successful Runs: 518

#### testCoordinatorFailover(String, String)[1]
* Success Rate: 98.97%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[2]
* Success Rate: 99.83%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.clients.consumer.internals.ApplicationEventHandlerTest
* Overall Success Rate: 98.64%
* Total Executions: 221
* Consecutive Successful Runs: 218

#### testRecordApplicationEventQueueSize()
* Success Rate: 98.53%
* Total Runs: 273

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorderTest
* Overall Success Rate: 98.54%
* Total Executions: 137
* Consecutive Successful Runs: 135

#### shouldThrowIfMetricRecorderIsInitialisedWithNullTaskId()
* Success Rate: 98.94%
* Total Runs: 189

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 01:56  passed     jftbd3tqqv23e
2024-12-17 02:41  passed     kbajkeckvufya
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
```

#### shouldThrowIfMetricRecorderIsInitialisedWithNullMetrics()
* Success Rate: 98.94%
* Total Runs: 189

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 01:56  passed     jftbd3tqqv23e
2024-12-17 02:41  passed     kbajkeckvufya
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
```

### org.apache.kafka.controller.QuorumControllerTest
* Overall Success Rate: 98.53%
* Total Executions: 273
* Consecutive Successful Runs: 269

#### testUncleanShutdownElrDisabled()
* Success Rate: 99.64%
* Total Runs: 277

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-14 03:24  passed     kxmtr5vf6jjos
2024-12-14 03:24  passed     2uthfvry5onu2
2024-12-14 14:27  passed     673h4uvqqp43i
2024-12-15 01:15  passed     657l6cmibrueo
2024-12-15 01:15  passed     sfttfmn2pt6am
```

#### testUncleanShutdownBrokerElrEnabled()
* Success Rate: 98.92%
* Total Runs: 277

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-14 03:24  passed     kxmtr5vf6jjos
2024-12-14 03:24  passed     2uthfvry5onu2
2024-12-14 14:27  passed     673h4uvqqp43i
2024-12-15 01:15  passed     657l6cmibrueo
2024-12-15 01:15  passed     sfttfmn2pt6am
```

### kafka.test.api.ShareConsumerTest
* Overall Success Rate: 98.47%
* Total Executions: 522
* Consecutive Successful Runs: 514

#### testAcknowledgementCommitCallbackCallsShareConsumerWakeup(String)[1]
* Success Rate: 99.83%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testAcknowledgementCommitCallbackCallsShareConsumerWakeup(String)[2]
* Success Rate: 99.66%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testAcknowledgementCommitCallbackInvalidRecordStateException(String)[1]
* Success Rate: 99.14%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testMultipleConsumersInGroupConcurrentConsumption(String)[1]
* Success Rate: 99.83%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testExplicitAcknowledgementCommitAsync(String)[1]
* Success Rate: 99.83%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.streams.integration.FineGrainedAutoResetIntegrationTest
* Overall Success Rate: 97.75%
* Total Executions: 356
* Consecutive Successful Runs: 348

#### shouldResetByDuration()
* Success Rate: 99.03%
* Total Runs: 412

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### shouldFailForResetNone()
* Success Rate: 99.03%
* Total Runs: 412

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.SaslMultiMechanismConsumerTest
* Overall Success Rate: 96.95%
* Total Executions: 524
* Consecutive Successful Runs: 508

#### testCoordinatorFailover(String, String)[1]
* Success Rate: 97.77%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[2]
* Success Rate: 98.97%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### org.apache.kafka.connect.integration.OffsetsApiIntegrationTest
* Overall Success Rate: 96.37%
* Total Executions: 524
* Consecutive Successful Runs: 505

#### testResetSinkConnectorOffsetsOverriddenConsumerGroupId()
* Success Rate: 98.80%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testResetSinkConnectorOffsets()
* Success Rate: 98.80%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testAlterSinkConnectorOffsetsOverriddenConsumerGroupId()
* Success Rate: 99.32%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testGetSinkConnectorOffsetsDifferentKafkaClusterTargeted()
* Success Rate: 98.29%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testAlterSinkConnectorOffsetsDifferentKafkaClusterTargeted()
* Success Rate: 97.60%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.network.DynamicConnectionQuotaTest
* Overall Success Rate: 95.59%
* Total Executions: 522
* Consecutive Successful Runs: 499

#### testDynamicConnectionQuota(String)[1]
* Success Rate: 95.53%
* Total Runs: 582

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.SaslPlaintextConsumerTest
* Overall Success Rate: 94.65%
* Total Executions: 523
* Consecutive Successful Runs: 495

#### testCoordinatorFailover(String, String)[1]
* Success Rate: 99.83%
* Total Runs: 583

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[2]
* Success Rate: 94.51%
* Total Runs: 583

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

### kafka.api.PlaintextConsumerTest
* Overall Success Rate: 84.16%
* Total Executions: 524
* Consecutive Successful Runs: 441

#### testCoordinatorFailover(String, String)[2]
* Success Rate: 96.92%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCoordinatorFailover(String, String)[1]
* Success Rate: 97.77%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCloseLeavesGroupOnInterrupt(String, String)[1]
* Success Rate: 97.60%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```

#### testCloseLeavesGroupOnInterrupt(String, String)[2]
* Success Rate: 90.41%
* Total Runs: 584

Recent Executions:
```
Date/Time (UTC)      Outcome    Build ID
--------------------------------------------
2024-12-17 02:41  passed     ypf6siwbjjev2
2024-12-17 05:05  passed     n3v7qodjqjces
2024-12-17 05:05  passed     ie6eoylrybum4
2024-12-17 05:10  passed     tesh2oqgxr5qu
2024-12-17 05:10  passed     dmojogsx5lrb4
```
</details>






### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
