### PR TITLE
KAFKA-18337:  KafkaProducer Memory Leak in JmxReporter Class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -212,7 +212,7 @@ public class JmxReporter implements MetricsReporter {
         // avoid re-registering after being closed, which could lead to memory leaks
         // See KAFKA-18337 for more detail.
         if (closed) {
-            log.warn("JmxReporter has been closed!, cannot re-registering mbean {}", mbean);
+            log.warn("JmxReporter has been closed. Cannot reregister mbean {}", mbean);
             return;
         }
         unregister(mbean);


### PR DESCRIPTION
Add a close status in JmxReporter, that avoid re-registering metrics to jmx after being closed, which could lead to memory leaks

relate [KAFKA-18337](https://issues.apache.org/jira/browse/KAFKA-18337)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
