### PR TITLE
MINOR: improve StreamsResetter logging

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -687,7 +687,9 @@ public class StreamsResetter {
         }
 
         public List<String> intermediateTopicsOption() {
-            System.out.println("intermediateTopicsOption is deprecated and will be removed in a future release");
+            if (options.has(intermediateTopicsOption)) {
+                System.out.println("WARN: `--intermediate-topics` is deprecated and will be removed in a future release");
+            }
             return options.valuesOf(intermediateTopicsOption);
         }
 


### PR DESCRIPTION
StreamsResetter should log the deprecation warning only if the deprecated flag is used.

Must be cherry-picked to `4.0` branch.
