### PR TITLE
MINOR: Mark KIP-848's public apis as stable

### DIFF
--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ConsumerGroupPartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ConsumerGroupPartitionAssignor.java
@@ -20,10 +20,6 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
  * Server-side partition assignor for consumer groups used by the GroupCoordinator.
- *
- * The new consumer group protocol is in preview so this interface is considered
- * unstable until Apache Kafka 4.0.
  */
-@InterfaceStability.Unstable
 public interface ConsumerGroupPartitionAssignor extends PartitionAssignor {
 }

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ConsumerGroupPartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ConsumerGroupPartitionAssignor.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.api.assignor;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 /**
  * Server-side partition assignor for consumer groups used by the GroupCoordinator.
  */

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupAssignment.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupAssignment.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.api.assignor;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 import java.util.Map;
 import java.util.Objects;
 

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupAssignment.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupAssignment.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 /**
  * The partition assignment for a consumer group.
  */
-@InterfaceStability.Unstable
 public class GroupAssignment {
     /**
      * The member assignments keyed by member id.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupSpec.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupSpec.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.coordinator.group.api.assignor;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
 

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupSpec.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/GroupSpec.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 /**
  * The group metadata specifications required to compute the target assignment.
  */
-@InterfaceStability.Unstable
 public interface GroupSpec {
     /**
      * @return All the member Ids of the consumer group.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberAssignment.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberAssignment.java
@@ -25,7 +25,6 @@ import java.util.Set;
 /**
  * The partition assignment for a consumer group member.
  */
-@InterfaceStability.Unstable
 public interface MemberAssignment {
     /**
      * @return The assigned partitions keyed by topic Ids.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberAssignment.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberAssignment.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.coordinator.group.api.assignor;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Map;
 import java.util.Set;

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberSubscription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberSubscription.java
@@ -25,7 +25,6 @@ import java.util.Set;
 /**
  * Interface representing the subscription metadata for a group member.
  */
-@InterfaceStability.Unstable
 public interface MemberSubscription {
     /**
      * Gets the rack Id if present.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberSubscription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/MemberSubscription.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.coordinator.group.api.assignor;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Optional;
 import java.util.Set;

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/PartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/PartitionAssignor.java
@@ -20,11 +20,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
  * Server-side partition assignor used by the GroupCoordinator.
- *
- * The new consumer group protocol is in preview so this interface is considered
- * unstable until Apache Kafka 4.0.
  */
-@InterfaceStability.Unstable
 public interface PartitionAssignor {
     /**
      * Unique name for this assignor.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/PartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/PartitionAssignor.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.api.assignor;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 /**
  * Server-side partition assignor used by the GroupCoordinator.
  */

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ShareGroupPartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ShareGroupPartitionAssignor.java
@@ -21,6 +21,5 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 /**
  * Server-side partition assignor for share groups used by the GroupCoordinator.
  */
-@InterfaceStability.Unstable
 public interface ShareGroupPartitionAssignor extends PartitionAssignor {
 }

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ShareGroupPartitionAssignor.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/ShareGroupPartitionAssignor.java
@@ -21,5 +21,6 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 /**
  * Server-side partition assignor for share groups used by the GroupCoordinator.
  */
+@InterfaceStability.Unstable
 public interface ShareGroupPartitionAssignor extends PartitionAssignor {
 }

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscribedTopicDescriber.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscribedTopicDescriber.java
@@ -24,11 +24,7 @@ import java.util.Set;
 /**
  * The subscribed topic describer is used by the {@link PartitionAssignor}
  * to obtain topic and partition metadata of the subscribed topics.
- *
- * The interface is kept in an internal module until KIP-848 is fully
- * implemented and ready to be released.
  */
-@InterfaceStability.Unstable
 public interface SubscribedTopicDescriber {
     /**
      * The number of partitions for the given topic Id.

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscribedTopicDescriber.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscribedTopicDescriber.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.coordinator.group.api.assignor;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Set;
 

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscriptionType.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscriptionType.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.api.assignor;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 /**
  * The subscription type followed by a consumer group.
  */

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscriptionType.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/SubscriptionType.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 /**
  * The subscription type followed by a consumer group.
  */
-@InterfaceStability.Unstable
 public enum SubscriptionType {
     /**
      * A homogeneous subscription type means that all the members

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupCurrentMemberAssignmentKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupCurrentMemberAssignmentValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupMemberMetadataKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupMemberMetadataValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupMetadataKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupMetadataValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupPartitionMetadataKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupPartitionMetadataValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupRegularExpressionKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupRegularExpressionValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupRegularExpressionValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMemberKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupTargetAssignmentMemberKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMemberValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupTargetAssignmentMemberValue",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupTargetAssignmentMetadataKey",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupTargetAssignmentMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-848 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "type": "data",
   "name": "ConsumerGroupTargetAssignmentMetadataValue",


### PR DESCRIPTION
KIP-848 will be release as GA in Apache Kafka 4.0. Hence we need to mark all the related public apis as stable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
