### PR TITLE
MINOR: fix TopicCommand warning message.format.version output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -175,7 +175,7 @@ public abstract class TopicCommand {
             .forEach(pair -> props.setProperty(pair.get(0).trim(), pair.get(1).trim()));
         LogConfig.validate(props);
         if (props.containsKey(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)) {
-            System.out.println("WARNING: The configuration ${TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG}=${props.getProperty(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)} is specified. " +
+            System.out.println("WARNING: The configuration " + TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG + "=" + props.getProperty(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG) + " is specified. " +
                 "This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker or " +
                 "if the inter.broker.protocol.version is 3.0 or newer. This configuration is deprecated and it will be removed in Apache Kafka 4.0.");
         }


### PR DESCRIPTION
Before:
```
> ./bin/kafka-topics.sh --create --topic my-topic --bootstrap-server localhost:9092 --config message.format.version=0.10.2-IV0
WARNING: The configuration ${TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG}=${props.getProperty(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)} is specified. This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker or if the inter.broker.protocol.version is 3.0 or newer. This configuration is deprecated and it will be removed in Apache Kafka 4.0.
Created topic my-topic.
```

After:
```
> ./bin/kafka-topics.sh --create --topic my-topic --bootstrap-server localhost:9092 --config message.format.version=0.10.2-IV0
WARNING: The configuration message.format.version=0.10.2-IV0 is specified. This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker or if the inter.broker.protocol.version is 3.0 or newer. This configuration is deprecated and it will be removed in Apache Kafka 4.0.
Created topic my-topic.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
