### PR TITLE
KAFKA-18334: Produce v4-v6 should be undeprecated

### DIFF
--- a/clients/src/main/resources/common/message/ProduceRequest.json
+++ b/clients/src/main/resources/common/message/ProduceRequest.json
@@ -43,7 +43,7 @@
   // AddPartitionsToTxn call. If V2 is disabled, the client can't use produce request version higher than 11 within
   // a transaction.
   "validVersions": "0-12",
-  "deprecatedVersions": "0-6",
+  "deprecatedVersions": "0-2",
   "flexibleVersions": "9+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "3+", "nullableVersions": "3+", "default": "null", "entityType": "transactionalId",

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -346,7 +346,7 @@ class SocketServerTest {
     assertTrue(requestsPerSec(requestVersion).getOrElse(0L) > 0, "RequestsPerSec should be higher than 0")
     assertEquals(None, deprecatedRequestsPerSec(requestVersion))
 
-    requestVersion = 3
+    requestVersion = 2
     sendRequest(plainSocket, producerRequestBytes(requestVersion))
     receivedReq = receiveRequest(server.dataPlaneRequestChannel)
     server.dataPlaneRequestChannel.sendNoOpResponse(receivedReq)


### PR DESCRIPTION
Librdkafka totally breaks if produce v3 is removed - it starts sending records with record format v0.
These api versions have to be undeprecated - KIP-896 has been updated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
