### PR TITLE
KAFKA-18280:fix e2e TestSecurityRollingUpgrade.test_rolling_upgrade_sasl_mechanism_phase_one

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -602,12 +602,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                         nodes_for_kdc += other_service.nodes
                     self.minikdc = MiniKdc(self.context, nodes_for_kdc, extra_principals = add_principals)
                     self.minikdc.start()
-        else:
-            self.minikdc = None
-            if self.quorum_info.using_kraft:
-                self.controller_quorum.minikdc = None
-                if self.isolated_kafka:
-                    self.isolated_kafka.minikdc = None
 
     def alive(self, node):
         return len(self.pids(node)) > 0


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-18280

In KRaft mode, miniKDC will start two services so client side token and server side token is unmatched after node restart.

In this patch, we do not unassign MiniKDC to avoid creating another service.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
