### PR TITLE
HOTFIX: fix incompatible types: Optional<TimestampAndOffset> cannot be converted to Option<TimestampAndOffset>

### DIFF
--- a/core/src/main/java/kafka/server/share/ShareFetchUtils.java
+++ b/core/src/main/java/kafka/server/share/ShareFetchUtils.java
@@ -167,7 +167,7 @@ public class ShareFetchUtils {
      * @return The offset for the given timestamp.
      */
     static long offsetForTimestamp(TopicIdPartition topicIdPartition, ReplicaManager replicaManager, long timestampToSearch, int leaderEpoch) {
-        Option<FileRecords.TimestampAndOffset> timestampAndOffset = replicaManager.fetchOffsetForTimestamp(
+        Optional<FileRecords.TimestampAndOffset> timestampAndOffset = replicaManager.fetchOffsetForTimestamp(
             topicIdPartition.topicPartition(), timestampToSearch, new Some<>(IsolationLevel.READ_UNCOMMITTED), Optional.of(leaderEpoch), true).timestampAndOffsetOpt();
         if (timestampAndOffset.isEmpty()) {
             throw new OffsetNotAvailableException("Offset for timestamp " + timestampToSearch + " not found for topic partition: " + topicIdPartition);

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -327,7 +327,7 @@ public class SharePartitionTest {
         ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
 
         FileRecords.TimestampAndOffset timestampAndOffset = new FileRecords.TimestampAndOffset(MOCK_TIME.milliseconds() - TimeUnit.HOURS.toMillis(1), 15L, Optional.empty());
-        Mockito.doReturn(new OffsetResultHolder(Option.apply(timestampAndOffset), Option.empty())).
+        Mockito.doReturn(new OffsetResultHolder(Optional.of(timestampAndOffset), Optional.empty())).
             when(replicaManager).fetchOffsetForTimestamp(Mockito.any(TopicPartition.class), Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
 
         SharePartition sharePartition = SharePartitionBuilder.builder()


### PR DESCRIPTION
The error was introduced by https://github.com/apache/kafka/commit/220c57852100e895b460e56d1132a3c9239aaa59.

Run `./gradlew build -x test` or `./gradlew checkstyleMain checkstyleTest spotlessCheck` on trunk and will get following error:

```
> Configure project :
Starting build with version 4.1.0-SNAPSHOT (commit id e8863c9e) using Gradle 8.10.2, Java 21 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=12, maxScalacThreads=8, maxTestRetries=0

> Task :share-coordinator:processMessages
MessageGenerator: processed 4 Kafka message JSON files(s).

> Task :raft:processMessages
MessageGenerator: processed 1 Kafka message JSON files(s).

> Task :storage:processMessages
MessageGenerator: processed 5 Kafka message JSON files(s).

> Task :transaction-coordinator:processMessages
MessageGenerator: processed 2 Kafka message JSON files(s).

> Task :metadata:processMessages
MessageGenerator: processed 25 Kafka message JSON files(s).

> Task :group-coordinator:processMessages
MessageGenerator: processed 48 Kafka message JSON files(s).

> Task :clients:processMessages
MessageGenerator: processed 190 Kafka message JSON files(s).

> Task :clients:processTestMessages
MessageGenerator: processed 4 Kafka message JSON files(s).

> Task :clients:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :core:compileScala
[Error] /Users/poanyang/Project/apache/kafka/core/src/main/java/kafka/server/share/ShareFetchUtils.java:171:  error: incompatible types: Optional<TimestampAndOffset> cannot be converted to Option<TimestampAndOffset>
javac exited with exit code 1

> Task :core:compileScala FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:compileScala'.
> javac returned non-zero exit code

* Try:
> Run with --info option to get more log output.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10.2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 19s
328 actionable tasks: 39 executed, 289 up-to-date
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
