### PR TITLE
KAFKA-18348: Remove the deprecated MockConsumer#setException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -314,14 +314,6 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         recs.add(record);
     }
 
-    /**
-     * @deprecated Use {@link #setPollException(KafkaException)} instead
-     */
-    @Deprecated
-    public synchronized void setException(KafkaException exception) {
-        setPollException(exception);
-    }
-
     public synchronized void setPollException(KafkaException exception) {
         this.pollException = exception;
     }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -188,6 +188,10 @@
                         <li>The <code>committed(TopicPartition)</code> and <code>committed(TopicPartition, Duration)</code> methods were removed from the consumer.
                             Please use <code>committed(Set&ltTopicPartition&gt)</code> and <code>committed(Set&ltTopicPartition&gt, Duration)</code> instead.
                         </li>
+                        <li>
+                            The <code>setException(KafkaException)</code> method was removed from the <code>org.apache.kafka.clients.consumer.MockConsumer</code>.
+                            Please use <code>setPollException(KafkaException)</code> instead.
+                        </li>
                     </ul>
                 </li>
                 <li><b>Producer</b>


### PR DESCRIPTION
As title

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
