### PR TITLE
KAFKA-18352: Add back DeleteGroups v0, it was incorrectly tagged as deprecated (KIP-896)

### DIFF
--- a/clients/src/main/resources/common/message/DeleteGroupsRequest.json
+++ b/clients/src/main/resources/common/message/DeleteGroupsRequest.json
@@ -18,12 +18,10 @@
   "type": "request",
   "listeners": ["zkBroker", "broker"],
   "name": "DeleteGroupsRequest",
-  // Version 0 was removed in Apache Kafka 4.0, Version 1 is the new baseline.
-  //
   // Version 1 is the same as version 0.
   //
   // Version 2 is the first flexible version.
-  "validVersions": "1-2",
+  "validVersions": "0-2",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "GroupsNames", "type": "[]string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/DeleteGroupsResponse.json
+++ b/clients/src/main/resources/common/message/DeleteGroupsResponse.json
@@ -17,12 +17,10 @@
   "apiKey": 42,
   "type": "response",
   "name": "DeleteGroupsResponse",
-  // Version 0 was removed in Apache Kafka 4.0, Version 1 is the new baseline.
-  //
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
   //
   // Version 2 is the first flexible version.
-  "validVersions": "1-2",
+  "validVersions": "0-2",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",


### PR DESCRIPTION
The Sarama version listed in the KIP only supports v0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
