### PR TITLE
MINOR: Add 3.8.1 version to version.py

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -274,7 +274,8 @@ LATEST_3_7 = V_3_7_2
 
 # 3.8.x version
 V_3_8_0 = KafkaVersion("3.8.0")
-LATEST_3_8 = V_3_8_0
+V_3_8_1 = KafkaVersion("3.8.1")
+LATEST_3_8 = V_3_8_1
 
 # 3.9.x version
 V_3_9_0 = KafkaVersion("3.9.0")


### PR DESCRIPTION
In https://github.com/apache/kafka/commit/bffe212b76247bab4d3613ffdd9eb75e9d4e7b26, we updated 3.8  download link to 3.8.1. We need to update version.py .