### PR TITLE
MINOR: Replace enum name with state name when parsing `ConsumerGroupState`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -184,7 +184,7 @@ public class ConsumerGroupDescription {
      */
     @Deprecated
     public ConsumerGroupState state() {
-        return ConsumerGroupState.parse(groupState.name());
+        return ConsumerGroupState.parse(groupState.toString());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -90,7 +90,7 @@ public class ConsumerGroupDescription {
         this.members = members == null ? Collections.emptyList() : List.copyOf(members);
         this.partitionAssignor = partitionAssignor == null ? "" : partitionAssignor;
         this.type = type;
-        this.groupState = GroupState.parse(state.name());
+        this.groupState = GroupState.parse(state.toString());
         this.coordinator = coordinator;
         this.authorizedOperations = authorizedOperations;
         this.groupEpoch = Optional.empty();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
@@ -53,7 +53,7 @@ public class ConsumerGroupListing {
      */
     @Deprecated
     public ConsumerGroupListing(String groupId, boolean isSimpleConsumerGroup, Optional<ConsumerGroupState> state) {
-        this(groupId, Objects.requireNonNull(state).map(state0 -> GroupState.parse(state0.name())), Optional.empty(), isSimpleConsumerGroup);
+        this(groupId, Objects.requireNonNull(state).map(state0 -> GroupState.parse(state0.toString())), Optional.empty(), isSimpleConsumerGroup);
     }
 
     /**
@@ -72,7 +72,7 @@ public class ConsumerGroupListing {
         Optional<ConsumerGroupState> state,
         Optional<GroupType> type
     ) {
-        this(groupId, Objects.requireNonNull(state).map(state0 -> GroupState.parse(state0.name())), type, isSimpleConsumerGroup);
+        this(groupId, Objects.requireNonNull(state).map(state0 -> GroupState.parse(state0.toString())), type, isSimpleConsumerGroup);
     }
 
     /**
@@ -137,7 +137,7 @@ public class ConsumerGroupListing {
      */
     @Deprecated
     public Optional<ConsumerGroupState> state() {
-        return groupState.map(state0 -> ConsumerGroupState.parse(state0.name()));
+        return groupState.map(state0 -> ConsumerGroupState.parse(state0.toString()));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
@@ -58,7 +58,7 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
     public ListConsumerGroupsOptions inStates(Set<ConsumerGroupState> states) {
         this.groupStates = (states == null || states.isEmpty())
             ? Collections.emptySet()
-            : states.stream().map(state -> GroupState.parse(state.name())).collect(Collectors.toSet());
+            : states.stream().map(state -> GroupState.parse(state.toString())).collect(Collectors.toSet());
         return this;
     }
 
@@ -84,7 +84,7 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
      */
     @Deprecated
     public Set<ConsumerGroupState> states() {
-        return groupStates.stream().map(groupState -> ConsumerGroupState.parse(groupState.name())).collect(Collectors.toSet());
+        return groupStates.stream().map(groupState -> ConsumerGroupState.parse(groupState.toString())).collect(Collectors.toSet());
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupDescriptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.ConsumerGroupState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsumerGroupDescriptionTest {
+    @Test
+    public void testState() {
+        for (ConsumerGroupState groupState : ConsumerGroupState.values()) {
+            ConsumerGroupDescription description = new ConsumerGroupDescription(
+                "groupId",
+                false,
+                null,
+                "assignor",
+                groupState,
+                null
+            );
+            assertEquals(groupState, description.state());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupDescriptionTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.ConsumerGroupState;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupListingTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConsumerGroupListingTest.java
@@ -20,21 +20,20 @@ import org.apache.kafka.common.ConsumerGroupState;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConsumerGroupDescriptionTest {
+public class ConsumerGroupListingTest {
     @Test
     public void testState() {
         for (ConsumerGroupState consumerGroupState : ConsumerGroupState.values()) {
-            ConsumerGroupDescription description = new ConsumerGroupDescription(
+            ConsumerGroupListing listing = new ConsumerGroupListing(
                 "groupId",
                 false,
-                null,
-                "assignor",
-                consumerGroupState,
-                null
+                Optional.of(consumerGroupState)
             );
-            assertEquals(consumerGroupState, description.state());
+            assertEquals(consumerGroupState, listing.state().get());
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptionsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.ConsumerGroupState;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ListConsumerGroupsOptionsTest {
+    @Test
+    public void testState() {
+        Set<ConsumerGroupState> consumerGroupStates = new HashSet<>(Arrays.asList(ConsumerGroupState.values()));
+        ListConsumerGroupsOptions options = new ListConsumerGroupsOptions().inStates(consumerGroupStates);
+        assertEquals(consumerGroupStates, options.states());
+    }
+}


### PR DESCRIPTION
`groupState.name()` returns the name of the enum while `ConsumerGroupState#parse` uses the state name.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
