### PR TITLE
KAFKA-18270: FindCoordinator v0 incorrectly tagged as deprecated

### DIFF
--- a/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+++ b/clients/src/main/resources/common/message/FindCoordinatorRequest.json
@@ -31,7 +31,6 @@
   // Version 6 adds support for share groups (KIP-932).
   // For key type SHARE (2), the coordinator key format is "groupId:topicId:partition".
   "validVersions": "0-6",
-  "deprecatedVersions": "0",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "Key", "type": "string", "versions": "0-3",


### PR DESCRIPTION
It's now consistent with KIP-896.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
