### PR TITLE
KAFKA-18294: Remove deprecated SourceTask#commitRecord

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -134,28 +134,6 @@ public abstract class SourceTask implements Task {
     /**
      * <p>
      * Commit an individual {@link SourceRecord} when the callback from the producer client is received. This method is
-     * also called when a record is filtered by a transformation, and thus will never be ACK'd by a broker.
-     * <p>
-     * This is an alias for {@link #commitRecord(SourceRecord, RecordMetadata)} for backwards compatibility. The default
-     * implementation of {@link #commitRecord(SourceRecord, RecordMetadata)} just calls this method. It is not necessary
-     * to override both methods.
-     * <p>
-     * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
-     * automatically. This hook is provided for systems that also need to store offsets internally
-     * in their own system.
-     *
-     * @param record {@link SourceRecord} that was successfully sent via the producer or filtered by a transformation
-     * @throws InterruptedException
-     * @deprecated Use {@link #commitRecord(SourceRecord, RecordMetadata)} instead.
-     */
-    @Deprecated
-    public void commitRecord(SourceRecord record) throws InterruptedException {
-        // This space intentionally left blank.
-    }
-
-    /**
-     * <p>
-     * Commit an individual {@link SourceRecord} when the callback from the producer client is received. This method is
      * also called when a record is filtered by a transformation or when "errors.tolerance" is set to "all"
      * and thus will never be ACK'd by a broker.
      * In both cases {@code metadata} will be null.
@@ -164,8 +142,7 @@ public abstract class SourceTask implements Task {
      * automatically. This hook is provided for systems that also need to store offsets internally
      * in their own system.
      * <p>
-     * The default implementation just calls {@link #commitRecord(SourceRecord)}, which is a nop by default. It is
-     * not necessary to implement both methods.
+     * The default implementation is a nop. It is not necessary to implement the method.
      *
      * @param record {@link SourceRecord} that was successfully sent via the producer, filtered by a transformation, or dropped on producer exception
      * @param metadata {@link RecordMetadata} record metadata returned from the broker, or null if the record was filtered or if producer exceptions are ignored
@@ -173,7 +150,6 @@ public abstract class SourceTask implements Task {
      */
     public void commitRecord(SourceRecord record, RecordMetadata metadata)
             throws InterruptedException {
-        // by default, just call other method for backwards compatibility
-        commitRecord(record);
+        // by default, just do nothing
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -737,15 +737,12 @@ public class BlockingConnectorTest {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
-            public void commitRecord(SourceRecord record) throws InterruptedException {
-                block.maybeBlockOn(SOURCE_TASK_COMMIT_RECORD);
-                super.commitRecord(record);
-            }
-
-            @Override
             public void commitRecord(SourceRecord record, RecordMetadata metadata) throws InterruptedException {
-                block.maybeBlockOn(SOURCE_TASK_COMMIT_RECORD_WITH_METADATA);
+                if (metadata == null) {
+                    block.maybeBlockOn(SOURCE_TASK_COMMIT_RECORD);
+                } else {
+                    block.maybeBlockOn(SOURCE_TASK_COMMIT_RECORD_WITH_METADATA);
+                }
                 super.commitRecord(record, metadata);
             }
         }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -162,6 +162,8 @@
                         <li>The <code>onPartitionsRevoked(Collection&lt;TopicPartition&gt;)</code> and <code>onPartitionsAssigned(Collection&lt;TopicPartition&gt;)</code> methods
                             were removed from <code>SinkTask</code>.
                         </li>
+                        <li>The <code>commitRecord(SourceRecord)</code> method was removed from <code>SourceTask</code>.
+                        </li>
                     </ul>
                 </li>
                 <li><b>Consumer</b>


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-18294

remove deprecated method `commitRecord(SourceRecord)`

<img width="633" alt="zzz" src="https://github.com/user-attachments/assets/e7ec58e1-2e1c-47c1-83f9-c001a8b94c16" />


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
