### PR TITLE
Fix handling of reordered records, add replay testing

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -565,7 +565,6 @@ public class GroupMetadataManagerTestContext {
 
             consumerGroupBuilders.forEach(builder -> builder.build(metadataImage.topics()).forEach(context::replay));
             shareGroupBuilders.forEach(builder -> builder.build(metadataImage.topics()).forEach(context::replay));
-
             streamsGroupBuilders.forEach(builder -> builder.build().forEach(context::replay));
 
             context.commit();


### PR DESCRIPTION
Replaying records from the offset topic has several corner
cases, that we need to take care of. In particular, due to
compaction it can happen that we only see the tombstone
record of a member or the group, but not the original record
of the group. Similarly, if the group metadata record is
updated after the last update to the current assignment
record of a member, the records will be replayed out of order,
that is, we first replay the current assignment of the member,
and then create the group.

Therefore, we need to change the code to always create groups
when replaying any kind of records (instead of failing, as before).
Also, tombstones of non-existing groups are ignored.

This change also adds unit tests for all replay methods for streams
records.

We also piggyback some changes to streamsGroupHeartbeat:
 - the structure of the method is cleaned up a bit
 - request validation is extended
 - unit test for request validation is extendend

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
