### PR TITLE
KAFKA-18292: Remove deprecated methods of UpdateFeaturesOptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/UpdateFeaturesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/UpdateFeaturesOptions.java
@@ -29,18 +29,8 @@ import java.util.Map;
 public class UpdateFeaturesOptions extends AbstractOptions<UpdateFeaturesOptions> {
     private boolean validateOnly = false;
 
-    @Deprecated
-    public boolean dryRun() {
-        return validateOnly;
-    }
-
     public boolean validateOnly() {
         return validateOnly;
-    }
-
-    @Deprecated
-    public UpdateFeaturesOptions dryRun(boolean dryRun) {
-        return validateOnly(dryRun);
     }
 
     public UpdateFeaturesOptions validateOnly(boolean validateOnly) {

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -199,6 +199,10 @@
                         <li>The <code>org.apache.kafka.clients.admin.TopicListing.TopicListing(String, boolean)</code> method were removed.
                             Please use <code>org.apache.kafka.clients.admin.TopicListing.TopicListing(String, Uuid, boolean)</code> instead.
                         </li>
+                        <li>
+                            The deprecated <code>dryRun</code> methods were removed from the <code>org.apache.kafka.clients.admin.UpdateFeaturesOptions</code>.
+                            Please use <code>validateOnly</code> instead.
+                        </li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Remove deprecated dryRun methods in UpdateFeaturesOptions class

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
