### PR TITLE
KAFKA-18173: Remove duplicate `assertFutureError`

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/DeleteConsumerGroupOffsetsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/DeleteConsumerGroupOffsetsResultTest.java
@@ -63,7 +63,7 @@ public class DeleteConsumerGroupOffsetsResultTest {
         partitionFutures.completeExceptionally(Errors.GROUP_AUTHORIZATION_FAILED.exception());
         DeleteConsumerGroupOffsetsResult topLevelErrorResult =
             new DeleteConsumerGroupOffsetsResult(partitionFutures, partitions);
-        TestUtils.assertFutureError(topLevelErrorResult.all(), GroupAuthorizationException.class);
+        TestUtils.assertFutureThrows(topLevelErrorResult.all(), GroupAuthorizationException.class);
     }
 
     @Test
@@ -79,9 +79,9 @@ public class DeleteConsumerGroupOffsetsResultTest {
         DeleteConsumerGroupOffsetsResult missingPartitionResult =
             new DeleteConsumerGroupOffsetsResult(partitionFutures, partitions);
 
-        TestUtils.assertFutureError(missingPartitionResult.all(), IllegalArgumentException.class);
+        TestUtils.assertFutureThrows(missingPartitionResult.all(), IllegalArgumentException.class);
         assertNull(missingPartitionResult.partitionResult(tpZero).get());
-        TestUtils.assertFutureError(missingPartitionResult.partitionResult(tpOne), IllegalArgumentException.class);
+        TestUtils.assertFutureThrows(missingPartitionResult.partitionResult(tpOne), IllegalArgumentException.class);
     }
 
     @Test
@@ -110,9 +110,9 @@ public class DeleteConsumerGroupOffsetsResultTest {
         DeleteConsumerGroupOffsetsResult partitionLevelErrorResult =
             new DeleteConsumerGroupOffsetsResult(partitionFutures, partitions);
 
-        TestUtils.assertFutureError(partitionLevelErrorResult.all(), UnknownTopicOrPartitionException.class);
+        TestUtils.assertFutureThrows(partitionLevelErrorResult.all(), UnknownTopicOrPartitionException.class);
         assertNull(partitionLevelErrorResult.partitionResult(tpZero).get());
-        TestUtils.assertFutureError(partitionLevelErrorResult.partitionResult(tpOne), UnknownTopicOrPartitionException.class);
+        TestUtils.assertFutureThrows(partitionLevelErrorResult.partitionResult(tpOne), UnknownTopicOrPartitionException.class);
         return partitionLevelErrorResult;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -79,6 +79,8 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.AddRaftVoterRequestData;
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignablePartitionResponse;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignableTopicResponse;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirPartitionResult;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirTopicResult;
@@ -134,6 +136,8 @@ import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingPartitionReassignment;
+import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingTopicReassignment;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
@@ -853,7 +857,7 @@ public class KafkaAdminClientTest {
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(1000)).all();
-            TestUtils.assertFutureError(future, TimeoutException.class);
+            TestUtils.assertFutureThrows(future, TimeoutException.class);
         }
     }
 
@@ -936,7 +940,7 @@ public class KafkaAdminClientTest {
             KafkaFuture<Void> future = env.adminClient().createTopics(
                 singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                 new CreateTopicsOptions().timeoutMs(1000)).all();
-            TestUtils.assertFutureError(future, SaslAuthenticationException.class);
+            TestUtils.assertFutureThrows(future, SaslAuthenticationException.class);
         }
     }
 
@@ -1180,14 +1184,14 @@ public class KafkaAdminClientTest {
                 prepareDeleteTopicsResponse("myTopic", Errors.TOPIC_DELETION_DISABLED));
             future = env.adminClient().deleteTopics(singletonList("myTopic"),
                 new DeleteTopicsOptions()).all();
-            TestUtils.assertFutureError(future, TopicDeletionDisabledException.class);
+            TestUtils.assertFutureThrows(future, TopicDeletionDisabledException.class);
 
             env.kafkaClient().prepareResponse(
                 expectDeleteTopicsRequestWithTopics("myTopic"),
                 prepareDeleteTopicsResponse("myTopic", Errors.UNKNOWN_TOPIC_OR_PARTITION));
             future = env.adminClient().deleteTopics(singletonList("myTopic"),
                 new DeleteTopicsOptions()).all();
-            TestUtils.assertFutureError(future, UnknownTopicOrPartitionException.class);
+            TestUtils.assertFutureThrows(future, UnknownTopicOrPartitionException.class);
 
             // With topic IDs
             Uuid topicId = Uuid.randomUuid();
@@ -1204,14 +1208,14 @@ public class KafkaAdminClientTest {
                     prepareDeleteTopicsResponseWithTopicId(topicId, Errors.TOPIC_DELETION_DISABLED));
             future = env.adminClient().deleteTopics(TopicCollection.ofTopicIds(singletonList(topicId)),
                     new DeleteTopicsOptions()).all();
-            TestUtils.assertFutureError(future, TopicDeletionDisabledException.class);
+            TestUtils.assertFutureThrows(future, TopicDeletionDisabledException.class);
 
             env.kafkaClient().prepareResponse(
                     expectDeleteTopicsRequestWithTopicIds(topicId),
                     prepareDeleteTopicsResponseWithTopicId(topicId, Errors.UNKNOWN_TOPIC_ID));
             future = env.adminClient().deleteTopics(TopicCollection.ofTopicIds(singletonList(topicId)),
                     new DeleteTopicsOptions()).all();
-            TestUtils.assertFutureError(future, UnknownTopicIdException.class);
+            TestUtils.assertFutureThrows(future, UnknownTopicIdException.class);
         }
     }
 
@@ -1412,7 +1416,7 @@ public class KafkaAdminClientTest {
             ThrottlingQuotaExceededException e = TestUtils.assertFutureThrows(result.topicNameValues().get("topic2"),
                 ThrottlingQuotaExceededException.class);
             assertEquals(1000, e.throttleTimeMs());
-            TestUtils.assertFutureError(result.topicNameValues().get("topic3"), TopicExistsException.class);
+            TestUtils.assertFutureThrows(result.topicNameValues().get("topic3"), TopicExistsException.class);
 
             // With topic IDs
             Uuid topicId1 = Uuid.randomUuid();
@@ -1433,7 +1437,7 @@ public class KafkaAdminClientTest {
             e = TestUtils.assertFutureThrows(resultIds.topicIdValues().get(topicId2),
                     ThrottlingQuotaExceededException.class);
             assertEquals(1000, e.throttleTimeMs());
-            TestUtils.assertFutureError(resultIds.topicIdValues().get(topicId3), UnknownTopicIdException.class);
+            TestUtils.assertFutureThrows(resultIds.topicIdValues().get(topicId3), UnknownTopicIdException.class);
         }
     }
 
@@ -1465,14 +1469,14 @@ public class KafkaAdminClientTest {
             List<String> sillyTopicNames = asList("", null);
             Map<String, KafkaFuture<Void>> deleteFutures = env.adminClient().deleteTopics(sillyTopicNames).topicNameValues();
             for (String sillyTopicName : sillyTopicNames) {
-                TestUtils.assertFutureError(deleteFutures.get(sillyTopicName), InvalidTopicException.class);
+                TestUtils.assertFutureThrows(deleteFutures.get(sillyTopicName), InvalidTopicException.class);
             }
             assertEquals(0, env.kafkaClient().inFlightRequestCount());
 
             Map<String, KafkaFuture<TopicDescription>> describeFutures =
                     env.adminClient().describeTopics(sillyTopicNames).topicNameValues();
             for (String sillyTopicName : sillyTopicNames) {
-                TestUtils.assertFutureError(describeFutures.get(sillyTopicName), InvalidTopicException.class);
+                TestUtils.assertFutureThrows(describeFutures.get(sillyTopicName), InvalidTopicException.class);
             }
             assertEquals(0, env.kafkaClient().inFlightRequestCount());
 
@@ -1483,7 +1487,7 @@ public class KafkaAdminClientTest {
 
             Map<String, KafkaFuture<Void>> createFutures = env.adminClient().createTopics(newTopics).values();
             for (String sillyTopicName : sillyTopicNames) {
-                TestUtils.assertFutureError(createFutures .get(sillyTopicName), InvalidTopicException.class);
+                TestUtils.assertFutureThrows(createFutures .get(sillyTopicName), InvalidTopicException.class);
             }
             assertEquals(0, env.kafkaClient().inFlightRequestCount());
         }
@@ -1774,7 +1778,7 @@ public class KafkaAdminClientTest {
                 asList(topicName1, topicName0), new DescribeTopicsOptions()
             );
 
-            TestUtils.assertFutureError(result.allTopicNames(), TopicAuthorizationException.class);
+            TestUtils.assertFutureThrows(result.allTopicNames(), TopicAuthorizationException.class);
 
         }
     }
@@ -1870,10 +1874,10 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(new DescribeAclsResponse(new DescribeAclsResponseData()
                 .setErrorCode(Errors.SECURITY_DISABLED.code())
                 .setErrorMessage("Security is disabled"), ApiKeys.DESCRIBE_ACLS.latestVersion()));
-            TestUtils.assertFutureError(env.adminClient().describeAcls(FILTER2).values(), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(env.adminClient().describeAcls(FILTER2).values(), SecurityDisabledException.class);
 
             // Test a call where we supply an invalid filter.
-            TestUtils.assertFutureError(env.adminClient().describeAcls(UNKNOWN_FILTER).values(),
+            TestUtils.assertFutureThrows(env.adminClient().describeAcls(UNKNOWN_FILTER).values(),
                 InvalidRequestException.class);
         }
     }
@@ -1901,9 +1905,9 @@ public class KafkaAdminClientTest {
                 new CreateAclsResponseData.AclCreationResult()))));
             results = env.adminClient().createAcls(asList(ACL1, ACL2));
             assertCollectionIs(results.values().keySet(), ACL1, ACL2);
-            TestUtils.assertFutureError(results.values().get(ACL1), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(results.values().get(ACL1), SecurityDisabledException.class);
             results.values().get(ACL2).get();
-            TestUtils.assertFutureError(results.all(), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(results.all(), SecurityDisabledException.class);
         }
     }
 
@@ -1931,8 +1935,8 @@ public class KafkaAdminClientTest {
             assertEquals(ACL1, filter1Results.values().get(0).binding());
             assertNull(filter1Results.values().get(1).exception());
             assertEquals(ACL2, filter1Results.values().get(1).binding());
-            TestUtils.assertFutureError(filterResults.get(FILTER2), SecurityDisabledException.class);
-            TestUtils.assertFutureError(results.all(), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(filterResults.get(FILTER2), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(results.all(), SecurityDisabledException.class);
 
             // Test a call where one deletion result has an error.
             env.kafkaClient().prepareResponse(new DeleteAclsResponse(new DeleteAclsResponseData()
@@ -1952,7 +1956,7 @@ public class KafkaAdminClientTest {
                     ApiKeys.DELETE_ACLS.latestVersion()));
             results = env.adminClient().deleteAcls(asList(FILTER1, FILTER2));
             assertTrue(results.values().get(FILTER2).get().values().isEmpty());
-            TestUtils.assertFutureError(results.all(), SecurityDisabledException.class);
+            TestUtils.assertFutureThrows(results.all(), SecurityDisabledException.class);
 
             // Test a call where there are no errors.
             env.kafkaClient().prepareResponse(new DeleteAclsResponse(new DeleteAclsResponseData()
@@ -2023,7 +2027,7 @@ public class KafkaAdminClientTest {
                         electionType,
                         new HashSet<>(asList(topic1, topic2)),
                         new ElectLeadersOptions().timeoutMs(100));
-                TestUtils.assertFutureError(results.partitions(), TimeoutException.class);
+                TestUtils.assertFutureThrows(results.partitions(), TimeoutException.class);
             }
         }
     }
@@ -2776,13 +2780,13 @@ public class KafkaAdminClientTest {
 
             DescribeTopicsResult result1 = env.adminClient().describeTopics(
                     TopicCollection.ofTopicIds(singletonList(nonExistID)));
-            TestUtils.assertFutureError(result1.allTopicIds(), UnknownTopicIdException.class);
+            TestUtils.assertFutureThrows(result1.allTopicIds(), UnknownTopicIdException.class);
             Exception e = assertThrows(Exception.class, () -> result1.allTopicIds().get(), "describe with non-exist topic ID should throw exception");
             assertEquals(String.format("org.apache.kafka.common.errors.UnknownTopicIdException: TopicId %s not found.", nonExistID), e.getMessage());
 
             DescribeTopicsResult result2 = env.adminClient().describeTopics(
                     TopicCollection.ofTopicIds(singletonList(Uuid.ZERO_UUID)));
-            TestUtils.assertFutureError(result2.allTopicIds(), InvalidTopicException.class);
+            TestUtils.assertFutureThrows(result2.allTopicIds(), InvalidTopicException.class);
             e = assertThrows(Exception.class, () -> result2.allTopicIds().get(), "describe with non-exist topic ID should throw exception");
             assertEquals("The given topic id 'AAAAAAAAAAAAAAAAAAAAAA' cannot be represented in a request.", e.getCause().getMessage());
 
@@ -3005,7 +3009,7 @@ public class KafkaAdminClientTest {
                 env.cluster().nodeById(3));
 
             final ListGroupsResult result = env.adminClient().listGroups();
-            TestUtils.assertFutureError(result.all(), UnknownServerException.class);
+            TestUtils.assertFutureThrows(result.all(), UnknownServerException.class);
 
             Collection<GroupListing> listings = result.valid().get();
             assertEquals(6, listings.size());
@@ -3039,7 +3043,7 @@ public class KafkaAdminClientTest {
                     Collections.emptyList()));
 
             final ListGroupsResult result = env.adminClient().listGroups();
-            TestUtils.assertFutureError(result.all(), KafkaException.class);
+            TestUtils.assertFutureThrows(result.all(), KafkaException.class);
         }
     }
 
@@ -3276,7 +3280,7 @@ public class KafkaAdminClientTest {
                     env.cluster().nodeById(3));
 
             final ListConsumerGroupsResult result = env.adminClient().listConsumerGroups();
-            TestUtils.assertFutureError(result.all(), UnknownServerException.class);
+            TestUtils.assertFutureThrows(result.all(), UnknownServerException.class);
 
             Collection<ConsumerGroupListing> listings = result.valid().get();
             assertEquals(3, listings.size());
@@ -3311,7 +3315,7 @@ public class KafkaAdminClientTest {
                             Collections.emptyList()));
 
             final ListConsumerGroupsResult result = env.adminClient().listConsumerGroups();
-            TestUtils.assertFutureError(result.all(), KafkaException.class);
+            TestUtils.assertFutureThrows(result.all(), KafkaException.class);
         }
     }
 
@@ -3526,7 +3530,7 @@ public class KafkaAdminClientTest {
             offsets.put(tp1, new OffsetAndMetadata(123L));
             final AlterConsumerGroupOffsetsResult result = env.adminClient().alterConsumerGroupOffsets(GROUP_ID, offsets);
 
-            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.all(), TimeoutException.class);
         }
     }
 
@@ -3557,9 +3561,9 @@ public class KafkaAdminClientTest {
                 .alterConsumerGroupOffsets(GROUP_ID, offsets);
 
             assertNull(result.partitionResult(foo0).get());
-            TestUtils.assertFutureError(result.partitionResult(foo1), UnknownTopicOrPartitionException.class);
+            TestUtils.assertFutureThrows(result.partitionResult(foo1), UnknownTopicOrPartitionException.class);
 
-            TestUtils.assertFutureError(result.all(), UnknownTopicOrPartitionException.class);
+            TestUtils.assertFutureThrows(result.all(), UnknownTopicOrPartitionException.class);
         }
     }
 
@@ -3638,7 +3642,7 @@ public class KafkaAdminClientTest {
 
             final DescribeConsumerGroupsResult result = env.adminClient().describeConsumerGroups(singletonList(GROUP_ID));
 
-            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.all(), TimeoutException.class);
         }
     }
 
@@ -4002,7 +4006,7 @@ public class KafkaAdminClientTest {
 
             final DescribeConsumerGroupsResult result = env.adminClient().describeConsumerGroups(singletonList(GROUP_ID));
 
-            TestUtils.assertFutureError(result.describedGroups().get(GROUP_ID), IllegalArgumentException.class);
+            TestUtils.assertFutureThrows(result.describedGroups().get(GROUP_ID), IllegalArgumentException.class);
         }
     }
 
@@ -4023,7 +4027,7 @@ public class KafkaAdminClientTest {
                 request -> request instanceof DescribeGroupsRequest);
 
             DescribeConsumerGroupsResult result = env.adminClient().describeConsumerGroups(singletonList(GROUP_ID));
-            TestUtils.assertFutureError(result.describedGroups().get(GROUP_ID), UnsupportedVersionException.class);
+            TestUtils.assertFutureThrows(result.describedGroups().get(GROUP_ID), UnsupportedVersionException.class);
         }
     }
 
@@ -4227,7 +4231,7 @@ public class KafkaAdminClientTest {
 
             final ListConsumerGroupOffsetsResult result = env.adminClient().listConsumerGroupOffsets(GROUP_ID);
 
-            TestUtils.assertFutureError(result.partitionsToOffsetAndMetadata(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.partitionsToOffsetAndMetadata(), TimeoutException.class);
         }
     }
 
@@ -4334,7 +4338,7 @@ public class KafkaAdminClientTest {
 
                 ListConsumerGroupOffsetsResult errorResult = env.adminClient().listConsumerGroupOffsets(GROUP_ID);
 
-                TestUtils.assertFutureError(errorResult.partitionsToOffsetAndMetadata(), error.exception().getClass());
+                TestUtils.assertFutureThrows(errorResult.partitionsToOffsetAndMetadata(), error.exception().getClass());
             }
         }
     }
@@ -4554,7 +4558,7 @@ public class KafkaAdminClientTest {
 
             final DeleteConsumerGroupsResult result = env.adminClient().deleteConsumerGroups(groupIds);
 
-            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.all(), TimeoutException.class);
         }
     }
 
@@ -4655,7 +4659,7 @@ public class KafkaAdminClientTest {
                 prepareOldFindCoordinatorResponse(Errors.GROUP_AUTHORIZATION_FAILED, Node.noNode()));
 
             DeleteConsumerGroupsResult errorResult = env.adminClient().deleteConsumerGroups(groupIds);
-            TestUtils.assertFutureError(errorResult.deletedGroups().get("groupId"), GroupAuthorizationException.class);
+            TestUtils.assertFutureThrows(errorResult.deletedGroups().get("groupId"), GroupAuthorizationException.class);
 
             // Retriable errors should be retried
             env.kafkaClient().prepareResponse(
@@ -4777,7 +4781,7 @@ public class KafkaAdminClientTest {
             final DeleteConsumerGroupOffsetsResult result = env.adminClient()
                 .deleteConsumerGroupOffsets(GROUP_ID, Stream.of(tp1).collect(Collectors.toSet()));
 
-            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.all(), TimeoutException.class);
         }
     }
 
@@ -4868,8 +4872,8 @@ public class KafkaAdminClientTest {
                 GROUP_ID, Stream.of(tp1, tp2).collect(Collectors.toSet()));
 
             assertNull(errorResult.partitionResult(tp1).get());
-            TestUtils.assertFutureError(errorResult.all(), GroupSubscribedToTopicException.class);
-            TestUtils.assertFutureError(errorResult.partitionResult(tp2), GroupSubscribedToTopicException.class);
+            TestUtils.assertFutureThrows(errorResult.all(), GroupSubscribedToTopicException.class);
+            TestUtils.assertFutureThrows(errorResult.partitionResult(tp2), GroupSubscribedToTopicException.class);
             assertThrows(IllegalArgumentException.class, () -> errorResult.partitionResult(tp3));
         }
     }
@@ -4940,8 +4944,8 @@ public class KafkaAdminClientTest {
                 DeleteConsumerGroupOffsetsResult errorResult = env.adminClient()
                     .deleteConsumerGroupOffsets(GROUP_ID, Stream.of(tp1).collect(Collectors.toSet()));
 
-                TestUtils.assertFutureError(errorResult.all(), error.exception().getClass());
-                TestUtils.assertFutureError(errorResult.partitionResult(tp1), error.exception().getClass());
+                TestUtils.assertFutureThrows(errorResult.all(), error.exception().getClass());
+                TestUtils.assertFutureThrows(errorResult.partitionResult(tp1), error.exception().getClass());
             }
         }
     }
@@ -4989,8 +4993,8 @@ public class KafkaAdminClientTest {
             final DeleteConsumerGroupOffsetsResult errorResult = env.adminClient()
                 .deleteConsumerGroupOffsets(GROUP_ID, Stream.of(tp1).collect(Collectors.toSet()));
 
-            TestUtils.assertFutureError(errorResult.all(), GroupAuthorizationException.class);
-            TestUtils.assertFutureError(errorResult.partitionResult(tp1), GroupAuthorizationException.class);
+            TestUtils.assertFutureThrows(errorResult.all(), GroupAuthorizationException.class);
+            TestUtils.assertFutureThrows(errorResult.partitionResult(tp1), GroupAuthorizationException.class);
         }
     }
 
@@ -5306,7 +5310,7 @@ public class KafkaAdminClientTest {
                 env.cluster().nodeById(3));
 
             final ListGroupsResult result = env.adminClient().listGroups(new ListGroupsOptions().withTypes(Set.of(GroupType.SHARE)));
-            TestUtils.assertFutureError(result.all(), UnknownServerException.class);
+            TestUtils.assertFutureThrows(result.all(), UnknownServerException.class);
 
             Collection<GroupListing> listings = result.valid().get();
             assertEquals(4, listings.size());
@@ -5341,7 +5345,7 @@ public class KafkaAdminClientTest {
                     Collections.emptyList()));
 
             final ListGroupsResult result = env.adminClient().listGroups(new ListGroupsOptions().withTypes(Set.of(GroupType.SHARE)));
-            TestUtils.assertFutureError(result.all(), KafkaException.class);
+            TestUtils.assertFutureThrows(result.all(), KafkaException.class);
         }
     }
 
@@ -5636,10 +5640,10 @@ public class KafkaAdminClientTest {
             configs.put(groupResource, singletonList(alterConfigOp4));
 
             AlterConfigsResult result = env.adminClient().incrementalAlterConfigs(configs);
-            TestUtils.assertFutureError(result.values().get(brokerResource), ClusterAuthorizationException.class);
-            TestUtils.assertFutureError(result.values().get(topicResource), InvalidRequestException.class);
-            TestUtils.assertFutureError(result.values().get(metricResource), InvalidRequestException.class);
-            TestUtils.assertFutureError(result.values().get(groupResource), InvalidConfigurationException.class);
+            TestUtils.assertFutureThrows(result.values().get(brokerResource), ClusterAuthorizationException.class);
+            TestUtils.assertFutureThrows(result.values().get(topicResource), InvalidRequestException.class);
+            TestUtils.assertFutureThrows(result.values().get(metricResource), InvalidRequestException.class);
+            TestUtils.assertFutureThrows(result.values().get(groupResource), InvalidConfigurationException.class);
 
             // Test a call where there are no errors.
             responseData =  new IncrementalAlterConfigsResponseData();
@@ -5688,7 +5692,7 @@ public class KafkaAdminClientTest {
             final RemoveMembersFromConsumerGroupResult result = env.adminClient().removeMembersFromConsumerGroup(
                 GROUP_ID, new RemoveMembersFromConsumerGroupOptions(membersToRemove));
 
-            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+            TestUtils.assertFutureThrows(result.all(), TimeoutException.class);
         }
     }
 
@@ -5824,8 +5828,8 @@ public class KafkaAdminClientTest {
                 final RemoveMembersFromConsumerGroupResult result = env.adminClient().removeMembersFromConsumerGroup(
                     GROUP_ID, new RemoveMembersFromConsumerGroupOptions(membersToRemove));
 
-                TestUtils.assertFutureError(result.all(), error.exception().getClass());
-                TestUtils.assertFutureError(result.memberResult(memberToRemove), error.exception().getClass());
+                TestUtils.assertFutureThrows(result.all(), error.exception().getClass());
+                TestUtils.assertFutureThrows(result.memberResult(memberToRemove), error.exception().getClass());
             }
         }
     }
@@ -5860,8 +5864,8 @@ public class KafkaAdminClientTest {
             MemberToRemove memberOne = new MemberToRemove(instanceOne);
             MemberToRemove memberTwo = new MemberToRemove(instanceTwo);
 
-            TestUtils.assertFutureError(unknownErrorResult.memberResult(memberOne), UnknownServerException.class);
-            TestUtils.assertFutureError(unknownErrorResult.memberResult(memberTwo), UnknownServerException.class);
+            TestUtils.assertFutureThrows(unknownErrorResult.memberResult(memberOne), UnknownServerException.class);
+            TestUtils.assertFutureThrows(unknownErrorResult.memberResult(memberTwo), UnknownServerException.class);
 
             MemberResponse responseOne = new MemberResponse()
                                              .setGroupInstanceId(instanceOne)
@@ -5882,8 +5886,8 @@ public class KafkaAdminClientTest {
                 new RemoveMembersFromConsumerGroupOptions(membersToRemove)
             );
 
-            TestUtils.assertFutureError(memberLevelErrorResult.all(), UnknownMemberIdException.class);
-            TestUtils.assertFutureError(memberLevelErrorResult.memberResult(memberOne), UnknownMemberIdException.class);
+            TestUtils.assertFutureThrows(memberLevelErrorResult.all(), UnknownMemberIdException.class);
+            TestUtils.assertFutureThrows(memberLevelErrorResult.memberResult(memberOne), UnknownMemberIdException.class);
             assertNull(memberLevelErrorResult.memberResult(memberTwo).get());
 
             // Return with missing member.
@@ -5897,9 +5901,9 @@ public class KafkaAdminClientTest {
                 new RemoveMembersFromConsumerGroupOptions(membersToRemove)
             );
 
-            TestUtils.assertFutureError(missingMemberResult.all(), IllegalArgumentException.class);
+            TestUtils.assertFutureThrows(missingMemberResult.all(), IllegalArgumentException.class);
             // The memberOne was not included in the response.
-            TestUtils.assertFutureError(missingMemberResult.memberResult(memberOne), IllegalArgumentException.class);
+            TestUtils.assertFutureThrows(missingMemberResult.memberResult(memberOne), IllegalArgumentException.class);
             assertNull(missingMemberResult.memberResult(memberTwo).get());
 
 
@@ -6051,8 +6055,8 @@ public class KafkaAdminClientTest {
             AlterPartitionReassignmentsResult result1 = env.adminClient().alterPartitionReassignments(reassignments);
             Future<Void> future1 = result1.all();
             Future<Void> future2 = result1.values().get(tp1);
-            TestUtils.assertFutureError(future1, UnknownServerException.class);
-            TestUtils.assertFutureError(future2, UnknownServerException.class);
+            TestUtils.assertFutureThrows(future1, UnknownServerException.class);
+            TestUtils.assertFutureThrows(future2, UnknownServerException.class);
 
             // 2. NOT_CONTROLLER error handling
             AlterPartitionReassignmentsResponseData controllerErrResponseData =
@@ -6103,7 +6107,7 @@ public class KafkaAdminClientTest {
                             );
             env.kafkaClient().prepareResponse(new AlterPartitionReassignmentsResponse(partitionLevelErrData));
             AlterPartitionReassignmentsResult partitionLevelErrResult = env.adminClient().alterPartitionReassignments(reassignments);
-            TestUtils.assertFutureError(partitionLevelErrResult.values().get(tp1), Errors.INVALID_REPLICA_ASSIGNMENT.exception().getClass());
+            TestUtils.assertFutureThrows(partitionLevelErrResult.values().get(tp1), Errors.INVALID_REPLICA_ASSIGNMENT.exception().getClass());
             partitionLevelErrResult.values().get(tp2).get();
 
             // 4. top-level error
@@ -6143,8 +6147,8 @@ public class KafkaAdminClientTest {
                             );
             env.kafkaClient().prepareResponse(new AlterPartitionReassignmentsResponse(singlePartResponseData));
             AlterPartitionReassignmentsResult unrepresentableTopicResult = env.adminClient().alterPartitionReassignments(invalidTopicReassignments);
-            TestUtils.assertFutureError(unrepresentableTopicResult.values().get(invalidTopicTP), InvalidTopicException.class);
-            TestUtils.assertFutureError(unrepresentableTopicResult.values().get(invalidPartitionTP), InvalidTopicException.class);
+            TestUtils.assertFutureThrows(unrepresentableTopicResult.values().get(invalidTopicTP), InvalidTopicException.class);
+            TestUtils.assertFutureThrows(unrepresentableTopicResult.values().get(invalidPartitionTP), InvalidTopicException.class);
             unrepresentableTopicResult.values().get(tp1).get();
 
             // Test success scenario
@@ -6213,7 +6217,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(new ListPartitionReassignmentsResponse(unknownTpData));
 
             ListPartitionReassignmentsResult unknownTpResult = env.adminClient().listPartitionReassignments(new HashSet<>(asList(tp1, tp2)));
-            TestUtils.assertFutureError(unknownTpResult.reassignments(), UnknownTopicOrPartitionException.class);
+            TestUtils.assertFutureThrows(unknownTpResult.reassignments(), UnknownTopicOrPartitionException.class);
 
             // 3. Success
             ListPartitionReassignmentsResponseData responseData = new ListPartitionReassignmentsResponseData()
@@ -6264,7 +6268,7 @@ public class KafkaAdminClientTest {
             assertNull(result.all().get());
             assertNull(result.partitionResult(tp1).get());
             assertNull(result.partitionResult(tp2).get());
-            TestUtils.assertFutureError(result.partitionResult(tp3), IllegalArgumentException.class);
+            TestUtils.assertFutureThrows(result.partitionResult(tp3), IllegalArgumentException.class);
         }
     }
 
@@ -6333,8 +6337,8 @@ public class KafkaAdminClientTest {
                 AlterConsumerGroupOffsetsResult errorResult = env.adminClient()
                     .alterConsumerGroupOffsets(GROUP_ID, offsets);
 
-                TestUtils.assertFutureError(errorResult.all(), error.exception().getClass());
-                TestUtils.assertFutureError(errorResult.partitionResult(tp1), error.exception().getClass());
+                TestUtils.assertFutureThrows(errorResult.all(), error.exception().getClass());
+                TestUtils.assertFutureThrows(errorResult.partitionResult(tp1), error.exception().getClass());
             }
         }
     }
@@ -6386,8 +6390,8 @@ public class KafkaAdminClientTest {
             final AlterConsumerGroupOffsetsResult errorResult = env.adminClient()
                 .alterConsumerGroupOffsets(GROUP_ID, offsets);
 
-            TestUtils.assertFutureError(errorResult.all(), GroupAuthorizationException.class);
-            TestUtils.assertFutureError(errorResult.partitionResult(tp1), GroupAuthorizationException.class);
+            TestUtils.assertFutureThrows(errorResult.all(), GroupAuthorizationException.class);
+            TestUtils.assertFutureThrows(errorResult.partitionResult(tp1), GroupAuthorizationException.class);
         }
     }
 
@@ -6561,7 +6565,7 @@ public class KafkaAdminClientTest {
             partitions.put(tp0, OffsetSpec.latest());
             ListOffsetsResult result = env.adminClient().listOffsets(partitions);
 
-            TestUtils.assertFutureError(result.all(), TopicAuthorizationException.class);
+            TestUtils.assertFutureThrows(result.all(), TopicAuthorizationException.class);
         }
     }
 
@@ -7325,7 +7329,7 @@ public class KafkaAdminClientTest {
             partitions.put(tp1, OffsetSpec.latest());
             ListOffsetsResult result = env.adminClient().listOffsets(partitions);
 
-            TestUtils.assertFutureError(result.all(), expectedFailure);
+            TestUtils.assertFutureThrows(result.all(), expectedFailure);
         }
     }
 
@@ -7643,8 +7647,8 @@ public class KafkaAdminClientTest {
 
             AlterClientQuotasResult result = env.adminClient().alterClientQuotas(entries);
             result.values().get(goodEntity);
-            TestUtils.assertFutureError(result.values().get(unauthorizedEntity), ClusterAuthorizationException.class);
-            TestUtils.assertFutureError(result.values().get(invalidEntity), InvalidRequestException.class);
+            TestUtils.assertFutureThrows(result.values().get(unauthorizedEntity), ClusterAuthorizationException.class);
+            TestUtils.assertFutureThrows(result.values().get(invalidEntity), InvalidRequestException.class);
 
             // ensure immutable
             assertThrows(UnsupportedOperationException.class, () -> result.values().put(newClientQuotaEntity(ClientQuotaEntity.USER, "user-3"), null));
@@ -7683,7 +7687,7 @@ public class KafkaAdminClientTest {
             logDirs.put(tpr1, "/data1");
             AlterReplicaLogDirsResult result = env.adminClient().alterReplicaLogDirs(logDirs);
             assertNull(result.values().get(tpr0).get());
-            TestUtils.assertFutureError(result.values().get(tpr1), LogDirNotFoundException.class);
+            TestUtils.assertFutureThrows(result.values().get(tpr1), LogDirNotFoundException.class);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2658,7 +2658,7 @@ public class KafkaAdminClientTest {
             DeleteRecordsResult results = env.adminClient().deleteRecords(recordsToDelete);
 
             assertEquals(3L, results.lowWatermarks().get(tp0).get().lowWatermark());
-            TestUtils.assertFutureThrows(results.lowWatermarks().get(tp1), AuthenticationException.class);
+            TestUtils.assertFutureThrows(results.lowWatermarks().get(tp1), SaslAuthenticationException.class);
         }
     }
 
@@ -7754,7 +7754,7 @@ public class KafkaAdminClientTest {
             // Advance time past the default api timeout to time out the inflight request
             time.sleep(defaultApiTimeout + 1);
 
-            TestUtils.assertFutureThrows(result.values().get(tpr1), ApiException.class);
+            TestUtils.assertFutureThrows(result.values().get(tpr1), TimeoutException.class);
             assertNull(result.values().get(tpr2).get());
         }
     }
@@ -7942,7 +7942,7 @@ public class KafkaAdminClientTest {
             // Advance time past the default api timeout to time out the inflight request
             time.sleep(defaultApiTimeout + 1);
 
-            TestUtils.assertFutureThrows(result.descriptions().get(0), ApiException.class);
+            TestUtils.assertFutureThrows(result.descriptions().get(0), TimeoutException.class);
             assertNotNull(result.descriptions().get(1).get());
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
@@ -62,7 +62,7 @@ public class RemoveMembersFromConsumerGroupResultTest {
         memberFutures.completeExceptionally(Errors.GROUP_AUTHORIZATION_FAILED.exception());
         RemoveMembersFromConsumerGroupResult topLevelErrorResult =
             new RemoveMembersFromConsumerGroupResult(memberFutures, membersToRemove);
-        TestUtils.assertFutureError(topLevelErrorResult.all(), GroupAuthorizationException.class);
+        TestUtils.assertFutureThrows(topLevelErrorResult.all(), GroupAuthorizationException.class);
     }
 
     @Test
@@ -78,9 +78,9 @@ public class RemoveMembersFromConsumerGroupResultTest {
         RemoveMembersFromConsumerGroupResult missingMemberResult =
             new RemoveMembersFromConsumerGroupResult(memberFutures, membersToRemove);
 
-        TestUtils.assertFutureError(missingMemberResult.all(), IllegalArgumentException.class);
+        TestUtils.assertFutureThrows(missingMemberResult.all(), IllegalArgumentException.class);
         assertNull(missingMemberResult.memberResult(instanceOne).get());
-        TestUtils.assertFutureError(missingMemberResult.memberResult(instanceTwo), IllegalArgumentException.class);
+        TestUtils.assertFutureThrows(missingMemberResult.memberResult(instanceTwo), IllegalArgumentException.class);
     }
 
     @Test
@@ -111,9 +111,9 @@ public class RemoveMembersFromConsumerGroupResultTest {
         RemoveMembersFromConsumerGroupResult memberLevelErrorResult =
             new RemoveMembersFromConsumerGroupResult(memberFutures, membersToRemove);
 
-        TestUtils.assertFutureError(memberLevelErrorResult.all(), FencedInstanceIdException.class);
+        TestUtils.assertFutureThrows(memberLevelErrorResult.all(), FencedInstanceIdException.class);
         assertNull(memberLevelErrorResult.memberResult(instanceOne).get());
-        TestUtils.assertFutureError(memberLevelErrorResult.memberResult(instanceTwo), FencedInstanceIdException.class);
+        TestUtils.assertFutureThrows(memberLevelErrorResult.memberResult(instanceTwo), FencedInstanceIdException.class);
         return memberLevelErrorResult;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1456,7 +1456,7 @@ public class KafkaProducerTest {
 
             client.prepareResponse(endTxnResponse(Errors.NONE));
             producer.beginTransaction();
-            TestUtils.assertFutureError(producer.send(largeRecord), RecordTooLargeException.class);
+            TestUtils.assertFutureThrows(producer.send(largeRecord), RecordTooLargeException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
         }
     }
@@ -1493,7 +1493,7 @@ public class KafkaProducerTest {
             producer.initTransactions();
             producer.beginTransaction();
 
-            TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
+            TestUtils.assertFutureThrows(producer.send(record), TimeoutException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
         }
     }
@@ -1530,7 +1530,7 @@ public class KafkaProducerTest {
             producer.initTransactions();
             producer.beginTransaction();
 
-            TestUtils.assertFutureError(producer.send(record), TimeoutException.class);
+            TestUtils.assertFutureThrows(producer.send(record), TimeoutException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
         }
     }
@@ -1569,7 +1569,7 @@ public class KafkaProducerTest {
             producer.initTransactions();
             producer.beginTransaction();
 
-            TestUtils.assertFutureError(producer.send(record), InvalidTopicException.class);
+            TestUtils.assertFutureThrows(producer.send(record), InvalidTopicException.class);
             assertThrows(KafkaException.class, producer::commitTransaction);
         }
     }
@@ -2008,7 +2008,7 @@ public class KafkaProducerTest {
 
         assertEquals(Collections.singleton(invalidTopicName),
                 metadata.fetch().invalidTopics(), "Cluster has incorrect invalid topic list.");
-        TestUtils.assertFutureError(future, InvalidTopicException.class);
+        TestUtils.assertFutureThrows(future, InvalidTopicException.class);
 
         producer.close(Duration.ofMillis(0));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -2492,7 +2492,7 @@ public class SenderTest {
             FutureRecordMetadata future = futureEntry.getValue();
             assertTrue(future.isDone());
 
-            KafkaException exception = TestUtils.assertFutureThrows(future, KafkaException.class);
+            KafkaException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
             Integer index = futureEntry.getKey();
             if (index == 0 || index == 2) {
                 assertInstanceOf(InvalidRecordException.class, exception);
@@ -2501,7 +2501,7 @@ public class SenderTest {
                 assertInstanceOf(InvalidRecordException.class, exception);
                 assertEquals(Errors.INVALID_RECORD.message(), exception.getMessage());
             } else {
-                assertEquals(KafkaException.class, exception.getClass());
+                assertEquals(InvalidRecordException.class, exception.getClass());
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -2492,16 +2492,18 @@ public class SenderTest {
             FutureRecordMetadata future = futureEntry.getValue();
             assertTrue(future.isDone());
 
-            KafkaException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
             Integer index = futureEntry.getKey();
             if (index == 0 || index == 2) {
+                InvalidRecordException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
                 assertInstanceOf(InvalidRecordException.class, exception);
                 assertEquals(index.toString(), exception.getMessage());
             } else if (index == 3) {
+                InvalidRecordException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
                 assertInstanceOf(InvalidRecordException.class, exception);
                 assertEquals(Errors.INVALID_RECORD.message(), exception.getMessage());
             } else {
-                assertEquals(InvalidRecordException.class, exception.getClass());
+                KafkaException exception = TestUtils.assertFutureThrows(future, KafkaException.class);
+                assertEquals(KafkaException.class, exception.getClass());
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TransactionAbortableException;
+import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
@@ -1529,8 +1530,8 @@ public class TransactionManagerTest {
         assertAbortableError(TopicAuthorizationException.class);
         sender.runOnce();
 
-        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
-        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
+        TestUtils.assertFutureThrows(firstPartitionAppend, TransactionAbortedException.class);
+        TestUtils.assertFutureThrows(secondPartitionAppend, TransactionAbortedException.class);
     }
 
     @Test
@@ -1577,8 +1578,8 @@ public class TransactionManagerTest {
         // the pending transaction commit.
         sender.runOnce();
         assertTrue(commitResult.isCompleted());
-        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
-        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
+        TestUtils.assertFutureThrows(firstPartitionAppend, TopicAuthorizationException.class);
+        TestUtils.assertFutureThrows(secondPartitionAppend, TopicAuthorizationException.class);
         assertInstanceOf(TopicAuthorizationException.class, commitResult.error());
     }
 
@@ -2375,7 +2376,7 @@ public class TransactionManagerTest {
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
 
-        TestUtils.assertFutureThrows(responseFuture, KafkaException.class);
+        TestUtils.assertFutureThrows(responseFuture, TransactionAbortedException.class);
     }
 
     @Test
@@ -2401,7 +2402,7 @@ public class TransactionManagerTest {
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
 
-        TestUtils.assertFutureThrows(responseFuture, KafkaException.class);
+        TestUtils.assertFutureThrows(responseFuture, TransactionAbortedException.class);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -583,19 +583,6 @@ public class TestUtils {
         assertEquals(expectedMessage, receivedException.getMessage());
     }
 
-    public static void assertFutureError(Future<?> future, Class<? extends Throwable> exceptionClass)
-        throws InterruptedException {
-        try {
-            future.get();
-            fail("Expected a " + exceptionClass.getSimpleName() + " exception, but got success.");
-        } catch (ExecutionException ee) {
-            Throwable cause = ee.getCause();
-            assertEquals(exceptionClass, cause.getClass(),
-                "Expected a " + exceptionClass.getSimpleName() + " exception, but got " +
-                    cause.getClass().getSimpleName());
-        }
-    }
-
     public static ApiKeys apiKeyFrom(NetworkReceive networkReceive) {
         return RequestHeader.parse(networkReceive.payload().duplicate()).apiKey();
     }

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -74,7 +74,6 @@ import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -569,8 +568,10 @@ public class TestUtils {
      */
     public static <T extends Throwable> T assertFutureThrows(Future<?> future, Class<T> exceptionCauseClass) {
         ExecutionException exception = assertThrows(ExecutionException.class, future::get);
-        assertInstanceOf(exceptionCauseClass, exception.getCause(),
-            "Unexpected exception cause " + exception.getCause());
+        Throwable cause = exception.getCause();
+        assertEquals(exceptionCauseClass, cause.getClass(),
+            "Expected a " + exceptionCauseClass.getSimpleName() + " exception, but got " +
+                        cause.getClass().getSimpleName());
         return exceptionCauseClass.cast(exception.getCause());
     }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -950,6 +950,6 @@ class GroupCoordinatorAdapterTest {
 
     assertTrue(future.isDone)
     assertTrue(future.isCompletedExceptionally)
-    assertFutureThrows(future, classOf[Exception])
+    assertFutureThrows(future, classOf[IllegalStateException])
   }
 }


### PR DESCRIPTION
`assertFutureError` is equal to `assertFutureThrows` in TestUtils.