### PR TITLE
MINOR: remove unused previousPartition from RoundRobinPartitioner.java

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.producer;
 
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 
 import java.util.List;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RoundRobinPartitioner implements Partitioner {
     private final ConcurrentMap<String, AtomicInteger> topicCounterMap = new ConcurrentHashMap<>();
-    private final ThreadLocal<TopicPartition> previousPartition = new ThreadLocal<>();
 
     public void configure(Map<String, ?> configs) {}
 
@@ -53,14 +52,6 @@ public class RoundRobinPartitioner implements Partitioner {
      */
     @Override
     public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
-        TopicPartition prevPartition = previousPartition.get();
-        if (prevPartition != null) {
-            previousPartition.remove();
-            if (topic.equals(prevPartition.topic())) {
-                return prevPartition.partition();
-            }
-        }
-
         int nextValue = nextValue(topic);
         List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
         if (!availablePartitions.isEmpty()) {


### PR DESCRIPTION
[https://github.com/apache/kafka/blob/e6d242113625f20108b64bf54e796fcbcff6d8a7/clie[…]va/org/apache/kafka/clients/producer/RoundRobinPartitioner.java](https://github.com/apache/kafka/blob/e6d242113625f20108b64bf54e796fcbcff6d8a7/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java#L40)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
