### PR TITLE
MINOR: Backport KAFKA-17141 - DescribeTopicPartitions API is not supported' warning message confuses users

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2290,7 +2290,6 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             boolean handleUnsupportedVersionException(UnsupportedVersionException exception) {
                 final long now = time.milliseconds();
-                log.warn("The DescribeTopicPartitions API is not supported, using Metadata API to describe topics.");
                 runnable.call(generateDescribeTopicsCallWithMetadataApi(topicNamesList, topicFutures, options, now), now);
                 return false;
             }


### PR DESCRIPTION
Backport KAFKA-17141 (#16612).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
