### PR TITLE
KAFKA-18352: DeleteGroups v0 incorrectly tagged as deprecated (3.9)

### DIFF
--- a/clients/src/main/resources/common/message/DeleteGroupsRequest.json
+++ b/clients/src/main/resources/common/message/DeleteGroupsRequest.json
@@ -22,7 +22,6 @@
   //
   // Version 2 is the first flexible version.
   "validVersions": "0-2",
-  "deprecatedVersions": "0",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "GroupsNames", "type": "[]string", "versions": "0+", "entityType": "groupId",


### PR DESCRIPTION
The Sarama version listed in the KIP only supports v0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
