### PR TITLE
KAFKA-18270: SaslHandshake v0 incorrectly tagged as deprecated

### DIFF
--- a/clients/src/main/resources/common/message/SaslHandshakeRequest.json
+++ b/clients/src/main/resources/common/message/SaslHandshakeRequest.json
@@ -23,7 +23,6 @@
   // client negotiation for clients <= 2.4.
   // See https://issues.apache.org/jira/browse/KAFKA-9577
   "validVersions": "0-1",
-  "deprecatedVersions": "0",
   "flexibleVersions": "none",
   "fields": [
     { "name": "Mechanism", "type": "string", "versions": "0+",


### PR DESCRIPTION
It's now consistent with KIP-896.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
