### PR TITLE
KAFKA-18278: Correct name and description for run-gradle step

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -16,8 +16,8 @@
 # under the License.
 #
 ---
-name: "Gradle Test Setup"
-description: "Setup Java and Gradle, then run the specified test suite."
+name: "Run Gradle Tests"
+description: "Run specified Gradle test tasks with configuration for timeout and test catalog."
 inputs:
   # Composite actions do not support typed parameters. Everything is treated as a string
   # See: https://github.com/actions/runner/issues/2238

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 ---
-name: "Run Gradle Tests"
+name: "Run Tests with Gradle"
 description: "Run specified Gradle test tasks with configuration for timeout and test catalog."
 inputs:
   # Composite actions do not support typed parameters. Everything is treated as a string

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -16,8 +16,8 @@
 # under the License.
 #
 ---
-name: "Gradle Setup"
-description: "Setup Java and Gradle"
+name: "Gradle Test Setup"
+description: "Setup Java and Gradle, then run the specified test suite."
 inputs:
   # Composite actions do not support typed parameters. Everything is treated as a string
   # See: https://github.com/actions/runner/issues/2238


### PR DESCRIPTION
*The name and description for the `run-gradle` step were updated to make them clearer and more consistent with the overall workflow. The updated names now better describe the purpose of the step.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
