### PR TITLE
KAFKA-18035, KAFKA-18306, KAFKA-18092: Address TransactionsTest flaky tests

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -741,7 +741,7 @@ class TransactionsTest extends IntegrationTestHarness {
 
       producer.beginTransaction()
       val successfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
-      TestUtils.waitUntilTrue(successfulFuture.isDone, "First message of the second transaction did not complete its send.")
+      successfulFuture.get(20, TimeUnit.SECONDS)
 
       killBroker(partitionLeader) // kill the partition leader to prevent the batch from being submitted
       val failedFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "3", "3", willBeCommitted = false))
@@ -803,7 +803,7 @@ class TransactionsTest extends IntegrationTestHarness {
       // Second transaction: abort
       producer.beginTransaction()
       val successfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
-      TestUtils.waitUntilTrue(successfulFuture.isDone, "First message of the second transaction did not complete its send.")
+      successfulFuture.get(20, TimeUnit.SECONDS)
 
       // Get producerId and epoch after first commit. Check after the first successful send of the next transaction to confirm the commit is complete.
       val log = brokers(partitionLeader).logManager.getLog(new TopicPartition(testTopic, 0)).get
@@ -825,7 +825,7 @@ class TransactionsTest extends IntegrationTestHarness {
       // Third transaction: commit
       producer.beginTransaction()
       val nextSuccessfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic2, null, "2", "2", willBeCommitted = true))
-      TestUtils.waitUntilTrue(nextSuccessfulFuture.isDone, "First message of the third transaction did not complete its send.")
+      nextSuccessfulFuture.get(20, TimeUnit.SECONDS)
 
       // Confirm the epoch bumped after the previous abort.
       producerStateEntry =

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -711,7 +711,6 @@ class TransactionsTest extends IntegrationTestHarness {
     assertThrows(classOf[IllegalStateException], () => producer.initTransactions())
   }
 
-  @Flaky("KAFKA-18035,KAFKA-18036")
   @ParameterizedTest
   @CsvSource(Array(
     "kraft,classic,false",
@@ -741,7 +740,8 @@ class TransactionsTest extends IntegrationTestHarness {
       val initialProducerEpoch = producerStateEntry.producerEpoch
 
       producer.beginTransaction()
-      producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
+      val successfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
+      TestUtils.waitUntilTrue(successfulFuture.isDone, "First message of the second transaction did not complete its send.")
 
       killBroker(partitionLeader) // kill the partition leader to prevent the batch from being submitted
       val failedFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "3", "3", willBeCommitted = false))
@@ -777,7 +777,6 @@ class TransactionsTest extends IntegrationTestHarness {
     }
   }
 
-  @Flaky("KAFKA-18092")
   @ParameterizedTest
   @CsvSource(Array(
     "kraft, classic, true",
@@ -801,20 +800,19 @@ class TransactionsTest extends IntegrationTestHarness {
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "4", "4", willBeCommitted = true))
       producer.commitTransaction()
 
-      // Get producerId and epoch after first commit
+      // Second transaction: abort
+      producer.beginTransaction()
+      val successfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
+      TestUtils.waitUntilTrue(successfulFuture.isDone, "First message of the second transaction did not complete its send.")
+
+      // Get producerId and epoch after first commit. Check after the first successful send of the next transaction to confirm the commit is complete.
       val log = brokers(partitionLeader).logManager.getLog(new TopicPartition(testTopic, 0)).get
       val producerStateManager = log.producerStateManager
       val activeProducersIter = producerStateManager.activeProducers.entrySet().iterator()
       assertTrue(activeProducersIter.hasNext)
       var producerStateEntry = activeProducersIter.next().getValue
       val producerId = producerStateEntry.producerId
-      var previousProducerEpoch = producerStateEntry.producerEpoch
-
-      Thread.sleep(3000) // Wait for the markers to be persisted and the transaction state to be updated.
-
-      // Second transaction: abort
-      producer.beginTransaction()
-      producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
+      val previousProducerEpoch = producerStateEntry.producerEpoch
 
       killBroker(partitionLeader) // kill the partition leader to prevent the batch from being submitted
       val failedFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "3", "3", willBeCommitted = false))
@@ -824,39 +822,21 @@ class TransactionsTest extends IntegrationTestHarness {
       org.apache.kafka.test.TestUtils.assertFutureThrows(failedFuture, classOf[TimeoutException])
       producer.abortTransaction()
 
-      // Get producer epoch after abortTransaction and verify it has increased.
-      producerStateEntry =
-        brokers(partitionLeader).logManager.getLog(new TopicPartition(testTopic, 0)).get.producerStateManager.activeProducers.get(producerId)
-      // Assert that producerStateEntry is not null
-      assertNotNull(producerStateEntry, "Producer state entry should not be null after abortTransaction")
-
-      val currentProducerEpoch = producerStateEntry.producerEpoch
-      assertTrue(currentProducerEpoch > previousProducerEpoch,
-        s"Producer epoch after abortTransaction ($currentProducerEpoch) should be greater than after first commit ($previousProducerEpoch)"
-      )
-      // Update previousProducerEpoch
-      previousProducerEpoch = currentProducerEpoch
-
       // Third transaction: commit
       producer.beginTransaction()
-      producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic2, null, "2", "2", willBeCommitted = true))
+      val nextSuccessfulFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic2, null, "2", "2", willBeCommitted = true))
+      TestUtils.waitUntilTrue(nextSuccessfulFuture.isDone, "First message of the third transaction did not complete its send.")
+
+      // Confirm the epoch bumped after the previous abort.
+      producerStateEntry =
+        brokers(partitionLeader).logManager.getLog(new TopicPartition(topic2, 0)).get.producerStateManager.activeProducers.get(producerId)
+      assertNotNull(producerStateEntry)
+      assertTrue(producerStateEntry.producerEpoch > previousProducerEpoch)
+
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "4", "4", willBeCommitted = true))
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "1", "1", willBeCommitted = true))
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "3", "3", willBeCommitted = true))
       producer.commitTransaction()
-
-      // Wait until the producer epoch has been updated on the broker
-      TestUtils.waitUntilTrue(() => {
-        val logOption = brokers(partitionLeader).logManager.getLog(new TopicPartition(testTopic, 0))
-        logOption.exists { log =>
-          val producerStateEntry = log.producerStateManager.activeProducers.get(producerId)
-          producerStateEntry != null && producerStateEntry.producerEpoch > previousProducerEpoch
-        }
-      }, "Timed out waiting for producer epoch to be incremented after second commit", 10000)
-
-      // Now that we've verified that the producer epoch has increased,
-      // update the previous producer epoch.
-      previousProducerEpoch = currentProducerEpoch
 
       consumer.subscribe(List(topic1, topic2, testTopic).asJava)
 
@@ -932,7 +912,7 @@ class TransactionsTest extends IntegrationTestHarness {
 
     // Check that the epoch only increased by 1 when TV2 is disabled.
     // With TV2 and the latest EndTxnRequest version, the epoch will be bumped at the end of every transaction aka
-    // three times (once after each commit and once after the timeout exception)
+    // three times (once after each commit and once after the timeout exception). The last bump is less consistent, so ensure the first two happen.
     producerStateEntry =
       brokers(partitionLeader).logManager.getLog(new TopicPartition(topic1, 0)).get.producerStateManager.activeProducers.get(producerId)
     assertNotNull(producerStateEntry)
@@ -940,10 +920,7 @@ class TransactionsTest extends IntegrationTestHarness {
     if (!isTV2Enabled) {
       assertEquals((initialProducerEpoch + 1).toShort, producerStateEntry.producerEpoch)
     } else {
-      // Wait until the producer epoch has been updated on the broker.
-      TestUtils.waitUntilTrue(() => {
-          producerStateEntry != null && producerStateEntry.producerEpoch == initialProducerEpoch + 3
-      }, "Timed out waiting for producer epoch to be incremented after second commit", 10000)
+      assertTrue((initialProducerEpoch + 1).toShort <= producerStateEntry.producerEpoch)
     }
   }
 


### PR DESCRIPTION
A lot of these tests assumed that the commit/abort happened immediately. Spoiler alert -- it does not. 

For some I ensure that the first send of the next transaction is successful before grabbing the epoch. I also loosened some checks since we don't need to guarantee the exact epoch. 

I went back and forth with completely deleting `testBumpTransactionalEpochWithTV2Enabled` since we don't have client side epoch bumps with V2 (which is what the test was originally testing), but I opted to keep it to just confirm the epoch on each transaction -- even in the timeout scenario.