### PR TITLE
Add and distribute IQv2 information in KIP-1071

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
@@ -120,7 +120,7 @@ public class StreamsAssignmentInterface {
     /**
      * List of partitions available on each host. Updated by the streams protocol client.
      */
-    public final AtomicReference<Map<HostInfo, List<TopicPartition>>> partitionsByHost = new AtomicReference<>(Collections.emptyMap());
+    public final AtomicReference<Map<HostInfo, Map<String, List<TopicPartition>>>> partitionsByHost = new AtomicReference<>(Collections.emptyMap());
 
     public static class HostInfo {
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -253,18 +253,26 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
         membershipManager.onHeartbeatSuccess(response);
     }
 
-    private static Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> convertHostInfoMap(
+    private static Map<StreamsAssignmentInterface.HostInfo, Map<String, List<TopicPartition>>> convertHostInfoMap(
         final StreamsGroupHeartbeatResponseData data) {
-        Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> partitionsByHost = new HashMap<>();
+        Map<StreamsAssignmentInterface.HostInfo, Map<String, List<TopicPartition>>> partitionsByHost = new HashMap<>();
         data.partitionsByUserEndpoint().forEach(endpoint -> {
-            List<TopicPartition> topicPartitions = endpoint.partitions().stream()
-                .flatMap(partition ->
-                    partition.partitions().stream().map(partitionId -> new TopicPartition(partition.topic(), partitionId)))
-                .collect(Collectors.toList());
+            List<TopicPartition> activeTopicPartitions = getTopicPartitionList(endpoint.activePartitions());
+            List<TopicPartition> standbyTopicPartitions = getTopicPartitionList(endpoint.standbyPartitions());
             Endpoint userEndpoint = endpoint.userEndpoint();
+            Map<String, List<TopicPartition>> topicPartitions = new HashMap<>();
+            topicPartitions.put("active", activeTopicPartitions);
+            topicPartitions.put("standby", standbyTopicPartitions);
             partitionsByHost.put(new StreamsAssignmentInterface.HostInfo(userEndpoint.host(), userEndpoint.port()), topicPartitions);
         });
         return partitionsByHost;
+    }
+
+    private static List<TopicPartition> getTopicPartitionList(List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions) {
+       return topicPartitions.stream()
+            .flatMap(partition ->
+                partition.partitions().stream().map(partitionId -> new TopicPartition(partition.topic(), partitionId)))
+            .collect(Collectors.toList());
     }
 
     private void updateTaskIdCollection(

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -70,8 +70,10 @@
       "fields": [
         { "name": "UserEndpoint", "type": "Endpoint", "versions": "0+",
           "about": "User-defined endpoint to connect to the node" },
-        { "name": "Partitions", "type": "[]TopicPartition", "versions": "0+",
-          "about": "All partitions available on the node" }
+        { "name": "ActivePartitions", "type": "[]TopicPartition", "versions": "0+",
+          "about": "All active partitions available on the node" },
+        { "name": "StandbyPartitions", "type": "[]TopicPartition", "versions": "0+",
+          "about": "All standby partitions available on the node" }
       ]
     }
   ],

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2270,20 +2270,19 @@ public class GroupMetadataManager {
         }
 
         // Build the endpoint to topic partition information
-        final Map<String, org.apache.kafka.coordinator.group.streams.Assignment> assignmentMap = group.targetAssignment();
         final Map<String, StreamsGroupMember> members = group.members();
         for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
             final String memberIdForAssignment = entry.getKey();
             // Don't need to provide host info to partitions for itself
             if (!memberIdForAssignment.equals(memberId)) {
                 final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+                StreamsGroupMember groupMember = entry.getValue();
                 if (endpoint != null) {
-                    final org.apache.kafka.coordinator.group.streams.Assignment assignment = assignmentMap.get(memberIdForAssignment);
                     final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
                     responseEndpoint.setHost(endpoint.host());
                     responseEndpoint.setPort(endpoint.port());
-                    addToEndpointToPartitions(assignment.activeTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                    addToEndpointToPartitions(assignment.standbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                    addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                    addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
                 }
             }
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2269,23 +2269,24 @@ public class GroupMetadataManager {
             );
         }
 
-            final Map<String, org.apache.kafka.coordinator.group.streams.Assignment> assignmentMap = group.targetAssignment();
-            final Map<String, StreamsGroupMember> members = group.members();
-            for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
-                final String memberIdForAssignment = entry.getKey();
-                // Don't need to provide host info to partitions for itself
-                if (!memberIdForAssignment.equals(memberId)) {
-                    final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
-                    if (endpoint != null) {
-                        final org.apache.kafka.coordinator.group.streams.Assignment assignment = assignmentMap.get(memberIdForAssignment);
-                        final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
-                        responseEndpoint.setHost(endpoint.host());
-                        responseEndpoint.setPort(endpoint.port());
-                        addToEndpointToPartitions(assignment.activeTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                        addToEndpointToPartitions(assignment.standbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                    }
+        // Build the endpoint to topic partition information
+        final Map<String, org.apache.kafka.coordinator.group.streams.Assignment> assignmentMap = group.targetAssignment();
+        final Map<String, StreamsGroupMember> members = group.members();
+        for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
+            final String memberIdForAssignment = entry.getKey();
+            // Don't need to provide host info to partitions for itself
+            if (!memberIdForAssignment.equals(memberId)) {
+                final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+                if (endpoint != null) {
+                    final org.apache.kafka.coordinator.group.streams.Assignment assignment = assignmentMap.get(memberIdForAssignment);
+                    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+                    responseEndpoint.setHost(endpoint.host());
+                    responseEndpoint.setPort(endpoint.port());
+                    addToEndpointToPartitions(assignment.activeTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                    addToEndpointToPartitions(assignment.standbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
                 }
             }
+        }
 
        // 3. Determine the partition metadata and any internal topics if needed.
         ConfiguredTopology updatedConfiguredTopology = group.configuredTopology();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -16,8 +16,10 @@
  */
 package org.apache.kafka.coordinator.group;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
@@ -146,6 +148,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
 import org.apache.kafka.coordinator.group.streams.topics.TopicConfigurationException;
@@ -175,6 +178,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -2153,6 +2157,7 @@ public class GroupMetadataManager {
         boolean createIfNotExists = memberEpoch == 0;
         final StreamsGroup group = getOrMaybeCreateStreamsGroup(groupId, createIfNotExists, records);
         throwIfStreamsGroupIsFull(group, memberId);
+        final List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList = new ArrayList<>();
 
         // Get or create the member.
         StreamsGroupMember member;
@@ -2267,7 +2272,42 @@ public class GroupMetadataManager {
             );
         }
 
-        // 3. Determine the partition metadata and any internal topics if needed.
+            final Map<String, org.apache.kafka.coordinator.group.streams.Assignment> assignmentMap = group.targetAssignment();
+            final Map<String, StreamsGroupMember> members = group.members();
+            for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
+                final String memberIdForAssignment = entry.getKey();
+                // Don't need to provide host info to partitions for itself
+                if (!memberIdForAssignment.equals(memberId)) {
+                    final org.apache.kafka.coordinator.group.streams.Assignment assignment = assignmentMap.get(memberIdForAssignment);
+                    final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+                    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+                    responseEndpoint.setHost(endpoint.host());
+                    responseEndpoint.setPort(endpoint.port());
+
+                    for (Map.Entry<String, Set<Integer>> activeTaskEntry : assignment.activeTasks().entrySet()) {
+                        String subtopologyId = activeTaskEntry.getKey();
+                        List<Integer> partitions = new ArrayList<>(activeTaskEntry.getValue());
+                        ConfiguredSubtopology configuredSubtopology = group.configuredTopology().subtopologies().get(subtopologyId);
+                        if (configuredSubtopology != null) {
+                            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = Stream.concat(
+                                    configuredSubtopology.sourceTopics().stream(),
+                                    configuredSubtopology.repartitionSourceTopics().keySet().stream()
+                            ).map(topic -> {
+                                StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
+                                tp.setTopic(topic);
+                                tp.setPartitions(partitions);
+                                return tp;
+                            }).toList();
+                            StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
+                            endpointToPartitions.setUserEndpoint(responseEndpoint);
+                            endpointToPartitions.setPartitions(topicPartitions);
+                            endpointToPartitionsList.add(endpointToPartitions);
+                        }
+                    }
+                }
+            }
+
+       // 3. Determine the partition metadata and any internal topics if needed.
         ConfiguredTopology updatedConfiguredTopology = group.configuredTopology();
         Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> updatedPartitionMetadata = group.partitionMetadata();
         if (reconfigureTopology || group.hasMetadataExpired(currentTimeMs)) {
@@ -2359,6 +2399,7 @@ public class GroupMetadataManager {
             response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedActiveTasks()));
             response.setStandbyTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedStandbyTasks()));
             response.setWarmupTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedWarmupTasks()));
+            response.setPartitionsByUserEndpoint(endpointToPartitionsList);
         }
 
         Map<String, CreatableTopic> internalTopicsToBeCreated = Collections.emptyMap();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2349,7 +2349,8 @@ public class GroupMetadataManager {
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
             .setMemberId(updatedMember.memberId())
             .setMemberEpoch(updatedMember.memberEpoch())
-            .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs);
+            .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs)
+            .setPartitionsByUserEndpoint(endpointToPartitionsList);
 
         // The assignment is only provided in the following cases:
         // 1. The member sent a full request.
@@ -2363,7 +2364,6 @@ public class GroupMetadataManager {
             response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedActiveTasks()));
             response.setStandbyTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedStandbyTasks()));
             response.setWarmupTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedWarmupTasks()));
-            response.setPartitionsByUserEndpoint(endpointToPartitionsList);
         }
 
         Map<String, CreatableTopic> internalTopicsToBeCreated = Collections.emptyMap();
@@ -2390,17 +2390,14 @@ public class GroupMetadataManager {
         final Map<String, StreamsGroupMember> members = group.members();
         for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
             final String memberIdForAssignment = entry.getKey();
-            // Don't need to provide host info to partitions for itself
-            if (!memberIdForAssignment.equals(memberId)) {
-                final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
-                StreamsGroupMember groupMember = entry.getValue();
-                if (endpoint != null) {
-                    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
-                    responseEndpoint.setHost(endpoint.host());
-                    responseEndpoint.setPort(endpoint.port());
-                    addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                    addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                }
+            final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+            StreamsGroupMember groupMember = entry.getValue();
+            if (endpoint != null) {
+                final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+                responseEndpoint.setHost(endpoint.host());
+                responseEndpoint.setPort(endpoint.port());
+                addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
             }
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -146,8 +146,8 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+import org.apache.kafka.coordinator.group.streams.topics.EndpointToPartitionsManager;
 import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
 import org.apache.kafka.coordinator.group.streams.topics.TopicConfigurationException;
 import org.apache.kafka.coordinator.group.taskassignor.TaskAssignor;
@@ -2411,30 +2411,9 @@ public class GroupMetadataManager {
                                            List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList) {
         for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
             String subtopologyId = taskEntry.getKey();
-            List<Integer> partitions = new ArrayList<>(taskEntry.getValue());
-            Collections.sort(partitions);
-            ConfiguredSubtopology configuredSubtopology = group.configuredTopology().subtopologies().get(subtopologyId);
-            if (configuredSubtopology != null) {
-                List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = Stream.concat(
-                        configuredSubtopology.sourceTopics().stream(),
-                        configuredSubtopology.repartitionSourceTopics().keySet().stream()
-                ).map(topic -> {
-                    StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
-                    tp.setTopic(topic);
-                    if (tp.partitions().size() < partitions.size()) {
-                        List<Integer> tpPartitions = new ArrayList<>(tp.partitions());
-                        Collections.sort(tpPartitions);
-                        tp.setPartitions(partitions);
-                    } else {
-                       tp.setPartitions(partitions);
-                    }
-                    return tp;
-                }).toList();
-                StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
-                endpointToPartitions.setUserEndpoint(responseEndpoint);
-                endpointToPartitions.setPartitions(topicPartitions);
-                endpointToPartitionsList.add(endpointToPartitions);
-            }
+            Set<Integer> taskPartitions = taskEntry.getValue();
+            EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager(subtopologyId, group, responseEndpoint, taskPartitions);
+            endpointToPartitionsList.add(endpointToPartitionsManager.endpointToPartitions());
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2269,25 +2269,7 @@ public class GroupMetadataManager {
             );
         }
 
-        // Build the endpoint to topic partition information
-        final Map<String, StreamsGroupMember> members = group.members();
-        for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
-            final String memberIdForAssignment = entry.getKey();
-            // Don't need to provide host info to partitions for itself
-            if (!memberIdForAssignment.equals(memberId)) {
-                final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
-                StreamsGroupMember groupMember = entry.getValue();
-                if (endpoint != null) {
-                    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
-                    responseEndpoint.setHost(endpoint.host());
-                    responseEndpoint.setPort(endpoint.port());
-                    addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                    addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                }
-            }
-        }
-
-       // 3. Determine the partition metadata and any internal topics if needed.
+        // 3. Determine the partition metadata and any internal topics if needed.
         ConfiguredTopology updatedConfiguredTopology = group.configuredTopology();
         Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> updatedPartitionMetadata = group.partitionMetadata();
         if (reconfigureTopology || group.hasMetadataExpired(currentTimeMs)) {
@@ -2361,6 +2343,8 @@ public class GroupMetadataManager {
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
 
+        maybeSetHostInfoPartitions(memberId, group, endpointToPartitionsList);
+
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
             .setMemberId(updatedMember.memberId())
@@ -2399,6 +2383,28 @@ public class GroupMetadataManager {
         return new CoordinatorResult<>(records, new StreamsGroupHeartbeatResult(response, internalTopicsToBeCreated));
     }
 
+    private void maybeSetHostInfoPartitions(String memberId,
+                                            StreamsGroup group,
+                                            List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList) {
+        // Build the endpoint to topic partition information
+        final Map<String, StreamsGroupMember> members = group.members();
+        for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
+            final String memberIdForAssignment = entry.getKey();
+            // Don't need to provide host info to partitions for itself
+            if (!memberIdForAssignment.equals(memberId)) {
+                final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+                StreamsGroupMember groupMember = entry.getValue();
+                if (endpoint != null) {
+                    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+                    responseEndpoint.setHost(endpoint.host());
+                    responseEndpoint.setPort(endpoint.port());
+                    addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                    addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                }
+            }
+        }
+    }
+
     private void addToEndpointToPartitions(Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
                                            StreamsGroup group,
                                            StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
@@ -2406,6 +2412,7 @@ public class GroupMetadataManager {
         for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
             String subtopologyId = taskEntry.getKey();
             List<Integer> partitions = new ArrayList<>(taskEntry.getValue());
+            Collections.sort(partitions);
             ConfiguredSubtopology configuredSubtopology = group.configuredTopology().subtopologies().get(subtopologyId);
             if (configuredSubtopology != null) {
                 List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = Stream.concat(
@@ -2414,7 +2421,13 @@ public class GroupMetadataManager {
                 ).map(topic -> {
                     StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
                     tp.setTopic(topic);
-                    tp.setPartitions(partitions);
+                    if (tp.partitions().size() < partitions.size()) {
+                        List<Integer> tpPartitions = new ArrayList<>(tp.partitions());
+                        Collections.sort(tpPartitions);
+                        tp.setPartitions(partitions);
+                    } else {
+                       tp.setPartitions(partitions);
+                    }
                     return tp;
                 }).toList();
                 StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2154,7 +2154,6 @@ public class GroupMetadataManager {
         boolean createIfNotExists = memberEpoch == 0;
         final StreamsGroup group = getOrMaybeCreateStreamsGroup(groupId, createIfNotExists, records);
         throwIfStreamsGroupIsFull(group, memberId);
-        final List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList = new ArrayList<>();
 
         // Get or create the member.
         StreamsGroupMember member;
@@ -2342,15 +2341,13 @@ public class GroupMetadataManager {
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
-
-        maybeSetHostInfoPartitions(memberId, group, endpointToPartitionsList);
-
+        List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitions = maybeBuildEndpointToPartitions(group);
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
             .setMemberId(updatedMember.memberId())
             .setMemberEpoch(updatedMember.memberEpoch())
             .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs)
-            .setPartitionsByUserEndpoint(endpointToPartitionsList);
+            .setPartitionsByUserEndpoint(endpointToPartitions);
 
         // The assignment is only provided in the following cases:
         // 1. The member sent a full request.
@@ -2383,9 +2380,9 @@ public class GroupMetadataManager {
         return new CoordinatorResult<>(records, new StreamsGroupHeartbeatResult(response, internalTopicsToBeCreated));
     }
 
-    private void maybeSetHostInfoPartitions(String memberId,
-                                            StreamsGroup group,
-                                            List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList) {
+    private List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> maybeBuildEndpointToPartitions(StreamsGroup group) {
+        List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList = new ArrayList<>();
+        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
         // Build the endpoint to topic partition information
         final Map<String, StreamsGroupMember> members = group.members();
         for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
@@ -2396,23 +2393,13 @@ public class GroupMetadataManager {
                 final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
                 responseEndpoint.setHost(endpoint.host());
                 responseEndpoint.setPort(endpoint.port());
-                addToEndpointToPartitions(groupMember.assignedActiveTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
-                addToEndpointToPartitions(groupMember.assignedStandbyTasks().entrySet(), group, responseEndpoint, endpointToPartitionsList);
+                StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = endpointToPartitionsManager.endpointToPartitions(groupMember, responseEndpoint, group);
+                endpointToPartitionsList.add(endpointToPartitions);
             }
         }
+        return endpointToPartitionsList;
     }
 
-    private void addToEndpointToPartitions(Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
-                                           StreamsGroup group,
-                                           StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
-                                           List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList) {
-        for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
-            String subtopologyId = taskEntry.getKey();
-            Set<Integer> taskPartitions = taskEntry.getValue();
-            EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager(subtopologyId, group, responseEndpoint, taskPartitions);
-            endpointToPartitionsList.add(endpointToPartitionsManager.endpointToPartitions());
-        }
-    }
 
     private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIds(final Map<String, Set<Integer>> taskIds) {
         return taskIds.entrySet().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -202,6 +202,8 @@ public class StreamsGroup implements Group {
      */
     private DeadlineAndEpoch metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
 
+    private final TimelineHashMap<String, TopicPartition> stateTopicPartitions;
+
     public StreamsGroup(
         LogContext logContext,
         SnapshotRegistry snapshotRegistry,
@@ -228,6 +230,7 @@ public class StreamsGroup implements Group {
         this.metrics = Objects.requireNonNull(metrics);
         this.topology = new TimelineObject<>(snapshotRegistry, Optional.empty());
         this.configuredTopology = new TimelineObject<>(snapshotRegistry, Optional.empty());
+        this.stateTopicPartitions = new TimelineHashMap<>(snapshotRegistry, 0);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -49,6 +49,7 @@ public class EndpointToPartitionsManager {
 
     public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions() {
         ConfiguredSubtopology configuredSubtopology = streamsGroup.configuredTopology().subtopologies().get(subtopologyId);
+        
         final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
 
         List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = Stream.concat(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+
+public class EndpointToPartitionsManager {
+
+
+    final StreamsGroup streamsGroup;
+    final Set<Integer> taskPartitions;
+    final String subtopologyId;
+    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint;
+
+    public EndpointToPartitionsManager(final String subtopologyId,
+                                       final StreamsGroup streamsGroup,
+                                       final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
+                                       final Set<Integer> taskPartitions) {
+        this.subtopologyId = subtopologyId;
+        this.streamsGroup = streamsGroup;
+        this.taskPartitions = taskPartitions;
+        this.responseEndpoint = responseEndpoint;
+    }
+
+    public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions() {
+        ConfiguredSubtopology configuredSubtopology = streamsGroup.configuredTopology().subtopologies().get(subtopologyId);
+        final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
+
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = Stream.concat(
+                configuredSubtopology.sourceTopics().stream(),
+                configuredSubtopology.repartitionSourceTopics().keySet().stream()
+        ).map(topic -> {
+            int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
+            StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
+            tp.setTopic(topic);
+            List<Integer> tpPartitions = new ArrayList<>(taskPartitions);
+            if (numPartitionsForTopic < taskPartitions.size()) {
+                Collections.sort(tpPartitions);
+                tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
+            } else {
+                tp.setPartitions(tpPartitions);
+            }
+            return tp;
+        }).toList();
+
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
+        endpointToPartitions.setUserEndpoint(responseEndpoint);
+        endpointToPartitions.setPartitions(topicPartitionList);
+
+        return endpointToPartitions;
+    }
+
+
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.streams.topics;
 
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TopicMetadata;
 
 import java.util.ArrayList;
@@ -32,49 +33,52 @@ import java.util.stream.Stream;
 public class EndpointToPartitionsManager {
 
 
-    final StreamsGroup streamsGroup;
-    final Set<Integer> taskPartitions;
-    final String subtopologyId;
-    final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint;
+    public EndpointToPartitionsManager() {}
 
-    public EndpointToPartitionsManager(final String subtopologyId,
-                                       final StreamsGroup streamsGroup,
-                                       final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
-                                       final Set<Integer> taskPartitions) {
-        this.subtopologyId = subtopologyId;
-        this.streamsGroup = streamsGroup;
-        this.taskPartitions = taskPartitions;
-        this.responseEndpoint = responseEndpoint;
-    }
-
-    public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions() {
-        ConfiguredSubtopology configuredSubtopology = streamsGroup.configuredTopology().subtopologies().get(subtopologyId);
-        
-        final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
-
-        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = Stream.concat(
-                configuredSubtopology.sourceTopics().stream(),
-                configuredSubtopology.repartitionSourceTopics().keySet().stream()
-        ).map(topic -> {
-            int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
-            StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
-            tp.setTopic(topic);
-            List<Integer> tpPartitions = new ArrayList<>(taskPartitions);
-            if (numPartitionsForTopic < taskPartitions.size()) {
-                Collections.sort(tpPartitions);
-                tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
-            } else {
-                tp.setPartitions(tpPartitions);
-            }
-            return tp;
-        }).toList();
+    public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions(final StreamsGroupMember streamsGroupMember,
+                                                                                       final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
+                                                                                       final StreamsGroup streamsGroup) {
 
         StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
-        endpointToPartitions.setUserEndpoint(responseEndpoint);
-        endpointToPartitions.setPartitions(topicPartitionList);
-
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> allTopicPartitions = new ArrayList<>();
+        for (Map.Entry<String, ConfiguredSubtopology> entry : streamsGroup.configuredTopology().subtopologies().entrySet()) {
+            ConfiguredSubtopology configuredSubtopology = entry.getValue();
+            endpointToPartitions.setUserEndpoint(responseEndpoint);
+            final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
+            getActiveTaskTopicPartitions(configuredSubtopology, groupTopicMetadata, streamsGroupMember, allTopicPartitions);
+        }
+        endpointToPartitions.setPartitions(allTopicPartitions);
         return endpointToPartitions;
     }
 
+    private void getActiveTaskTopicPartitions(final ConfiguredSubtopology configuredSubtopology,
+                                              final Map<String, TopicMetadata> groupTopicMetadata,
+                                              final StreamsGroupMember streamsGroupMember,
+                                              final List<StreamsGroupHeartbeatResponseData.TopicPartition> allTopicPartitions) {
+
+        List<String> standbyTopicNames = configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name).toList();
+
+        for (Map.Entry<String, Set<Integer>> taskEntry : streamsGroupMember.assignedActiveTasks().entrySet()) {
+            Set<Integer> taskPartitions = taskEntry.getValue();
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList =
+                    Stream.concat(
+                            configuredSubtopology.sourceTopics().stream(),
+                            configuredSubtopology.repartitionSourceTopics().keySet().stream()
+            ).map(topic -> {
+                int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
+                StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
+                tp.setTopic(topic);
+                List<Integer> tpPartitions = new ArrayList<>(taskPartitions);
+                if (numPartitionsForTopic < taskPartitions.size()) {
+                    Collections.sort(tpPartitions);
+                    tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
+                } else {
+                    tp.setPartitions(tpPartitions);
+                }
+                return tp;
+            }).toList();
+            allTopicPartitions.addAll(topicPartitionList);
+        }
+    }
 
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -41,7 +41,8 @@ public class EndpointToPartitionsManager {
                                                                                        final StreamsGroup streamsGroup) {
 
         StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
-        List<StreamsGroupHeartbeatResponseData.TopicPartition> allTopicPartitions = new ArrayList<>();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> activeTopicPartitions = new ArrayList<>();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyTopicPartitions = new ArrayList<>();
         for (Map.Entry<String, ConfiguredSubtopology> entry : streamsGroup.configuredTopology().subtopologies().entrySet()) {
             ConfiguredSubtopology configuredSubtopology = entry.getValue();
             endpointToPartitions.setUserEndpoint(responseEndpoint);
@@ -50,14 +51,15 @@ public class EndpointToPartitionsManager {
             Supplier<Stream<String>> topicNameStreamSupplier = () -> Stream.concat(configuredSubtopology.sourceTopics().stream(),
                     configuredSubtopology.repartitionSourceTopics().keySet().stream());
             List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = getTopicPartitions(taskEntrySet, topicNameStreamSupplier, groupTopicMetadata);
-            allTopicPartitions.addAll(topicPartitionList);
+            activeTopicPartitions.addAll(topicPartitionList);
 
             Set<Map.Entry<String, Set<Integer>>> standbyTaskEntrySet = streamsGroupMember.assignedStandbyTasks().entrySet();
             Supplier<Stream<String>> changelogTopicNameStreamSupplier = () -> configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name);
-            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyTopicPartitionList = getTopicPartitions(standbyTaskEntrySet, changelogTopicNameStreamSupplier, groupTopicMetadata);
-            allTopicPartitions.addAll(standbyTopicPartitionList);
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyList = getTopicPartitions(standbyTaskEntrySet, changelogTopicNameStreamSupplier, groupTopicMetadata);
+            standbyTopicPartitions.addAll(standbyList);
         }
-        endpointToPartitions.setPartitions(allTopicPartitions);
+        endpointToPartitions.setActivePartitions(activeTopicPartitions);
+        endpointToPartitions.setStandbyPartitions(standbyTopicPartitions);
         return endpointToPartitions;
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 
@@ -45,40 +46,42 @@ public class EndpointToPartitionsManager {
             ConfiguredSubtopology configuredSubtopology = entry.getValue();
             endpointToPartitions.setUserEndpoint(responseEndpoint);
             final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
-            getActiveTaskTopicPartitions(configuredSubtopology, groupTopicMetadata, streamsGroupMember, allTopicPartitions);
+            Set<Map.Entry<String, Set<Integer>>> taskEntrySet = streamsGroupMember.assignedActiveTasks().entrySet();
+            Supplier<Stream<String>> topicNameStreamSupplier = () -> Stream.concat(configuredSubtopology.sourceTopics().stream(),
+                    configuredSubtopology.repartitionSourceTopics().keySet().stream());
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = getTopicPartitions(taskEntrySet, topicNameStreamSupplier, groupTopicMetadata);
+            allTopicPartitions.addAll(topicPartitionList);
+
+            Set<Map.Entry<String, Set<Integer>>> standbyTaskEntrySet = streamsGroupMember.assignedStandbyTasks().entrySet();
+            Supplier<Stream<String>> changelogTopicNameStreamSupplier = () -> configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name);
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyTopicPartitionList = getTopicPartitions(standbyTaskEntrySet, changelogTopicNameStreamSupplier, groupTopicMetadata);
+            allTopicPartitions.addAll(standbyTopicPartitionList);
         }
         endpointToPartitions.setPartitions(allTopicPartitions);
         return endpointToPartitions;
     }
 
-    private void getActiveTaskTopicPartitions(final ConfiguredSubtopology configuredSubtopology,
-                                              final Map<String, TopicMetadata> groupTopicMetadata,
-                                              final StreamsGroupMember streamsGroupMember,
-                                              final List<StreamsGroupHeartbeatResponseData.TopicPartition> allTopicPartitions) {
-
-        List<String> standbyTopicNames = configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name).toList();
-
-        for (Map.Entry<String, Set<Integer>> taskEntry : streamsGroupMember.assignedActiveTasks().entrySet()) {
-            Set<Integer> taskPartitions = taskEntry.getValue();
+    private List<StreamsGroupHeartbeatResponseData.TopicPartition> getTopicPartitions(final Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
+                                                                                      final Supplier<Stream<String>> topicNameStreamSupplier,
+                                                                                      final Map<String, TopicMetadata> groupTopicMetadata) {
+        final List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionsForTasks = new ArrayList<>();
+        for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
             List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList =
-                    Stream.concat(
-                            configuredSubtopology.sourceTopics().stream(),
-                            configuredSubtopology.repartitionSourceTopics().keySet().stream()
-            ).map(topic -> {
-                int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
-                StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
-                tp.setTopic(topic);
-                List<Integer> tpPartitions = new ArrayList<>(taskPartitions);
-                if (numPartitionsForTopic < taskPartitions.size()) {
-                    Collections.sort(tpPartitions);
-                    tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
-                } else {
-                    tp.setPartitions(tpPartitions);
-                }
-                return tp;
-            }).toList();
-            allTopicPartitions.addAll(topicPartitionList);
+                    topicNameStreamSupplier.get().map(topic -> {
+                        int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
+                        StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
+                        tp.setTopic(topic);
+                        List<Integer> tpPartitions = new ArrayList<>(taskEntry.getValue());
+                        if (numPartitionsForTopic < taskEntry.getValue().size()) {
+                            Collections.sort(tpPartitions);
+                            tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
+                        } else {
+                            tp.setPartitions(tpPartitions);
+                        }
+                        return tp;
+                    }).toList();
+            topicPartitionsForTasks.addAll(topicPartitionList);
         }
+        return topicPartitionsForTasks;
     }
-
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -110,6 +110,7 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
 import org.apache.kafka.server.common.MetadataVersion;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
+import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsTopology;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+import org.apache.kafka.timeline.SnapshotRegistry;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
+class EndpointToPartitionsManagerTest {
+
+    private static final LogContext LOG_CONTEXT = new LogContext();
+
+    @ParameterizedTest(name = "{5}")
+    @MethodSource("argsProvider")
+    void testEndpointToPartitionsWithTwoTopicsAndDifferentPartitions(int topicAPartitions,
+                                                                     int topicBPartitions,
+                                                                     Set<Integer> taskPartitions,
+                                                                     List<Integer> topicAExpectedPartitions,
+                                                                     List<Integer> topicBExpectedPartitions,
+                                                                     String testName
+                                                                     ) {
+        Uuid topicAId = Uuid.randomUuid();
+        Uuid topicBId = Uuid.randomUuid();
+
+        Map<Integer, Set<String>> emptyRackMap = Collections.emptyMap();
+        StreamsGroupHeartbeatResponseData.Endpoint endpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+        endpoint.setPort(8080);
+        endpoint.setHost("localhost");
+
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put("Topic-A", new TopicMetadata(topicAId, "Topic-A", topicAPartitions, emptyRackMap));
+        topicMetadata.put("Topic-B", new TopicMetadata(topicBId, "Topic-B", topicBPartitions, emptyRackMap));
+
+        StreamsGroup streamsGroup = createStreamsGroup("streamsGroup");
+        streamsGroup.setPartitionMetadata(topicMetadata);
+        streamsGroup.setGroupEpoch(1);
+        streamsGroup.setTopology(topology());
+
+        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager(
+                "subtopology-1",
+                streamsGroup,
+                endpoint,
+                taskPartitions
+        );
+
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions();
+
+        assertEquals(endpoint, result.userEndpoint());
+        assertEquals(2, result.partitions().size());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.partitions().get(0);
+        assertEquals("Topic-A", topicAPartition.topic());
+        assertEquals(topicAExpectedPartitions, topicAPartition.partitions());
+        
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.partitions().get(1);
+        assertEquals("Topic-B", topicBPartition.topic());
+        assertEquals(topicBExpectedPartitions, topicBPartition.partitions());
+    }
+
+    static Stream<Arguments> argsProvider() {
+        return Stream.of(
+                arguments(2, 5, new TreeSet<>(List.of(0, 1, 2, 3, 4)), List.of(0, 1), List.of(0, 1, 2, 3, 4), "Should assign correct partitions when partitions differ between topics"),
+                arguments(3, 3, new TreeSet<>(List.of(0, 1, 2)), List.of(0, 1, 2), List.of(0, 1, 2), "Should assign correct partitions when partitions same between topics")
+        );
+    }
+
+    private StreamsTopology topology() {
+        StreamsGroupTopologyValue.Subtopology subtopology = new StreamsGroupTopologyValue.Subtopology();
+        subtopology.setSubtopologyId("subtopology-1");
+        subtopology.setSourceTopics(List.of("Topic-A", "Topic-B"));
+        return new StreamsTopology(1, Map.of("subtopology-1", subtopology));
+    }
+
+    private StreamsGroup createStreamsGroup(String groupId) {
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(LOG_CONTEXT);
+        return new StreamsGroup(
+                LOG_CONTEXT,
+                snapshotRegistry,
+                groupId,
+                mock(GroupCoordinatorMetricsShard.class)
+        );
+    }
+
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -95,25 +95,27 @@ class EndpointToPartitionsManagerTest {
 
         // Validate the results
         assertEquals(responseEndpoint, result.userEndpoint());
-        assertEquals(4, result.partitions().size());
+        assertEquals(2, result.activePartitions().size());
+        assertEquals(2, result.standbyPartitions().size());
 
-        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> activePartitions = result.activePartitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyPartitions = result.standbyPartitions();
 
-        topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
+        activePartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
         
-        StreamsGroupHeartbeatResponseData.TopicPartition activePartition = topicPartitions.get(0);
-        assertEquals("StateChangeLog-A", activePartition.topic());
-        assertEquals(List.of(0, 1, 2), activePartition.partitions().stream().sorted().toList());
+        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionA = standbyPartitions.stream().filter(tp -> tp.topic().equals("StateChangeLog-A")).findFirst().get();
+        assertEquals("StateChangeLog-A", standbyPartitionA.topic());
+        assertEquals(List.of(0, 1, 2), standbyPartitionA.partitions().stream().sorted().toList());
 
-        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartition = result.partitions().get(1);
-        assertEquals("StateChangeLog-B", standbyPartition.topic());
-        assertEquals(List.of(0, 1, 2), standbyPartition.partitions().stream().sorted().toList());
+        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionB = result.standbyPartitions().stream().filter(tp -> tp.topic().equals("StateChangeLog-B")).findFirst().get();
+        assertEquals("StateChangeLog-B", standbyPartitionB.topic());
+        assertEquals(List.of(0, 1, 2), standbyPartitionB.partitions().stream().sorted().toList());
 
-        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.partitions().get(2);
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-A")).findFirst().get();
         assertEquals("Topic-A", topicAPartition.topic());
         assertEquals(List.of(0, 1, 2), topicAPartition.partitions().stream().sorted().toList());
 
-        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.partitions().get(3);
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-B")).findFirst().get();
         assertEquals("Topic-B", topicBPartition.topic());
         assertEquals(List.of(0, 1, 2), topicBPartition.partitions().stream().sorted().toList());
     }
@@ -145,16 +147,16 @@ class EndpointToPartitionsManagerTest {
         StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
 
         assertEquals(responseEndpoint, result.userEndpoint());
-        assertEquals(2, result.partitions().size());
+        assertEquals(2, result.activePartitions().size());
 
-        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.activePartitions();
         topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
 
-        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.partitions().get(0);
+            StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.activePartitions().get(0);
         assertEquals("Topic-A", topicAPartition.topic());
         assertEquals(topicAExpectedPartitions, topicAPartition.partitions().stream().sorted().toList());
         
-        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.partitions().get(1);
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.activePartitions().get(1);
         assertEquals("Topic-B", topicBPartition.topic());
         assertEquals(topicBExpectedPartitions, topicBPartition.partitions().stream().sorted().toList());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TopicMetadata;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -51,7 +52,6 @@ class EndpointToPartitionsManagerTest {
     @MethodSource("argsProvider")
     void testEndpointToPartitionsWithTwoTopicsAndDifferentPartitions(int topicAPartitions,
                                                                      int topicBPartitions,
-                                                                     Set<Integer> taskPartitions,
                                                                      List<Integer> topicAExpectedPartitions,
                                                                      List<Integer> topicBExpectedPartitions,
                                                                      String testName
@@ -73,14 +73,9 @@ class EndpointToPartitionsManagerTest {
         streamsGroup.setGroupEpoch(1);
         streamsGroup.setTopology(topology());
 
-        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager(
-                "subtopology-1",
-                streamsGroup,
-                endpoint,
-                taskPartitions
-        );
+        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
 
-        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions();
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(null, endpoint, streamsGroup);
 
         assertEquals(endpoint, result.userEndpoint());
         assertEquals(2, result.partitions().size());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -19,36 +19,105 @@ package org.apache.kafka.coordinator.group.streams.topics;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
-import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TopicMetadata;
-import org.apache.kafka.timeline.SnapshotRegistry;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class EndpointToPartitionsManagerTest {
 
-    private static final LogContext LOG_CONTEXT = new LogContext();
+    private StreamsGroup streamsGroup;
+    private StreamsGroupMember streamsGroupMember;
+    private ConfiguredTopology configuredTopology;
+    private ConfiguredSubtopology configuredSubtopology;
 
-    @ParameterizedTest(name = "{5}")
+    private EndpointToPartitionsManager endpointToPartitionsManager;
+    private final Map<String, Set<Integer>> activeTasks = new HashMap<>();
+    private final Map<String, Set<Integer>> standbyTasks = new HashMap<>();
+    private final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+
+    @BeforeEach
+    public void setUp() {
+        streamsGroup = mock(StreamsGroup.class);
+        streamsGroupMember = mock(StreamsGroupMember.class);
+        configuredTopology = mock(ConfiguredTopology.class);
+        endpointToPartitionsManager = new EndpointToPartitionsManager();
+
+        configuredSubtopology = new ConfiguredSubtopology();
+        configuredSubtopology.setSourceTopics( Set.of( "Topic-A", "Topic-B"));
+        ConfiguredInternalTopic stateChangelogTopic = new ConfiguredInternalTopic("StateChangeLog-A");
+        ConfiguredInternalTopic stateChangelogTopic2 = new ConfiguredInternalTopic("StateChangeLog-B");
+        configuredSubtopology.setStateChangelogTopics( Map.of( "StateChangeLog-A", stateChangelogTopic, "StateChangeLog-B", stateChangelogTopic2 ) );
+        configuredTopology.subtopologies().put("0", configuredSubtopology);
+
+        responseEndpoint.setHost("localhost");
+        responseEndpoint.setPort(9092);
+    }
+
+    @Test
+    void testEndpointToPartitionsWithStandbyTaskAssignments() {
+
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", 3, Collections.emptyMap()));
+        topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", 3, Collections.emptyMap()));
+        topicMetadata.put("StateChangeLog-A", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-A", 3, Collections.emptyMap()));
+        topicMetadata.put("StateChangeLog-B", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-B", 3, Collections.emptyMap()));
+
+         activeTasks.put("0", Set.of(0, 1, 2));
+         standbyTasks.put("0", Set.of(0, 1, 2));
+         when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
+         when(streamsGroupMember.assignedStandbyTasks()).thenReturn(standbyTasks);
+         when((streamsGroup.partitionMetadata())).thenReturn(topicMetadata);
+         when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
+         when(configuredTopology.subtopologies()).thenReturn(Map.of( "0", configuredSubtopology ) );
+
+        // Invoke the method under test
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result =
+                endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
+
+        // Validate the results
+        assertEquals(responseEndpoint, result.userEndpoint());
+        assertEquals(4, result.partitions().size());
+
+        List< StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
+
+        topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
+        
+        StreamsGroupHeartbeatResponseData.TopicPartition activePartition = topicPartitions.get(0);
+        assertEquals("StateChangeLog-A", activePartition.topic());
+        assertEquals(List.of(0, 1, 2), activePartition.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartition = result.partitions().get(1);
+        assertEquals("StateChangeLog-B", standbyPartition.topic());
+        assertEquals(List.of(0, 1, 2), standbyPartition.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.partitions().get(2);
+        assertEquals("Topic-A", topicAPartition.topic());
+        assertEquals(List.of(0, 1, 2), topicAPartition.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.partitions().get(3);
+        assertEquals("Topic-B", topicBPartition.topic());
+        assertEquals(List.of(0, 1, 2), topicBPartition.partitions().stream().sorted().toList());
+    }
+
+    @ParameterizedTest(name = "{4}")
     @MethodSource("argsProvider")
     void testEndpointToPartitionsWithTwoTopicsAndDifferentPartitions(int topicAPartitions,
                                                                      int topicBPartitions,
@@ -56,60 +125,45 @@ class EndpointToPartitionsManagerTest {
                                                                      List<Integer> topicBExpectedPartitions,
                                                                      String testName
                                                                      ) {
-        Uuid topicAId = Uuid.randomUuid();
-        Uuid topicBId = Uuid.randomUuid();
 
         Map<Integer, Set<String>> emptyRackMap = Collections.emptyMap();
-        StreamsGroupHeartbeatResponseData.Endpoint endpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
-        endpoint.setPort(8080);
-        endpoint.setHost("localhost");
 
         Map<String, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put("Topic-A", new TopicMetadata(topicAId, "Topic-A", topicAPartitions, emptyRackMap));
-        topicMetadata.put("Topic-B", new TopicMetadata(topicBId, "Topic-B", topicBPartitions, emptyRackMap));
+        topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", topicAPartitions, emptyRackMap));
+        topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", topicBPartitions, emptyRackMap));
 
-        StreamsGroup streamsGroup = createStreamsGroup("streamsGroup");
-        streamsGroup.setPartitionMetadata(topicMetadata);
-        streamsGroup.setGroupEpoch(1);
-        streamsGroup.setTopology(topology());
+        activeTasks.put("0", Set.of(0, 1, 2, 3, 4));
+        when(streamsGroupMember.assignedStandbyTasks()).thenReturn(Collections.emptyMap());
+        when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
+        when(streamsGroup.partitionMetadata()).thenReturn(topicMetadata);
+        when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
+        when(configuredTopology.subtopologies()).thenReturn(Map.of( "0", configuredSubtopology ) );
 
         EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
 
-        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(null, endpoint, streamsGroup);
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
 
-        assertEquals(endpoint, result.userEndpoint());
+        assertEquals(responseEndpoint, result.userEndpoint());
         assertEquals(2, result.partitions().size());
+
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
+        topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
 
         StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.partitions().get(0);
         assertEquals("Topic-A", topicAPartition.topic());
-        assertEquals(topicAExpectedPartitions, topicAPartition.partitions());
+        assertEquals(topicAExpectedPartitions, topicAPartition.partitions().stream().sorted().toList());
         
         StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.partitions().get(1);
         assertEquals("Topic-B", topicBPartition.topic());
-        assertEquals(topicBExpectedPartitions, topicBPartition.partitions());
+        assertEquals(topicBExpectedPartitions, topicBPartition.partitions().stream().sorted().toList());
     }
+
+
 
     static Stream<Arguments> argsProvider() {
         return Stream.of(
-                arguments(2, 5, new TreeSet<>(List.of(0, 1, 2, 3, 4)), List.of(0, 1), List.of(0, 1, 2, 3, 4), "Should assign correct partitions when partitions differ between topics"),
-                arguments(3, 3, new TreeSet<>(List.of(0, 1, 2)), List.of(0, 1, 2), List.of(0, 1, 2), "Should assign correct partitions when partitions same between topics")
-        );
-    }
-
-    private StreamsTopology topology() {
-        StreamsGroupTopologyValue.Subtopology subtopology = new StreamsGroupTopologyValue.Subtopology();
-        subtopology.setSubtopologyId("subtopology-1");
-        subtopology.setSourceTopics(List.of("Topic-A", "Topic-B"));
-        return new StreamsTopology(1, Map.of("subtopology-1", subtopology));
-    }
-
-    private StreamsGroup createStreamsGroup(String groupId) {
-        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(LOG_CONTEXT);
-        return new StreamsGroup(
-                LOG_CONTEXT,
-                snapshotRegistry,
-                groupId,
-                mock(GroupCoordinatorMetricsShard.class)
+                arguments(2, 5, List.of(0, 1), List.of(0, 1, 2, 3, 4), "Should assign correct partitions when partitions differ between topics"),
+                arguments(3, 3, List.of(0, 1, 2), List.of(0, 1, 2), "Should assign correct partitions when partitions same between topics")
         );
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,10 +62,10 @@ class EndpointToPartitionsManagerTest {
         endpointToPartitionsManager = new EndpointToPartitionsManager();
 
         configuredSubtopology = new ConfiguredSubtopology();
-        configuredSubtopology.setSourceTopics( Set.of( "Topic-A", "Topic-B"));
+        configuredSubtopology.setSourceTopics(Set.of("Topic-A", "Topic-B"));
         ConfiguredInternalTopic stateChangelogTopic = new ConfiguredInternalTopic("StateChangeLog-A");
         ConfiguredInternalTopic stateChangelogTopic2 = new ConfiguredInternalTopic("StateChangeLog-B");
-        configuredSubtopology.setStateChangelogTopics( Map.of( "StateChangeLog-A", stateChangelogTopic, "StateChangeLog-B", stateChangelogTopic2 ) );
+        configuredSubtopology.setStateChangelogTopics(Map.of("StateChangeLog-A", stateChangelogTopic, "StateChangeLog-B", stateChangelogTopic2));
         configuredTopology.subtopologies().put("0", configuredSubtopology);
 
         responseEndpoint.setHost("localhost");
@@ -80,13 +81,13 @@ class EndpointToPartitionsManagerTest {
         topicMetadata.put("StateChangeLog-A", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-A", 3, Collections.emptyMap()));
         topicMetadata.put("StateChangeLog-B", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-B", 3, Collections.emptyMap()));
 
-         activeTasks.put("0", Set.of(0, 1, 2));
-         standbyTasks.put("0", Set.of(0, 1, 2));
-         when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
-         when(streamsGroupMember.assignedStandbyTasks()).thenReturn(standbyTasks);
-         when((streamsGroup.partitionMetadata())).thenReturn(topicMetadata);
-         when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
-         when(configuredTopology.subtopologies()).thenReturn(Map.of( "0", configuredSubtopology ) );
+        activeTasks.put("0", Set.of(0, 1, 2));
+        standbyTasks.put("0", Set.of(0, 1, 2));
+        when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
+        when(streamsGroupMember.assignedStandbyTasks()).thenReturn(standbyTasks);
+        when((streamsGroup.partitionMetadata())).thenReturn(topicMetadata);
+        when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
+        when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
 
         // Invoke the method under test
         StreamsGroupHeartbeatResponseData.EndpointToPartitions result =
@@ -96,7 +97,7 @@ class EndpointToPartitionsManagerTest {
         assertEquals(responseEndpoint, result.userEndpoint());
         assertEquals(4, result.partitions().size());
 
-        List< StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.partitions();
 
         topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
         
@@ -137,7 +138,7 @@ class EndpointToPartitionsManagerTest {
         when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
         when(streamsGroup.partitionMetadata()).thenReturn(topicMetadata);
         when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
-        when(configuredTopology.subtopologies()).thenReturn(Map.of( "0", configuredSubtopology ) );
+        when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
 
         EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/taskassignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/taskassignor/StickyTaskAssignorTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.coordinator.group.taskassignor;
 
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -74,15 +76,20 @@ public class ConsistencyVectorIntegrationTest {
     private static final int KEY = 1;
     private static final int NUMBER_OF_MESSAGES = 100;
 
-    public final EmbeddedKafkaCluster cluster = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public EmbeddedKafkaCluster cluster;
 
     private final List<KafkaStreams> streamsToCleanup = new ArrayList<>();
-    private final MockTime mockTime = cluster.time;
+    private MockTime mockTime;
 
     @BeforeEach
     public void before() throws InterruptedException, IOException {
+        final Properties props = new Properties();
+        props.setProperty(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        props.setProperty(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true");
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, props);
         cluster.start();
         cluster.createTopic(INPUT_TOPIC_NAME, 1, 1);
+        mockTime = cluster.time;
     }
 
     @AfterEach

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -220,6 +220,7 @@ public class ConsistencyVectorIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         config.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         return config;
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -122,7 +124,9 @@ public class EosIntegrationTest {
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
         NUM_BROKERS,
-        Utils.mkProperties(Collections.singletonMap("auto.create.topics.enable", "true"))
+        Utils.mkProperties(Map.of("auto.create.topics.enable", "true",
+                GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams",
+                ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true"))
     );
 
     @BeforeAll
@@ -248,6 +252,7 @@ public class EosIntegrationTest {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
         properties.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+        properties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:7777");
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         properties.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), 1);
         properties.put(StreamsConfig.consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -253,6 +253,7 @@ public class EosIntegrationTest {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
         properties.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         properties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:7777");
+        properties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         properties.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), 1);
         properties.put(StreamsConfig.consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.test.TestUtils;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -102,9 +103,9 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     }
 
 
-    @ParameterizedTest(name = "{2}" )
+    @ParameterizedTest(name = "{2}")
     @MethodSource("groupProtocolParameters")
-    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, boolean usingStandbyReplicas, final String testName) throws Exception {
+    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, final boolean usingStandbyReplicas, final String testName) throws Exception {
 
         final Properties streamOneProperties = new Properties();
         streamOneProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1");
@@ -134,14 +135,14 @@ public class IQv2EndpointToPartitionsIntegrationTest {
             List<StreamsMetadata> streamsMetadataAllClients = new ArrayList<>(streamsOne.metadataForAllStreamsClients());
             assertEquals(1, streamsMetadataAllClients.size());
             StreamsMetadata streamsOneMetadataOne = streamsMetadataAllClients.get(0);
-            Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
+            final Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
             assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
             assertEquals(4, topicPartitions.size());
             // Only one KS client instance should be no standby assigned
             assertEquals(0, streamsOneMetadataOne.standbyTopicPartitions().size());
 
-            long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-            long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+            final long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+            final long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
             assertEquals(2, repartitionTopicTaskCount);
             assertEquals(2, sourceTopicTaskCount);
             
@@ -157,27 +158,27 @@ public class IQv2EndpointToPartitionsIntegrationTest {
                 assertEquals(2, streamsMetadataAllClients.size());
                 streamsOneMetadataOne = streamsMetadataAllClients.get(0);
 
-                Set<TopicPartition> streamsOneTopicPartitions = streamsOneMetadataOne.topicPartitions();
+                final Set<TopicPartition> streamsOneTopicPartitions = streamsOneMetadataOne.topicPartitions();
                 LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneTopicPartitions);
                 assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
                 assertEquals(2, streamsOneTopicPartitions.size());
-                int standbyTopicPartitionCount = usingStandbyReplicas ? 1 : 0;
+                final int standbyTopicPartitionCount = usingStandbyReplicas ? 1 : 0;
                 assertEquals(standbyTopicPartitionCount, streamsOneMetadataOne.standbyTopicPartitions().size());
 
-                long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-                long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                final long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                final long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
                 assertEquals(1, streamsOneRepartitionTopicTaskCount);
                 assertEquals(1, streamsOneSourceTopicTaskCount);
                 
-                StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
-                Set<TopicPartition> streamsTwoTopicPartitions = streamsOneMetadataTwo.topicPartitions();
+                final StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
+                final Set<TopicPartition> streamsTwoTopicPartitions = streamsOneMetadataTwo.topicPartitions();
                 LOG.info("StreamsMetadata topicPartitions for streamsTwo: {}", streamsTwoTopicPartitions);
                 assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
                 assertEquals(2, streamsTwoTopicPartitions.size());
                 assertEquals(standbyTopicPartitionCount, streamsOneMetadataTwo.standbyTopicPartitions().size());
 
-                long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-                long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                final long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                final long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
                 assertEquals(1, streamsTwoRepartitionTopicTaskCount);
                 assertEquals(1, streamsTwoSourceTopicTaskCount);
             }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -113,7 +113,6 @@ public class IQv2EndpointToPartitionsIntegrationTest {
         streamOneProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:2020");
         streamOneProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
         if (usingStandbyReplicas) {
-            streamOneProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 3);
             streamOneProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
         }
         streamsApplicationProperties = props(streamOneProperties);
@@ -124,7 +123,6 @@ public class IQv2EndpointToPartitionsIntegrationTest {
         streamTwoProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:3030");
         streamTwoProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
         if (usingStandbyReplicas) {
-            streamTwoProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 3);
             streamTwoProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
         }
         streamsSecondApplicationProperties = props(streamTwoProperties);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -102,15 +102,19 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     }
 
 
-    @ParameterizedTest(name = "{1}" )
+    @ParameterizedTest(name = "{2}" )
     @MethodSource("groupProtocolParameters")
-    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, final String testName) throws Exception {
+    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, boolean usingStandbyReplicas, final String testName) throws Exception {
 
         final Properties streamOneProperties = new Properties();
         streamOneProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1");
         streamOneProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1");
         streamOneProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:2020");
         streamOneProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+        if (usingStandbyReplicas) {
+            streamOneProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 3);
+            streamOneProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        }
         streamsApplicationProperties = props(streamOneProperties);
 
         final Properties streamTwoProperties = new Properties();
@@ -118,6 +122,10 @@ public class IQv2EndpointToPartitionsIntegrationTest {
         streamTwoProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2");
         streamTwoProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:3030");
         streamTwoProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+        if (usingStandbyReplicas) {
+            streamTwoProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 3);
+            streamTwoProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        }
         streamsSecondApplicationProperties = props(streamTwoProperties);
 
         final Topology topology = complexTopology();
@@ -129,12 +137,13 @@ public class IQv2EndpointToPartitionsIntegrationTest {
             Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
             assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
             assertEquals(4, topicPartitions.size());
+            // Only one KS client instance should be no standby assigned
+            assertEquals(0, streamsOneMetadataOne.standbyTopicPartitions().size());
 
             long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
             long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
             assertEquals(2, repartitionTopicTaskCount);
             assertEquals(2, sourceTopicTaskCount);
-
             
             LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneMetadataOne.topicPartitions());
 
@@ -152,6 +161,8 @@ public class IQv2EndpointToPartitionsIntegrationTest {
                 LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneTopicPartitions);
                 assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
                 assertEquals(2, streamsOneTopicPartitions.size());
+                int standbyTopicPartitionCount = usingStandbyReplicas ? 1 : 0;
+                assertEquals(standbyTopicPartitionCount, streamsOneMetadataOne.standbyTopicPartitions().size());
 
                 long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
                 long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
@@ -163,19 +174,21 @@ public class IQv2EndpointToPartitionsIntegrationTest {
                 LOG.info("StreamsMetadata topicPartitions for streamsTwo: {}", streamsTwoTopicPartitions);
                 assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
                 assertEquals(2, streamsTwoTopicPartitions.size());
+                assertEquals(standbyTopicPartitionCount, streamsOneMetadataTwo.standbyTopicPartitions().size());
 
                 long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
                 long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
                 assertEquals(1, streamsTwoRepartitionTopicTaskCount);
                 assertEquals(1, streamsTwoSourceTopicTaskCount);
-
             }
         }
     }
 
     private static Stream<Arguments> groupProtocolParameters() {
-        return Stream.of(Arguments.of("streams", "Using STREAMS group protocol"),
-                Arguments.of("classic", "Using CLASSIC group protocol"));
+        return Stream.of(Arguments.of("streams", false, "STREAMS protocol No standby"),
+                Arguments.of("classic", false, "CLASSIC protocol No standby"),
+                Arguments.of("streams", true, "STREAMS protocol With standby"),
+                Arguments.of("classic", true, "CLASSIC protocol With standby"));
     }
 
     private Properties props(final Properties extraProperties) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Timeout(600)
+@Tag("integration")
+public class IQv2EndpointToPartitionsIntegrationTest {
+    private String appId;
+    private String inputTopicTwoPartitions;
+    private String outputTopicTwoPartitions;
+    private String inputTopicOnePartition;
+    private String outputTopicOnePartition;
+    private Properties streamsApplicationProperties = new Properties();
+    private Properties streamsSecondApplicationProperties = new Properties();
+
+    private static EmbeddedKafkaCluster cluster;
+    private static final int NUM_BROKERS = 3;
+    private static final Logger LOG = LoggerFactory.getLogger(IQv2EndpointToPartitionsIntegrationTest.class);
+
+
+    @BeforeAll
+    public static void startCluster() throws IOException {
+        final Properties properties = new Properties();
+        properties.put(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, properties);
+        cluster.start();
+    }
+
+    @BeforeEach
+    public void setUp(final TestInfo testInfo) throws InterruptedException {
+        appId = safeUniqueTestName(testInfo);
+        inputTopicTwoPartitions = appId + "-input-two";
+        outputTopicTwoPartitions = appId + "-output-two";
+        inputTopicOnePartition = appId + "-input-one";
+        outputTopicOnePartition = appId + "-output-one";
+        cluster.createTopic(inputTopicTwoPartitions, 2, 1);
+        cluster.createTopic(outputTopicTwoPartitions, 2, 1);
+        cluster.createTopic(inputTopicOnePartition, 1, 1);
+        cluster.createTopic(outputTopicOnePartition, 1, 1);
+    }
+
+    @AfterAll
+    public static void closeCluster() {
+        cluster.stop();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        IntegrationTestUtils.purgeLocalStreamsState(streamsApplicationProperties);
+        if (!streamsSecondApplicationProperties.isEmpty()) {
+            IntegrationTestUtils.purgeLocalStreamsState(streamsSecondApplicationProperties);
+        }
+    }
+
+
+    @ParameterizedTest(name = "{1}" )
+    @MethodSource("groupProtocolParameters")
+    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, final String testName) throws Exception {
+
+        final Properties streamOneProperties = new Properties();
+        streamOneProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1");
+        streamOneProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1");
+        streamOneProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:2020");
+        streamOneProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+        streamsApplicationProperties = props(streamOneProperties);
+
+        final Properties streamTwoProperties = new Properties();
+        streamTwoProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks2");
+        streamTwoProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2");
+        streamTwoProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:3030");
+        streamTwoProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+        streamsSecondApplicationProperties = props(streamTwoProperties);
+
+        final Topology topology = complexTopology();
+        try (final KafkaStreams streamsOne = new KafkaStreams(topology, streamsApplicationProperties)) {
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streamsOne);
+            List<StreamsMetadata> streamsMetadataAllClients = new ArrayList<>(streamsOne.metadataForAllStreamsClients());
+            assertEquals(1, streamsMetadataAllClients.size());
+            StreamsMetadata streamsOneMetadataOne = streamsMetadataAllClients.get(0);
+            assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
+            assertEquals(4, streamsOneMetadataOne.topicPartitions().size());
+
+            try (final KafkaStreams streamsTwo = new KafkaStreams(topology, streamsSecondApplicationProperties)) {
+                streamsTwo.start();
+                waitForCondition(() -> KafkaStreams.State.RUNNING == streamsTwo.state() && KafkaStreams.State.RUNNING == streamsOne.state(),
+                        IntegrationTestUtils.DEFAULT_TIMEOUT,
+                        () -> "Kafka Streams one or two never transitioned to a RUNNING state.");
+
+                streamsMetadataAllClients = new ArrayList<>(streamsTwo.metadataForAllStreamsClients());
+                assertEquals(2, streamsMetadataAllClients.size());
+                streamsOneMetadataOne = streamsMetadataAllClients.get(0);
+                assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
+                assertEquals(2, streamsOneMetadataOne.topicPartitions().size());
+
+                StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
+                assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
+                assertEquals(2, streamsOneMetadataTwo.topicPartitions().size());
+
+            }
+        }
+    }
+
+
+
+
+
+    private List<String> getTaskIdsAsStrings(final KafkaStreams streams) {
+        return streams.metadataForLocalThreads().stream()
+                .flatMap(threadMeta -> threadMeta.activeTasks().stream()
+                        .map(taskMeta -> taskMeta.taskId().toString()))
+                .collect(Collectors.toList());
+    }
+
+
+    private static Stream<Arguments> groupProtocolParameters() {
+        return Stream.of(Arguments.of("streams", "Using STREAMS group protocol"),
+                Arguments.of("classic", "Using CLASSIC group protocol"));
+    }
+
+
+    private Properties props(final Properties extraProperties) {
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.putAll(extraProperties);
+        return streamsConfiguration;
+    }
+
+    private Topology complexTopology() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopicTwoPartitions, Consumed.with(Serdes.String(), Serdes.String()))
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
+                .groupBy((key, value) -> value)
+                .count()
+                .toStream().to(outputTopicTwoPartitions, Produced.with(Serdes.String(), Serdes.Long()));
+        return builder.build();
+    }
+
+    private Topology simpleTopology() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopicOnePartition, Consumed.with(Serdes.String(), Serdes.String()))
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
+                .to(outputTopicOnePartition, Produced.with(Serdes.String(), Serdes.String()));
+        return builder.build();
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -72,25 +72,24 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     private static final Logger LOG = LoggerFactory.getLogger(IQv2EndpointToPartitionsIntegrationTest.class);
 
 
-    @BeforeAll
-    public static void startCluster() throws IOException {
+
+    public void startCluster(int standbyConfig) throws IOException {
         final Properties properties = new Properties();
         properties.put(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        properties.put(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_CONFIG, standbyConfig);
         cluster = new EmbeddedKafkaCluster(NUM_BROKERS, properties);
         cluster.start();
     }
 
-    @BeforeEach
     public void setUp(final TestInfo testInfo) throws InterruptedException {
-        appId = safeUniqueTestName(testInfo);
+        appId = safeUniqueTestName("endpointIntegrationTest");
         inputTopicTwoPartitions = appId + "-input-two";
         outputTopicTwoPartitions = appId + "-output-two";
         cluster.createTopic(inputTopicTwoPartitions, 2, 1);
         cluster.createTopic(outputTopicTwoPartitions, 2, 1);
     }
 
-    @AfterAll
-    public static void closeCluster() {
+    public void closeCluster() {
         cluster.stop();
     }
 
@@ -103,91 +102,100 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     }
 
 
-    @ParameterizedTest(name = "{2}")
+    @ParameterizedTest(name = "{3}")
     @MethodSource("groupProtocolParameters")
-    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig, final boolean usingStandbyReplicas, final String testName) throws Exception {
+    public void shouldGetCorrectHostPartitionInformation(final String groupProtocolConfig,
+                                                         final boolean usingStandbyReplicas,
+                                                         final int numStandbyReplicas,
+                                                         final String testName) throws Exception {
+        try {
+             startCluster(usingStandbyReplicas ? numStandbyReplicas : 0);
+             setUp(null);
 
-        final Properties streamOneProperties = new Properties();
-        streamOneProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1");
-        streamOneProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1");
-        streamOneProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:2020");
-        streamOneProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
-        if (usingStandbyReplicas) {
-            streamOneProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
-        }
-        streamsApplicationProperties = props(streamOneProperties);
-
-        final Properties streamTwoProperties = new Properties();
-        streamTwoProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks2");
-        streamTwoProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2");
-        streamTwoProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:3030");
-        streamTwoProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
-        if (usingStandbyReplicas) {
-            streamTwoProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
-        }
-        streamsSecondApplicationProperties = props(streamTwoProperties);
-
-        final Topology topology = complexTopology();
-        try (final KafkaStreams streamsOne = new KafkaStreams(topology, streamsApplicationProperties)) {
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streamsOne);
-            List<StreamsMetadata> streamsMetadataAllClients = new ArrayList<>(streamsOne.metadataForAllStreamsClients());
-            assertEquals(1, streamsMetadataAllClients.size());
-            StreamsMetadata streamsOneMetadataOne = streamsMetadataAllClients.get(0);
-            final Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
-            assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
-            assertEquals(4, topicPartitions.size());
-            // Only one KS client instance should be no standby assigned
-            assertEquals(0, streamsOneMetadataOne.standbyTopicPartitions().size());
-
-            final long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-            final long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
-            assertEquals(2, repartitionTopicTaskCount);
-            assertEquals(2, sourceTopicTaskCount);
-            
-            LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneMetadataOne.topicPartitions());
-
-            try (final KafkaStreams streamsTwo = new KafkaStreams(topology, streamsSecondApplicationProperties)) {
-                streamsTwo.start();
-                waitForCondition(() -> KafkaStreams.State.RUNNING == streamsTwo.state() && KafkaStreams.State.RUNNING == streamsOne.state(),
-                        IntegrationTestUtils.DEFAULT_TIMEOUT,
-                        () -> "Kafka Streams one or two never transitioned to a RUNNING state.");
-
-                streamsMetadataAllClients = new ArrayList<>(streamsTwo.metadataForAllStreamsClients());
-                assertEquals(2, streamsMetadataAllClients.size());
-                streamsOneMetadataOne = streamsMetadataAllClients.get(0);
-
-                final Set<TopicPartition> streamsOneTopicPartitions = streamsOneMetadataOne.topicPartitions();
-                LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneTopicPartitions);
-                assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
-                assertEquals(2, streamsOneTopicPartitions.size());
-                final int standbyTopicPartitionCount = usingStandbyReplicas ? 1 : 0;
-                assertEquals(standbyTopicPartitionCount, streamsOneMetadataOne.standbyTopicPartitions().size());
-
-                final long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-                final long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
-                assertEquals(1, streamsOneRepartitionTopicTaskCount);
-                assertEquals(1, streamsOneSourceTopicTaskCount);
-                
-                final StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
-                final Set<TopicPartition> streamsTwoTopicPartitions = streamsOneMetadataTwo.topicPartitions();
-                LOG.info("StreamsMetadata topicPartitions for streamsTwo: {}", streamsTwoTopicPartitions);
-                assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
-                assertEquals(2, streamsTwoTopicPartitions.size());
-                assertEquals(standbyTopicPartitionCount, streamsOneMetadataTwo.standbyTopicPartitions().size());
-
-                final long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
-                final long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
-                assertEquals(1, streamsTwoRepartitionTopicTaskCount);
-                assertEquals(1, streamsTwoSourceTopicTaskCount);
+            final Properties streamOneProperties = new Properties();
+            streamOneProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks1");
+            streamOneProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks1");
+            streamOneProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:2020");
+            streamOneProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+            if (usingStandbyReplicas) {
+                streamOneProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
             }
+            streamsApplicationProperties = props(streamOneProperties);
+
+            final Properties streamTwoProperties = new Properties();
+            streamTwoProperties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(appId).getPath() + "-ks2");
+            streamTwoProperties.put(StreamsConfig.CLIENT_ID_CONFIG, appId + "-ks2");
+            streamTwoProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:3030");
+            streamTwoProperties.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocolConfig);
+            if (usingStandbyReplicas) {
+                streamTwoProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
+            }
+            streamsSecondApplicationProperties = props(streamTwoProperties);
+
+            final Topology topology = complexTopology();
+            try (final KafkaStreams streamsOne = new KafkaStreams(topology, streamsApplicationProperties)) {
+                IntegrationTestUtils.startApplicationAndWaitUntilRunning(streamsOne);
+                List<StreamsMetadata> streamsMetadataAllClients = new ArrayList<>(streamsOne.metadataForAllStreamsClients());
+                assertEquals(1, streamsMetadataAllClients.size());
+                StreamsMetadata streamsOneMetadataOne = streamsMetadataAllClients.get(0);
+                final Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
+                assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
+                assertEquals(4, topicPartitions.size());
+                // Only one KS client instance should be no standby assigned
+                assertEquals(0, streamsOneMetadataOne.standbyTopicPartitions().size());
+
+                final long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                final long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                assertEquals(2, repartitionTopicTaskCount);
+                assertEquals(2, sourceTopicTaskCount);
+
+                LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneMetadataOne.topicPartitions());
+
+                try (final KafkaStreams streamsTwo = new KafkaStreams(topology, streamsSecondApplicationProperties)) {
+                    streamsTwo.start();
+                    waitForCondition(() -> KafkaStreams.State.RUNNING == streamsTwo.state() && KafkaStreams.State.RUNNING == streamsOne.state(),
+                            IntegrationTestUtils.DEFAULT_TIMEOUT,
+                            () -> "Kafka Streams one or two never transitioned to a RUNNING state.");
+
+                    streamsMetadataAllClients = new ArrayList<>(streamsTwo.metadataForAllStreamsClients());
+                    assertEquals(2, streamsMetadataAllClients.size());
+                    streamsOneMetadataOne = streamsMetadataAllClients.get(0);
+
+                    final Set<TopicPartition> streamsOneTopicPartitions = streamsOneMetadataOne.topicPartitions();
+                    LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneTopicPartitions);
+                    assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
+                    assertEquals(4, streamsOneTopicPartitions.size());
+                    final int standbyTopicPartitionCount = usingStandbyReplicas ? 1 : 0;
+                    assertEquals(standbyTopicPartitionCount, streamsOneMetadataOne.standbyTopicPartitions().size());
+
+                    final long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                    final long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                    assertEquals(1, streamsOneRepartitionTopicTaskCount);
+                    assertEquals(1, streamsOneSourceTopicTaskCount);
+
+                    final StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
+                    final Set<TopicPartition> streamsTwoTopicPartitions = streamsOneMetadataTwo.topicPartitions();
+                    LOG.info("StreamsMetadata topicPartitions for streamsTwo: {}", streamsTwoTopicPartitions);
+                    assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
+                    assertEquals(2, streamsTwoTopicPartitions.size());
+                    assertEquals(standbyTopicPartitionCount, streamsOneMetadataTwo.standbyTopicPartitions().size());
+
+                    final long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                    final long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                    assertEquals(1, streamsTwoRepartitionTopicTaskCount);
+                    assertEquals(1, streamsTwoSourceTopicTaskCount);
+                }
+            }
+        } finally {
+            closeCluster();
         }
     }
 
     private static Stream<Arguments> groupProtocolParameters() {
-        return Stream.of(Arguments.of("streams", false, "STREAMS protocol No standby"),
-                Arguments.of("classic", false, "CLASSIC protocol No standby"),
-                Arguments.of("streams", true, "STREAMS protocol With standby"),
-                Arguments.of("classic", true, "CLASSIC protocol With standby"));
+        return Stream.of(Arguments.of("streams", false, 0, "STREAMS protocol No standby"),
+                Arguments.of("classic", false, 0, "CLASSIC protocol No standby"),
+                Arguments.of("streams", true, 1, "STREAMS protocol With standby"),
+                Arguments.of("classic", true, 1, "CLASSIC protocol With standby"));
     }
 
     private Properties props(final Properties extraProperties) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.streams.KafkaStreams;
@@ -49,7 +50,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
-import java.util.stream.Collectors;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
@@ -62,8 +63,6 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     private String appId;
     private String inputTopicTwoPartitions;
     private String outputTopicTwoPartitions;
-    private String inputTopicOnePartition;
-    private String outputTopicOnePartition;
     private Properties streamsApplicationProperties = new Properties();
     private Properties streamsSecondApplicationProperties = new Properties();
 
@@ -85,12 +84,8 @@ public class IQv2EndpointToPartitionsIntegrationTest {
         appId = safeUniqueTestName(testInfo);
         inputTopicTwoPartitions = appId + "-input-two";
         outputTopicTwoPartitions = appId + "-output-two";
-        inputTopicOnePartition = appId + "-input-one";
-        outputTopicOnePartition = appId + "-output-one";
         cluster.createTopic(inputTopicTwoPartitions, 2, 1);
         cluster.createTopic(outputTopicTwoPartitions, 2, 1);
-        cluster.createTopic(inputTopicOnePartition, 1, 1);
-        cluster.createTopic(outputTopicOnePartition, 1, 1);
     }
 
     @AfterAll
@@ -131,8 +126,17 @@ public class IQv2EndpointToPartitionsIntegrationTest {
             List<StreamsMetadata> streamsMetadataAllClients = new ArrayList<>(streamsOne.metadataForAllStreamsClients());
             assertEquals(1, streamsMetadataAllClients.size());
             StreamsMetadata streamsOneMetadataOne = streamsMetadataAllClients.get(0);
+            Set<TopicPartition> topicPartitions = streamsOneMetadataOne.topicPartitions();
             assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
-            assertEquals(4, streamsOneMetadataOne.topicPartitions().size());
+            assertEquals(4, topicPartitions.size());
+
+            long repartitionTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+            long sourceTopicTaskCount = topicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+            assertEquals(2, repartitionTopicTaskCount);
+            assertEquals(2, sourceTopicTaskCount);
+
+            
+            LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneMetadataOne.topicPartitions());
 
             try (final KafkaStreams streamsTwo = new KafkaStreams(topology, streamsSecondApplicationProperties)) {
                 streamsTwo.start();
@@ -143,34 +147,36 @@ public class IQv2EndpointToPartitionsIntegrationTest {
                 streamsMetadataAllClients = new ArrayList<>(streamsTwo.metadataForAllStreamsClients());
                 assertEquals(2, streamsMetadataAllClients.size());
                 streamsOneMetadataOne = streamsMetadataAllClients.get(0);
-                assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
-                assertEquals(2, streamsOneMetadataOne.topicPartitions().size());
 
+                Set<TopicPartition> streamsOneTopicPartitions = streamsOneMetadataOne.topicPartitions();
+                LOG.info("StreamsMetadata topicPartitions for streamsOne: {}", streamsOneTopicPartitions);
+                assertEquals(2020, streamsOneMetadataOne.hostInfo().port());
+                assertEquals(2, streamsOneTopicPartitions.size());
+
+                long streamsOneRepartitionTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                long streamsOneSourceTopicTaskCount = streamsOneTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                assertEquals(1, streamsOneRepartitionTopicTaskCount);
+                assertEquals(1, streamsOneSourceTopicTaskCount);
+                
                 StreamsMetadata streamsOneMetadataTwo = streamsMetadataAllClients.get(1);
+                Set<TopicPartition> streamsTwoTopicPartitions = streamsOneMetadataTwo.topicPartitions();
+                LOG.info("StreamsMetadata topicPartitions for streamsTwo: {}", streamsTwoTopicPartitions);
                 assertEquals(3030, streamsOneMetadataTwo.hostInfo().port());
-                assertEquals(2, streamsOneMetadataTwo.topicPartitions().size());
+                assertEquals(2, streamsTwoTopicPartitions.size());
+
+                long streamsTwoRepartitionTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-repartition")).count();
+                long streamsTwoSourceTopicTaskCount = streamsTwoTopicPartitions.stream().filter(tp -> tp.topic().contains("-input-two")).count();
+                assertEquals(1, streamsTwoRepartitionTopicTaskCount);
+                assertEquals(1, streamsTwoSourceTopicTaskCount);
 
             }
         }
     }
 
-
-
-
-
-    private List<String> getTaskIdsAsStrings(final KafkaStreams streams) {
-        return streams.metadataForLocalThreads().stream()
-                .flatMap(threadMeta -> threadMeta.activeTasks().stream()
-                        .map(taskMeta -> taskMeta.taskId().toString()))
-                .collect(Collectors.toList());
-    }
-
-
     private static Stream<Arguments> groupProtocolParameters() {
         return Stream.of(Arguments.of("streams", "Using STREAMS group protocol"),
                 Arguments.of("classic", "Using CLASSIC group protocol"));
     }
-
 
     private Properties props(final Properties extraProperties) {
         final Properties streamsConfiguration = new Properties();
@@ -195,11 +201,4 @@ public class IQv2EndpointToPartitionsIntegrationTest {
         return builder.build();
     }
 
-    private Topology simpleTopology() {
-        final StreamsBuilder builder = new StreamsBuilder();
-        builder.stream(inputTopicOnePartition, Consumed.with(Serdes.String(), Serdes.String()))
-                .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
-                .to(outputTopicOnePartition, Produced.with(Serdes.String(), Serdes.String()));
-        return builder.build();
-    }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -96,19 +98,23 @@ public class IQv2IntegrationTest {
     private static final Position INPUT_POSITION = Position.emptyPosition();
     private static final String STORE_NAME = "kv-store";
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public static EmbeddedKafkaCluster cluster;
 
     private KafkaStreams kafkaStreams;
 
     @BeforeAll
     public static void before()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-        CLUSTER.start();
+        final Properties props = new Properties();
+        props.setProperty(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        props.setProperty(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true");
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, props);
+        cluster.start();
         final int partitions = 2;
-        CLUSTER.createTopic(INPUT_TOPIC_NAME, partitions, 1);
+        cluster.createTopic(INPUT_TOPIC_NAME, partitions, 1);
 
         final Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
 
@@ -173,7 +179,7 @@ public class IQv2IntegrationTest {
 
     @AfterAll
     public static void after() {
-        CLUSTER.stop();
+        cluster.stop();
     }
 
     @Test
@@ -448,7 +454,7 @@ public class IQv2IntegrationTest {
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + (++port));
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -462,6 +462,7 @@ public class IQv2IntegrationTest {
         config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
         return config;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -136,7 +138,7 @@ public class IQv2StoreIntegrationTest {
     private static final long WINDOW_START =
         (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public static EmbeddedKafkaCluster cluster;
     private static final Position POSITION_0 =
         Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 5L)))));
 
@@ -376,14 +378,17 @@ public class IQv2StoreIntegrationTest {
     @BeforeAll
     public static void before()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-
-        CLUSTER.start();
-        CLUSTER.deleteAllTopics();
+        final Properties props = new Properties();
+        props.setProperty(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        props.setProperty(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true");
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, props);
+        cluster.start();
+        cluster.deleteAllTopics();
         final int partitions = 2;
-        CLUSTER.createTopic(INPUT_TOPIC_NAME, partitions, 1);
+        cluster.createTopic(INPUT_TOPIC_NAME, partitions, 1);
 
         final Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
 
@@ -760,7 +765,7 @@ public class IQv2StoreIntegrationTest {
 
     @AfterAll
     public static void after() {
-        CLUSTER.stop();
+        cluster.stop();
     }
 
     @ParameterizedTest
@@ -2038,7 +2043,7 @@ public class IQv2StoreIntegrationTest {
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + (++port));
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -2047,6 +2047,7 @@ public class IQv2StoreIntegrationTest {
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         config.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
         config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -52,7 +54,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoField;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -85,7 +86,9 @@ public class IQv2VersionedStoreIntegrationTest {
     private static final int LAST_INDEX = RECORD_NUMBER - 1;
     private static final Position INPUT_POSITION = Position.emptyPosition();
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, Utils.mkProperties(Collections.singletonMap("auto.create.topics.enable", "true")));
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, Utils.mkProperties(Map.of("auto.create.topics.enable", "true",
+             GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams",
+            ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")));
 
     private KafkaStreams kafkaStreams;
 
@@ -113,6 +116,7 @@ public class IQv2VersionedStoreIntegrationTest {
             Materialized.as(Stores.persistentVersionedKeyValueStore(STORE_NAME, HISTORY_RETENTION, SEGMENT_INTERVAL)));
         final Properties configs = new Properties();
         configs.put(StreamsConfig.APPLICATION_ID_CONFIG, "app");
+        configs.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:7070");
         configs.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         configs.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class.getName());
         configs.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class.getName());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
@@ -120,6 +120,7 @@ public class IQv2VersionedStoreIntegrationTest {
         configs.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         configs.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class.getName());
         configs.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class.getName());
+        configs.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         kafkaStreams = IntegrationTestUtils.getStartedStreams(configs, builder, true);
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/InternalTopicIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/InternalTopicIntegrationTest.java
@@ -114,6 +114,7 @@ public class InternalTopicIntegrationTest {
         streamsProp.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsProp.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsProp.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsProp.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:4040");
         streamsProp.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsProp.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         streamsProp.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.telemetry.ClientTelemetry;
 import org.apache.kafka.server.telemetry.ClientTelemetryPayload;
@@ -114,6 +115,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
     public static void startCluster() throws IOException {
         final Properties properties = new Properties();
         properties.put("metric.reporters", TelemetryPlugin.class.getName());
+        properties.put(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
         cluster = new EmbeddedKafkaCluster(NUM_BROKERS, properties);
         cluster.start();
     }
@@ -394,6 +396,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
         streamsConfiguration.put(StreamsConfig.DEFAULT_CLIENT_SUPPLIER_CONFIG, TestClientSupplier.class);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "classic");
         streamsConfiguration.putAll(extraProperties);
         return streamsConfiguration;
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -120,6 +120,7 @@ public class LagFetchIntegrationTest {
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        streamsConfiguration.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
 
         consumerConfiguration = new Properties();
         consumerConfiguration.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.KeyValue;
@@ -78,24 +80,28 @@ public class OptimizedKTableIntegrationTest {
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public static EmbeddedKafkaCluster cluster;
 
     @BeforeAll
     public static void startCluster() throws IOException {
-        CLUSTER.start();
+        final Properties props = new Properties();
+        props.setProperty(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,streams");
+        props.setProperty(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true");
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, props);
+        cluster.start();
     }
 
     @AfterAll
     public static void closeCluster() {
-        CLUSTER.stop();
+        cluster.stop();
     }
 
     private final List<KafkaStreams> streamsToCleanup = new ArrayList<>();
-    private final MockTime mockTime = CLUSTER.time;
+    private final MockTime mockTime = cluster.time;
 
     @BeforeEach
     public void before() throws InterruptedException {
-        CLUSTER.createTopic(INPUT_TOPIC_NAME, 2, 1);
+        cluster.createTopic(INPUT_TOPIC_NAME, 2, 1);
     }
 
     @AfterEach
@@ -186,7 +192,7 @@ public class OptimizedKTableIntegrationTest {
 
     private void produceValueRange(final int key, final int start, final int endExclusive) {
         final Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
 
@@ -210,7 +216,7 @@ public class OptimizedKTableIntegrationTest {
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + (++port));
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -226,6 +226,7 @@ public class OptimizedKTableIntegrationTest {
         config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         return config;
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
@@ -672,6 +672,7 @@ public class PositionRestartIntegrationTest {
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         config.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         return config;
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -234,6 +234,7 @@ public class QueryableStateIntegrationTest {
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         streamsConfiguration.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000);
+        streamsConfiguration.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
 
         stringComparator = Comparator.comparing((KeyValue<String, String> o) -> o.key).thenComparing(o -> o.value);
         stringLongComparator = Comparator.comparing((KeyValue<String, Long> o) -> o.key).thenComparingLong(o -> o.value);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -137,6 +137,7 @@ public class SmokeTestDriverIntegrationTest {
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
         props.put(InternalConfig.PROCESSING_THREADS_ENABLED, processingThreadsEnabled);
+        props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:7777");
         // decrease the session timeout so that we can trigger the rebalance soon after old client left closed
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000);
         if (streamsProtocolEnabled) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -679,6 +679,7 @@ public class StoreQueryIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        config.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         return config;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1403,15 +1403,20 @@ public class StreamThread extends Thread implements ProcessingThread {
             }
 
             // Process metadata from Streams Rebalance Protocol
-            final Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> partitionsByEndpoint =
+            final Map<StreamsAssignmentInterface.HostInfo, Map<String, List<TopicPartition>>> partitionsByEndpoint =
                 streamsAssignmentInterface.get().partitionsByHost.get();
-            final Map<HostInfo, Set<TopicPartition>> convertedHostInfoMap = new HashMap<>();
-            partitionsByEndpoint.forEach((hostInfo, topicPartitions) ->
-                convertedHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(topicPartitions)));
+            final Map<HostInfo,Set<TopicPartition>> activeHostInfoMap = new HashMap<>();
+            partitionsByEndpoint.forEach((hostInfo, topicPartitions) -> {
+                        activeHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(topicPartitions.get("active")));
+                    });
+            final Map<HostInfo,Set<TopicPartition>> standbyHostInfoMap = new HashMap<>();
+            partitionsByEndpoint.forEach((hostInfo, topicPartitions) -> {
+                standbyHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(topicPartitions.get("standby")));
+            });
             streamsMetadataState.onChange(
-                convertedHostInfoMap,
-                Collections.emptyMap(), // TODO: We cannot differentiate between standby and active tasks here?!
-                getTopicPartitionInfo(convertedHostInfoMap)
+                activeHostInfoMap,
+                standbyHostInfoMap, // TODO: We cannot differentiate between standby and active tasks here?!
+                getTopicPartitionInfo(activeHostInfoMap)
             );
 
             // Process assignment from Streams Rebalance Protocol

--- a/streams/src/test/java/org/apache/kafka/streams/utils/TestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/utils/TestUtils.java
@@ -90,7 +90,7 @@ public class TestUtils {
         return safeUniqueTestName(methodName);
     }
 
-    private static String safeUniqueTestName(final String testName) {
+    public static String safeUniqueTestName(final String testName) {
         return sanitize(testName + Uuid.randomUuid().toString());
     }
 


### PR DESCRIPTION
This PR adds IQv2 information to the `StreamsGroupHeartbeat` response.

For testing, all IQv2 related integration tests have been updated (and are passing) to use the new streams protocol to exercise the newly added code.  A specific integration test and unit tests are coming.

Among the tests updated:
1. `ConsistencyVectorIntegrationTest`
2. `EosIntegrationTest` 
3. `IQv2IntegrationTest`
4. `IQv2StoreIntegrationTest`
5. `IQv2VersionedStoreIntegrationTest`
6. `LagFetchIntegrationTest` 
7. `OptimizedKTableIntegrationTest`
8. `PositionRestartIntegrationTest` 
9. `QueryableStateIntegrationTest`
10. `StoreQueryIntegrationTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
