### PR TITLE
MINOR: log4j2 upgrade follow-up

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -24,10 +24,6 @@ base_dir=$(dirname $0)
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$base_dir/../config/connect-log4j2.yaml"
-elif echo "$KAFKA_LOG4J_OPTS" | grep -qE "log4j\.[^[:space:]]+$"; then
-    echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
-    echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-    echo You can also use the \$KAFKA_HOME/config/connect-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/connect-mirror-maker.sh
+++ b/bin/connect-mirror-maker.sh
@@ -24,10 +24,6 @@ base_dir=$(dirname $0)
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$base_dir/../config/connect-log4j2.yaml"
-elif echo "$KAFKA_LOG4J_OPTS" | grep -qE "log4j\.[^[:space:]]+$"; then
-    echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
-    echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-    echo You can also use the \$KAFKA_HOME/config/connect-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -24,10 +24,6 @@ base_dir=$(dirname $0)
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$base_dir/../config/connect-log4j2.yaml"
-elif echo "$KAFKA_LOG4J_OPTS" | grep -qE "log4j\.[^[:space:]]+$"; then
-    echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
-    echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-    echo You can also use the \$KAFKA_HOME/config/connect-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -225,6 +225,13 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
   KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
 else
+  if echo "$KAFKA_LOG4J_OPTS" | grep -E "log4j\.[^[:space:]]+(\.properties|\.xml)$"; then
+      # Enable Log4j 1.x configuration compatibility mode for Log4j 2
+      export LOG4J_COMPATIBILITY=true
+      echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
+      echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
+      echo You can also use the \$KAFKA_HOME/config/tools-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
+  fi
   # create logs directory
   if [ ! -d "$LOG_DIR" ]; then
     mkdir -p "$LOG_DIR"

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -23,10 +23,6 @@ base_dir=$(dirname $0)
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$base_dir/../config/log4j2.yaml"
-elif echo "$KAFKA_LOG4J_OPTS" | grep -qE "log4j\.[^[:space:]]+$"; then
-    echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
-    echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-    echo You can also use the \$KAFKA_HOME/config/log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/windows/connect-distributed.bat
+++ b/bin/windows/connect-distributed.bat
@@ -28,13 +28,6 @@ popd
 rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
         set KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%BASE_DIR%/config/connect-log4j2.yaml
-) ELSE (
-        echo %KAFKA_LOG4J_OPTS% | findstr /r /c:"log4j\.[^ ]*$" >nul
-        IF %ERRORLEVEL% == 0 (
-            echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended.
-            echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-            echo You can also use the %BASE_DIR%/config/connect-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
-        )
 )
 
 "%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectDistributed %*

--- a/bin/windows/connect-standalone.bat
+++ b/bin/windows/connect-standalone.bat
@@ -28,13 +28,6 @@ popd
 rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
         set KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%BASE_DIR%/config/connect-log4j2.yaml
-) ELSE (
-        echo %KAFKA_LOG4J_OPTS% | findstr /r /c:"log4j\.[^ ]*$" >nul
-        IF %ERRORLEVEL% == 0 (
-            echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended.
-            echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration.
-            echo You can also use the %BASE_DIR%/config/connect-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration.
-        )
 )
 
 "%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectStandalone %*

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -118,6 +118,15 @@ rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
 ) ELSE (
+    rem Check if Log4j 1.x configuration options are present in KAFKA_LOG4J_OPTS
+    echo %KAFKA_LOG4J_OPTS% | findstr /r /c:"log4j\.[^ ]*(\.properties|\.xml)$" >nul
+    IF %ERRORLEVEL% == 0 (
+        rem Enable Log4j 1.x configuration compatibility mode for Log4j 2
+        set LOG4J_COMPATIBILITY=true
+        echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
+        echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
+        echo You can also use the %BASE_DIR%/config/tool-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
+    )
   rem create logs directory
   IF not exist "%LOG_DIR%" (
       mkdir "%LOG_DIR%"

--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -22,13 +22,6 @@ IF [%1] EQU [] (
 SetLocal
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
     set KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%~dp0../../config/log4j2.yaml
-) ELSE (
-    echo %KAFKA_LOG4J_OPTS% | findstr /r /c:"log4j\.[^ ]*$" >nul
-    IF %ERRORLEVEL% == 0 (
-        echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended.
-        echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration.
-        echo You can also use the %~dp0../../config/log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration.
-    )
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     rem detect OS architecture

--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,18 @@ ext {
     libs.junitPlatformLanucher,
     project(":test-common:test-common-runtime")
   ]
+
+  log4jRuntimeLibs = [
+    libs.log4j1Bridge2Api,
+    libs.jacksonDatabindYaml
+  ]
+
+  log4jLibs = [
+    libs.slf4jApi,
+    libs.slf4jLog4j2,
+    libs.log4j2Api,
+    libs.log4j2Core
+  ]
 }
 
 allprojects {
@@ -964,20 +976,16 @@ project(':server') {
     implementation project(':group-coordinator')
     implementation project(':transaction-coordinator')
     implementation project(':raft')
-    implementation libs.metrics
     implementation libs.jacksonDatabind
+    implementation libs.metrics
+    implementation log4jLibs
 
-    implementation libs.slf4jApi
-
-    compileOnly libs.log4j2Api
-    compileOnly libs.log4j2Core
-    compileOnly libs.log4j1Bridge2Api
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
 
     testImplementation libs.mockitoCore
     testImplementation libs.junitJupiter
-    testImplementation libs.slf4jLog4j2
 
     testRuntimeOnly runtimeTestLibs
   }
@@ -1028,15 +1036,15 @@ project(':share') {
 
   dependencies {
     implementation project(':server-common')
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output
 
-    implementation libs.slf4jApi
-
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
-    testImplementation libs.slf4jLog4j2
 
     testRuntimeOnly runtimeTestLibs
   }
@@ -1099,7 +1107,6 @@ project(':core') {
     // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
     implementation libs.scalaReflect
     implementation libs.scalaLogging
-    implementation libs.slf4jApi
     implementation libs.commonsIo // ZooKeeper dependency. Do not use, this is going away.
     implementation(libs.zookeeper) {
       // Dropwizard Metrics are required by ZooKeeper as of v3.6.0,
@@ -1114,10 +1121,9 @@ project(':core') {
     }
     // ZooKeeperMain depends on commons-cli but declares the dependency as `provided`
     implementation libs.commonsCli
-    implementation libs.log4j2Core
-    implementation libs.log4j2Api
-    implementation libs.log4j1Bridge2Api
-    implementation libs.jacksonDatabindYaml
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':group-coordinator').sourceSets.test.output
@@ -1147,7 +1153,6 @@ project(':core') {
     testImplementation libs.apachedsMavibotPartition
     testImplementation libs.apachedsJdbmPartition
     testImplementation libs.junitJupiter
-    testImplementation libs.slf4jLog4j2
     testImplementation libs.caffeine
 
     testRuntimeOnly runtimeTestLibs
@@ -1391,14 +1396,13 @@ project(':metadata') {
     implementation libs.jacksonDatabind
     implementation libs.jacksonJDK8Datatypes
     implementation libs.metrics
-    compileOnly libs.log4j2Api
-    compileOnly libs.log4j2Core
-    compileOnly libs.log4j1Bridge2Api
-    testImplementation libs.jacksonDatabindYaml
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation libs.junitJupiter
     testImplementation libs.jqwik
     testImplementation libs.mockitoCore
-    testImplementation libs.slf4jLog4j2
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':raft').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output
@@ -1515,10 +1519,12 @@ project(':group-coordinator') {
     implementation project(':coordinator-common')
     implementation libs.jacksonDatabind
     implementation libs.jacksonJDK8Datatypes
-    implementation libs.slf4jApi
     implementation libs.metrics
     implementation libs.hdrHistogram
     implementation libs.re2j
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output
@@ -1586,8 +1592,11 @@ project(':test-common') {
     implementation project(':raft')
     implementation project(':storage')
     implementation project(':server-common')
-    implementation libs.slf4jApi
     implementation libs.jacksonDatabindYaml
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
 
@@ -1643,10 +1652,12 @@ project(':test-common:test-common-runtime') {
   }
 
   dependencies {
-    implementation libs.slf4jApi
     implementation libs.junitPlatformLanucher
     implementation libs.junitJupiterApi
     implementation libs.junitJupiter
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
   }
 
   checkstyle {
@@ -1672,13 +1683,16 @@ project(':transaction-coordinator') {
     implementation project(':clients')
     implementation project(':server-common')
     implementation project(':coordinator-common')
-    implementation libs.slf4jApi
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':test-common')
     testImplementation project(':test-common:test-common-api')
+
     testRuntimeOnly runtimeTestLibs
 
     generator project(':generator')
@@ -1734,9 +1748,11 @@ project(':coordinator-common') {
     implementation project(':server-common')
     implementation project(':metadata')
     implementation project(':storage')
-    implementation libs.slf4jApi
+    implementation log4jLibs
     implementation libs.metrics
     implementation libs.hdrHistogram
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output
@@ -1772,8 +1788,10 @@ project(':share-coordinator') {
     implementation project(':server')
     implementation project(':server-common')
     implementation project(':share')
-    implementation libs.slf4jApi
     implementation libs.metrics
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output
@@ -1881,9 +1899,9 @@ project(':clients') {
     implementation libs.zstd
     implementation libs.lz4
     implementation libs.snappy
-    implementation libs.slf4jApi
     implementation libs.opentelemetryProto
     implementation libs.protobuf
+    implementation libs.slf4jApi
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
     shadowed libs.zstd
@@ -1895,23 +1913,22 @@ project(':clients') {
     compileOnly libs.jacksonJDK8Datatypes
     compileOnly libs.jose4j          // for SASL/OAUTHBEARER JWT validation; only used by broker
 
+
     testImplementation libs.bcpkix
     testImplementation libs.jacksonJakartarsJsonProvider
-    testImplementation libs.jacksonDatabindYaml
     testImplementation libs.jose4j
     testImplementation libs.junitJupiter
-    testImplementation libs.log4j2Api
-    testImplementation libs.log4j2Core
-    testImplementation libs.log4j1Bridge2Api
     testImplementation libs.spotbugs
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
+    testImplementation log4jLibs
 
     testCompileOnly libs.bndlib
 
     testRuntimeOnly libs.jacksonDatabind
     testRuntimeOnly libs.jacksonJDK8Datatypes
     testRuntimeOnly runtimeTestLibs
+    testRuntimeOnly log4jRuntimeLibs
 
     generator project(':generator')
   }
@@ -2064,9 +2081,10 @@ project(':raft') {
   dependencies {
     implementation project(':server-common')
     implementation project(':clients')
-    implementation libs.slf4jApi
     implementation libs.jacksonDatabind
-    implementation libs.jacksonDatabindYaml
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':server-common')
     testImplementation project(':server-common').sourceSets.test.output
@@ -2160,11 +2178,13 @@ project(':server-common') {
 
   dependencies {
     api project(':clients')
-    implementation libs.slf4jApi
     implementation libs.metrics
     implementation libs.joptSimple
     implementation libs.jacksonDatabind
     implementation libs.pcollections
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients')
     testImplementation project(':clients').sourceSets.test.output
@@ -2223,7 +2243,9 @@ project(':storage:storage-api') {
     implementation project(':clients')
     implementation project(':server-common')
     implementation libs.metrics
-    implementation libs.slf4jApi
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients')
     testImplementation project(':clients').sourceSets.test.output
@@ -2288,9 +2310,11 @@ project(':storage') {
     implementation(libs.caffeine) {
       exclude group: 'org.checkerframework', module: 'checker-qual'
     }
-    implementation libs.slf4jApi
+    implementation log4jLibs
     implementation libs.jacksonDatabind
     implementation libs.metrics
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients')
     testImplementation project(':clients').sourceSets.test.output
@@ -2463,16 +2487,14 @@ project(':tools') {
     implementation libs.jacksonDatabind
     implementation libs.jacksonDataformatCsv
     implementation libs.jacksonJDK8Datatypes
-    implementation libs.slf4jApi
-    implementation libs.slf4jLog4j2
-    implementation libs.log4j2Api
-    implementation libs.log4j2Core
-    implementation libs.log4j1Bridge2Api
     implementation libs.joptSimple
+    implementation log4jLibs
     implementation libs.re2j
 
     implementation libs.jose4j                    // for SASL/OAUTHBEARER JWT validation
     implementation libs.jacksonJakartarsJsonProvider
+
+    runtimeOnly log4jRuntimeLibs
 
     compileOnly libs.spotbugs
 
@@ -2539,10 +2561,7 @@ project(':trogdor') {
     implementation libs.argparse4j
     implementation libs.jacksonDatabind
     implementation libs.jacksonJDK8Datatypes
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
 
     implementation libs.jacksonJakartarsJsonProvider
     implementation libs.jerseyContainerServlet
@@ -2562,6 +2581,8 @@ project(':trogdor') {
     implementation project(':group-coordinator')
     implementation project(':group-coordinator:group-coordinator-api')
 
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation project(':clients')
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':group-coordinator')
@@ -2569,9 +2590,6 @@ project(':trogdor') {
     testImplementation libs.mockitoCore
 
     testRuntimeOnly runtimeTestLibs
-    testRuntimeOnly libs.log4j2Api
-    testRuntimeOnly libs.log4j2Core
-    testRuntimeOnly libs.log4j1Bridge2Api
     testRuntimeOnly libs.junitPlatformLanucher
   }
 
@@ -2602,7 +2620,7 @@ project(':shell') {
     implementation libs.jacksonDatabind
     implementation libs.jacksonJDK8Datatypes
     implementation libs.jline
-    implementation libs.slf4jApi
+    implementation log4jLibs
     implementation project(':server-common')
     implementation project(':clients')
     implementation project(':core')
@@ -2611,6 +2629,8 @@ project(':shell') {
 
     implementation libs.jose4j                    // for SASL/OAUTHBEARER JWT validation
     implementation libs.jacksonJakartarsJsonProvider
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients')
     testImplementation project(':clients').sourceSets.test.output
@@ -2656,18 +2676,15 @@ project(':streams') {
     // `org.rocksdb.Options` is part of Kafka Streams public api via `RocksDBConfigSetter`
     api libs.rocksDBJni
 
-    implementation libs.slf4jApi
     implementation libs.jacksonAnnotations
     implementation libs.jacksonDatabind
+    implementation libs.slf4jApi
 
     // testCompileOnly prevents streams from exporting a dependency on test-utils, which would cause a dependency cycle
     testCompileOnly project(':streams:test-utils')
     testCompileOnly libs.bndlib
 
     testImplementation project(':clients').sourceSets.test.output
-    testImplementation libs.log4j2Api
-    testImplementation libs.log4j2Core
-    testImplementation libs.log4j1Bridge2Api
     testImplementation libs.jacksonDatabindYaml
     testImplementation libs.junitJupiter
     testImplementation libs.bcpkix
@@ -2675,9 +2692,11 @@ project(':streams') {
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
     testImplementation libs.junitPlatformSuiteEngine // supports suite test
+    testImplementation log4jLibs
 
     testRuntimeOnly project(':streams:test-utils')
     testRuntimeOnly runtimeTestLibs
+    testRuntimeOnly log4jRuntimeLibs
 
     generator project(':generator')
   }
@@ -2855,6 +2874,10 @@ project(':streams:integration-tests') {
   }
 
   dependencies {
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':group-coordinator')
     testImplementation project(':server')
@@ -2868,14 +2891,9 @@ project(':streams:integration-tests') {
     testImplementation project(':transaction-coordinator')
     testImplementation libs.bcpkix
     testImplementation libs.hamcrest
-    testImplementation libs.jacksonDatabindYaml
     testImplementation libs.junitJupiter
     testImplementation libs.junitPlatformSuiteEngine // supports suite test
     testImplementation libs.mockitoCore
-    testImplementation libs.log4j2Api
-    testImplementation libs.log4j2Core
-    testImplementation libs.log4j1Bridge2Api
-    testImplementation libs.slf4jApi
     testImplementation project(':streams:test-utils')
 
     testRuntimeOnly runtimeTestLibs
@@ -2911,7 +2929,9 @@ project(':streams:test-utils') {
     api project(':streams')
     api project(':clients')
 
-    implementation libs.slf4jApi
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation libs.jacksonDatabindYaml
@@ -2945,8 +2965,9 @@ project(':streams:examples') {
     // this dependency should be removed after we unify data API
     implementation(project(':connect:json'))
     implementation project(':streams')
+    implementation log4jLibs
 
-    implementation libs.slf4jLog4j2
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation project(':streams:test-utils')
     testImplementation project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
@@ -3341,8 +3362,10 @@ project(':jmh-benchmarks') {
     implementation libs.jacksonDatabind
     implementation libs.metrics
     implementation libs.mockitoCore
-    implementation libs.slf4jLog4j2
     implementation libs.scalaLibrary
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
   }
 
   tasks.withType(JavaCompile) {
@@ -3384,11 +3407,10 @@ project(':connect:api') {
 
   dependencies {
     api project(':clients')
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
     implementation libs.jakartaRsApi
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.junitJupiter
     testImplementation project(':clients').sourceSets.test.output
@@ -3422,13 +3444,11 @@ project(':connect:transforms') {
   dependencies {
     api project(':connect:api')
 
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.junitJupiter
-
     testImplementation project(':clients').sourceSets.test.output
 
     testRuntimeOnly runtimeTestLibs
@@ -3464,10 +3484,9 @@ project(':connect:json') {
     api libs.jacksonJDK8Datatypes
     api libs.jacksonBlackbird
 
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.junitJupiter
 
@@ -3511,11 +3530,7 @@ project(':connect:runtime') {
     api project(':connect:json')
     api project(':connect:transforms')
 
-    implementation libs.slf4jApi
-    implementation libs.slf4jLog4j2
-    implementation libs.log4j2Api
-    implementation libs.log4j2Core
-    implementation libs.log4j1Bridge2Api
+    implementation log4jLibs
     implementation libs.jose4j                    // for SASL/OAUTHBEARER JWT validation
     implementation libs.jacksonAnnotations
     implementation libs.jacksonJakartarsJsonProvider
@@ -3541,6 +3556,8 @@ project(':connect:runtime') {
 
     compileOnly libs.bndlib
     compileOnly libs.spotbugs
+
+    runtimeOnly log4jRuntimeLibs
 
     // We use this library to generate OpenAPI docs for the REST API, but we don't want or need it at compile
     // or run time. So, we add it to a separate configuration, which we use later on during docs generation
@@ -3662,12 +3679,10 @@ project(':connect:file') {
 
   dependencies {
     implementation project(':connect:api')
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
 
-    testImplementation libs.jacksonDatabindYaml
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
 
@@ -3706,12 +3721,12 @@ project(':connect:basic-auth-extension') {
 
   dependencies {
     implementation project(':connect:api')
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+
+    implementation log4jLibs
     implementation libs.jakartaRsApi
     implementation libs.jaxAnnotationApi
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.bcpkix
     testImplementation libs.mockitoCore
@@ -3752,11 +3767,7 @@ project(':connect:mirror') {
     implementation project(':clients')
 
     implementation libs.argparse4j
-    implementation libs.jacksonAnnotations
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
     implementation libs.jacksonAnnotations
     implementation libs.jacksonJakartarsJsonProvider
     implementation libs.jerseyContainerServlet
@@ -3777,12 +3788,10 @@ project(':connect:mirror') {
     }
     implementation libs.swaggerAnnotations
 
+    runtimeOnly log4jRuntimeLibs
+
     testImplementation libs.junitJupiter
-    testImplementation libs.log4j2Api
-    testImplementation libs.log4j2Core
-    testImplementation libs.log4j1Bridge2Api
     testImplementation libs.bndlib
-    testImplementation libs.jacksonDatabindYaml
     testImplementation libs.mockitoCore
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':connect:runtime').sourceSets.test.output
@@ -3790,6 +3799,7 @@ project(':connect:mirror') {
     testImplementation project(':test-common')
     testImplementation project(':server')
     testImplementation project(':server-common').sourceSets.test.output
+
 
     testRuntimeOnly project(':connect:runtime')
     testRuntimeOnly libs.bcpkix
@@ -3849,10 +3859,9 @@ project(':connect:mirror-client') {
 
   dependencies {
     implementation project(':clients')
-    implementation libs.slf4jApi
-    runtimeOnly libs.log4j2Api
-    runtimeOnly libs.log4j2Core
-    runtimeOnly libs.log4j1Bridge2Api
+    implementation log4jLibs
+
+    runtimeOnly log4jRuntimeLibs
 
     testImplementation libs.junitJupiter
     testImplementation project(':clients').sourceSets.test.output
@@ -3887,8 +3896,10 @@ project(':connect:test-plugins') {
     api project(':connect:api')
 
     implementation project(':server-common')
-    implementation libs.slf4jApi
+    implementation log4jLibs
     implementation libs.jacksonDatabind
+
+    runtimeOnly log4jRuntimeLibs
   }
 }
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -266,6 +266,13 @@
                     See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308218">KIP-751</a> for more details
                 </li>
                 <li>
+                    Logging framework has been migrated from Log4j to Log4j2.
+                    Users can use the log4j-transform-cli tool to automatically convert their existing Log4j configuration files to Log4j2 format.
+                    See <a href="https://logging.staged.apache.org/log4j/transform/cli.html#log4j-transform-cli">log4j-transform-cli</a> for more details.
+                    Log4j2 provides limited compatibility for Log4j configurations.
+                    See <a href="https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#ConfigurationCompatibility">Use Log4j 1 to Log4j 2 bridge</a> for more information,
+                </li>
+                <li>
                     KafkaLog4jAppender has been removed, users should migrate to the log4j2 appender
                     See <a href="https://logging.apache.org/log4j/2.x/manual/appenders.html#KafkaAppender">KafkaAppender</a> for more details
                 </li>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -213,7 +213,6 @@ libs += [
   log4j1Bridge2Api: "org.apache.logging.log4j:log4j-1.2-api:$versions.log4j2",
   log4j2Api: "org.apache.logging.log4j:log4j-api:$versions.log4j2",
   log4j2Core: "org.apache.logging.log4j:log4j-core:$versions.log4j2",
-  log4j2CoreTest: "org.apache.logging.log4j:log4j-core-test:$versions.log4j2",
   lz4: "org.lz4:lz4-java:$versions.lz4",
   metrics: "com.yammer.metrics:metrics-core:$versions.metrics",
   dropwizardMetrics: "io.dropwizard.metrics:metrics-core:$versions.dropwizardMetrics",


### PR DESCRIPTION
Please refer to https://github.com/apache/kafka/pull/17373#issuecomment-2557311234 for further details.
This PR does the following things:
- Move deprecation warning to `kafka-run-class`
- Remove unnecessary jacksonDatabindYaml dependency from modules
- Add upgrade notes about log4j2.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
