### PR TITLE
KAFKA-18321: Add StreamsGroupMember, MemberState and Assignment classes

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -321,7 +321,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(ConsumerGroupMember|GroupMetadataManager|GeneralUniformAssignmentBuilder|GroupCoordinatorRecordSerde).java"/>
     <suppress checks="(NPathComplexity|MethodLength)"
-              files="(GroupMetadataManager|ConsumerGroupTest|ShareGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder).java"/>
+              files="(GroupMetadataManager|ConsumerGroupTest|ShareGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder|StreamsGroupMemberTest).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"
@@ -329,7 +329,7 @@
     <suppress checks="ClassDataAbstractionCouplingCheck"
               files="(RecordHelpersTest|GroupCoordinatorRecordHelpers|GroupMetadataManager|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest|GroupCoordinatorRecordSerde).java"/>
     <suppress checks="JavaNCSS"
-              files="(GroupMetadataManager|GroupMetadataManagerTest).java"/>
+              files="(GroupMetadataManager|GroupMetadataManagerTest|StreamsGroupMemberTest).java"/>
 
     <!-- coordinator-common -->
     <suppress checks="NPathComplexity"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -321,7 +321,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(ConsumerGroupMember|GroupMetadataManager|GeneralUniformAssignmentBuilder|GroupCoordinatorRecordSerde).java"/>
     <suppress checks="(NPathComplexity|MethodLength)"
-              files="(GroupMetadataManager|ConsumerGroupTest|ShareGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder|StreamsGroupMemberTest).java"/>
+              files="(GroupMetadataManager|ConsumerGroupTest|ShareGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -329,7 +329,7 @@
     <suppress checks="ClassDataAbstractionCouplingCheck"
               files="(RecordHelpersTest|GroupCoordinatorRecordHelpers|GroupMetadataManager|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest|GroupCoordinatorRecordSerde).java"/>
     <suppress checks="JavaNCSS"
-              files="(GroupMetadataManager|GroupMetadataManagerTest|StreamsGroupMemberTest).java"/>
+              files="(GroupMetadataManager|GroupMetadataManagerTest).java"/>
 
     <!-- coordinator-common -->
     <suppress checks="NPathComplexity"

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An immutable assignment for a member.
+ */
+public class Assignment {
+
+    public static final Assignment EMPTY = new Assignment(
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap()
+    );
+
+    private final Map<String, Set<Integer>> activeTasks;
+    private final Map<String, Set<Integer>> standbyTasks;
+    private final Map<String, Set<Integer>> warmupTasks;
+
+    public Assignment(final Map<String, Set<Integer>> activeTasks,
+                      final Map<String, Set<Integer>> standbyTasks,
+                      final Map<String, Set<Integer>> warmupTasks) {
+        this.activeTasks = Collections.unmodifiableMap(Objects.requireNonNull(activeTasks));
+        this.standbyTasks = Collections.unmodifiableMap(Objects.requireNonNull(standbyTasks));
+        this.warmupTasks = Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks));
+    }
+
+    /**
+     * @return The assigned active tasks.
+     */
+    public Map<String, Set<Integer>> activeTasks() {
+        return activeTasks;
+    }
+
+    /**
+     * @return The assigned standby tasks.
+     */
+    public Map<String, Set<Integer>> standbyTasks() {
+        return standbyTasks;
+    }
+
+    /**
+     * @return The assigned warm-up tasks.
+     */
+    public Map<String, Set<Integer>> warmupTasks() {
+        return warmupTasks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Assignment that = (Assignment) o;
+        return Objects.equals(activeTasks, that.activeTasks)
+            && Objects.equals(standbyTasks, that.standbyTasks)
+            && Objects.equals(warmupTasks, that.warmupTasks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activeTasks, standbyTasks, warmupTasks);
+    }
+
+    @Override
+    public String toString() {
+        return "Assignment(active tasks=" + activeTasks +
+            ", standby tasks=" + standbyTasks +
+            ", warm-up tasks=" + warmupTasks + ')';
+    }
+
+    /**
+     * Creates a {{@link org.apache.kafka.coordinator.group.streams.Assignment}} from a
+     * {{@link org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue}}.
+     *
+     * @param record The record.
+     * @return A {{@link org.apache.kafka.coordinator.group.streams.Assignment}}.
+     */
+    public static Assignment fromRecord(
+        StreamsGroupTargetAssignmentMemberValue record
+    ) {
+        return new Assignment(
+            record.activeTasks().stream()
+                .collect(Collectors.toMap(
+                        StreamsGroupTargetAssignmentMemberValue.TaskIds::subtopologyId,
+                        taskId -> new HashSet<>(taskId.partitions())
+                    )
+                ),
+            record.standbyTasks().stream()
+                .collect(Collectors.toMap(
+                        StreamsGroupTargetAssignmentMemberValue.TaskIds::subtopologyId,
+                        taskId -> new HashSet<>(taskId.partitions())
+                    )
+                ),
+            record.warmupTasks().stream()
+                .collect(Collectors.toMap(
+                        StreamsGroupTargetAssignmentMemberValue.TaskIds::subtopologyId,
+                        taskId -> new HashSet<>(taskId.partitions())
+                    )
+                )
+        );
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
@@ -28,72 +28,21 @@ import java.util.stream.Collectors;
 /**
  * An immutable assignment for a member.
  */
-public class Assignment {
+public record Assignment(Map<String, Set<Integer>> activeTasks,
+                         Map<String, Set<Integer>> standbyTasks,
+                         Map<String, Set<Integer>> warmupTasks) {
+
+    public Assignment {
+        activeTasks = Collections.unmodifiableMap(Objects.requireNonNull(activeTasks));
+        standbyTasks = Collections.unmodifiableMap(Objects.requireNonNull(standbyTasks));
+        warmupTasks = Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks));
+    }
 
     public static final Assignment EMPTY = new Assignment(
         Collections.emptyMap(),
         Collections.emptyMap(),
         Collections.emptyMap()
     );
-
-    private final Map<String, Set<Integer>> activeTasks;
-    private final Map<String, Set<Integer>> standbyTasks;
-    private final Map<String, Set<Integer>> warmupTasks;
-
-    public Assignment(final Map<String, Set<Integer>> activeTasks,
-                      final Map<String, Set<Integer>> standbyTasks,
-                      final Map<String, Set<Integer>> warmupTasks) {
-        this.activeTasks = Collections.unmodifiableMap(Objects.requireNonNull(activeTasks));
-        this.standbyTasks = Collections.unmodifiableMap(Objects.requireNonNull(standbyTasks));
-        this.warmupTasks = Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks));
-    }
-
-    /**
-     * @return The assigned active tasks.
-     */
-    public Map<String, Set<Integer>> activeTasks() {
-        return activeTasks;
-    }
-
-    /**
-     * @return The assigned standby tasks.
-     */
-    public Map<String, Set<Integer>> standbyTasks() {
-        return standbyTasks;
-    }
-
-    /**
-     * @return The assigned warm-up tasks.
-     */
-    public Map<String, Set<Integer>> warmupTasks() {
-        return warmupTasks;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Assignment that = (Assignment) o;
-        return Objects.equals(activeTasks, that.activeTasks)
-            && Objects.equals(standbyTasks, that.standbyTasks)
-            && Objects.equals(warmupTasks, that.warmupTasks);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(activeTasks, standbyTasks, warmupTasks);
-    }
-
-    @Override
-    public String toString() {
-        return "Assignment(active tasks=" + activeTasks +
-            ", standby tasks=" + standbyTasks +
-            ", warm-up tasks=" + warmupTasks + ')';
-    }
 
     /**
      * Creates a {{@link org.apache.kafka.coordinator.group.streams.Assignment}} from a

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/Assignment.java
@@ -27,6 +27,13 @@ import java.util.stream.Collectors;
 
 /**
  * An immutable assignment for a member.
+ *
+ * @param activeTasks           Active tasks assigned to the member.
+ *                              The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param standbyTasks          Standby tasks assigned to the member.
+ *                              The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param warmupTasks           Warm-up tasks assigned to the member.
+ *                              The key of the map is the subtopology ID and the value is the set of partition IDs.
  */
 public record Assignment(Map<String, Set<Integer>> activeTasks,
                          Map<String, Set<Integer>> standbyTasks,
@@ -38,6 +45,9 @@ public record Assignment(Map<String, Set<Integer>> activeTasks,
         warmupTasks = Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks));
     }
 
+    /**
+     * An empty assignment.
+     */
     public static final Assignment EMPTY = new Assignment(
         Collections.emptyMap(),
         Collections.emptyMap(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/MemberState.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/MemberState.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The various states that a member can be in. For their definition, refer to the documentation of
+ * {{@link org.apache.kafka.coordinator.group.streams.CurrentAssignmentBuilder}}.
+ */
+public enum MemberState {
+
+    /**
+     * The member is fully reconciled with the desired target assignment.
+     */
+    STABLE((byte) 1),
+
+    /**
+     * The member must revoke some tasks in order to be able to transition to the next epoch.
+     */
+    UNREVOKED_TASKS((byte) 2),
+
+    /**
+     * The member transitioned to the last epoch but waits on some tasks which have not been revoked by their previous owners yet.
+     */
+    UNRELEASED_TASKS((byte) 3),
+
+    /**
+     * The member is in an unknown state. This can only happen if a future version of the software introduces a new state unknown by this
+     * version.
+     */
+    UNKNOWN((byte) 127);
+
+    private static final Map<Byte, MemberState> VALUES_TO_ENUMS = new HashMap<>();
+
+    static {
+        for (MemberState state : MemberState.values()) {
+            VALUES_TO_ENUMS.put(state.value(), state);
+        }
+    }
+
+    private final byte value;
+
+    MemberState(byte value) {
+        this.value = value;
+    }
+
+    public byte value() {
+        return value;
+    }
+
+    public static MemberState fromValue(byte value) {
+        MemberState state = VALUES_TO_ENUMS.get(value);
+        if (state == null) {
+            return UNKNOWN;
+        }
+        return state;
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -1,0 +1,756 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * StreamsGroupMember contains all the information related to a member within a Streams group. This class is immutable and is fully backed
+ * by records stored in the __consumer_offsets topic.
+ */
+public class StreamsGroupMember {
+
+  /**
+     * A builder that facilitates the creation of a new member or the update of an existing one.
+     * <p>
+     * Please refer to the javadoc of {{@link StreamsGroupMember}} for the definition of the fields.
+     */
+    public static class Builder {
+
+        private final String memberId;
+        private int memberEpoch = 0;
+        private int previousMemberEpoch = -1;
+        private MemberState state = MemberState.STABLE;
+        private String instanceId = null;
+        private String rackId = null;
+        private int rebalanceTimeoutMs = -1;
+        private String clientId = "";
+        private String clientHost = "";
+        private int topologyEpoch = -1;
+        private String processId;
+        private StreamsGroupMemberMetadataValue.Endpoint userEndpoint;
+        private Map<String, String> clientTags = Collections.emptyMap();
+        private Map<String, Set<Integer>> assignedActiveTasks = Collections.emptyMap();
+        private Map<String, Set<Integer>> assignedStandbyTasks = Collections.emptyMap();
+        private Map<String, Set<Integer>> assignedWarmupTasks = Collections.emptyMap();
+        private Map<String, Set<Integer>> activeTasksPendingRevocation = Collections.emptyMap();
+        private Map<String, Set<Integer>> standbyTasksPendingRevocation = Collections.emptyMap();
+        private Map<String, Set<Integer>> warmupTasksPendingRevocation = Collections.emptyMap();
+
+        public Builder(String memberId) {
+            this.memberId = Objects.requireNonNull(memberId);
+        }
+
+        public Builder(StreamsGroupMember member) {
+            Objects.requireNonNull(member);
+
+            this.memberId = member.memberId;
+            this.memberEpoch = member.memberEpoch;
+            this.previousMemberEpoch = member.previousMemberEpoch;
+            this.instanceId = member.instanceId;
+            this.rackId = member.rackId;
+            this.rebalanceTimeoutMs = member.rebalanceTimeoutMs;
+            this.clientId = member.clientId;
+            this.clientHost = member.clientHost;
+            this.topologyEpoch = member.topologyEpoch;
+            this.processId = member.processId;
+            this.userEndpoint = member.userEndpoint;
+            this.clientTags = member.clientTags;
+            this.state = member.state;
+            this.assignedActiveTasks = member.assignedActiveTasks;
+            this.assignedStandbyTasks = member.assignedStandbyTasks;
+            this.assignedWarmupTasks = member.assignedWarmupTasks;
+            this.activeTasksPendingRevocation = member.activeTasksPendingRevocation;
+            this.standbyTasksPendingRevocation = member.standbyTasksPendingRevocation;
+            this.warmupTasksPendingRevocation = member.warmupTasksPendingRevocation;
+        }
+
+        public Builder updateMemberEpoch(int memberEpoch) {
+            int currentMemberEpoch = this.memberEpoch;
+            this.memberEpoch = memberEpoch;
+            this.previousMemberEpoch = currentMemberEpoch;
+            return this;
+        }
+
+        public Builder setMemberEpoch(int memberEpoch) {
+            this.memberEpoch = memberEpoch;
+            return this;
+        }
+
+        public Builder setPreviousMemberEpoch(int previousMemberEpoch) {
+            this.previousMemberEpoch = previousMemberEpoch;
+            return this;
+        }
+
+        public Builder setInstanceId(String instanceId) {
+            this.instanceId = instanceId;
+            return this;
+        }
+
+        public Builder maybeUpdateInstanceId(Optional<String> instanceId) {
+            this.instanceId = instanceId.orElse(this.instanceId);
+            return this;
+        }
+
+        public Builder setRackId(String rackId) {
+            this.rackId = rackId;
+            return this;
+        }
+
+        public Builder maybeUpdateRackId(Optional<String> rackId) {
+            this.rackId = rackId.orElse(this.rackId);
+            return this;
+        }
+
+        public Builder setRebalanceTimeoutMs(int rebalanceTimeoutMs) {
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+            return this;
+        }
+
+        public Builder maybeUpdateRebalanceTimeoutMs(OptionalInt rebalanceTimeoutMs) {
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs.orElse(this.rebalanceTimeoutMs);
+            return this;
+        }
+
+        public Builder setClientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder setClientHost(String clientHost) {
+            this.clientHost = clientHost;
+            return this;
+        }
+
+        public Builder setState(MemberState state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder setTopologyEpoch(int topologyEpoch) {
+            this.topologyEpoch = topologyEpoch;
+            return this;
+        }
+
+        public Builder maybeUpdateTopologyEpoch(OptionalInt topologyEpoch) {
+            this.topologyEpoch = topologyEpoch.orElse(this.topologyEpoch);
+            return this;
+        }
+
+        public Builder setProcessId(String processId) {
+            this.processId = processId;
+            return this;
+        }
+
+        public Builder maybeUpdateProcessId(Optional<String> processId) {
+            this.processId = processId.orElse(this.processId);
+            return this;
+        }
+
+        public Builder setUserEndpoint(StreamsGroupMemberMetadataValue.Endpoint userEndpoint) {
+            this.userEndpoint = userEndpoint;
+            return this;
+        }
+
+        public Builder maybeUpdateUserEndpoint(Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint) {
+            this.userEndpoint = userEndpoint.orElse(this.userEndpoint);
+            return this;
+        }
+
+        public Builder setClientTags(Map<String, String> clientTags) {
+            this.clientTags = clientTags;
+            return this;
+        }
+
+        public Builder maybeUpdateClientTags(Optional<Map<String, String>> clientTags) {
+            this.clientTags = clientTags.orElse(this.clientTags);
+            return this;
+        }
+
+        public Builder setAssignment(Assignment assignment) {
+            this.assignedActiveTasks = assignment.activeTasks();
+            this.assignedStandbyTasks = assignment.standbyTasks();
+            this.assignedWarmupTasks = assignment.warmupTasks();
+            return this;
+        }
+
+        public Builder setAssignedActiveTasks(Map<String, Set<Integer>> assignedActiveTasks) {
+            this.assignedActiveTasks = assignedActiveTasks;
+            return this;
+        }
+
+        public Builder setAssignedStandbyTasks(Map<String, Set<Integer>> assignedStandbyTasks) {
+            this.assignedStandbyTasks = assignedStandbyTasks;
+            return this;
+        }
+
+        public Builder setAssignedWarmupTasks(Map<String, Set<Integer>> assignedWarmupTasks) {
+            this.assignedWarmupTasks = assignedWarmupTasks;
+            return this;
+        }
+
+        public Builder setAssignmentPendingRevocation(Assignment assignment) {
+            this.activeTasksPendingRevocation = assignment.activeTasks();
+            this.standbyTasksPendingRevocation = assignment.standbyTasks();
+            this.warmupTasksPendingRevocation = assignment.warmupTasks();
+            return this;
+        }
+
+        public Builder setActiveTasksPendingRevocation(
+            Map<String, Set<Integer>> activeTasksPendingRevocation) {
+            this.activeTasksPendingRevocation = activeTasksPendingRevocation;
+            return this;
+        }
+
+        public Builder setStandbyTasksPendingRevocation(
+            Map<String, Set<Integer>> standbyTasksPendingRevocation) {
+            this.standbyTasksPendingRevocation = standbyTasksPendingRevocation;
+            return this;
+        }
+
+        public Builder setWarmupTasksPendingRevocation(
+            Map<String, Set<Integer>> warmupTasksPendingRevocation) {
+            this.warmupTasksPendingRevocation = warmupTasksPendingRevocation;
+            return this;
+        }
+
+        public Builder updateWith(StreamsGroupMemberMetadataValue record) {
+            setInstanceId(record.instanceId());
+            setRackId(record.rackId());
+            setClientId(record.clientId());
+            setClientHost(record.clientHost());
+            setRebalanceTimeoutMs(record.rebalanceTimeoutMs());
+            setTopologyEpoch(record.topologyEpoch());
+            setProcessId(record.processId());
+            setUserEndpoint(record.userEndpoint());
+            setClientTags(record.clientTags().stream().collect(Collectors.toMap(
+                StreamsGroupMemberMetadataValue.KeyValue::key,
+                StreamsGroupMemberMetadataValue.KeyValue::value
+            )));
+            return this;
+        }
+
+        public Builder updateWith(StreamsGroupCurrentMemberAssignmentValue record) {
+            setMemberEpoch(record.memberEpoch());
+            setPreviousMemberEpoch(record.previousMemberEpoch());
+            setState(MemberState.fromValue(record.state()));
+            setAssignedActiveTasks(assignmentFromTaskIds(record.activeTasks()));
+            setAssignedStandbyTasks(assignmentFromTaskIds(record.standbyTasks()));
+            setAssignedWarmupTasks(assignmentFromTaskIds(record.warmupTasks()));
+            setActiveTasksPendingRevocation(
+                assignmentFromTaskIds(record.activeTasksPendingRevocation()));
+            setStandbyTasksPendingRevocation(
+                assignmentFromTaskIds(record.standbyTasksPendingRevocation()));
+            setWarmupTasksPendingRevocation(
+                assignmentFromTaskIds(record.warmupTasksPendingRevocation()));
+            return this;
+        }
+
+        private Map<String, Set<Integer>> assignmentFromTaskIds(
+            List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> topicPartitionsList
+        ) {
+            return topicPartitionsList.stream().collect(Collectors.toMap(
+                StreamsGroupCurrentMemberAssignmentValue.TaskIds::subtopologyId,
+                taskIds -> Collections.unmodifiableSet(new HashSet<>(taskIds.partitions()))));
+        }
+
+        public StreamsGroupMember build() {
+            return new StreamsGroupMember(
+                memberId,
+                memberEpoch,
+                previousMemberEpoch,
+                instanceId,
+                rackId,
+                rebalanceTimeoutMs,
+                clientId,
+                clientHost,
+                topologyEpoch,
+                processId,
+                userEndpoint,
+                clientTags,
+                state,
+                assignedActiveTasks,
+                assignedStandbyTasks,
+                assignedWarmupTasks,
+                activeTasksPendingRevocation,
+                standbyTasksPendingRevocation,
+                warmupTasksPendingRevocation
+            );
+        }
+    }
+
+    /**
+     * The member id.
+     */
+    private final String memberId;
+
+    /**
+     * The current member epoch.
+     */
+    private final int memberEpoch;
+
+    /**
+     * The previous member epoch.
+     */
+    private final int previousMemberEpoch;
+
+    /**
+     * The member state.
+     */
+    private final MemberState state;
+
+    /**
+     * The instance id provided by the member.
+     */
+    private final String instanceId;
+
+    /**
+     * The rack id provided by the member.
+     */
+    private final String rackId;
+
+    /**
+     * The rebalance timeout provided by the member.
+     */
+    private final int rebalanceTimeoutMs;
+
+    /**
+     * The client id reported by the member.
+     */
+    private final String clientId;
+
+    /**
+     * The host reported by the member.
+     */
+    private final String clientHost;
+
+    /**
+     * The topology epoch
+     */
+    private final int topologyEpoch;
+
+    /**
+     * The process ID
+     */
+    private final String processId;
+
+    /**
+     * The endpoint
+     */
+    private final StreamsGroupMemberMetadataValue.Endpoint userEndpoint;
+
+    /**
+     * The client tags
+     */
+    private final Map<String, String> clientTags;
+
+    /**
+     * Active tasks assigned to this member.
+     */
+    private final Map<String, Set<Integer>> assignedActiveTasks;
+
+    /**
+     * Standby tasks assigned to this member.
+     */
+    private final Map<String, Set<Integer>> assignedStandbyTasks;
+
+    /**
+     * Warmup tasks assigned to this member.
+     */
+    private final Map<String, Set<Integer>> assignedWarmupTasks;
+
+    /**
+     * Active tasks being revoked by this member.
+     */
+    private final Map<String, Set<Integer>> activeTasksPendingRevocation;
+
+    /**
+     * Standby tasks being revoked by this member.
+     */
+    private final Map<String, Set<Integer>> standbyTasksPendingRevocation;
+
+    /**
+     * Warmup tasks being revoked by this member.
+     */
+    private final Map<String, Set<Integer>> warmupTasksPendingRevocation;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private StreamsGroupMember(
+        String memberId,
+        int memberEpoch,
+        int previousMemberEpoch,
+        String instanceId,
+        String rackId,
+        int rebalanceTimeoutMs,
+        String clientId,
+        String clientHost,
+        int topologyEpoch,
+        String processId,
+        StreamsGroupMemberMetadataValue.Endpoint userEndpoint,
+        Map<String, String> clientTags,
+        MemberState state,
+        Map<String, Set<Integer>> assignedActiveTasks,
+        Map<String, Set<Integer>> assignedStandbyTasks,
+        Map<String, Set<Integer>> assignedWarmupTasks,
+        Map<String, Set<Integer>> activeTasksPendingRevocation,
+        Map<String, Set<Integer>> standbyTasksPendingRevocation,
+        Map<String, Set<Integer>> warmupTasksPendingRevocation
+    ) {
+        this.memberId = memberId;
+        this.memberEpoch = memberEpoch;
+        this.previousMemberEpoch = previousMemberEpoch;
+        this.state = state;
+        this.instanceId = instanceId;
+        this.rackId = rackId;
+        this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+        this.clientId = clientId;
+        this.clientHost = clientHost;
+        this.topologyEpoch = topologyEpoch;
+        this.processId = processId;
+        this.userEndpoint = userEndpoint;
+        this.clientTags = clientTags;
+        this.assignedActiveTasks = assignedActiveTasks;
+        this.assignedStandbyTasks = assignedStandbyTasks;
+        this.assignedWarmupTasks = assignedWarmupTasks;
+        this.activeTasksPendingRevocation = activeTasksPendingRevocation;
+        this.standbyTasksPendingRevocation = standbyTasksPendingRevocation;
+        this.warmupTasksPendingRevocation = warmupTasksPendingRevocation;
+    }
+
+    /**
+     * @return The member id.
+     */
+    public String memberId() {
+        return memberId;
+    }
+
+    /**
+     * @return The current member epoch.
+     */
+    public int memberEpoch() {
+        return memberEpoch;
+    }
+
+    /**
+     * @return The previous member epoch.
+     */
+    public int previousMemberEpoch() {
+        return previousMemberEpoch;
+    }
+
+    /**
+     * @return The instance id.
+     */
+    public String instanceId() {
+        return instanceId;
+    }
+
+    /**
+     * @return The rack id.
+     */
+    public String rackId() {
+        return rackId;
+    }
+
+    /**
+     * @return The rebalance timeout in millis.
+     */
+    public int rebalanceTimeoutMs() {
+        return rebalanceTimeoutMs;
+    }
+
+    /**
+     * @return The client id.
+     */
+    public String clientId() {
+        return clientId;
+    }
+
+    /**
+     * @return The client host.
+     */
+    public String clientHost() {
+        return clientHost;
+    }
+
+    /**
+     * @return The topology epoch
+     */
+    public int topologyEpoch() {
+        return topologyEpoch;
+    }
+
+    /**
+     * @return The process ID
+     */
+    public String processId() {
+        return processId;
+    }
+
+    /**
+     * @return The user endpoint
+     */
+    public StreamsGroupMemberMetadataValue.Endpoint userEndpoint() {
+        return userEndpoint;
+    }
+
+    /**
+     * @return The client tags
+     */
+    public Map<String, String> clientTags() {
+        return clientTags;
+    }
+
+    /**
+     * @return The current state.
+     */
+    public MemberState state() {
+        return state;
+    }
+
+    /**
+     * @return True if the member is in the Stable state and at the desired epoch.
+     */
+    public boolean isReconciledTo(int targetAssignmentEpoch) {
+        return state == MemberState.STABLE && memberEpoch == targetAssignmentEpoch;
+    }
+
+    /**
+     * @return The set of assigned active tasks.
+     */
+    public Map<String, Set<Integer>> assignedActiveTasks() {
+        return assignedActiveTasks;
+    }
+
+    /**
+     * @return The set of assigned standby tasks.
+     */
+    public Map<String, Set<Integer>> assignedStandbyTasks() {
+        return assignedStandbyTasks;
+    }
+
+    /**
+     * @return The set of assigned warm-up tasks.
+     */
+    public Map<String, Set<Integer>> assignedWarmupTasks() {
+        return assignedWarmupTasks;
+    }
+
+    /**
+     * @return The set of active tasks awaiting revocation from the member.
+     */
+    public Map<String, Set<Integer>> activeTasksPendingRevocation() {
+        return activeTasksPendingRevocation;
+    }
+
+    /**
+     * @return The set of standby tasks awaiting revocation from the member.
+     */
+    public Map<String, Set<Integer>> standbyTasksPendingRevocation() {
+        return standbyTasksPendingRevocation;
+    }
+
+    /**
+     * @return The set of warmup tasks awaiting revocation from the member.
+     */
+    public Map<String, Set<Integer>> warmupTasksPendingRevocation() {
+        return warmupTasksPendingRevocation;
+    }
+
+    /**
+     * @param targetAssignment The target assignment of this member in the corresponding group.
+     *
+     * @return The StreamsGroupMember mapped as StreamsGroupDescribeResponseData.Member.
+     */
+    public StreamsGroupDescribeResponseData.Member asStreamsGroupDescribeMember(
+        Assignment targetAssignment
+    ) {
+        final StreamsGroupDescribeResponseData.Assignment describedTargetAssignment =
+            new StreamsGroupDescribeResponseData.Assignment();
+
+        if (targetAssignment != null) {
+            describedTargetAssignment
+                .setActiveTasks(taskIdsFromMap(targetAssignment.activeTasks()))
+                .setStandbyTasks(taskIdsFromMap(targetAssignment.standbyTasks()))
+                .setWarmupTasks(taskIdsFromMap(targetAssignment.warmupTasks()));
+        }
+
+        return new StreamsGroupDescribeResponseData.Member()
+            .setMemberEpoch(memberEpoch)
+            .setMemberId(memberId)
+            .setAssignment(
+                new StreamsGroupDescribeResponseData.Assignment()
+                    .setActiveTasks(taskIdsFromMap(assignedActiveTasks))
+                    .setStandbyTasks(taskIdsFromMap(assignedStandbyTasks))
+                    .setWarmupTasks(taskIdsFromMap(assignedWarmupTasks)))
+            .setTargetAssignment(describedTargetAssignment)
+            .setClientHost(clientHost)
+            .setClientId(clientId)
+            .setInstanceId(instanceId)
+            .setRackId(rackId)
+            .setClientTags(clientTags.entrySet().stream().map(
+                entry -> new StreamsGroupDescribeResponseData.KeyValue()
+                    .setKey(entry.getKey())
+                    .setValue(entry.getValue())
+            ).collect(Collectors.toList()))
+            .setProcessId(processId)
+            .setTopologyEpoch(topologyEpoch)
+            .setUserEndpoint(
+                userEndpoint == null ? null :
+                    new StreamsGroupDescribeResponseData.Endpoint()
+                        .setHost(userEndpoint.host())
+                        .setPort(userEndpoint.port())
+            );
+        // TODO: TaskOffset, TaskEndOffset, IsClassic are to be implemented.
+    }
+
+    private static List<StreamsGroupDescribeResponseData.TaskIds> taskIdsFromMap(
+        Map<String, Set<Integer>> tasks
+    ) {
+        List<StreamsGroupDescribeResponseData.TaskIds> taskIds = new ArrayList<>();
+        tasks.forEach((subtopologyId, partitionSet) -> {
+            taskIds.add(new StreamsGroupDescribeResponseData.TaskIds()
+                .setSubtopologyId(subtopologyId)
+                .setPartitions(new ArrayList<>(partitionSet)));
+        });
+        return taskIds;
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StreamsGroupMember that = (StreamsGroupMember) o;
+        return memberEpoch == that.memberEpoch
+            && previousMemberEpoch == that.previousMemberEpoch
+            && rebalanceTimeoutMs == that.rebalanceTimeoutMs
+            && Objects.equals(memberId, that.memberId)
+            && state == that.state
+            && Objects.equals(instanceId, that.instanceId)
+            && Objects.equals(rackId, that.rackId)
+            && Objects.equals(clientId, that.clientId)
+            && Objects.equals(clientHost, that.clientHost)
+            && Objects.equals(topologyEpoch, that.topologyEpoch)
+            && Objects.equals(processId, that.processId)
+            && Objects.equals(userEndpoint, that.userEndpoint)
+            && Objects.equals(clientTags, that.clientTags)
+            && Objects.equals(assignedActiveTasks, that.assignedActiveTasks)
+            && Objects.equals(assignedStandbyTasks, that.assignedStandbyTasks)
+            && Objects.equals(assignedWarmupTasks, that.assignedWarmupTasks)
+            && Objects.equals(activeTasksPendingRevocation, that.activeTasksPendingRevocation)
+            && Objects.equals(standbyTasksPendingRevocation, that.standbyTasksPendingRevocation)
+            && Objects.equals(warmupTasksPendingRevocation, that.warmupTasksPendingRevocation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            memberId,
+            memberEpoch,
+            previousMemberEpoch,
+            state,
+            instanceId,
+            rackId,
+            rebalanceTimeoutMs,
+            clientId,
+            clientHost,
+            topologyEpoch,
+            processId,
+            userEndpoint,
+            clientTags,
+            assignedActiveTasks,
+            assignedStandbyTasks,
+            assignedWarmupTasks,
+            activeTasksPendingRevocation,
+            standbyTasksPendingRevocation,
+            warmupTasksPendingRevocation
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "StreamsGroupMember(" +
+            "memberId='" + memberId + '\'' +
+            ", memberEpoch=" + memberEpoch +
+            ", previousMemberEpoch=" + previousMemberEpoch +
+            ", state='" + state + '\'' +
+            ", instanceId='" + instanceId + '\'' +
+            ", rackId='" + rackId + '\'' +
+            ", rebalanceTimeoutMs=" + rebalanceTimeoutMs +
+            ", clientId='" + clientId + '\'' +
+            ", clientHost='" + clientHost + '\'' +
+            ", topologyEpoch='" + topologyEpoch + '\'' +
+            ", processId='" + processId + '\'' +
+            ", userEndpoint=" + userEndpoint +
+            ", clientTags=" + clientTags +
+            ", assignedActiveTasks=" + assignedActiveTasks +
+            ", assignedStandbyTasks=" + assignedStandbyTasks +
+            ", assignedWarmupTasks=" + assignedWarmupTasks +
+            ", activeTasksPendingRevocation=" + activeTasksPendingRevocation +
+            ", standbyTasksPendingRevocation=" + standbyTasksPendingRevocation +
+            ", warmupTasksPendingRevocation=" + warmupTasksPendingRevocation +
+            ')';
+    }
+
+    /**
+     * @return True if the two provided members have different assigned active tasks.
+     */
+    public static boolean hasAssignedActiveTasksChanged(
+        StreamsGroupMember member1,
+        StreamsGroupMember member2
+    ) {
+        return !member1.assignedActiveTasks().equals(member2.assignedActiveTasks());
+    }
+
+    /**
+     * @return True if the two provided members have different assigned active tasks.
+     */
+    public static boolean hasAssignedStandbyTasksChanged(
+        StreamsGroupMember member1,
+        StreamsGroupMember member2
+    ) {
+        return !member1.assignedStandbyTasks().equals(member2.assignedStandbyTasks());
+    }
+
+    /**
+     * @return True if the two provided members have different assigned active tasks.
+     */
+    public static boolean hasAssignedWarmupTasksChanged(
+        StreamsGroupMember member1,
+        StreamsGroupMember member2
+    ) {
+        return !member1.assignedWarmupTasks().equals(member2.assignedWarmupTasks());
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -22,7 +22,6 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataVa
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -273,12 +273,12 @@ public class StreamsGroupMember {
             return this;
         }
 
-        private Map<String, Set<Integer>> assignmentFromTaskIds(
+        static private Map<String, Set<Integer>> assignmentFromTaskIds(
             List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> topicPartitionsList
         ) {
             return topicPartitionsList.stream().collect(Collectors.toMap(
                 StreamsGroupCurrentMemberAssignmentValue.TaskIds::subtopologyId,
-                taskIds -> Collections.unmodifiableSet(new HashSet<>(taskIds.partitions()))));
+                taskIds -> Set.copyOf(taskIds.partitions())));
         }
 
         public StreamsGroupMember build() {
@@ -307,7 +307,7 @@ public class StreamsGroupMember {
     }
 
     /**
-     * The member id.
+     * The member ID.
      */
     private final String memberId;
 
@@ -327,12 +327,12 @@ public class StreamsGroupMember {
     private final MemberState state;
 
     /**
-     * The instance id provided by the member.
+     * The instance ID provided by the member.
      */
     private final String instanceId;
 
     /**
-     * The rack id provided by the member.
+     * The rack ID provided by the member.
      */
     private final String rackId;
 
@@ -342,7 +342,7 @@ public class StreamsGroupMember {
     private final int rebalanceTimeoutMs;
 
     /**
-     * The client id reported by the member.
+     * The client ID reported by the member.
      */
     private final String clientId;
 
@@ -352,22 +352,22 @@ public class StreamsGroupMember {
     private final String clientHost;
 
     /**
-     * The topology epoch
+     * The topology epoch.
      */
     private final int topologyEpoch;
 
     /**
-     * The process ID
+     * The process ID.
      */
     private final String processId;
 
     /**
-     * The endpoint
+     * The endpoint.
      */
     private final StreamsGroupMemberMetadataValue.Endpoint userEndpoint;
 
     /**
-     * The client tags
+     * The client tags.
      */
     private final Map<String, String> clientTags;
 
@@ -445,7 +445,7 @@ public class StreamsGroupMember {
     }
 
     /**
-     * @return The member id.
+     * @return The member ID.
      */
     public String memberId() {
         return memberId;
@@ -466,14 +466,14 @@ public class StreamsGroupMember {
     }
 
     /**
-     * @return The instance id.
+     * @return The instance ID.
      */
     public String instanceId() {
         return instanceId;
     }
 
     /**
-     * @return The rack id.
+     * @return The rack ID.
      */
     public String rackId() {
         return rackId;
@@ -487,7 +487,7 @@ public class StreamsGroupMember {
     }
 
     /**
-     * @return The client id.
+     * @return The client ID.
      */
     public String clientId() {
         return clientId;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -409,7 +409,7 @@ public record StreamsGroupMember(String memberId,
     }
 
     /**
-     * @return The topology epoch
+     * @return The topology epoch.
      */
     public int topologyEpoch() {
         return topologyEpoch;
@@ -539,7 +539,6 @@ public record StreamsGroupMember(String memberId,
                         .setPort(endpoint.port())
                     ).orElse(null)
             );
-        // TODO: TaskOffset, TaskEndOffset, IsClassic are to be implemented.
     }
 
     private static List<StreamsGroupDescribeResponseData.TaskIds> taskIdsFromMap(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -83,7 +83,39 @@ public record StreamsGroupMember(String memberId,
                                  Map<String, Set<Integer>> standbyTasksPendingRevocation,
                                  Map<String, Set<Integer>> warmupTasksPendingRevocation) {
 
-  /**
+    public StreamsGroupMember {
+        Objects.requireNonNull(memberId, "memberId cannot be null");
+        Objects.requireNonNull(state, "state cannot be null");
+        Objects.requireNonNull(instanceId, "instanceId cannot be null");
+        Objects.requireNonNull(rackId, "rackId cannot be null");
+        Objects.requireNonNull(clientId, "clientId cannot be null");
+        Objects.requireNonNull(clientHost, "clientHost cannot be null");
+        Objects.requireNonNull(processId, "processId cannot be null");
+        Objects.requireNonNull(userEndpoint, "userEndpoint cannot be null");
+        clientTags = Collections.unmodifiableMap(
+            Objects.requireNonNull(clientTags, "clientTags cannot be null")
+        );
+        assignedActiveTasks = Collections.unmodifiableMap(
+            Objects.requireNonNull(assignedActiveTasks, "assignedActiveTasks cannot be null")
+        );
+        assignedStandbyTasks = Collections.unmodifiableMap(
+            Objects.requireNonNull(assignedStandbyTasks, "assignedStandbyTasks cannot be null")
+        );
+        assignedWarmupTasks = Collections.unmodifiableMap(
+            Objects.requireNonNull(assignedWarmupTasks, "assignedWarmupTasks cannot be null")
+        );
+        activeTasksPendingRevocation = Collections.unmodifiableMap(
+            Objects.requireNonNull(activeTasksPendingRevocation, "activeTasksPendingRevocation cannot be null")
+        );
+        standbyTasksPendingRevocation = Collections.unmodifiableMap(
+            Objects.requireNonNull(standbyTasksPendingRevocation, "standbyTasksPendingRevocation cannot be null")
+        );
+        warmupTasksPendingRevocation = Collections.unmodifiableMap(
+            Objects.requireNonNull(warmupTasksPendingRevocation, "warmupTasksPendingRevocation cannot be null")
+        );
+    }
+
+    /**
      * A builder that facilitates the creation of a new member or the update of an existing one.
      * <p>
      * Please refer to the javadoc of {{@link StreamsGroupMember}} for the definition of the fields.
@@ -111,11 +143,11 @@ public record StreamsGroupMember(String memberId,
         private Map<String, Set<Integer>> warmupTasksPendingRevocation = Collections.emptyMap();
 
         public Builder(String memberId) {
-            this.memberId = Objects.requireNonNull(memberId);
+            this.memberId = Objects.requireNonNull(memberId, "memberId cannot be null");
         }
 
         public Builder(StreamsGroupMember member) {
-            Objects.requireNonNull(member);
+            Objects.requireNonNull(member, "member cannot be null");
 
             this.memberId = member.memberId;
             this.memberEpoch = member.memberEpoch;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -64,15 +64,15 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("checkstyle:JavaNCSS")
 public record StreamsGroupMember(String memberId,
-                                 int memberEpoch,
-                                 int previousMemberEpoch,
+                                 Integer memberEpoch,
+                                 Integer previousMemberEpoch,
                                  MemberState state,
                                  Optional<String> instanceId,
                                  Optional<String> rackId,
                                  String clientId,
                                  String clientHost,
-                                 int rebalanceTimeoutMs,
-                                 int topologyEpoch,
+                                 Integer rebalanceTimeoutMs,
+                                 Integer topologyEpoch,
                                  String processId,
                                  Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint,
                                  Map<String, String> clientTags,
@@ -85,34 +85,13 @@ public record StreamsGroupMember(String memberId,
 
     public StreamsGroupMember {
         Objects.requireNonNull(memberId, "memberId cannot be null");
-        Objects.requireNonNull(state, "state cannot be null");
-        Objects.requireNonNull(instanceId, "instanceId cannot be null");
-        Objects.requireNonNull(rackId, "rackId cannot be null");
-        Objects.requireNonNull(clientId, "clientId cannot be null");
-        Objects.requireNonNull(clientHost, "clientHost cannot be null");
-        Objects.requireNonNull(processId, "processId cannot be null");
-        Objects.requireNonNull(userEndpoint, "userEndpoint cannot be null");
-        clientTags = Collections.unmodifiableMap(
-            Objects.requireNonNull(clientTags, "clientTags cannot be null")
-        );
-        assignedActiveTasks = Collections.unmodifiableMap(
-            Objects.requireNonNull(assignedActiveTasks, "assignedActiveTasks cannot be null")
-        );
-        assignedStandbyTasks = Collections.unmodifiableMap(
-            Objects.requireNonNull(assignedStandbyTasks, "assignedStandbyTasks cannot be null")
-        );
-        assignedWarmupTasks = Collections.unmodifiableMap(
-            Objects.requireNonNull(assignedWarmupTasks, "assignedWarmupTasks cannot be null")
-        );
-        activeTasksPendingRevocation = Collections.unmodifiableMap(
-            Objects.requireNonNull(activeTasksPendingRevocation, "activeTasksPendingRevocation cannot be null")
-        );
-        standbyTasksPendingRevocation = Collections.unmodifiableMap(
-            Objects.requireNonNull(standbyTasksPendingRevocation, "standbyTasksPendingRevocation cannot be null")
-        );
-        warmupTasksPendingRevocation = Collections.unmodifiableMap(
-            Objects.requireNonNull(warmupTasksPendingRevocation, "warmupTasksPendingRevocation cannot be null")
-        );
+        clientTags = clientTags != null ? Collections.unmodifiableMap(clientTags) : null;
+        assignedActiveTasks = assignedActiveTasks != null ? Collections.unmodifiableMap(assignedActiveTasks) : null;
+        assignedStandbyTasks = assignedStandbyTasks != null ? Collections.unmodifiableMap(assignedStandbyTasks) : null;
+        assignedWarmupTasks = assignedWarmupTasks != null ? Collections.unmodifiableMap(assignedWarmupTasks) : null;
+        activeTasksPendingRevocation = activeTasksPendingRevocation != null ? Collections.unmodifiableMap(activeTasksPendingRevocation) : null;
+        standbyTasksPendingRevocation = standbyTasksPendingRevocation != null ? Collections.unmodifiableMap(standbyTasksPendingRevocation) : null;
+        warmupTasksPendingRevocation = warmupTasksPendingRevocation != null ? Collections.unmodifiableMap(warmupTasksPendingRevocation) : null;
     }
 
     /**
@@ -123,24 +102,24 @@ public record StreamsGroupMember(String memberId,
     public static class Builder {
 
         private final String memberId;
-        private int memberEpoch = 0;
-        private int previousMemberEpoch = -1;
-        private MemberState state = MemberState.STABLE;
-        private Optional<String> instanceId = Optional.empty();
-        private Optional<String> rackId = Optional.empty();
-        private int rebalanceTimeoutMs = -1;
-        private String clientId = "";
-        private String clientHost = "";
-        private int topologyEpoch = -1;
-        private String processId = "";
-        private Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint = Optional.empty();
-        private Map<String, String> clientTags = Collections.emptyMap();
-        private Map<String, Set<Integer>> assignedActiveTasks = Collections.emptyMap();
-        private Map<String, Set<Integer>> assignedStandbyTasks = Collections.emptyMap();
-        private Map<String, Set<Integer>> assignedWarmupTasks = Collections.emptyMap();
-        private Map<String, Set<Integer>> activeTasksPendingRevocation = Collections.emptyMap();
-        private Map<String, Set<Integer>> standbyTasksPendingRevocation = Collections.emptyMap();
-        private Map<String, Set<Integer>> warmupTasksPendingRevocation = Collections.emptyMap();
+        private Integer memberEpoch = null;
+        private Integer previousMemberEpoch = null;
+        private MemberState state = null;
+        private Optional<String> instanceId = null;
+        private Optional<String> rackId = null;
+        private Integer rebalanceTimeoutMs = null;
+        private String clientId = null;
+        private String clientHost = null;
+        private Integer topologyEpoch = null;
+        private String processId = null;
+        private Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint = null;
+        private Map<String, String> clientTags = null;
+        private Map<String, Set<Integer>> assignedActiveTasks = null;
+        private Map<String, Set<Integer>> assignedStandbyTasks = null;
+        private Map<String, Set<Integer>> assignedWarmupTasks = null;
+        private Map<String, Set<Integer>> activeTasksPendingRevocation = null;
+        private Map<String, Set<Integer>> standbyTasksPendingRevocation = null;
+        private Map<String, Set<Integer>> warmupTasksPendingRevocation = null;
 
         public Builder(String memberId) {
             this.memberId = Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -385,143 +364,10 @@ public record StreamsGroupMember(String memberId,
     }
 
     /**
-     * @return The member ID.
-     */
-    public String memberId() {
-        return memberId;
-    }
-
-    /**
-     * @return The current member epoch.
-     */
-    public int memberEpoch() {
-        return memberEpoch;
-    }
-
-    /**
-     * @return The previous member epoch.
-     */
-    public int previousMemberEpoch() {
-        return previousMemberEpoch;
-    }
-
-    /**
-     * @return The instance ID.
-     */
-    public Optional<String> instanceId() {
-        return instanceId;
-    }
-
-    /**
-     * @return The rack ID.
-     */
-    public Optional<String> rackId() {
-        return rackId;
-    }
-
-    /**
-     * @return The rebalance timeout in millis.
-     */
-    public int rebalanceTimeoutMs() {
-        return rebalanceTimeoutMs;
-    }
-
-    /**
-     * @return The client ID.
-     */
-    public String clientId() {
-        return clientId;
-    }
-
-    /**
-     * @return The client host.
-     */
-    public String clientHost() {
-        return clientHost;
-    }
-
-    /**
-     * @return The topology epoch.
-     */
-    public int topologyEpoch() {
-        return topologyEpoch;
-    }
-
-    /**
-     * @return The process ID
-     */
-    public String processId() {
-        return processId;
-    }
-
-    /**
-     * @return The user endpoint
-     */
-    public Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint() {
-        return userEndpoint;
-    }
-
-    /**
-     * @return The client tags
-     */
-    public Map<String, String> clientTags() {
-        return clientTags;
-    }
-
-    /**
-     * @return The current state.
-     */
-    public MemberState state() {
-        return state;
-    }
-
-    /**
      * @return True if the member is in the Stable state and at the desired epoch.
      */
     public boolean isReconciledTo(int targetAssignmentEpoch) {
         return state == MemberState.STABLE && memberEpoch == targetAssignmentEpoch;
-    }
-
-    /**
-     * @return The set of assigned active tasks.
-     */
-    public Map<String, Set<Integer>> assignedActiveTasks() {
-        return assignedActiveTasks;
-    }
-
-    /**
-     * @return The set of assigned standby tasks.
-     */
-    public Map<String, Set<Integer>> assignedStandbyTasks() {
-        return assignedStandbyTasks;
-    }
-
-    /**
-     * @return The set of assigned warm-up tasks.
-     */
-    public Map<String, Set<Integer>> assignedWarmupTasks() {
-        return assignedWarmupTasks;
-    }
-
-    /**
-     * @return The set of active tasks awaiting revocation from the member.
-     */
-    public Map<String, Set<Integer>> activeTasksPendingRevocation() {
-        return activeTasksPendingRevocation;
-    }
-
-    /**
-     * @return The set of standby tasks awaiting revocation from the member.
-     */
-    public Map<String, Set<Integer>> standbyTasksPendingRevocation() {
-        return standbyTasksPendingRevocation;
-    }
-
-    /**
-     * @return The set of warmup tasks awaiting revocation from the member.
-     */
-    public Map<String, Set<Integer>> warmupTasksPendingRevocation() {
-        return warmupTasksPendingRevocation;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -31,10 +31,57 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * StreamsGroupMember contains all the information related to a member within a Streams group. This class is immutable and is fully backed
- * by records stored in the __consumer_offsets topic.
+ * Contains all information related to a member within a Streams group.
+ * <p>
+ * This class is immutable and is fully backed by records stored in the __consumer_offsets topic.
+ *
+ * @param memberId                      The ID of the member.
+ * @param memberEpoch                   The current epoch of the member.
+ * @param previousMemberEpoch           The previous epoch of the member.
+ * @param state                         The current state of the member.
+ * @param instanceId                    The instance ID of the member.
+ * @param rackId                        The rack ID of the member.
+ * @param clientId                      The client ID of the member.
+ * @param clientHost                    The host of the member.
+ * @param rebalanceTimeoutMs            The rebalance timeout in milliseconds.
+ * @param topologyEpoch                 The epoch of the topology the member uses.
+ * @param processId                     The ID of the Streams client that contains the member.
+ * @param userEndpoint                  The user endpoint exposed for Interactive Queries by the Streams client that
+ *                                      contains the member.
+ * @param clientTags                    Tags of the client of the member used for rack-aware assignment.
+ * @param assignedActiveTasks           Active tasks assigned to the member.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param assignedStandbyTasks          Standby tasks assigned to the member.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param assignedWarmupTasks           Warm-up tasks assigned to the member.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param activeTasksPendingRevocation  Active tasks assigned to the member pending revocation.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param standbyTasksPendingRevocation Standby tasks assigned to the member pending revocation.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
+ * @param warmupTasksPendingRevocation  Warm-up tasks assigned to the member pending revocation.
+ *                                      The key of the map is the subtopology ID and the value is the set of partition IDs.
  */
-public class StreamsGroupMember {
+@SuppressWarnings("checkstyle:JavaNCSS")
+public record StreamsGroupMember(String memberId,
+                                 int memberEpoch,
+                                 int previousMemberEpoch,
+                                 MemberState state,
+                                 Optional<String> instanceId,
+                                 Optional<String> rackId,
+                                 String clientId,
+                                 String clientHost,
+                                 int rebalanceTimeoutMs,
+                                 int topologyEpoch,
+                                 String processId,
+                                 Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint,
+                                 Map<String, String> clientTags,
+                                 Map<String, Set<Integer>> assignedActiveTasks,
+                                 Map<String, Set<Integer>> assignedStandbyTasks,
+                                 Map<String, Set<Integer>> assignedWarmupTasks,
+                                 Map<String, Set<Integer>> activeTasksPendingRevocation,
+                                 Map<String, Set<Integer>> standbyTasksPendingRevocation,
+                                 Map<String, Set<Integer>> warmupTasksPendingRevocation) {
 
   /**
      * A builder that facilitates the creation of a new member or the update of an existing one.
@@ -47,14 +94,14 @@ public class StreamsGroupMember {
         private int memberEpoch = 0;
         private int previousMemberEpoch = -1;
         private MemberState state = MemberState.STABLE;
-        private String instanceId = null;
-        private String rackId = null;
+        private Optional<String> instanceId = Optional.empty();
+        private Optional<String> rackId = Optional.empty();
         private int rebalanceTimeoutMs = -1;
         private String clientId = "";
         private String clientHost = "";
         private int topologyEpoch = -1;
-        private String processId;
-        private StreamsGroupMemberMetadataValue.Endpoint userEndpoint;
+        private String processId = "";
+        private Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint = Optional.empty();
         private Map<String, String> clientTags = Collections.emptyMap();
         private Map<String, Set<Integer>> assignedActiveTasks = Collections.emptyMap();
         private Map<String, Set<Integer>> assignedStandbyTasks = Collections.emptyMap();
@@ -109,22 +156,22 @@ public class StreamsGroupMember {
         }
 
         public Builder setInstanceId(String instanceId) {
-            this.instanceId = instanceId;
+            this.instanceId = Optional.ofNullable(instanceId);
             return this;
         }
 
         public Builder maybeUpdateInstanceId(Optional<String> instanceId) {
-            this.instanceId = instanceId.orElse(this.instanceId);
+            instanceId.ifPresent(this::setInstanceId);
             return this;
         }
 
         public Builder setRackId(String rackId) {
-            this.rackId = rackId;
+            this.rackId = Optional.ofNullable(rackId);
             return this;
         }
 
         public Builder maybeUpdateRackId(Optional<String> rackId) {
-            this.rackId = rackId.orElse(this.rackId);
+            rackId.ifPresent(this::setRackId);
             return this;
         }
 
@@ -174,12 +221,12 @@ public class StreamsGroupMember {
         }
 
         public Builder setUserEndpoint(StreamsGroupMemberMetadataValue.Endpoint userEndpoint) {
-            this.userEndpoint = userEndpoint;
+            this.userEndpoint = Optional.ofNullable(userEndpoint);
             return this;
         }
 
         public Builder maybeUpdateUserEndpoint(Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint) {
-            this.userEndpoint = userEndpoint.orElse(this.userEndpoint);
+            userEndpoint.ifPresent(this::setUserEndpoint);
             return this;
         }
 
@@ -285,16 +332,16 @@ public class StreamsGroupMember {
                 memberId,
                 memberEpoch,
                 previousMemberEpoch,
+                state,
                 instanceId,
                 rackId,
-                rebalanceTimeoutMs,
                 clientId,
                 clientHost,
+                rebalanceTimeoutMs,
                 topologyEpoch,
                 processId,
                 userEndpoint,
                 clientTags,
-                state,
                 assignedActiveTasks,
                 assignedStandbyTasks,
                 assignedWarmupTasks,
@@ -303,144 +350,6 @@ public class StreamsGroupMember {
                 warmupTasksPendingRevocation
             );
         }
-    }
-
-    /**
-     * The member ID.
-     */
-    private final String memberId;
-
-    /**
-     * The current member epoch.
-     */
-    private final int memberEpoch;
-
-    /**
-     * The previous member epoch.
-     */
-    private final int previousMemberEpoch;
-
-    /**
-     * The member state.
-     */
-    private final MemberState state;
-
-    /**
-     * The instance ID provided by the member.
-     */
-    private final String instanceId;
-
-    /**
-     * The rack ID provided by the member.
-     */
-    private final String rackId;
-
-    /**
-     * The rebalance timeout provided by the member.
-     */
-    private final int rebalanceTimeoutMs;
-
-    /**
-     * The client ID reported by the member.
-     */
-    private final String clientId;
-
-    /**
-     * The host reported by the member.
-     */
-    private final String clientHost;
-
-    /**
-     * The topology epoch.
-     */
-    private final int topologyEpoch;
-
-    /**
-     * The process ID.
-     */
-    private final String processId;
-
-    /**
-     * The endpoint.
-     */
-    private final StreamsGroupMemberMetadataValue.Endpoint userEndpoint;
-
-    /**
-     * The client tags.
-     */
-    private final Map<String, String> clientTags;
-
-    /**
-     * Active tasks assigned to this member.
-     */
-    private final Map<String, Set<Integer>> assignedActiveTasks;
-
-    /**
-     * Standby tasks assigned to this member.
-     */
-    private final Map<String, Set<Integer>> assignedStandbyTasks;
-
-    /**
-     * Warmup tasks assigned to this member.
-     */
-    private final Map<String, Set<Integer>> assignedWarmupTasks;
-
-    /**
-     * Active tasks being revoked by this member.
-     */
-    private final Map<String, Set<Integer>> activeTasksPendingRevocation;
-
-    /**
-     * Standby tasks being revoked by this member.
-     */
-    private final Map<String, Set<Integer>> standbyTasksPendingRevocation;
-
-    /**
-     * Warmup tasks being revoked by this member.
-     */
-    private final Map<String, Set<Integer>> warmupTasksPendingRevocation;
-
-    @SuppressWarnings("checkstyle:ParameterNumber")
-    private StreamsGroupMember(
-        String memberId,
-        int memberEpoch,
-        int previousMemberEpoch,
-        String instanceId,
-        String rackId,
-        int rebalanceTimeoutMs,
-        String clientId,
-        String clientHost,
-        int topologyEpoch,
-        String processId,
-        StreamsGroupMemberMetadataValue.Endpoint userEndpoint,
-        Map<String, String> clientTags,
-        MemberState state,
-        Map<String, Set<Integer>> assignedActiveTasks,
-        Map<String, Set<Integer>> assignedStandbyTasks,
-        Map<String, Set<Integer>> assignedWarmupTasks,
-        Map<String, Set<Integer>> activeTasksPendingRevocation,
-        Map<String, Set<Integer>> standbyTasksPendingRevocation,
-        Map<String, Set<Integer>> warmupTasksPendingRevocation
-    ) {
-        this.memberId = memberId;
-        this.memberEpoch = memberEpoch;
-        this.previousMemberEpoch = previousMemberEpoch;
-        this.state = state;
-        this.instanceId = instanceId;
-        this.rackId = rackId;
-        this.rebalanceTimeoutMs = rebalanceTimeoutMs;
-        this.clientId = clientId;
-        this.clientHost = clientHost;
-        this.topologyEpoch = topologyEpoch;
-        this.processId = processId;
-        this.userEndpoint = userEndpoint;
-        this.clientTags = clientTags;
-        this.assignedActiveTasks = assignedActiveTasks;
-        this.assignedStandbyTasks = assignedStandbyTasks;
-        this.assignedWarmupTasks = assignedWarmupTasks;
-        this.activeTasksPendingRevocation = activeTasksPendingRevocation;
-        this.standbyTasksPendingRevocation = standbyTasksPendingRevocation;
-        this.warmupTasksPendingRevocation = warmupTasksPendingRevocation;
     }
 
     /**
@@ -467,14 +376,14 @@ public class StreamsGroupMember {
     /**
      * @return The instance ID.
      */
-    public String instanceId() {
+    public Optional<String> instanceId() {
         return instanceId;
     }
 
     /**
      * @return The rack ID.
      */
-    public String rackId() {
+    public Optional<String> rackId() {
         return rackId;
     }
 
@@ -516,7 +425,7 @@ public class StreamsGroupMember {
     /**
      * @return The user endpoint
      */
-    public StreamsGroupMemberMetadataValue.Endpoint userEndpoint() {
+    public Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint() {
         return userEndpoint;
     }
 
@@ -584,6 +493,8 @@ public class StreamsGroupMember {
     }
 
     /**
+     * Creates a member description for the Streams group describe response from this member.
+     *
      * @param targetAssignment The target assignment of this member in the corresponding group.
      *
      * @return The StreamsGroupMember mapped as StreamsGroupDescribeResponseData.Member.
@@ -612,8 +523,8 @@ public class StreamsGroupMember {
             .setTargetAssignment(describedTargetAssignment)
             .setClientHost(clientHost)
             .setClientId(clientId)
-            .setInstanceId(instanceId)
-            .setRackId(rackId)
+            .setInstanceId(instanceId.orElse(null))
+            .setRackId(rackId.orElse(null))
             .setClientTags(clientTags.entrySet().stream().map(
                 entry -> new StreamsGroupDescribeResponseData.KeyValue()
                     .setKey(entry.getKey())
@@ -622,10 +533,11 @@ public class StreamsGroupMember {
             .setProcessId(processId)
             .setTopologyEpoch(topologyEpoch)
             .setUserEndpoint(
-                userEndpoint == null ? null :
-                    new StreamsGroupDescribeResponseData.Endpoint()
-                        .setHost(userEndpoint.host())
-                        .setPort(userEndpoint.port())
+                userEndpoint.map(
+                    endpoint -> new StreamsGroupDescribeResponseData.Endpoint()
+                        .setHost(endpoint.host())
+                        .setPort(endpoint.port())
+                    ).orElse(null)
             );
         // TODO: TaskOffset, TaskEndOffset, IsClassic are to be implemented.
     }
@@ -640,87 +552,6 @@ public class StreamsGroupMember {
                 .setPartitions(new ArrayList<>(partitionSet)));
         });
         return taskIds;
-    }
-
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StreamsGroupMember that = (StreamsGroupMember) o;
-        return memberEpoch == that.memberEpoch
-            && previousMemberEpoch == that.previousMemberEpoch
-            && rebalanceTimeoutMs == that.rebalanceTimeoutMs
-            && Objects.equals(memberId, that.memberId)
-            && state == that.state
-            && Objects.equals(instanceId, that.instanceId)
-            && Objects.equals(rackId, that.rackId)
-            && Objects.equals(clientId, that.clientId)
-            && Objects.equals(clientHost, that.clientHost)
-            && Objects.equals(topologyEpoch, that.topologyEpoch)
-            && Objects.equals(processId, that.processId)
-            && Objects.equals(userEndpoint, that.userEndpoint)
-            && Objects.equals(clientTags, that.clientTags)
-            && Objects.equals(assignedActiveTasks, that.assignedActiveTasks)
-            && Objects.equals(assignedStandbyTasks, that.assignedStandbyTasks)
-            && Objects.equals(assignedWarmupTasks, that.assignedWarmupTasks)
-            && Objects.equals(activeTasksPendingRevocation, that.activeTasksPendingRevocation)
-            && Objects.equals(standbyTasksPendingRevocation, that.standbyTasksPendingRevocation)
-            && Objects.equals(warmupTasksPendingRevocation, that.warmupTasksPendingRevocation);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            memberId,
-            memberEpoch,
-            previousMemberEpoch,
-            state,
-            instanceId,
-            rackId,
-            rebalanceTimeoutMs,
-            clientId,
-            clientHost,
-            topologyEpoch,
-            processId,
-            userEndpoint,
-            clientTags,
-            assignedActiveTasks,
-            assignedStandbyTasks,
-            assignedWarmupTasks,
-            activeTasksPendingRevocation,
-            standbyTasksPendingRevocation,
-            warmupTasksPendingRevocation
-        );
-    }
-
-    @Override
-    public String toString() {
-        return "StreamsGroupMember(" +
-            "memberId='" + memberId + '\'' +
-            ", memberEpoch=" + memberEpoch +
-            ", previousMemberEpoch=" + previousMemberEpoch +
-            ", state='" + state + '\'' +
-            ", instanceId='" + instanceId + '\'' +
-            ", rackId='" + rackId + '\'' +
-            ", rebalanceTimeoutMs=" + rebalanceTimeoutMs +
-            ", clientId='" + clientId + '\'' +
-            ", clientHost='" + clientHost + '\'' +
-            ", topologyEpoch='" + topologyEpoch + '\'' +
-            ", processId='" + processId + '\'' +
-            ", userEndpoint=" + userEndpoint +
-            ", clientTags=" + clientTags +
-            ", assignedActiveTasks=" + assignedActiveTasks +
-            ", assignedStandbyTasks=" + assignedStandbyTasks +
-            ", assignedWarmupTasks=" + assignedWarmupTasks +
-            ", activeTasksPendingRevocation=" + activeTasksPendingRevocation +
-            ", standbyTasksPendingRevocation=" + standbyTasksPendingRevocation +
-            ", warmupTasksPendingRevocation=" + warmupTasksPendingRevocation +
-            ')';
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -272,7 +272,7 @@ public class StreamsGroupMember {
             return this;
         }
 
-        static private Map<String, Set<Integer>> assignmentFromTaskIds(
+        private static Map<String, Set<Integer>> assignmentFromTaskIds(
             List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> topicPartitionsList
         ) {
             return topicPartitionsList.stream().collect(Collectors.toMap(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AssignmentTest {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
@@ -120,40 +120,4 @@ public class AssignmentTest {
             assignment.warmupTasks()
         );
     }
-
-    @Test
-    public void testEquals() {
-        Map<String, Set<Integer>> activeTasks = mkTasksPerSubtopology(
-            mkTasks("subtopology1", 1, 2, 3)
-        );
-        Map<String, Set<Integer>> standbyTasks = mkTasksPerSubtopology(
-            mkTasks("subtopology2", 9, 8, 7)
-        );
-        Map<String, Set<Integer>> warmupTasks = mkTasksPerSubtopology(
-            mkTasks("subtopology3", 4, 5, 6)
-        );
-        Map<String, Set<Integer>> activeTasks2 = mkTasksPerSubtopology(
-            mkTasks("subtopology1", 4, 5, 6)
-        );
-        Map<String, Set<Integer>> standbyTasks2 = mkTasksPerSubtopology(
-            mkTasks("subtopology2", 1, 2, 3)
-        );
-        Map<String, Set<Integer>> warmupTasks2 = mkTasksPerSubtopology(
-            mkTasks("subtopology3", 9, 8, 7)
-        );
-
-        final Assignment referenceAssignment = new Assignment(activeTasks, standbyTasks, warmupTasks);
-        final Assignment equalAssignment = new Assignment(activeTasks, standbyTasks, warmupTasks);
-        assertEquals(referenceAssignment, equalAssignment);
-        assertEquals(referenceAssignment.hashCode(), equalAssignment.hashCode());
-        final Assignment nonEqualActiveTasks = new Assignment(activeTasks2, standbyTasks, warmupTasks);
-        assertNotEquals(referenceAssignment, nonEqualActiveTasks);
-        assertNotEquals(referenceAssignment.hashCode(), nonEqualActiveTasks.hashCode());
-        final Assignment nonEqualStandbyTasks = new Assignment(activeTasks, standbyTasks2, warmupTasks2);
-        assertNotEquals(referenceAssignment, nonEqualStandbyTasks);
-        assertNotEquals(referenceAssignment.hashCode(), nonEqualStandbyTasks.hashCode());
-        final Assignment nonEqualWarmupTasks = new Assignment(activeTasks, standbyTasks, warmupTasks2);
-        assertNotEquals(referenceAssignment, nonEqualWarmupTasks);
-        assertNotEquals(referenceAssignment.hashCode(), nonEqualWarmupTasks.hashCode());
-    }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AssignmentTest {
+
+    static final String SUBTOPOLOGY_1 = "subtopology1";
+    static final String SUBTOPOLOGY_2 = "subtopology2";
+    static final String SUBTOPOLOGY_3 = "subtopology3";
+
+    @Test
+    public void testTasksCannotBeNull() {
+        assertThrows(NullPointerException.class, () -> new Assignment(null, Collections.emptyMap(), Collections.emptyMap()));
+        assertThrows(NullPointerException.class, () -> new Assignment(Collections.emptyMap(), null, Collections.emptyMap()));
+        assertThrows(NullPointerException.class, () -> new Assignment(Collections.emptyMap(), Collections.emptyMap(), null));
+    }
+
+    @Test
+    public void testReturnUnmodifiableTaskAssignments() {
+        Map<String, Set<Integer>> activeTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_1, 1, 2, 3)
+        );
+        Map<String, Set<Integer>> standbyTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_2, 9, 8, 7)
+        );
+        Map<String, Set<Integer>> warmupTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_3, 4, 5, 6)
+        );
+        Assignment assignment = new Assignment(activeTasks, standbyTasks, warmupTasks);
+
+        assertEquals(activeTasks, assignment.activeTasks());
+        assertThrows(UnsupportedOperationException.class, () -> assignment.activeTasks().put("not allowed", Collections.emptySet()));
+        assertEquals(standbyTasks, assignment.standbyTasks());
+        assertThrows(UnsupportedOperationException.class, () -> assignment.standbyTasks().put("not allowed", Collections.emptySet()));
+        assertEquals(warmupTasks, assignment.warmupTasks());
+        assertThrows(UnsupportedOperationException.class, () -> assignment.warmupTasks().put("not allowed", Collections.emptySet()));
+    }
+
+    @Test
+    public void testFromTargetAssignmentRecord() {
+        List<StreamsGroupTargetAssignmentMemberValue.TaskIds> activeTasks = new ArrayList<>();
+        activeTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(1, 2, 3)));
+        activeTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(4, 5, 6)));
+        List<StreamsGroupTargetAssignmentMemberValue.TaskIds> standbyTasks = new ArrayList<>();
+        standbyTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(7, 8, 9)));
+        standbyTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(1, 2, 3)));
+        List<StreamsGroupTargetAssignmentMemberValue.TaskIds> warmupTasks = new ArrayList<>();
+        warmupTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(4, 5, 6)));
+        warmupTasks.add(new StreamsGroupTargetAssignmentMemberValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(7, 8, 9)));
+
+        StreamsGroupTargetAssignmentMemberValue record = new StreamsGroupTargetAssignmentMemberValue()
+            .setActiveTasks(activeTasks)
+            .setStandbyTasks(standbyTasks)
+            .setWarmupTasks(warmupTasks);
+
+        Assignment assignment = Assignment.fromRecord(record);
+
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_1, 1, 2, 3),
+                mkTasks(SUBTOPOLOGY_2, 4, 5, 6)
+            ),
+            assignment.activeTasks()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_1, 7, 8, 9),
+                mkTasks(SUBTOPOLOGY_2, 1, 2, 3)
+            ),
+            assignment.standbyTasks()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_1, 4, 5, 6),
+                mkTasks(SUBTOPOLOGY_2, 7, 8, 9)
+            ),
+            assignment.warmupTasks()
+        );
+    }
+
+    @Test
+    public void testEquals() {
+        Map<String, Set<Integer>> activeTasks = mkTasksPerSubtopology(
+            mkTasks("subtopology1", 1, 2, 3)
+        );
+        Map<String, Set<Integer>> standbyTasks = mkTasksPerSubtopology(
+            mkTasks("subtopology2", 9, 8, 7)
+        );
+        Map<String, Set<Integer>> warmupTasks = mkTasksPerSubtopology(
+            mkTasks("subtopology3", 4, 5, 6)
+        );
+        Map<String, Set<Integer>> activeTasks2 = mkTasksPerSubtopology(
+            mkTasks("subtopology1", 4, 5, 6)
+        );
+        Map<String, Set<Integer>> standbyTasks2 = mkTasksPerSubtopology(
+            mkTasks("subtopology2", 1, 2, 3)
+        );
+        Map<String, Set<Integer>> warmupTasks2 = mkTasksPerSubtopology(
+            mkTasks("subtopology3", 9, 8, 7)
+        );
+
+        final Assignment referenceAssignment = new Assignment(activeTasks, standbyTasks, warmupTasks);
+        final Assignment equalAssignment = new Assignment(activeTasks, standbyTasks, warmupTasks);
+        assertEquals(referenceAssignment, equalAssignment);
+        assertEquals(referenceAssignment.hashCode(), equalAssignment.hashCode());
+        final Assignment nonEqualActiveTasks = new Assignment(activeTasks2, standbyTasks, warmupTasks);
+        assertNotEquals(referenceAssignment, nonEqualActiveTasks);
+        assertNotEquals(referenceAssignment.hashCode(), nonEqualActiveTasks.hashCode());
+        final Assignment nonEqualStandbyTasks = new Assignment(activeTasks, standbyTasks2, warmupTasks2);
+        assertNotEquals(referenceAssignment, nonEqualStandbyTasks);
+        assertNotEquals(referenceAssignment.hashCode(), nonEqualStandbyTasks.hashCode());
+        final Assignment nonEqualWarmupTasks = new Assignment(activeTasks, standbyTasks, warmupTasks2);
+        assertNotEquals(referenceAssignment, nonEqualWarmupTasks);
+        assertNotEquals(referenceAssignment.hashCode(), nonEqualWarmupTasks.hashCode());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAss
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue.TaskIds;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue.KeyValue;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -33,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -1,0 +1,678 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue.TaskIds;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue.KeyValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class StreamsGroupMemberTest {
+
+    @Test
+    public void testNewMemberDefaults() {
+        final String memberId = Uuid.randomUuid().toString();
+        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId).build();
+
+        assertEquals(memberId, member.memberId());
+        assertEquals(0, member.memberEpoch());
+        assertEquals(-1, member.previousMemberEpoch());
+        assertEquals(MemberState.STABLE, member.state());
+        assertNull(member.instanceId());
+        assertNull(member.rackId());
+        assertEquals(-1, member.rebalanceTimeoutMs());
+        assertEquals("", member.clientId());
+        assertEquals("", member.clientHost());
+        assertEquals(-1, member.topologyEpoch());
+        assertNull(member.processId());
+        assertNull(member.userEndpoint());
+        assertEquals(Collections.emptyMap(), member.clientTags());
+        assertEquals(Collections.emptyMap(), member.assignedActiveTasks());
+        assertEquals(Collections.emptyMap(), member.assignedStandbyTasks());
+        assertEquals(Collections.emptyMap(), member.assignedWarmupTasks());
+        assertEquals(Collections.emptyMap(), member.activeTasksPendingRevocation());
+        assertEquals(Collections.emptyMap(), member.standbyTasksPendingRevocation());
+        assertEquals(Collections.emptyMap(), member.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testNewMember() {
+        final String memberId = "member-id";
+        final int memberEpoch = 10;
+        final int previousMemberEpoch = 9;
+        final MemberState state = MemberState.UNRELEASED_TASKS;
+        final String instanceId = "instance-id";
+        final String rackId = "rack-id";
+        final int rebalanceTimeout = 5000;
+        final String clientId = "client-id";
+        final String hostname = "hostname";
+        final int topologyEpoch = 3;
+        final String processId = "process-id";
+        final String subtopology1 = "subtopology1";
+        final String subtopology2 = "subtopology2";
+        final StreamsGroupMemberMetadataValue.Endpoint userEndpoint =
+            new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090);
+        final Map<String, String> clientTags = mkMap(mkEntry("client", "tag"));
+        final Map<String, Set<Integer>> assignedActiveTasks = mkTasksPerSubtopology(mkTasks(subtopology1, 1, 2, 3));
+        final Map<String, Set<Integer>> assignedStandbyTasks = mkTasksPerSubtopology(mkTasks(subtopology2, 6, 5, 4));
+        final Map<String, Set<Integer>> assignedWarmupTasks = mkTasksPerSubtopology(mkTasks(subtopology1, 7, 8, 9));
+        final Map<String, Set<Integer>> activeTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology2, 3, 2, 1));
+        final Map<String, Set<Integer>> standbyTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology1, 4, 5, 6));
+        final Map<String, Set<Integer>> warmupTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology2, 9, 8, 7));
+        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(previousMemberEpoch)
+            .setState(state)
+            .setInstanceId(instanceId)
+            .setRackId(rackId)
+            .setRebalanceTimeoutMs(rebalanceTimeout)
+            .setClientId(clientId)
+            .setClientHost(hostname)
+            .setTopologyEpoch(topologyEpoch)
+            .setProcessId(processId)
+            .setUserEndpoint(userEndpoint)
+            .setClientTags(clientTags)
+            .setAssignedActiveTasks(assignedActiveTasks)
+            .setAssignedStandbyTasks(assignedStandbyTasks)
+            .setAssignedWarmupTasks(assignedWarmupTasks)
+            .setActiveTasksPendingRevocation(activeTasksPendingRevocation)
+            .setStandbyTasksPendingRevocation(standbyTasksPendingRevocation)
+            .setWarmupTasksPendingRevocation(warmupTasksPendingRevocation)
+            .build();
+
+        assertEquals(memberId, member.memberId());
+        assertEquals(memberEpoch, member.memberEpoch());
+        assertEquals(previousMemberEpoch, member.previousMemberEpoch());
+        assertEquals(state, member.state());
+        assertEquals(instanceId, member.instanceId());
+        assertEquals(rackId, member.rackId());
+        assertEquals(clientId, member.clientId());
+        assertEquals(hostname, member.clientHost());
+        assertEquals(topologyEpoch, member.topologyEpoch());
+        assertEquals(processId, member.processId());
+        assertEquals(userEndpoint, member.userEndpoint());
+        assertEquals(clientTags, member.clientTags());
+        assertEquals(assignedActiveTasks, member.assignedActiveTasks());
+        assertEquals(assignedStandbyTasks, member.assignedStandbyTasks());
+        assertEquals(assignedWarmupTasks, member.assignedWarmupTasks());
+        assertEquals(activeTasksPendingRevocation, member.activeTasksPendingRevocation());
+        assertEquals(standbyTasksPendingRevocation, member.standbyTasksPendingRevocation());
+        assertEquals(warmupTasksPendingRevocation, member.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testEquals() {
+        StreamsGroupMember member1 = new StreamsGroupMember.Builder("member-id").build();
+        StreamsGroupMember member2 = new StreamsGroupMember.Builder(member1.memberId()).build();
+        assertEquals(member1, member2);
+        assertEquals(member1.hashCode(), member2.hashCode());
+
+        final StreamsGroupMember member3 = new StreamsGroupMember.Builder(member1.memberId() + "2")
+            .build();
+        assertNotEquals(member1, member3);
+        assertNotEquals(member1.hashCode(), member3.hashCode());
+
+        final StreamsGroupMember member4 = new StreamsGroupMember.Builder(member1.memberId())
+            .setMemberEpoch(member1.memberEpoch() + 1)
+            .build();
+        assertNotEquals(member1, member4);
+        assertNotEquals(member1.hashCode(), member4.hashCode());
+
+        final StreamsGroupMember member5 = new StreamsGroupMember.Builder(member1.memberId())
+            .setPreviousMemberEpoch(member1.previousMemberEpoch() + 1)
+            .build();
+        assertNotEquals(member1, member5);
+        assertNotEquals(member1.hashCode(), member5.hashCode());
+
+        final StreamsGroupMember member6 = new StreamsGroupMember.Builder(member1.memberId())
+            .setState(MemberState.UNREVOKED_TASKS)
+            .build();
+        assertNotEquals(member1, member6);
+        assertNotEquals(member1.hashCode(), member6.hashCode());
+
+        final StreamsGroupMember member7 = new StreamsGroupMember.Builder(member1.memberId())
+            .setInstanceId("instance-id")
+            .build();
+        final StreamsGroupMember member8 = new StreamsGroupMember.Builder(member7.memberId())
+            .setInstanceId(member7.instanceId())
+            .build();
+        final StreamsGroupMember member9 = new StreamsGroupMember.Builder(member7.memberId())
+            .setInstanceId(member7.instanceId() + "2")
+            .build();
+        assertEquals(member7, member8);
+        assertEquals(member7.hashCode(), member8.hashCode());
+        assertNotEquals(member7, member9);
+        assertNotEquals(member7.hashCode(), member9.hashCode());
+
+        final StreamsGroupMember member10 = new StreamsGroupMember.Builder(member1.memberId())
+            .setRackId("rack-id")
+            .build();
+        final StreamsGroupMember member11 = new StreamsGroupMember.Builder(member10.memberId())
+            .setRackId(member10.rackId())
+            .build();
+        final StreamsGroupMember member12 = new StreamsGroupMember.Builder(member11.memberId())
+            .setRackId(member10.rackId() + "2")
+            .build();
+        assertEquals(member10, member11);
+        assertEquals(member10.hashCode(), member11.hashCode());
+        assertNotEquals(member10, member12);
+        assertNotEquals(member10.hashCode(), member12.hashCode());
+
+        final StreamsGroupMember member13 = new StreamsGroupMember.Builder(member1.memberId())
+            .setClientHost("hostname")
+            .build();
+        final StreamsGroupMember member14 = new StreamsGroupMember.Builder(member13.memberId())
+            .setClientHost(member13.clientHost())
+            .build();
+        final StreamsGroupMember member15 = new StreamsGroupMember.Builder(member13.memberId())
+            .setClientHost(member13.clientHost() + "2")
+            .build();
+        assertEquals(member13, member14);
+        assertEquals(member13.hashCode(), member14.hashCode());
+        assertNotEquals(member13, member15);
+        assertNotEquals(member13.hashCode(), member15.hashCode());
+
+        final StreamsGroupMember member16 = new StreamsGroupMember.Builder(member1.memberId())
+            .setClientId("hostname")
+            .build();
+        final StreamsGroupMember member17 = new StreamsGroupMember.Builder(member16.memberId())
+            .setClientId(member16.clientId())
+            .build();
+        final StreamsGroupMember member18 = new StreamsGroupMember.Builder(member16.memberId())
+            .setClientId(member16.clientId() + "2")
+            .build();
+        assertEquals(member16, member17);
+        assertEquals(member16.hashCode(), member17.hashCode());
+        assertNotEquals(member16, member18);
+        assertNotEquals(member16.hashCode(), member18.hashCode());
+
+        final StreamsGroupMember member19 = new StreamsGroupMember.Builder(member1.memberId())
+            .setRebalanceTimeoutMs(member1.rebalanceTimeoutMs() + 1)
+            .build();
+        assertNotEquals(member1, member19);
+        assertNotEquals(member1.hashCode(), member19.hashCode());
+
+        final StreamsGroupMember member20 = new StreamsGroupMember.Builder(member1.memberId())
+            .setTopologyEpoch(member1.topologyEpoch() + 1)
+            .build();
+        assertNotEquals(member1, member20);
+        assertNotEquals(member1.hashCode(), member20.hashCode());
+
+        final StreamsGroupMember member21 = new StreamsGroupMember.Builder(member1.memberId())
+            .setProcessId("process-id")
+            .build();
+        final StreamsGroupMember member22 = new StreamsGroupMember.Builder(member21.memberId())
+            .setProcessId(member21.processId())
+            .build();
+        final StreamsGroupMember member23 = new StreamsGroupMember.Builder(member21.memberId())
+            .setClientId(member21.processId() + "2")
+            .build();
+        assertEquals(member21, member22);
+        assertEquals(member21.hashCode(), member22.hashCode());
+        assertNotEquals(member21, member23);
+        assertNotEquals(member21.hashCode(), member23.hashCode());
+
+        final StreamsGroupMember member24 = new StreamsGroupMember.Builder(member1.memberId())
+            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
+            .build();
+        final StreamsGroupMember member25 = new StreamsGroupMember.Builder(member24.memberId())
+            .setUserEndpoint(member24.userEndpoint())
+            .build();
+        final StreamsGroupMember member26 = new StreamsGroupMember.Builder(member24.memberId())
+            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint()
+                .setHost("host")
+                .setPort(member24.userEndpoint().port() + 1)
+            ).build();
+        assertEquals(member24, member25);
+        assertEquals(member24.hashCode(), member25.hashCode());
+        assertNotEquals(member24, member26);
+        assertNotEquals(member24.hashCode(), member26.hashCode());
+
+        final StreamsGroupMember member27 = new StreamsGroupMember.Builder(member1.memberId())
+            .setClientTags(mkMap(mkEntry("client", "tag")))
+            .build();
+        final StreamsGroupMember member28 = new StreamsGroupMember.Builder(member27.memberId())
+            .setClientTags(member27.clientTags())
+            .build();
+        final Map<String, String> clientTags = new HashMap<>(member27.clientTags());
+        clientTags.put("client2", "tag2");
+        final StreamsGroupMember member29 = new StreamsGroupMember.Builder(member27.memberId())
+            .setClientTags(clientTags)
+            .build();
+        assertEquals(member27, member28);
+        assertEquals(member27.hashCode(), member28.hashCode());
+        assertNotEquals(member27, member29);
+        assertNotEquals(member27.hashCode(), member29.hashCode());
+
+        final StreamsGroupMember member30 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member31 = new StreamsGroupMember.Builder(member30.memberId())
+            .setAssignedActiveTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
+            .build();
+        assertEquals(member1, member30);
+        assertEquals(member1.hashCode(), member30.hashCode());
+        assertNotEquals(member1, member31);
+        assertNotEquals(member1.hashCode(), member31.hashCode());
+
+        final StreamsGroupMember member32 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member33 = new StreamsGroupMember.Builder(member32.memberId())
+            .setAssignedStandbyTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
+            .build();
+        assertEquals(member1, member32);
+        assertEquals(member1.hashCode(), member32.hashCode());
+        assertNotEquals(member1, member33);
+        assertNotEquals(member1.hashCode(), member33.hashCode());
+
+        final StreamsGroupMember member34 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member35 = new StreamsGroupMember.Builder(member34.memberId())
+            .setAssignedWarmupTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
+            .build();
+        assertEquals(member1, member34);
+        assertEquals(member1.hashCode(), member34.hashCode());
+        assertNotEquals(member1, member35);
+        assertNotEquals(member1.hashCode(), member35.hashCode());
+
+        final StreamsGroupMember member36 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member37 = new StreamsGroupMember.Builder(member36.memberId())
+            .setActiveTasksPendingRevocation(
+                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
+            ).build();
+        assertEquals(member1, member36);
+        assertEquals(member1.hashCode(), member36.hashCode());
+        assertNotEquals(member1, member37);
+        assertNotEquals(member1.hashCode(), member37.hashCode());
+
+        final StreamsGroupMember member38 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member39 = new StreamsGroupMember.Builder(member38.memberId())
+            .setStandbyTasksPendingRevocation(
+                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
+            ).build();
+        assertEquals(member1, member38);
+        assertEquals(member1.hashCode(), member38.hashCode());
+        assertNotEquals(member1, member39);
+        assertNotEquals(member1.hashCode(), member39.hashCode());
+
+        final StreamsGroupMember member40 = new StreamsGroupMember.Builder(member1.memberId())
+            .build();
+        final StreamsGroupMember member41 = new StreamsGroupMember.Builder(member40.memberId())
+            .setWarmupTasksPendingRevocation(
+                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
+            ).build();
+        assertEquals(member1, member40);
+        assertEquals(member1.hashCode(), member40.hashCode());
+        assertNotEquals(member1, member41);
+        assertNotEquals(member1.hashCode(), member41.hashCode());
+    }
+
+    @Test
+    public void testUpdateWithStreamsGroupMemberMetadataValue() {
+        StreamsGroupMemberMetadataValue record = new StreamsGroupMemberMetadataValue()
+            .setClientId("client-id")
+            .setClientHost("host-id")
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(1000)
+            .setTopologyEpoch(3)
+            .setProcessId("process-id")
+            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
+            .setClientTags(Collections.singletonList(new KeyValue().setKey("client").setValue("tag")));
+
+        StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
+            .updateWith(record)
+            .build();
+
+        assertEquals(record.clientId(), member.clientId());
+        assertEquals(record.clientHost(), member.clientHost());
+        assertEquals(record.instanceId(), member.instanceId());
+        assertEquals(record.rackId(), member.rackId());
+        assertEquals(record.rebalanceTimeoutMs(), member.rebalanceTimeoutMs());
+        assertEquals(record.topologyEpoch(), member.topologyEpoch());
+        assertEquals(record.processId(), member.processId());
+        assertEquals(record.userEndpoint(), member.userEndpoint());
+        assertEquals(
+            record.clientTags().stream().collect(Collectors.toMap(KeyValue::key, KeyValue::value)),
+            member.clientTags()
+        );
+        assertEquals("member-id", member.memberId());
+        assertEquals(0, member.memberEpoch());
+        assertEquals(-1, member.previousMemberEpoch());
+        assertEquals(MemberState.STABLE, member.state());
+        assertEquals(Collections.emptyMap(), member.assignedActiveTasks());
+        assertEquals(Collections.emptyMap(), member.assignedStandbyTasks());
+        assertEquals(Collections.emptyMap(), member.assignedWarmupTasks());
+        assertEquals(Collections.emptyMap(), member.activeTasksPendingRevocation());
+        assertEquals(Collections.emptyMap(), member.standbyTasksPendingRevocation());
+        assertEquals(Collections.emptyMap(), member.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testUpdateWithConsumerGroupCurrentMemberAssignmentValue() {
+        final String subtopology1 = "subtopology-id1";
+        final String subtopology2 = "subtopology-id2";
+        final List<Integer> partitions1 = Arrays.asList(1, 2);
+        final List<Integer> partitions2 = Arrays.asList(3, 4);
+        final List<Integer> partitions3 = Arrays.asList(5, 6);
+        final List<Integer> partitions4 = Arrays.asList(7, 8);
+        final List<Integer> partitions5 = Arrays.asList(9, 10);
+        final List<Integer> partitions6 = Arrays.asList(11, 12);
+
+        StreamsGroupCurrentMemberAssignmentValue record = new StreamsGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setState((byte) 2)
+            .setActiveTasks(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology1)
+                .setPartitions(partitions1))
+            )
+            .setStandbyTasks(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology2)
+                .setPartitions(partitions2))
+            )
+            .setWarmupTasks(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology1)
+                .setPartitions(partitions3))
+            )
+            .setActiveTasksPendingRevocation(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology2)
+                .setPartitions(partitions4))
+            )
+            .setStandbyTasksPendingRevocation(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology1)
+                .setPartitions(partitions5))
+            )
+            .setWarmupTasksPendingRevocation(Collections.singletonList(new TaskIds()
+                .setSubtopologyId(subtopology2)
+                .setPartitions(partitions6))
+            );
+
+        StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
+            .updateWith(record)
+            .build();
+
+        assertEquals(record.memberEpoch(), member.memberEpoch());
+        assertEquals(record.previousMemberEpoch(), member.previousMemberEpoch());
+        assertEquals(MemberState.fromValue(record.state()), member.state());
+        assertEquals(
+            Map.of(subtopology1, new HashSet<>(partitions1)),
+            member.assignedActiveTasks()
+        );
+        assertEquals(
+            Map.of(subtopology2, new HashSet<>(partitions2)),
+            member.assignedStandbyTasks()
+        );
+        assertEquals(
+            Map.of(subtopology1, new HashSet<>(partitions3)),
+            member.assignedWarmupTasks()
+        );
+        assertEquals(
+            Map.of(subtopology2, new HashSet<>(partitions4)),
+            member.activeTasksPendingRevocation()
+        );
+        assertEquals(
+            Map.of(subtopology1, new HashSet<>(partitions5)),
+            member.standbyTasksPendingRevocation()
+        );
+        assertEquals(
+            Map.of(subtopology2, new HashSet<>(partitions6)),
+            member.warmupTasksPendingRevocation()
+        );
+        assertEquals("member-id", member.memberId());
+        assertNull(member.instanceId());
+        assertNull(member.rackId());
+        assertEquals(-1, member.rebalanceTimeoutMs());
+        assertEquals("", member.clientId());
+        assertEquals("", member.clientHost());
+        assertEquals(-1, member.topologyEpoch());
+        assertNull(member.processId());
+        assertNull(member.userEndpoint());
+        assertEquals(Collections.emptyMap(), member.clientTags());
+    }
+
+    @Test
+    public void testMaybeUpdateMember() {
+        final String subtopology1 = "subtopology-id1";
+        final String subtopology2 = "subtopology-id2";
+
+        final StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("hostname")
+            .setTopologyEpoch(3)
+            .setProcessId("process-id")
+            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
+            .setClientTags(mkMap(mkEntry("client", "tag")))
+            .setAssignedActiveTasks(mkTasksPerSubtopology(mkTasks(subtopology1, 1, 2, 3)))
+            .setAssignedStandbyTasks(mkTasksPerSubtopology(mkTasks(subtopology2, 6, 5, 4)))
+            .setAssignedWarmupTasks(mkTasksPerSubtopology(mkTasks(subtopology1, 7, 8, 9)))
+            .setActiveTasksPendingRevocation(
+                mkTasksPerSubtopology(mkTasks(subtopology2, 3, 2, 1)))
+            .build();
+
+        // This is a no-op.
+        StreamsGroupMember updatedMember = new StreamsGroupMember.Builder(member)
+            .maybeUpdateRackId(Optional.empty())
+            .maybeUpdateInstanceId(Optional.empty())
+            .maybeUpdateRebalanceTimeoutMs(OptionalInt.empty())
+            .maybeUpdateProcessId(Optional.empty())
+            .maybeUpdateTopologyEpoch(OptionalInt.empty())
+            .maybeUpdateUserEndpoint(Optional.empty())
+            .maybeUpdateClientTags(Optional.empty())
+            .build();
+
+        assertEquals(member, updatedMember);
+
+        final String newRackId = "new" + member.rackId();
+        final String newInstanceId = "new" + member.instanceId();
+        final long newRebalanceTimeout = member.rebalanceTimeoutMs() + 1000;
+        final String newProcessId = "new" + member.processId();
+        final int newTopologyEpoch = member.topologyEpoch() + 1;
+        final StreamsGroupMemberMetadataValue.Endpoint newUserEndpoint =
+            new StreamsGroupMemberMetadataValue.Endpoint().setHost(member.userEndpoint().host() + "2").setPort(9090);
+        final Map<String, String> newClientTags = new HashMap<>(member.clientTags());
+        newClientTags.put("client2", "tag2");
+
+        updatedMember = new StreamsGroupMember.Builder(member)
+            .maybeUpdateRackId(Optional.of(newRackId))
+            .maybeUpdateInstanceId(Optional.of(newInstanceId))
+            .maybeUpdateRebalanceTimeoutMs(OptionalInt.of(6000))
+            .maybeUpdateProcessId(Optional.of(newProcessId))
+            .maybeUpdateTopologyEpoch(OptionalInt.of(newTopologyEpoch))
+            .maybeUpdateUserEndpoint(Optional.of(newUserEndpoint))
+            .maybeUpdateClientTags(Optional.of(newClientTags))
+            .build();
+
+        assertEquals(newRackId, updatedMember.rackId());
+        assertEquals(newInstanceId, updatedMember.instanceId());
+        assertEquals(newRebalanceTimeout, updatedMember.rebalanceTimeoutMs());
+        assertEquals(newProcessId, updatedMember.processId());
+        assertEquals(newTopologyEpoch, updatedMember.topologyEpoch());
+        assertEquals(newUserEndpoint, updatedMember.userEndpoint());
+        assertEquals(newClientTags, updatedMember.clientTags());
+        assertEquals(member.memberId(), updatedMember.memberId());
+        assertEquals(member.memberEpoch(), updatedMember.memberEpoch());
+        assertEquals(member.previousMemberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.state(), updatedMember.state());
+        assertEquals(member.clientId(), updatedMember.clientId());
+        assertEquals(member.clientHost(), updatedMember.clientHost());
+        assertEquals(member.assignedActiveTasks(), updatedMember.assignedActiveTasks());
+        assertEquals(member.assignedStandbyTasks(), updatedMember.assignedStandbyTasks());
+        assertEquals(member.assignedWarmupTasks(), updatedMember.assignedWarmupTasks());
+        assertEquals(member.activeTasksPendingRevocation(), updatedMember.activeTasksPendingRevocation());
+        assertEquals(member.standbyTasksPendingRevocation(), updatedMember.standbyTasksPendingRevocation());
+        assertEquals(member.warmupTasksPendingRevocation(), updatedMember.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testUpdateMemberEpoch() {
+        final StreamsGroupMember member = new StreamsGroupMember.Builder("member-id").build();
+
+        final int newMemberEpoch = member.memberEpoch() + 1;
+        final StreamsGroupMember updatedMember = new StreamsGroupMember.Builder(member)
+            .updateMemberEpoch(newMemberEpoch)
+            .build();
+
+        assertEquals(member.memberId(), updatedMember.memberId());
+        assertEquals(newMemberEpoch, updatedMember.memberEpoch());
+        // The previous member epoch becomes the old current member epoch.
+        assertEquals(member.memberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.state(), updatedMember.state());
+        assertEquals(member.instanceId(), updatedMember.instanceId());
+        assertEquals(member.rackId(), updatedMember.rackId());
+        assertEquals(member.rebalanceTimeoutMs(), updatedMember.rebalanceTimeoutMs());
+        assertEquals(member.clientId(), updatedMember.clientId());
+        assertEquals(member.clientHost(), updatedMember.clientHost());
+        assertEquals(member.topologyEpoch(), updatedMember.topologyEpoch());
+        assertNull(member.processId());
+        assertNull(member.userEndpoint());
+        assertEquals(member.clientTags(), updatedMember.clientTags());
+        assertEquals(member.assignedActiveTasks(), updatedMember.assignedActiveTasks());
+        assertEquals(member.assignedStandbyTasks(), updatedMember.assignedStandbyTasks());
+        assertEquals(member.assignedWarmupTasks(), updatedMember.assignedWarmupTasks());
+        assertEquals(member.activeTasksPendingRevocation(), updatedMember.activeTasksPendingRevocation());
+        assertEquals(member.standbyTasksPendingRevocation(), updatedMember.standbyTasksPendingRevocation());
+        assertEquals(member.warmupTasksPendingRevocation(), updatedMember.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testAsStreamsGroupDescribeMember() {
+        String subTopology1 = Uuid.randomUuid().toString();
+        String subTopology2 = Uuid.randomUuid().toString();
+        String subTopology3 = Uuid.randomUuid().toString();
+        List<Integer> assignedTasks1 = Arrays.asList(0, 1, 2);
+        List<Integer> assignedTasks2 = Arrays.asList(3, 4, 5);
+        List<Integer> assignedTasks3 = Arrays.asList(6, 7, 8);
+        int epoch = 10;
+        String memberId = Uuid.randomUuid().toString();
+        String clientId = "clientId";
+        String instanceId = "instanceId";
+        String rackId = "rackId";
+        String clientHost = "clientHost";
+        String processId = "processId";
+        int topologyEpoch = 3;
+        Map<String, String> clientTags = Collections.singletonMap("key", "value");
+        Assignment targetAssignment = new Assignment(
+            mkMap(mkEntry(subTopology1, new HashSet<>(assignedTasks3))),
+            mkMap(mkEntry(subTopology2, new HashSet<>(assignedTasks2))),
+            mkMap(mkEntry(subTopology3, new HashSet<>(assignedTasks1)))
+        );
+        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId)
+            .setMemberEpoch(epoch)
+            .setPreviousMemberEpoch(epoch - 1)
+            .setClientId(clientId)
+            .setInstanceId(instanceId)
+            .setRackId(rackId)
+            .setClientHost(clientHost)
+            .setProcessId(processId)
+            .setTopologyEpoch(topologyEpoch)
+            .setClientTags(clientTags)
+            .setAssignedActiveTasks(
+                mkMap(mkEntry(subTopology1, new HashSet<>(assignedTasks1)))
+            )
+            .setAssignedStandbyTasks(
+                mkMap(mkEntry(subTopology2, new HashSet<>(assignedTasks2)))
+            )
+            .setAssignedWarmupTasks(
+                mkMap(mkEntry(subTopology3, new HashSet<>(assignedTasks3)))
+            )
+            .setUserEndpoint(
+                new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090)
+            )
+            .build();
+
+        StreamsGroupDescribeResponseData.Member actual = member.asStreamsGroupDescribeMember(targetAssignment);
+        StreamsGroupDescribeResponseData.Member expected = new StreamsGroupDescribeResponseData.Member()
+            .setMemberId(memberId)
+            .setMemberEpoch(epoch)
+            .setClientId(clientId)
+            .setInstanceId(instanceId)
+            .setRackId(rackId)
+            .setClientHost(clientHost)
+            .setProcessId(processId)
+            .setTopologyEpoch(topologyEpoch)
+            .setClientTags(Collections.singletonList(new StreamsGroupDescribeResponseData.KeyValue().setKey("key").setValue("value")))
+            .setAssignment(
+                new StreamsGroupDescribeResponseData.Assignment()
+                    .setActiveTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology1)
+                        .setPartitions(assignedTasks1)))
+                    .setStandbyTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology2)
+                        .setPartitions(assignedTasks2)))
+                    .setWarmupTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology3)
+                        .setPartitions(assignedTasks3)))
+            )
+            .setTargetAssignment(
+                new StreamsGroupDescribeResponseData.Assignment()
+                    .setActiveTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology1)
+                        .setPartitions(assignedTasks3)))
+                    .setStandbyTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology2)
+                        .setPartitions(assignedTasks2)))
+                    .setWarmupTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
+                        .setSubtopologyId(subTopology3)
+                        .setPartitions(assignedTasks1)))
+            )
+            .setUserEndpoint(new StreamsGroupDescribeResponseData.Endpoint().setHost("host").setPort(9090));
+        // TODO: TaskOffset, TaskEndOffset, IsClassic are to be implemented.
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsStreamsGroupDescribeWithTargetAssignmentNull() {
+        StreamsGroupMember member = new StreamsGroupMember.Builder(Uuid.randomUuid().toString())
+            .build();
+
+        StreamsGroupDescribeResponseData.Member streamsGroupDescribeMember = member.asStreamsGroupDescribeMember(
+            null);
+
+        assertEquals(new StreamsGroupDescribeResponseData.Assignment(), streamsGroupDescribeMember.targetAssignment());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -42,7 +42,6 @@ import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class StreamsGroupMemberTest {
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -41,12 +41,31 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamsGroupMemberTest {
 
     @Test
-    public void testNewMemberDefaults() {
+    public void testBuilderWithMemberIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember.Builder((String) null).build()
+        );
+        assertEquals("memberId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderWithMemberIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember.Builder((StreamsGroupMember) null).build()
+        );
+        assertEquals("member cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderWithDefaults() {
         final String memberId = Uuid.randomUuid().toString();
         StreamsGroupMember member = new StreamsGroupMember.Builder(memberId).build();
 
@@ -72,7 +91,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testNewMember() {
+    public void testBuilderNewMember() {
         final String memberId = "member-id";
         final int memberEpoch = 10;
         final int previousMemberEpoch = 9;
@@ -137,7 +156,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testUpdateWithStreamsGroupMemberMetadataValue() {
+    public void testBuilderUpdateWithStreamsGroupMemberMetadataValue() {
         StreamsGroupMemberMetadataValue record = new StreamsGroupMemberMetadataValue()
             .setClientId("client-id")
             .setClientHost("host-id")
@@ -178,7 +197,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testUpdateWithConsumerGroupCurrentMemberAssignmentValue() {
+    public void testBuilderUpdateWithConsumerGroupCurrentMemberAssignmentValue() {
         final String subtopology1 = "subtopology-id1";
         final String subtopology2 = "subtopology-id2";
         final List<Integer> partitions1 = Arrays.asList(1, 2);
@@ -261,7 +280,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testMaybeUpdateMember() {
+    public void testBuilderMaybeUpdateMember() {
         final String subtopology1 = "subtopology-id1";
         final String subtopology2 = "subtopology-id2";
 
@@ -339,7 +358,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testUpdateMemberEpoch() {
+    public void testBuilderUpdateMemberEpoch() {
         final StreamsGroupMember member = new StreamsGroupMember.Builder("member-id").build();
 
         final int newMemberEpoch = member.memberEpoch() + 1;
@@ -367,6 +386,474 @@ public class StreamsGroupMemberTest {
         assertEquals(member.activeTasksPendingRevocation(), updatedMember.activeTasksPendingRevocation());
         assertEquals(member.standbyTasksPendingRevocation(), updatedMember.standbyTasksPendingRevocation());
         assertEquals(member.warmupTasksPendingRevocation(), updatedMember.warmupTasksPendingRevocation());
+    }
+
+    @Test
+    public void testConstructorWithMemberIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                null,
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("memberId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithMemberStateIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                null,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("state cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithInstanceIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                null,
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("instanceId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithRackIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                null,
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("rackId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithClientIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                null,
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("clientId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithClientHostIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                null,
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("clientHost cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithProcessIdIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                null,
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("processId cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithUserEndpointIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("userEndpoint cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithClientTagsIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("clientTags cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithAssignedActiveTasksIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("assignedActiveTasks cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithAssignedStandbyTasksIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("assignedStandbyTasks cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithAssignedWarmupTasksIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("assignedWarmupTasks cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithActiveTasksPendingRevocationIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("activeTasksPendingRevocation cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithStandbyTasksPendingRevocationIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                null,
+                Collections.emptyMap()
+            )
+        );
+        assertEquals("standbyTasksPendingRevocation cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithWarmupTasksPendingRevocationIsNull() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> new StreamsGroupMember(
+                "",
+                0,
+                -1,
+                MemberState.STABLE,
+                Optional.empty(),
+                Optional.empty(),
+                "",
+                "",
+                -1,
+                -1,
+                "",
+                Optional.empty(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                null
+            )
+        );
+        assertEquals("warmupTasksPendingRevocation cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void testReturnUnmodifiableFields() {
+        final StreamsGroupMember member = new StreamsGroupMember(
+            "",
+            0,
+            -1,
+            MemberState.STABLE,
+            Optional.empty(),
+            Optional.empty(),
+            "",
+            "",
+            -1,
+            -1,
+            "",
+            Optional.empty(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertThrows(UnsupportedOperationException.class, () -> member.clientTags().put("not allowed", ""));
+        assertThrows(UnsupportedOperationException.class, () -> member.assignedActiveTasks().put("not allowed", Collections.emptySet()));
+        assertThrows(UnsupportedOperationException.class, () -> member.assignedStandbyTasks().put("not allowed", Collections.emptySet()));
+        assertThrows(UnsupportedOperationException.class, () -> member.assignedWarmupTasks().put("not allowed", Collections.emptySet()));
+        assertThrows(UnsupportedOperationException.class, () -> member.activeTasksPendingRevocation().put("not allowed", Collections.emptySet()));
+        assertThrows(UnsupportedOperationException.class, () -> member.standbyTasksPendingRevocation().put("not allowed", Collections.emptySet()));
+        assertThrows(UnsupportedOperationException.class, () -> member.warmupTasksPendingRevocation().put("not allowed", Collections.emptySet()));
     }
 
     @Test
@@ -451,7 +938,6 @@ public class StreamsGroupMemberTest {
                         .setPartitions(assignedTasks1)))
             )
             .setUserEndpoint(new StreamsGroupDescribeResponseData.Endpoint().setHost("host").setPort(9090));
-        // TODO: TaskOffset, TaskEndOffset, IsClassic are to be implemented.
 
         assertEquals(expected, actual);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -41,8 +41,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamsGroupMemberTest {
 
@@ -55,14 +54,14 @@ public class StreamsGroupMemberTest {
         assertEquals(0, member.memberEpoch());
         assertEquals(-1, member.previousMemberEpoch());
         assertEquals(MemberState.STABLE, member.state());
-        assertNull(member.instanceId());
-        assertNull(member.rackId());
+        assertTrue(member.instanceId().isEmpty());
+        assertTrue(member.rackId().isEmpty());
         assertEquals(-1, member.rebalanceTimeoutMs());
         assertEquals("", member.clientId());
         assertEquals("", member.clientHost());
         assertEquals(-1, member.topologyEpoch());
-        assertNull(member.processId());
-        assertNull(member.userEndpoint());
+        assertTrue(member.processId().isEmpty());
+        assertTrue(member.userEndpoint().isEmpty());
         assertEquals(Collections.emptyMap(), member.clientTags());
         assertEquals(Collections.emptyMap(), member.assignedActiveTasks());
         assertEquals(Collections.emptyMap(), member.assignedStandbyTasks());
@@ -121,13 +120,13 @@ public class StreamsGroupMemberTest {
         assertEquals(memberEpoch, member.memberEpoch());
         assertEquals(previousMemberEpoch, member.previousMemberEpoch());
         assertEquals(state, member.state());
-        assertEquals(instanceId, member.instanceId());
-        assertEquals(rackId, member.rackId());
+        assertEquals(Optional.of(instanceId), member.instanceId());
+        assertEquals(Optional.of(rackId), member.rackId());
         assertEquals(clientId, member.clientId());
         assertEquals(hostname, member.clientHost());
         assertEquals(topologyEpoch, member.topologyEpoch());
         assertEquals(processId, member.processId());
-        assertEquals(userEndpoint, member.userEndpoint());
+        assertEquals(Optional.of(userEndpoint), member.userEndpoint());
         assertEquals(clientTags, member.clientTags());
         assertEquals(assignedActiveTasks, member.assignedActiveTasks());
         assertEquals(assignedStandbyTasks, member.assignedStandbyTasks());
@@ -135,214 +134,6 @@ public class StreamsGroupMemberTest {
         assertEquals(activeTasksPendingRevocation, member.activeTasksPendingRevocation());
         assertEquals(standbyTasksPendingRevocation, member.standbyTasksPendingRevocation());
         assertEquals(warmupTasksPendingRevocation, member.warmupTasksPendingRevocation());
-    }
-
-    @Test
-    public void testEquals() {
-        StreamsGroupMember member1 = new StreamsGroupMember.Builder("member-id").build();
-        StreamsGroupMember member2 = new StreamsGroupMember.Builder(member1.memberId()).build();
-        assertEquals(member1, member2);
-        assertEquals(member1.hashCode(), member2.hashCode());
-
-        final StreamsGroupMember member3 = new StreamsGroupMember.Builder(member1.memberId() + "2")
-            .build();
-        assertNotEquals(member1, member3);
-        assertNotEquals(member1.hashCode(), member3.hashCode());
-
-        final StreamsGroupMember member4 = new StreamsGroupMember.Builder(member1.memberId())
-            .setMemberEpoch(member1.memberEpoch() + 1)
-            .build();
-        assertNotEquals(member1, member4);
-        assertNotEquals(member1.hashCode(), member4.hashCode());
-
-        final StreamsGroupMember member5 = new StreamsGroupMember.Builder(member1.memberId())
-            .setPreviousMemberEpoch(member1.previousMemberEpoch() + 1)
-            .build();
-        assertNotEquals(member1, member5);
-        assertNotEquals(member1.hashCode(), member5.hashCode());
-
-        final StreamsGroupMember member6 = new StreamsGroupMember.Builder(member1.memberId())
-            .setState(MemberState.UNREVOKED_TASKS)
-            .build();
-        assertNotEquals(member1, member6);
-        assertNotEquals(member1.hashCode(), member6.hashCode());
-
-        final StreamsGroupMember member7 = new StreamsGroupMember.Builder(member1.memberId())
-            .setInstanceId("instance-id")
-            .build();
-        final StreamsGroupMember member8 = new StreamsGroupMember.Builder(member7.memberId())
-            .setInstanceId(member7.instanceId())
-            .build();
-        final StreamsGroupMember member9 = new StreamsGroupMember.Builder(member7.memberId())
-            .setInstanceId(member7.instanceId() + "2")
-            .build();
-        assertEquals(member7, member8);
-        assertEquals(member7.hashCode(), member8.hashCode());
-        assertNotEquals(member7, member9);
-        assertNotEquals(member7.hashCode(), member9.hashCode());
-
-        final StreamsGroupMember member10 = new StreamsGroupMember.Builder(member1.memberId())
-            .setRackId("rack-id")
-            .build();
-        final StreamsGroupMember member11 = new StreamsGroupMember.Builder(member10.memberId())
-            .setRackId(member10.rackId())
-            .build();
-        final StreamsGroupMember member12 = new StreamsGroupMember.Builder(member11.memberId())
-            .setRackId(member10.rackId() + "2")
-            .build();
-        assertEquals(member10, member11);
-        assertEquals(member10.hashCode(), member11.hashCode());
-        assertNotEquals(member10, member12);
-        assertNotEquals(member10.hashCode(), member12.hashCode());
-
-        final StreamsGroupMember member13 = new StreamsGroupMember.Builder(member1.memberId())
-            .setClientHost("hostname")
-            .build();
-        final StreamsGroupMember member14 = new StreamsGroupMember.Builder(member13.memberId())
-            .setClientHost(member13.clientHost())
-            .build();
-        final StreamsGroupMember member15 = new StreamsGroupMember.Builder(member13.memberId())
-            .setClientHost(member13.clientHost() + "2")
-            .build();
-        assertEquals(member13, member14);
-        assertEquals(member13.hashCode(), member14.hashCode());
-        assertNotEquals(member13, member15);
-        assertNotEquals(member13.hashCode(), member15.hashCode());
-
-        final StreamsGroupMember member16 = new StreamsGroupMember.Builder(member1.memberId())
-            .setClientId("hostname")
-            .build();
-        final StreamsGroupMember member17 = new StreamsGroupMember.Builder(member16.memberId())
-            .setClientId(member16.clientId())
-            .build();
-        final StreamsGroupMember member18 = new StreamsGroupMember.Builder(member16.memberId())
-            .setClientId(member16.clientId() + "2")
-            .build();
-        assertEquals(member16, member17);
-        assertEquals(member16.hashCode(), member17.hashCode());
-        assertNotEquals(member16, member18);
-        assertNotEquals(member16.hashCode(), member18.hashCode());
-
-        final StreamsGroupMember member19 = new StreamsGroupMember.Builder(member1.memberId())
-            .setRebalanceTimeoutMs(member1.rebalanceTimeoutMs() + 1)
-            .build();
-        assertNotEquals(member1, member19);
-        assertNotEquals(member1.hashCode(), member19.hashCode());
-
-        final StreamsGroupMember member20 = new StreamsGroupMember.Builder(member1.memberId())
-            .setTopologyEpoch(member1.topologyEpoch() + 1)
-            .build();
-        assertNotEquals(member1, member20);
-        assertNotEquals(member1.hashCode(), member20.hashCode());
-
-        final StreamsGroupMember member21 = new StreamsGroupMember.Builder(member1.memberId())
-            .setProcessId("process-id")
-            .build();
-        final StreamsGroupMember member22 = new StreamsGroupMember.Builder(member21.memberId())
-            .setProcessId(member21.processId())
-            .build();
-        final StreamsGroupMember member23 = new StreamsGroupMember.Builder(member21.memberId())
-            .setClientId(member21.processId() + "2")
-            .build();
-        assertEquals(member21, member22);
-        assertEquals(member21.hashCode(), member22.hashCode());
-        assertNotEquals(member21, member23);
-        assertNotEquals(member21.hashCode(), member23.hashCode());
-
-        final StreamsGroupMember member24 = new StreamsGroupMember.Builder(member1.memberId())
-            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
-            .build();
-        final StreamsGroupMember member25 = new StreamsGroupMember.Builder(member24.memberId())
-            .setUserEndpoint(member24.userEndpoint())
-            .build();
-        final StreamsGroupMember member26 = new StreamsGroupMember.Builder(member24.memberId())
-            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint()
-                .setHost("host")
-                .setPort(member24.userEndpoint().port() + 1)
-            ).build();
-        assertEquals(member24, member25);
-        assertEquals(member24.hashCode(), member25.hashCode());
-        assertNotEquals(member24, member26);
-        assertNotEquals(member24.hashCode(), member26.hashCode());
-
-        final StreamsGroupMember member27 = new StreamsGroupMember.Builder(member1.memberId())
-            .setClientTags(mkMap(mkEntry("client", "tag")))
-            .build();
-        final StreamsGroupMember member28 = new StreamsGroupMember.Builder(member27.memberId())
-            .setClientTags(member27.clientTags())
-            .build();
-        final Map<String, String> clientTags = new HashMap<>(member27.clientTags());
-        clientTags.put("client2", "tag2");
-        final StreamsGroupMember member29 = new StreamsGroupMember.Builder(member27.memberId())
-            .setClientTags(clientTags)
-            .build();
-        assertEquals(member27, member28);
-        assertEquals(member27.hashCode(), member28.hashCode());
-        assertNotEquals(member27, member29);
-        assertNotEquals(member27.hashCode(), member29.hashCode());
-
-        final StreamsGroupMember member30 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member31 = new StreamsGroupMember.Builder(member30.memberId())
-            .setAssignedActiveTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
-            .build();
-        assertEquals(member1, member30);
-        assertEquals(member1.hashCode(), member30.hashCode());
-        assertNotEquals(member1, member31);
-        assertNotEquals(member1.hashCode(), member31.hashCode());
-
-        final StreamsGroupMember member32 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member33 = new StreamsGroupMember.Builder(member32.memberId())
-            .setAssignedStandbyTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
-            .build();
-        assertEquals(member1, member32);
-        assertEquals(member1.hashCode(), member32.hashCode());
-        assertNotEquals(member1, member33);
-        assertNotEquals(member1.hashCode(), member33.hashCode());
-
-        final StreamsGroupMember member34 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member35 = new StreamsGroupMember.Builder(member34.memberId())
-            .setAssignedWarmupTasks(mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3)))
-            .build();
-        assertEquals(member1, member34);
-        assertEquals(member1.hashCode(), member34.hashCode());
-        assertNotEquals(member1, member35);
-        assertNotEquals(member1.hashCode(), member35.hashCode());
-
-        final StreamsGroupMember member36 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member37 = new StreamsGroupMember.Builder(member36.memberId())
-            .setActiveTasksPendingRevocation(
-                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
-            ).build();
-        assertEquals(member1, member36);
-        assertEquals(member1.hashCode(), member36.hashCode());
-        assertNotEquals(member1, member37);
-        assertNotEquals(member1.hashCode(), member37.hashCode());
-
-        final StreamsGroupMember member38 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member39 = new StreamsGroupMember.Builder(member38.memberId())
-            .setStandbyTasksPendingRevocation(
-                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
-            ).build();
-        assertEquals(member1, member38);
-        assertEquals(member1.hashCode(), member38.hashCode());
-        assertNotEquals(member1, member39);
-        assertNotEquals(member1.hashCode(), member39.hashCode());
-
-        final StreamsGroupMember member40 = new StreamsGroupMember.Builder(member1.memberId())
-            .build();
-        final StreamsGroupMember member41 = new StreamsGroupMember.Builder(member40.memberId())
-            .setWarmupTasksPendingRevocation(
-                mkTasksPerSubtopology(mkTasks("subtopology-id", 1, 2, 3))
-            ).build();
-        assertEquals(member1, member40);
-        assertEquals(member1.hashCode(), member40.hashCode());
-        assertNotEquals(member1, member41);
-        assertNotEquals(member1.hashCode(), member41.hashCode());
     }
 
     @Test
@@ -364,12 +155,12 @@ public class StreamsGroupMemberTest {
 
         assertEquals(record.clientId(), member.clientId());
         assertEquals(record.clientHost(), member.clientHost());
-        assertEquals(record.instanceId(), member.instanceId());
-        assertEquals(record.rackId(), member.rackId());
+        assertEquals(Optional.of(record.instanceId()), member.instanceId());
+        assertEquals(Optional.of(record.rackId()), member.rackId());
         assertEquals(record.rebalanceTimeoutMs(), member.rebalanceTimeoutMs());
         assertEquals(record.topologyEpoch(), member.topologyEpoch());
         assertEquals(record.processId(), member.processId());
-        assertEquals(record.userEndpoint(), member.userEndpoint());
+        assertEquals(Optional.of(record.userEndpoint()), member.userEndpoint());
         assertEquals(
             record.clientTags().stream().collect(Collectors.toMap(KeyValue::key, KeyValue::value)),
             member.clientTags()
@@ -458,14 +249,14 @@ public class StreamsGroupMemberTest {
             member.warmupTasksPendingRevocation()
         );
         assertEquals("member-id", member.memberId());
-        assertNull(member.instanceId());
-        assertNull(member.rackId());
+        assertTrue(member.instanceId().isEmpty());
+        assertTrue(member.rackId().isEmpty());
         assertEquals(-1, member.rebalanceTimeoutMs());
         assertEquals("", member.clientId());
         assertEquals("", member.clientHost());
         assertEquals(-1, member.topologyEpoch());
-        assertNull(member.processId());
-        assertNull(member.userEndpoint());
+        assertTrue(member.processId().isEmpty());
+        assertTrue(member.userEndpoint().isEmpty());
         assertEquals(Collections.emptyMap(), member.clientTags());
     }
 
@@ -512,7 +303,7 @@ public class StreamsGroupMemberTest {
         final String newProcessId = "new" + member.processId();
         final int newTopologyEpoch = member.topologyEpoch() + 1;
         final StreamsGroupMemberMetadataValue.Endpoint newUserEndpoint =
-            new StreamsGroupMemberMetadataValue.Endpoint().setHost(member.userEndpoint().host() + "2").setPort(9090);
+            new StreamsGroupMemberMetadataValue.Endpoint().setHost(member.userEndpoint().get().host() + "2").setPort(9090);
         final Map<String, String> newClientTags = new HashMap<>(member.clientTags());
         newClientTags.put("client2", "tag2");
 
@@ -526,12 +317,12 @@ public class StreamsGroupMemberTest {
             .maybeUpdateClientTags(Optional.of(newClientTags))
             .build();
 
-        assertEquals(newRackId, updatedMember.rackId());
-        assertEquals(newInstanceId, updatedMember.instanceId());
+        assertEquals(Optional.of(newRackId), updatedMember.rackId());
+        assertEquals(Optional.of(newInstanceId), updatedMember.instanceId());
         assertEquals(newRebalanceTimeout, updatedMember.rebalanceTimeoutMs());
         assertEquals(newProcessId, updatedMember.processId());
         assertEquals(newTopologyEpoch, updatedMember.topologyEpoch());
-        assertEquals(newUserEndpoint, updatedMember.userEndpoint());
+        assertEquals(Optional.of(newUserEndpoint), updatedMember.userEndpoint());
         assertEquals(newClientTags, updatedMember.clientTags());
         assertEquals(member.memberId(), updatedMember.memberId());
         assertEquals(member.memberEpoch(), updatedMember.memberEpoch());
@@ -567,8 +358,8 @@ public class StreamsGroupMemberTest {
         assertEquals(member.clientId(), updatedMember.clientId());
         assertEquals(member.clientHost(), updatedMember.clientHost());
         assertEquals(member.topologyEpoch(), updatedMember.topologyEpoch());
-        assertNull(member.processId());
-        assertNull(member.userEndpoint());
+        assertTrue(member.processId().isEmpty());
+        assertTrue(member.userEndpoint().isEmpty());
         assertEquals(member.clientTags(), updatedMember.clientTags());
         assertEquals(member.assignedActiveTasks(), updatedMember.assignedActiveTasks());
         assertEquals(member.assignedStandbyTasks(), updatedMember.assignedStandbyTasks());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue.TaskIds;
@@ -41,10 +40,43 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class StreamsGroupMemberTest {
+
+    private static final String MEMBER_ID = "member-id";
+    private static final int MEMBER_EPOCH = 10;
+    private static final int PREVIOUS_MEMBER_EPOCH = 9;
+    private static final MemberState STATE = MemberState.UNRELEASED_TASKS;
+    private static final String INSTANCE_ID = "instance-id";
+    private static final String RACK_ID = "rack-id";
+    private static final int REBALANCE_TIMEOUT = 5000;
+    private static final String CLIENT_ID = "client-id";
+    private static final String HOSTNAME = "hostname";
+    private static final int TOPOLOGY_EPOCH = 3;
+    private static final String PROCESS_ID = "process-id";
+    private static final String SUBTOPOLOGY1 = "subtopology1";
+    private static final String SUBTOPOLOGY2 = "subtopology2";
+    private static final String SUBTOPOLOGY3 = "subtopology3";
+    private static final StreamsGroupMemberMetadataValue.Endpoint USER_ENDPOINT =
+        new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090);
+    private static final String CLIENT_TAG_KEY = "client";
+    private static final String CLIENT_TAG_VALUE = "tag";
+    private static final Map<String, String> CLIENT_TAGS = mkMap(mkEntry(CLIENT_TAG_KEY, CLIENT_TAG_VALUE));
+    private static final List<Integer> TASKS1 = List.of(1, 2, 3);
+    private static final List<Integer> TASKS2 = List.of(4, 5, 6);
+    private static final List<Integer> TASKS3 = List.of(7, 8);
+    private static final List<Integer> TASKS4 = List.of(3, 2, 1);
+    private static final List<Integer> TASKS5 = List.of(6, 5, 4);
+    private static final List<Integer> TASKS6 = List.of(9, 7);
+    private static final Map<String, Set<Integer>> ASSIGNED_ACTIVE_TASKS = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS1.toArray(Integer[]::new)));
+    private static final Map<String, Set<Integer>> ASSIGNED_STANDBY_TASKS = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS2.toArray(Integer[]::new)));
+    private static final Map<String, Set<Integer>> ASSIGNED_WARMUP_TASKS = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS3.toArray(Integer[]::new)));
+    private static final Map<String, Set<Integer>> ACTIVE_TASKS_PENDING_REVOCATION = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS4.toArray(Integer[]::new)));
+    private static final Map<String, Set<Integer>> STANDBY_TASKS_PENDING_REVOCATION = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS5.toArray(Integer[]::new)));
+    private static final Map<String, Set<Integer>> WARMUP_TASKS_PENDING_REVOCATION = mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS6.toArray(Integer[]::new)));
 
     @Test
     public void testBuilderWithMemberIdIsNull() {
@@ -66,107 +98,68 @@ public class StreamsGroupMemberTest {
 
     @Test
     public void testBuilderWithDefaults() {
-        final String memberId = Uuid.randomUuid().toString();
-        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId).build();
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID).build();
 
-        assertEquals(memberId, member.memberId());
-        assertEquals(0, member.memberEpoch());
-        assertEquals(-1, member.previousMemberEpoch());
-        assertEquals(MemberState.STABLE, member.state());
-        assertTrue(member.instanceId().isEmpty());
-        assertTrue(member.rackId().isEmpty());
-        assertEquals(-1, member.rebalanceTimeoutMs());
-        assertEquals("", member.clientId());
-        assertEquals("", member.clientHost());
-        assertEquals(-1, member.topologyEpoch());
-        assertTrue(member.processId().isEmpty());
-        assertTrue(member.userEndpoint().isEmpty());
-        assertEquals(Collections.emptyMap(), member.clientTags());
-        assertEquals(Collections.emptyMap(), member.assignedActiveTasks());
-        assertEquals(Collections.emptyMap(), member.assignedStandbyTasks());
-        assertEquals(Collections.emptyMap(), member.assignedWarmupTasks());
-        assertEquals(Collections.emptyMap(), member.activeTasksPendingRevocation());
-        assertEquals(Collections.emptyMap(), member.standbyTasksPendingRevocation());
-        assertEquals(Collections.emptyMap(), member.warmupTasksPendingRevocation());
+        fail();
+        assertEquals(MEMBER_ID, member.memberId());
+        assertNull(member.memberEpoch());
+        assertNull(member.previousMemberEpoch());
+        assertNull(member.state());
+        assertNull(member.instanceId());
+        assertNull(member.rackId());
+        assertNull(member.rebalanceTimeoutMs());
+        assertNull(member.clientId());
+        assertNull(member.clientHost());
+        assertNull(member.topologyEpoch());
+        assertNull(member.processId());
+        assertNull(member.userEndpoint());
+        assertNull(member.clientTags());
+        assertNull(member.assignedActiveTasks());
+        assertNull(member.assignedStandbyTasks());
+        assertNull(member.assignedWarmupTasks());
+        assertNull(member.activeTasksPendingRevocation());
+        assertNull(member.standbyTasksPendingRevocation());
+        assertNull(member.warmupTasksPendingRevocation());
     }
 
     @Test
     public void testBuilderNewMember() {
-        final String memberId = "member-id";
-        final int memberEpoch = 10;
-        final int previousMemberEpoch = 9;
-        final MemberState state = MemberState.UNRELEASED_TASKS;
-        final String instanceId = "instance-id";
-        final String rackId = "rack-id";
-        final int rebalanceTimeout = 5000;
-        final String clientId = "client-id";
-        final String hostname = "hostname";
-        final int topologyEpoch = 3;
-        final String processId = "process-id";
-        final String subtopology1 = "subtopology1";
-        final String subtopology2 = "subtopology2";
-        final StreamsGroupMemberMetadataValue.Endpoint userEndpoint =
-            new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090);
-        final Map<String, String> clientTags = mkMap(mkEntry("client", "tag"));
-        final Map<String, Set<Integer>> assignedActiveTasks = mkTasksPerSubtopology(mkTasks(subtopology1, 1, 2, 3));
-        final Map<String, Set<Integer>> assignedStandbyTasks = mkTasksPerSubtopology(mkTasks(subtopology2, 6, 5, 4));
-        final Map<String, Set<Integer>> assignedWarmupTasks = mkTasksPerSubtopology(mkTasks(subtopology1, 7, 8, 9));
-        final Map<String, Set<Integer>> activeTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology2, 3, 2, 1));
-        final Map<String, Set<Integer>> standbyTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology1, 4, 5, 6));
-        final Map<String, Set<Integer>> warmupTasksPendingRevocation = mkTasksPerSubtopology(mkTasks(subtopology2, 9, 8, 7));
-        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId)
-            .setMemberEpoch(memberEpoch)
-            .setPreviousMemberEpoch(previousMemberEpoch)
-            .setState(state)
-            .setInstanceId(instanceId)
-            .setRackId(rackId)
-            .setRebalanceTimeoutMs(rebalanceTimeout)
-            .setClientId(clientId)
-            .setClientHost(hostname)
-            .setTopologyEpoch(topologyEpoch)
-            .setProcessId(processId)
-            .setUserEndpoint(userEndpoint)
-            .setClientTags(clientTags)
-            .setAssignedActiveTasks(assignedActiveTasks)
-            .setAssignedStandbyTasks(assignedStandbyTasks)
-            .setAssignedWarmupTasks(assignedWarmupTasks)
-            .setActiveTasksPendingRevocation(activeTasksPendingRevocation)
-            .setStandbyTasksPendingRevocation(standbyTasksPendingRevocation)
-            .setWarmupTasksPendingRevocation(warmupTasksPendingRevocation)
-            .build();
+        StreamsGroupMember member = createStreamsGroupMember();
 
-        assertEquals(memberId, member.memberId());
-        assertEquals(memberEpoch, member.memberEpoch());
-        assertEquals(previousMemberEpoch, member.previousMemberEpoch());
-        assertEquals(state, member.state());
-        assertEquals(Optional.of(instanceId), member.instanceId());
-        assertEquals(Optional.of(rackId), member.rackId());
-        assertEquals(clientId, member.clientId());
-        assertEquals(hostname, member.clientHost());
-        assertEquals(topologyEpoch, member.topologyEpoch());
-        assertEquals(processId, member.processId());
-        assertEquals(Optional.of(userEndpoint), member.userEndpoint());
-        assertEquals(clientTags, member.clientTags());
-        assertEquals(assignedActiveTasks, member.assignedActiveTasks());
-        assertEquals(assignedStandbyTasks, member.assignedStandbyTasks());
-        assertEquals(assignedWarmupTasks, member.assignedWarmupTasks());
-        assertEquals(activeTasksPendingRevocation, member.activeTasksPendingRevocation());
-        assertEquals(standbyTasksPendingRevocation, member.standbyTasksPendingRevocation());
-        assertEquals(warmupTasksPendingRevocation, member.warmupTasksPendingRevocation());
+        assertEquals(MEMBER_ID, member.memberId());
+        assertEquals(MEMBER_EPOCH, member.memberEpoch());
+        assertEquals(PREVIOUS_MEMBER_EPOCH, member.previousMemberEpoch());
+        assertEquals(STATE, member.state());
+        assertEquals(Optional.of(INSTANCE_ID), member.instanceId());
+        assertEquals(Optional.of(RACK_ID), member.rackId());
+        assertEquals(CLIENT_ID, member.clientId());
+        assertEquals(HOSTNAME, member.clientHost());
+        assertEquals(TOPOLOGY_EPOCH, member.topologyEpoch());
+        assertEquals(PROCESS_ID, member.processId());
+        assertEquals(Optional.of(USER_ENDPOINT), member.userEndpoint());
+        assertEquals(CLIENT_TAGS, member.clientTags());
+        assertEquals(ASSIGNED_ACTIVE_TASKS, member.assignedActiveTasks());
+        assertEquals(ASSIGNED_STANDBY_TASKS, member.assignedStandbyTasks());
+        assertEquals(ASSIGNED_WARMUP_TASKS, member.assignedWarmupTasks());
+        assertEquals(ACTIVE_TASKS_PENDING_REVOCATION, member.activeTasksPendingRevocation());
+        assertEquals(STANDBY_TASKS_PENDING_REVOCATION, member.standbyTasksPendingRevocation());
+        assertEquals(WARMUP_TASKS_PENDING_REVOCATION, member.warmupTasksPendingRevocation());
     }
 
     @Test
     public void testBuilderUpdateWithStreamsGroupMemberMetadataValue() {
         StreamsGroupMemberMetadataValue record = new StreamsGroupMemberMetadataValue()
-            .setClientId("client-id")
-            .setClientHost("host-id")
-            .setInstanceId("instance-id")
-            .setRackId("rack-id")
-            .setRebalanceTimeoutMs(1000)
-            .setTopologyEpoch(3)
-            .setProcessId("process-id")
-            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
-            .setClientTags(Collections.singletonList(new KeyValue().setKey("client").setValue("tag")));
+            .setClientId(CLIENT_ID)
+            .setClientHost(HOSTNAME)
+            .setInstanceId(INSTANCE_ID)
+            .setRackId(RACK_ID)
+            .setRebalanceTimeoutMs(REBALANCE_TIMEOUT)
+            .setTopologyEpoch(TOPOLOGY_EPOCH)
+            .setProcessId(PROCESS_ID)
+            .setUserEndpoint(USER_ENDPOINT)
+            .setClientTags(CLIENT_TAGS.entrySet().stream()
+                .map(e -> new KeyValue().setKey(e.getKey()).setValue(e.getValue()))
+                .collect(Collectors.toList()));
 
         StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
             .updateWith(record)
@@ -184,124 +177,59 @@ public class StreamsGroupMemberTest {
             record.clientTags().stream().collect(Collectors.toMap(KeyValue::key, KeyValue::value)),
             member.clientTags()
         );
-        assertEquals("member-id", member.memberId());
-        assertEquals(0, member.memberEpoch());
-        assertEquals(-1, member.previousMemberEpoch());
-        assertEquals(MemberState.STABLE, member.state());
-        assertEquals(Collections.emptyMap(), member.assignedActiveTasks());
-        assertEquals(Collections.emptyMap(), member.assignedStandbyTasks());
-        assertEquals(Collections.emptyMap(), member.assignedWarmupTasks());
-        assertEquals(Collections.emptyMap(), member.activeTasksPendingRevocation());
-        assertEquals(Collections.emptyMap(), member.standbyTasksPendingRevocation());
-        assertEquals(Collections.emptyMap(), member.warmupTasksPendingRevocation());
+        assertEquals(MEMBER_ID, member.memberId());
+        assertNull(member.memberEpoch());
+        assertNull(member.previousMemberEpoch());
+        assertNull(member.state());
+        assertNull(member.assignedActiveTasks());
+        assertNull(member.assignedStandbyTasks());
+        assertNull(member.assignedWarmupTasks());
+        assertNull(member.activeTasksPendingRevocation());
+        assertNull(member.standbyTasksPendingRevocation());
+        assertNull(member.warmupTasksPendingRevocation());
     }
 
     @Test
     public void testBuilderUpdateWithConsumerGroupCurrentMemberAssignmentValue() {
-        final String subtopology1 = "subtopology-id1";
-        final String subtopology2 = "subtopology-id2";
-        final List<Integer> partitions1 = Arrays.asList(1, 2);
-        final List<Integer> partitions2 = Arrays.asList(3, 4);
-        final List<Integer> partitions3 = Arrays.asList(5, 6);
-        final List<Integer> partitions4 = Arrays.asList(7, 8);
-        final List<Integer> partitions5 = Arrays.asList(9, 10);
-        final List<Integer> partitions6 = Arrays.asList(11, 12);
-
         StreamsGroupCurrentMemberAssignmentValue record = new StreamsGroupCurrentMemberAssignmentValue()
-            .setMemberEpoch(10)
-            .setPreviousMemberEpoch(9)
-            .setState((byte) 2)
-            .setActiveTasks(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology1)
-                .setPartitions(partitions1))
-            )
-            .setStandbyTasks(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology2)
-                .setPartitions(partitions2))
-            )
-            .setWarmupTasks(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology1)
-                .setPartitions(partitions3))
-            )
-            .setActiveTasksPendingRevocation(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology2)
-                .setPartitions(partitions4))
-            )
-            .setStandbyTasksPendingRevocation(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology1)
-                .setPartitions(partitions5))
-            )
-            .setWarmupTasksPendingRevocation(Collections.singletonList(new TaskIds()
-                .setSubtopologyId(subtopology2)
-                .setPartitions(partitions6))
-            );
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setPreviousMemberEpoch(PREVIOUS_MEMBER_EPOCH)
+            .setState(STATE.value())
+            .setActiveTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS1)))
+            .setStandbyTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS2)))
+            .setWarmupTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS3)))
+            .setActiveTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS4)))
+            .setStandbyTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS5)))
+            .setWarmupTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS6)));
 
-        StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID)
             .updateWith(record)
             .build();
 
+        assertEquals(MEMBER_ID, member.memberId());
         assertEquals(record.memberEpoch(), member.memberEpoch());
         assertEquals(record.previousMemberEpoch(), member.previousMemberEpoch());
         assertEquals(MemberState.fromValue(record.state()), member.state());
-        assertEquals(
-            Map.of(subtopology1, new HashSet<>(partitions1)),
-            member.assignedActiveTasks()
-        );
-        assertEquals(
-            Map.of(subtopology2, new HashSet<>(partitions2)),
-            member.assignedStandbyTasks()
-        );
-        assertEquals(
-            Map.of(subtopology1, new HashSet<>(partitions3)),
-            member.assignedWarmupTasks()
-        );
-        assertEquals(
-            Map.of(subtopology2, new HashSet<>(partitions4)),
-            member.activeTasksPendingRevocation()
-        );
-        assertEquals(
-            Map.of(subtopology1, new HashSet<>(partitions5)),
-            member.standbyTasksPendingRevocation()
-        );
-        assertEquals(
-            Map.of(subtopology2, new HashSet<>(partitions6)),
-            member.warmupTasksPendingRevocation()
-        );
-        assertEquals("member-id", member.memberId());
-        assertTrue(member.instanceId().isEmpty());
-        assertTrue(member.rackId().isEmpty());
-        assertEquals(-1, member.rebalanceTimeoutMs());
-        assertEquals("", member.clientId());
-        assertEquals("", member.clientHost());
-        assertEquals(-1, member.topologyEpoch());
-        assertTrue(member.processId().isEmpty());
-        assertTrue(member.userEndpoint().isEmpty());
-        assertEquals(Collections.emptyMap(), member.clientTags());
+        assertEquals(ASSIGNED_ACTIVE_TASKS, member.assignedActiveTasks());
+        assertEquals(ASSIGNED_STANDBY_TASKS, member.assignedStandbyTasks());
+        assertEquals(ASSIGNED_WARMUP_TASKS, member.assignedWarmupTasks());
+        assertEquals(ACTIVE_TASKS_PENDING_REVOCATION, member.activeTasksPendingRevocation());
+        assertEquals(STANDBY_TASKS_PENDING_REVOCATION, member.standbyTasksPendingRevocation());
+        assertEquals(WARMUP_TASKS_PENDING_REVOCATION, member.warmupTasksPendingRevocation());
+        assertNull(member.instanceId());
+        assertNull(member.rackId());
+        assertNull(member.rebalanceTimeoutMs());
+        assertNull(member.clientId());
+        assertNull(member.clientHost());
+        assertNull(member.topologyEpoch());
+        assertNull(member.processId());
+        assertNull(member.userEndpoint());
+        assertNull(member.clientTags());
     }
 
     @Test
     public void testBuilderMaybeUpdateMember() {
-        final String subtopology1 = "subtopology-id1";
-        final String subtopology2 = "subtopology-id2";
-
-        final StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
-            .setMemberEpoch(10)
-            .setPreviousMemberEpoch(9)
-            .setInstanceId("instance-id")
-            .setRackId("rack-id")
-            .setRebalanceTimeoutMs(5000)
-            .setClientId("client-id")
-            .setClientHost("hostname")
-            .setTopologyEpoch(3)
-            .setProcessId("process-id")
-            .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090))
-            .setClientTags(mkMap(mkEntry("client", "tag")))
-            .setAssignedActiveTasks(mkTasksPerSubtopology(mkTasks(subtopology1, 1, 2, 3)))
-            .setAssignedStandbyTasks(mkTasksPerSubtopology(mkTasks(subtopology2, 6, 5, 4)))
-            .setAssignedWarmupTasks(mkTasksPerSubtopology(mkTasks(subtopology1, 7, 8, 9)))
-            .setActiveTasksPendingRevocation(
-                mkTasksPerSubtopology(mkTasks(subtopology2, 3, 2, 1)))
-            .build();
+        final StreamsGroupMember member = createStreamsGroupMember();
 
         // This is a no-op.
         StreamsGroupMember updatedMember = new StreamsGroupMember.Builder(member)
@@ -318,9 +246,9 @@ public class StreamsGroupMemberTest {
 
         final String newRackId = "new" + member.rackId();
         final String newInstanceId = "new" + member.instanceId();
-        final long newRebalanceTimeout = member.rebalanceTimeoutMs() + 1000;
+        final Integer newRebalanceTimeout = member.rebalanceTimeoutMs() + 1000;
         final String newProcessId = "new" + member.processId();
-        final int newTopologyEpoch = member.topologyEpoch() + 1;
+        final Integer newTopologyEpoch = member.topologyEpoch() + 1;
         final StreamsGroupMemberMetadataValue.Endpoint newUserEndpoint =
             new StreamsGroupMemberMetadataValue.Endpoint().setHost(member.userEndpoint().get().host() + "2").setPort(9090);
         final Map<String, String> newClientTags = new HashMap<>(member.clientTags());
@@ -359,7 +287,7 @@ public class StreamsGroupMemberTest {
 
     @Test
     public void testBuilderUpdateMemberEpoch() {
-        final StreamsGroupMember member = new StreamsGroupMember.Builder("member-id").build();
+        final StreamsGroupMember member = createStreamsGroupMember();
 
         final int newMemberEpoch = member.memberEpoch() + 1;
         final StreamsGroupMember updatedMember = new StreamsGroupMember.Builder(member)
@@ -377,8 +305,8 @@ public class StreamsGroupMemberTest {
         assertEquals(member.clientId(), updatedMember.clientId());
         assertEquals(member.clientHost(), updatedMember.clientHost());
         assertEquals(member.topologyEpoch(), updatedMember.topologyEpoch());
-        assertTrue(member.processId().isEmpty());
-        assertTrue(member.userEndpoint().isEmpty());
+        assertEquals(member.processId(), updatedMember.processId());
+        assertEquals(member.userEndpoint(), updatedMember.userEndpoint());
         assertEquals(member.clientTags(), updatedMember.clientTags());
         assertEquals(member.assignedActiveTasks(), updatedMember.assignedActiveTasks());
         assertEquals(member.assignedStandbyTasks(), updatedMember.assignedStandbyTasks());
@@ -389,463 +317,8 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testConstructorWithMemberIdIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                null,
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("memberId cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithMemberStateIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                null,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("state cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithInstanceIdIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                null,
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("instanceId cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithRackIdIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                null,
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("rackId cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithClientIdIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                null,
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("clientId cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithClientHostIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                null,
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("clientHost cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithProcessIdIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                null,
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("processId cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithUserEndpointIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("userEndpoint cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithClientTagsIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("clientTags cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithAssignedActiveTasksIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("assignedActiveTasks cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithAssignedStandbyTasksIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("assignedStandbyTasks cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithAssignedWarmupTasksIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("assignedWarmupTasks cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithActiveTasksPendingRevocationIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                null,
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("activeTasksPendingRevocation cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithStandbyTasksPendingRevocationIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                null,
-                Collections.emptyMap()
-            )
-        );
-        assertEquals("standbyTasksPendingRevocation cannot be null", exception.getMessage());
-    }
-
-    @Test
-    public void testConstructorWithWarmupTasksPendingRevocationIsNull() {
-        final Exception exception = assertThrows(
-            NullPointerException.class,
-            () -> new StreamsGroupMember(
-                "",
-                0,
-                -1,
-                MemberState.STABLE,
-                Optional.empty(),
-                Optional.empty(),
-                "",
-                "",
-                -1,
-                -1,
-                "",
-                Optional.empty(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                null
-            )
-        );
-        assertEquals("warmupTasksPendingRevocation cannot be null", exception.getMessage());
-    }
-
-    @Test
     public void testReturnUnmodifiableFields() {
-        final StreamsGroupMember member = new StreamsGroupMember(
-            "",
-            0,
-            -1,
-            MemberState.STABLE,
-            Optional.empty(),
-            Optional.empty(),
-            "",
-            "",
-            -1,
-            -1,
-            "",
-            Optional.empty(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap()
-        );
+        final StreamsGroupMember member = createStreamsGroupMember();
 
         assertThrows(UnsupportedOperationException.class, () -> member.clientTags().put("not allowed", ""));
         assertThrows(UnsupportedOperationException.class, () -> member.assignedActiveTasks().put("not allowed", Collections.emptySet()));
@@ -858,98 +331,101 @@ public class StreamsGroupMemberTest {
 
     @Test
     public void testAsStreamsGroupDescribeMember() {
-        String subTopology1 = Uuid.randomUuid().toString();
-        String subTopology2 = Uuid.randomUuid().toString();
-        String subTopology3 = Uuid.randomUuid().toString();
-        List<Integer> assignedTasks1 = Arrays.asList(0, 1, 2);
-        List<Integer> assignedTasks2 = Arrays.asList(3, 4, 5);
-        List<Integer> assignedTasks3 = Arrays.asList(6, 7, 8);
-        int epoch = 10;
-        String memberId = Uuid.randomUuid().toString();
-        String clientId = "clientId";
-        String instanceId = "instanceId";
-        String rackId = "rackId";
-        String clientHost = "clientHost";
-        String processId = "processId";
-        int topologyEpoch = 3;
-        Map<String, String> clientTags = Collections.singletonMap("key", "value");
+        final StreamsGroupMember member = createStreamsGroupMember();
+        List<Integer> assignedTasks1 = Arrays.asList(10, 11, 12);
+        List<Integer> assignedTasks2 = Arrays.asList(13, 14, 15);
+        List<Integer> assignedTasks3 = Arrays.asList(16, 17, 18);
         Assignment targetAssignment = new Assignment(
-            mkMap(mkEntry(subTopology1, new HashSet<>(assignedTasks3))),
-            mkMap(mkEntry(subTopology2, new HashSet<>(assignedTasks2))),
-            mkMap(mkEntry(subTopology3, new HashSet<>(assignedTasks1)))
+            mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(assignedTasks3))),
+            mkMap(mkEntry(SUBTOPOLOGY2, new HashSet<>(assignedTasks2))),
+            mkMap(mkEntry(SUBTOPOLOGY3, new HashSet<>(assignedTasks1)))
         );
-        StreamsGroupMember member = new StreamsGroupMember.Builder(memberId)
-            .setMemberEpoch(epoch)
-            .setPreviousMemberEpoch(epoch - 1)
-            .setClientId(clientId)
-            .setInstanceId(instanceId)
-            .setRackId(rackId)
-            .setClientHost(clientHost)
-            .setProcessId(processId)
-            .setTopologyEpoch(topologyEpoch)
-            .setClientTags(clientTags)
-            .setAssignedActiveTasks(
-                mkMap(mkEntry(subTopology1, new HashSet<>(assignedTasks1)))
-            )
-            .setAssignedStandbyTasks(
-                mkMap(mkEntry(subTopology2, new HashSet<>(assignedTasks2)))
-            )
-            .setAssignedWarmupTasks(
-                mkMap(mkEntry(subTopology3, new HashSet<>(assignedTasks3)))
-            )
-            .setUserEndpoint(
-                new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090)
-            )
-            .build();
 
         StreamsGroupDescribeResponseData.Member actual = member.asStreamsGroupDescribeMember(targetAssignment);
         StreamsGroupDescribeResponseData.Member expected = new StreamsGroupDescribeResponseData.Member()
-            .setMemberId(memberId)
-            .setMemberEpoch(epoch)
-            .setClientId(clientId)
-            .setInstanceId(instanceId)
-            .setRackId(rackId)
-            .setClientHost(clientHost)
-            .setProcessId(processId)
-            .setTopologyEpoch(topologyEpoch)
-            .setClientTags(Collections.singletonList(new StreamsGroupDescribeResponseData.KeyValue().setKey("key").setValue("value")))
+            .setMemberId(MEMBER_ID)
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setClientId(CLIENT_ID)
+            .setInstanceId(INSTANCE_ID)
+            .setRackId(RACK_ID)
+            .setClientHost(HOSTNAME)
+            .setProcessId(PROCESS_ID)
+            .setTopologyEpoch(TOPOLOGY_EPOCH)
+            .setClientTags(List.of(
+                new StreamsGroupDescribeResponseData.KeyValue().setKey(CLIENT_TAG_KEY).setValue(CLIENT_TAG_VALUE))
+            )
             .setAssignment(
                 new StreamsGroupDescribeResponseData.Assignment()
-                    .setActiveTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology1)
-                        .setPartitions(assignedTasks1)))
-                    .setStandbyTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology2)
-                        .setPartitions(assignedTasks2)))
-                    .setWarmupTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology3)
-                        .setPartitions(assignedTasks3)))
+                    .setActiveTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY1)
+                            .setPartitions(TASKS1))
+                    )
+                    .setStandbyTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY2)
+                            .setPartitions(TASKS2))
+                    )
+                    .setWarmupTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY1)
+                            .setPartitions(TASKS3))
+                    )
             )
             .setTargetAssignment(
                 new StreamsGroupDescribeResponseData.Assignment()
-                    .setActiveTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology1)
-                        .setPartitions(assignedTasks3)))
-                    .setStandbyTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology2)
-                        .setPartitions(assignedTasks2)))
-                    .setWarmupTasks(Collections.singletonList(new StreamsGroupDescribeResponseData.TaskIds()
-                        .setSubtopologyId(subTopology3)
-                        .setPartitions(assignedTasks1)))
+                    .setActiveTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY1)
+                            .setPartitions(assignedTasks3))
+                    )
+                    .setStandbyTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY2)
+                            .setPartitions(assignedTasks2))
+                    )
+                    .setWarmupTasks(List.of(
+                        new StreamsGroupDescribeResponseData.TaskIds()
+                            .setSubtopologyId(SUBTOPOLOGY3)
+                            .setPartitions(assignedTasks1))
+                    )
             )
-            .setUserEndpoint(new StreamsGroupDescribeResponseData.Endpoint().setHost("host").setPort(9090));
+            .setUserEndpoint(new StreamsGroupDescribeResponseData.Endpoint()
+                .setHost(USER_ENDPOINT.host())
+                .setPort(USER_ENDPOINT.port())
+            );
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testAsStreamsGroupDescribeWithTargetAssignmentNull() {
-        StreamsGroupMember member = new StreamsGroupMember.Builder(Uuid.randomUuid().toString())
-            .build();
-
-        StreamsGroupDescribeResponseData.Member streamsGroupDescribeMember = member.asStreamsGroupDescribeMember(
-            null);
+        final StreamsGroupMember member = createStreamsGroupMember();
+        StreamsGroupDescribeResponseData.Member streamsGroupDescribeMember = member.asStreamsGroupDescribeMember(null);
 
         assertEquals(new StreamsGroupDescribeResponseData.Assignment(), streamsGroupDescribeMember.targetAssignment());
+    }
+
+    private StreamsGroupMember createStreamsGroupMember() {
+        return new StreamsGroupMember.Builder(MEMBER_ID)
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setPreviousMemberEpoch(PREVIOUS_MEMBER_EPOCH)
+            .setState(STATE)
+            .setInstanceId(INSTANCE_ID)
+            .setRackId(RACK_ID)
+            .setRebalanceTimeoutMs(REBALANCE_TIMEOUT)
+            .setClientId(CLIENT_ID)
+            .setClientHost(HOSTNAME)
+            .setTopologyEpoch(TOPOLOGY_EPOCH)
+            .setProcessId(PROCESS_ID)
+            .setUserEndpoint(USER_ENDPOINT)
+            .setClientTags(CLIENT_TAGS)
+            .setAssignedActiveTasks(ASSIGNED_ACTIVE_TASKS)
+            .setAssignedStandbyTasks(ASSIGNED_STANDBY_TASKS)
+            .setAssignedWarmupTasks(ASSIGNED_WARMUP_TASKS)
+            .setActiveTasksPendingRevocation(ACTIVE_TASKS_PENDING_REVOCATION)
+            .setStandbyTasksPendingRevocation(STANDBY_TASKS_PENDING_REVOCATION)
+            .setWarmupTasksPendingRevocation(WARMUP_TASKS_PENDING_REVOCATION)
+            .build();
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -100,7 +100,6 @@ public class StreamsGroupMemberTest {
     public void testBuilderWithDefaults() {
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID).build();
 
-        fail();
         assertEquals(MEMBER_ID, member.memberId());
         assertNull(member.memberEpoch());
         assertNull(member.previousMemberEpoch());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
@@ -27,11 +27,6 @@ import java.util.Set;
 
 public class TaskAssignmentTestUtil {
 
-    public enum TaskRole {
-        ACTIVE,
-        STANDBY,
-        WARMUP
-    }
     public static Assignment mkAssignment(final Map<String, Set<Integer>> activeTasks,
                                           final Map<String, Set<Integer>> standbyTasks,
                                           final Map<String, Set<Integer>> warmupTasks) {
@@ -42,33 +37,8 @@ public class TaskAssignmentTestUtil {
         );
     }
 
-    // TODO: Tests using this util probably should be extended to cover standby tasks
-    public static Assignment mkAssignment(final Map<String, Set<Integer>> activeTasks) {
-        return new Assignment(
-            Collections.unmodifiableMap(Objects.requireNonNull(activeTasks)),
-            Collections.emptyMap(),
-            Collections.emptyMap()
-        );
-    }
-
-    @SafeVarargs
-    public static Assignment mkAssignment(TaskRole taskRole, Map.Entry<String, Set<Integer>>... entries) {
-        switch (taskRole) {
-            case ACTIVE:
-                return new Assignment(mkTasksPerSubtopology(entries), new HashMap<>(), new HashMap<>());
-            case STANDBY:
-                return new Assignment(new HashMap<>(), mkTasksPerSubtopology(entries), new HashMap<>());
-            case WARMUP:
-                return new Assignment(new HashMap<>(), new HashMap<>(), mkTasksPerSubtopology(entries));
-            default:
-                throw new IllegalArgumentException("Unknown task role: " + taskRole);
-        }
-    }
-
-    public static Map.Entry<String, Set<Integer>> mkTasks(
-        String subtopologyId,
-        Integer... tasks
-    ) {
+    public static Map.Entry<String, Set<Integer>> mkTasks(String subtopologyId,
+                                                          Integer... tasks) {
         return new AbstractMap.SimpleEntry<>(
             subtopologyId,
             new HashSet<>(List.of(tasks))
@@ -76,7 +46,8 @@ public class TaskAssignmentTestUtil {
     }
 
     @SafeVarargs
-    public static Map<String, Set<Integer>> mkTasksPerSubtopology(Map.Entry<String, Set<Integer>>... entries) {
+    public static Map<String, Set<Integer>> mkTasksPerSubtopology(Map.Entry<String,
+                                                                  Set<Integer>>... entries) {
         Map<String, Set<Integer>> assignment = new HashMap<>();
         for (Map.Entry<String, Set<Integer>> entry : entries) {
             assignment.put(entry.getKey(), entry.getValue());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class TaskAssignmentTestUtil {
+
+    public enum TaskRole {
+        ACTIVE,
+        STANDBY,
+        WARMUP
+    }
+    public static Assignment mkAssignment(final Map<String, Set<Integer>> activeTasks,
+                                          final Map<String, Set<Integer>> standbyTasks,
+                                          final Map<String, Set<Integer>> warmupTasks) {
+        return new Assignment(
+            Collections.unmodifiableMap(Objects.requireNonNull(activeTasks)),
+            Collections.unmodifiableMap(Objects.requireNonNull(standbyTasks)),
+            Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks))
+        );
+    }
+
+    // TODO: Tests using this util probably should be extended to cover standby tasks
+    public static Assignment mkAssignment(final Map<String, Set<Integer>> activeTasks) {
+        return new Assignment(
+            Collections.unmodifiableMap(Objects.requireNonNull(activeTasks)),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+    }
+
+    @SafeVarargs
+    public static Assignment mkAssignment(TaskRole taskRole, Map.Entry<String, Set<Integer>>... entries) {
+        switch (taskRole) {
+            case ACTIVE:
+                return new Assignment(mkTasksPerSubtopology(entries), new HashMap<>(), new HashMap<>());
+            case STANDBY:
+                return new Assignment(new HashMap<>(), mkTasksPerSubtopology(entries), new HashMap<>());
+            case WARMUP:
+                return new Assignment(new HashMap<>(), new HashMap<>(), mkTasksPerSubtopology(entries));
+            default:
+                throw new IllegalArgumentException("Unknown task role: " + taskRole);
+        }
+    }
+
+    public static Map.Entry<String, Set<Integer>> mkTasks(
+        String subtopologyId,
+        Integer... tasks
+    ) {
+        return new AbstractMap.SimpleEntry<>(
+            subtopologyId,
+            new HashSet<>(List.of(tasks))
+        );
+    }
+
+    @SafeVarargs
+    public static Map<String, Set<Integer>> mkTasksPerSubtopology(Map.Entry<String, Set<Integer>>... entries) {
+        Map<String, Set<Integer>> assignment = new HashMap<>();
+        for (Map.Entry<String, Set<Integer>> entry : entries) {
+            assignment.put(entry.getKey(), entry.getValue());
+        }
+        return assignment;
+    }
+}


### PR DESCRIPTION
This commit adds the classes to represent a Streams group member in the consumer coordinator. The class for the Streams group member is immutable and is backed by a records in the consumer offset topic. 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
