### PR TITLE
MINOR: remove zkBroker from StreamsGroupHeartbeatRequest and StreamsGroupDescribeRequest

### DIFF
--- a/clients/src/main/resources/common/message/StreamsGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 89,
   "type": "request",
-  "listeners": ["broker", "zkBroker"],
+  "listeners": ["broker"],
   "name": "StreamsGroupDescribeRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 88,
   "type": "request",
-  "listeners": ["broker", "zkBroker"],
+  "listeners": ["broker"],
   "name": "StreamsGroupHeartbeatRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",


### PR DESCRIPTION
The Zookeeper will be removed from Apache Kafka 4.0 (KAFKA-17611). New API like StreamsGroupHeartbeatRequest and StreamsGroupDescribeRequest don't need to use `zkBroker` as listeners.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
