### PR TITLE
KAFKA-18342: Vagrantfile can't work with ruby 3.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ jdk_major = '17'
 jdk_full = '17-linux-x64'
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
-if File.exists?(local_config_file) then
+if File.exist?(local_config_file) then
   eval(File.read(local_config_file), binding, "Vagrantfile.local")
 end
 


### PR DESCRIPTION
## Description
`File.exists` was removed from ruby 3.2 [0], and the newest vagrant could use ruby 3.2 and 3.3 [1]. Hence, we should ensure Vagrantfile[2] can work with ruby 3.2+.
That is, we use `File.exist` instead.

[0] https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2
[1] https://github.com/hashicorp/vagrant/blob/main/vagrant.gemspec#L15
[2] https://github.com/apache/kafka/blob/trunk/Vagrantfile#L62

## Before change
```
$ vagrant up
Vagrant failed to initialize at a very early stage:

There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /home/yungh/kafka/kafka_fork/kafka_test/Vagrantfile
Line number: 62
Message: NoMethodError: undefined method `exists?' for class File
```
## After change
```
$ vagrant up
Bringing machine 'worker1' up with 'virtualbox' provider...
Bringing machine 'worker2' up with 'virtualbox' provider...
Bringing machine 'worker3' up with 'virtualbox' provider...
Bringing machine 'worker4' up with 'virtualbox' provider...
Bringing machine 'worker5' up with 'virtualbox' provider...
Bringing machine 'worker6' up with 'virtualbox' provider...
Bringing machine 'worker7' up with 'virtualbox' provider...
Bringing machine 'worker8' up with 'virtualbox' provider...
Bringing machine 'worker9' up with 'virtualbox' provider...
==> worker1: Importing base box 'kafkatest-worker'...
==> worker1: Waiting for cleanup before exiting...
-- snip --
```

Jira: https://issues.apache.org/jira/browse/KAFKA-18342
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
