### PR TITLE
[MINOR] Fix the failure in streams:testAll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2766,7 +2766,7 @@ project(':streams') {
   task testAll(
     dependsOn: [
             ':streams:test',
-            ':streams:integration-tests',
+            ':streams:integration-tests:test',
             ':streams:test-utils:test',
             ':streams:streams-scala:test',
             ':streams:upgrade-system-tests-0110:test',


### PR DESCRIPTION
Currently the command `./gradlew :streams:testAll` as suggested in README is failing with the following error:
```
./gradlew streams:testAll                                                          
Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details
> Configure project :
Starting build with version 4.1.0-SNAPSHOT (commit id 2e113428) using Gradle 8.10.2, Java 21 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=16, maxScalacThreads=8, maxTestRetries=0
FAILURE: Build failed with an exception.
* What went wrong:
Could not determine the dependencies of task ':streams:testAll'.
> Task with path ':streams:integration-tests' not found in project ':streams'.
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org/.
```

Following this commit, the command was able to pass and start running the tests in streams suite. The command passed too!