### PR TITLE
KAFKA 18238 - fIdentify the first commit where a test became flaky

### DIFF
--- a/.github/scripts/develocity_find_flaky_commit.py
+++ b/.github/scripts/develocity_find_flaky_commit.py
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import logging
 from datetime import datetime, timedelta

--- a/.github/scripts/develocity_find_flaky_commit.py
+++ b/.github/scripts/develocity_find_flaky_commit.py
@@ -1,0 +1,188 @@
+import os
+import logging
+from datetime import datetime, timedelta
+import pytz
+from typing import Optional, Dict, Tuple, List
+import argparse
+from develocity_reports import TestAnalyzer  # Import the TestAnalyzer class
+
+logger = logging.getLogger(__name__)
+
+def find_first_flaky_commit(
+    test_class: str,
+    test_case: str,
+    N: int = 2,
+    M: int = 6,
+    days_to_check: int = 30
+) -> List[Tuple[str, Dict]]:
+    """
+    Find the first commit that introduced flakiness for a given test.
+    
+    Args:
+        test_class: Full name of the test class
+        test_case: Name of the test case/method
+        N: Number of flaky/fail occurrences needed in window
+        M: Window size to confirm flakiness pattern
+        days_to_check: Number of days to look back in history
+        
+    Returns:
+        List of (commit_id, details_dict) or empty list if not found
+    """
+    # Initialize TestAnalyzer with Develocity credentials
+    token = os.environ.get("DEVELOCITY_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("DEVELOCITY_ACCESS_TOKEN environment variable must be set")
+    
+    analyzer = TestAnalyzer("https://ge.apache.org", token)
+    
+    try:
+        # Calculate time range
+        end_time = datetime.now(pytz.UTC)
+        start_time = end_time - timedelta(days=days_to_check)
+
+        analyzer.clear_cache()
+        
+        # Get test execution history
+        test_results = analyzer.get_test_case_details(
+            container_name=test_class,
+            project="kafka",
+            chunk_start=start_time,
+            chunk_end=end_time,
+            test_type="test",
+            include_passed=True
+        )
+        
+        if not test_results:
+            logger.warning(f"No test results found for {test_class}")
+            return []
+        
+        # Print all test case names
+        logger.info("Found test cases:")
+        for result in test_results:
+            logger.info(f"  - {result.name}")
+
+        # Construct full test case name by combining test class and test case
+        test_case = f"{test_class}.{test_case}"
+        logger.info(f"Looking for test case: {test_case}")
+        
+        # Filter for specific test case
+        matching_results = [r for r in test_results if r.name.endswith(test_case)]
+        if not matching_results:
+            logger.warning(f"No results found for test case {test_case}")
+            return []
+        
+        # Get timeline entries sorted by timestamp
+        timeline = []
+        for result in matching_results:
+            timeline.extend(result.timeline)
+        
+        timeline.sort(key=lambda x: x.timestamp)
+        
+        # Print all test executions in chronological order with commit IDs
+        logger.info("\nComplete test execution history:")
+        builds_info = {}
+        build_ids = [entry.build_id for entry in timeline]
+        builds_info = analyzer.get_build_info(build_ids, "kafka", "test", days_to_check)
+        
+        for entry in timeline:
+            build_info = builds_info.get(entry.build_id)
+            commit_id = build_info.git_commit if build_info else "unknown"
+            logger.info(f"Timestamp: {entry.timestamp.isoformat()} - Build ID: {entry.build_id} - Commit: {commit_id} - Status: {entry.outcome.upper()}")
+
+        # Get all build info once at the beginning
+        all_build_ids = set(entry.build_id for entry in timeline)
+        builds_info = analyzer.get_build_info(list(all_build_ids), "kafka", "test", days_to_check)
+        
+        # Convert timeline to (build_id, commit, status) tuples using cached build info
+        test_history = [
+            (
+                entry.build_id,
+                builds_info.get(entry.build_id).git_commit if builds_info.get(entry.build_id) else "unknown",
+                entry.outcome.upper()
+            ) 
+            for entry in timeline
+        ]
+        
+        logger.info(f"\nAnalyzing {len(test_history)} test executions")
+        
+        # Initialize list to store all potential flaky patterns
+        flaky_patterns = []
+        
+        # Find all flaky commit patterns using cached build info
+        for i in range(len(test_history)):
+            build_id, commit, status = test_history[i]
+            
+            if status in ("FLAKY", "FAILED"):
+                window_end = min(i + M, len(test_history))
+                window_data = test_history[i:window_end]
+                flaky_count = sum(1 for _, _, s in window_data if s in ("FLAKY", "FAILED"))
+                
+                if flaky_count >= N:
+                    build_info = builds_info.get(build_id)
+                    if build_info:
+                        details = {
+                            'build_id': build_id,
+                            'git_commit': build_info.git_commit,
+                            'timestamp': build_info.timestamp,
+                            'duration': build_info.duration,
+                            'failed': build_info.has_failed,
+                            'window_data': [
+                                {
+                                    'build_id': bid,
+                                    'git_commit': commit,
+                                    'status': status,
+                                    'timestamp': builds_info.get(bid).timestamp  # Use cached build info
+                                }
+                                for bid, commit, status in window_data
+                            ]
+                        }
+                        flaky_patterns.append((build_info.git_commit, details))
+        
+        return flaky_patterns
+        
+    except Exception as e:
+        logger.error(f"Error finding flaky commit: {str(e)}")
+        return []
+
+def main():
+    # Hardcoded test values
+    test_class = "kafka.api.PlaintextAdminIntegrationTest"
+    test_case = "testConsumerGroups(String, String)[2]"
+    occurrences = 3
+    window = 5
+    days = 30
+    
+    # Configure logging
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[logging.StreamHandler(), logging.FileHandler("flaky_commit.log")]
+    )
+    
+    # Find flaky commits
+    flaky_patterns = find_first_flaky_commit(
+        test_class,
+        test_case,
+        occurrences,
+        window,
+        days
+    )
+    
+    # Print results
+    if flaky_patterns:
+        print("\nPotential flaky commit patterns found:")
+        for commit, details in flaky_patterns:
+            print(f"\nGit Commit: {commit}")
+            print(f"Build ID: {details['build_id']}")
+            print(f"Timestamp: {details['timestamp'].isoformat()}")
+            print(f"Build Failed: {details['failed']}")
+            print("\nWindow data:")
+            for entry in details['window_data']:
+                print(f"  {entry['timestamp'].isoformat()} - {entry['status']}")
+                print(f"    Build ID: {entry['build_id']}")
+                print(f"    Git Commit: {entry['git_commit']}")
+    else:
+        print("\nNo flaky commit patterns found")
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -1122,7 +1122,7 @@ if __name__ == "__main__":
         level=logging.INFO,
         format='%(asctime)s - %(levelname)s - %(message)s',
         handlers=[
-            logging.StreamHandler()
+            logging.FileHandler("flaky_test_report.log")
         ]
     )
     main()

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -168,8 +168,8 @@ class TestAnalyzer:
         
         # Initialize cache providers
         self.cache_providers = [
-            GitHubActionsCacheProvider(),
-            LocalCacheProvider()
+            # GitHubActionsCacheProvider(),
+            # LocalCacheProvider()
         ]
         self.build_cache = None
         self._load_cache()
@@ -212,7 +212,7 @@ class TestAnalyzer:
         chunk_end: datetime,
         project: str,
         test_type: str,
-        remaining_build_ids: set,
+        remaining_build_ids: set | None,
         max_builds_per_request: int
     ) -> Dict[str, BuildInfo]:
         """Helper method to process a single chunk of build information"""
@@ -225,7 +225,7 @@ class TestAnalyzer:
         from_build = None
         continue_chunk = True
 
-        while continue_chunk and remaining_build_ids:
+        while continue_chunk and (remaining_build_ids is None or remaining_build_ids):
             query_params = {
                 'query': query,
                 'models': ['gradle-attributes'],
@@ -273,7 +273,7 @@ class TestAnalyzer:
                             continue_chunk = False
                             break
                         
-                        if build_id in remaining_build_ids:
+                        if remaining_build_ids is None or build_id in remaining_build_ids:
                             if 'problem' not in gradle_attrs:
                                 chunk_builds[build_id] = BuildInfo(
                                     id=build_id,
@@ -281,6 +281,8 @@ class TestAnalyzer:
                                     duration=attrs.get('buildDuration'),
                                     has_failed=attrs.get('hasFailed', False)
                                 )
+                                if remaining_build_ids is not None:
+                                    remaining_build_ids.remove(build_id)
             
             if continue_chunk and response_json:
                 from_build = response_json[-1]['id']
@@ -290,38 +292,47 @@ class TestAnalyzer:
             time.sleep(0.5)  # Rate limiting between pagination requests
             
         return chunk_builds
-
-    def get_build_info(self, build_ids: List[str], project: str, test_type: str, query_days: int) -> Dict[str, BuildInfo]:
+    def get_build_info(self, build_ids: List[str] = None, project: str = None, test_type: str = None, query_days: int = None, bypass_cache: bool = False, fetch_all: bool = False) -> Dict[str, BuildInfo]:
         builds = {}
         max_builds_per_request = 100
         cutoff_date = datetime.now(pytz.UTC) - timedelta(days=query_days)
+        current_time = datetime.now(pytz.UTC)
         
-        # Get builds from cache if available
-        if self.build_cache:
+        if not fetch_all and not build_ids:
+            raise ValueError("Either build_ids must be provided or fetch_all must be True")
+        
+        # Get builds from cache if available and bypass_cache is False
+        if not bypass_cache and self.build_cache:
             cached_builds = self.build_cache.builds
             cached_cutoff = self.build_cache.last_update - timedelta(days=query_days)
             
-            # Use cached data for builds within the cache period
-            for build_id in build_ids:
-                if build_id in cached_builds:
-                    build = cached_builds[build_id]
+            if fetch_all:
+                # Use all cached builds within the time period
+                for build_id, build in cached_builds.items():
                     if build.timestamp >= cached_cutoff:
                         builds[build_id] = build
+            else:
+                # Use cached data for specific builds within the cache period
+                for build_id in build_ids:
+                    if build_id in cached_builds:
+                        build = cached_builds[build_id]
+                        if build.timestamp >= cached_cutoff:
+                            builds[build_id] = build
             
             # Update cutoff date to only fetch new data
             cutoff_date = self.build_cache.last_update
             logger.info(f"Using cached data up to {cutoff_date.isoformat()}")
             
-            # Remove already found builds from the search list
-            build_ids = [bid for bid in build_ids if bid not in builds]
-        
-        if not build_ids:
-            logger.info("All builds found in cache")
-            return builds
+            if not fetch_all:
+                # Remove already found builds from the search list
+                build_ids = [bid for bid in build_ids if bid not in builds]
+            
+                if not build_ids:
+                    logger.info("All builds found in cache")
+                    return builds
         
         # Fetch remaining builds from API
-        remaining_build_ids = set(build_ids)
-        current_time = datetime.now(pytz.UTC)
+        remaining_build_ids = set(build_ids) if not fetch_all else None
         chunk_size = self.default_chunk_size
 
         # Create time chunks
@@ -343,7 +354,7 @@ class TestAnalyzer:
                     chunk[1], 
                     project, 
                     test_type, 
-                    remaining_build_ids.copy(),
+                    remaining_build_ids.copy() if remaining_build_ids else None,
                     max_builds_per_request
                 ): chunk for chunk in chunks
             }
@@ -352,7 +363,8 @@ class TestAnalyzer:
                 try:
                     chunk_builds = future.result()
                     builds.update(chunk_builds)
-                    remaining_build_ids -= set(chunk_builds.keys())
+                    if remaining_build_ids:
+                        remaining_build_ids -= set(chunk_builds.keys())
                 except Exception as e:
                     logger.error(f"Chunk processing generated an exception: {str(e)}")
 
@@ -361,11 +373,11 @@ class TestAnalyzer:
             f"\nBuild Info Performance:"
             f"\n  Total Duration: {total_duration:.2f}s"
             f"\n  Builds Retrieved: {len(builds)}"
-            f"\n  Builds Not Found: {len(remaining_build_ids)}"
+            f"\n  Builds Not Found: {len(remaining_build_ids) if remaining_build_ids else 0}"
         )
         
-        # Update cache with new data
-        if builds:
+        # Update cache with new data if not bypassing cache
+        if builds and not bypass_cache:
             if not self.build_cache:
                 self.build_cache = BuildCache(current_time, {})
             self.build_cache.builds.update(builds)
@@ -373,7 +385,6 @@ class TestAnalyzer:
             self._save_cache()
         
         return builds
-
     def get_test_results(self, project: str, threshold_days: int, test_type: str = "quarantinedTest",
                         outcomes: List[str] = None) -> List[TestResult]:
         """Fetch test results with timeline information"""
@@ -464,6 +475,11 @@ class TestAnalyzer:
             # Sort timeline by timestamp
             result.timeline = sorted(timeline, key=lambda x: x.timestamp)
             logger.debug(f"Final timeline entries for {test_name}: {len(result.timeline)}")
+
+            # Print build details for debugging
+            logger.debug("Timeline entries:")
+            for entry in timeline:
+                logger.debug(f"Build ID: {entry.build_id}, Timestamp: {entry.timestamp}, Outcome: {entry.outcome}")
             
             # Calculate recent failure rate
             recent_cutoff = datetime.now(pytz.UTC) - timedelta(days=30)
@@ -768,6 +784,28 @@ class TestAnalyzer:
         
         return cleared_tests
 
+    def update_cache(self, builds: Dict[str, BuildInfo]):
+        """
+        Update the build cache with new build information.
+        
+        Args:
+            builds: Dictionary of build IDs to BuildInfo objects
+        """
+        current_time = datetime.now(pytz.UTC)
+        
+        # Initialize cache if it doesn't exist
+        if not self.build_cache:
+            self.build_cache = BuildCache(current_time, {})
+        
+        # Update builds and last update time
+        self.build_cache.builds.update(builds)
+        self.build_cache.last_update = current_time
+        
+        # Save to all cache providers
+        self._save_cache()
+        
+        logger.info(f"Updated cache with {len(builds)} builds")
+
 def get_develocity_class_link(class_name: str, threshold_days: int, test_type: str = None) -> str:
     """
     Generate Develocity link for a test class
@@ -1025,6 +1063,12 @@ def main():
     analyzer = TestAnalyzer(BASE_URL, token)
     
     try:
+        quarantined_builds = analyzer.get_build_info([], PROJECT, "quarantinedTest", 7, bypass_cache=True, fetch_all=True)
+        regular_builds = analyzer.get_build_info([], PROJECT, "test", 7, bypass_cache=True, fetch_all=True)
+
+        analyzer.update_cache(quarantined_builds)
+        analyzer.update_cache(regular_builds)
+
         # Get test results
         quarantined_results = analyzer.get_test_results(
             PROJECT, 
@@ -1075,10 +1119,11 @@ def main():
 if __name__ == "__main__":
     # Configure logging
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG,
         format='%(asctime)s - %(levelname)s - %(message)s',
         handlers=[
-            logging.FileHandler("flaky_test_report.log")
+            logging.FileHandler("flaky_test_report.log"),
+            logging.StreamHandler()
         ]
     )
     main()

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -204,7 +204,7 @@ class TestAnalyzer:
         Returns:
             A formatted query string.
         """
-        return f'project:{project} buildStartTime:[{chunk_start.isoformat()} TO {chunk_end.isoformat()}] gradle.requestedTasks:{test_type}'
+        return f'project:{project} buildStartTime:[{chunk_start.isoformat()} TO {chunk_end.isoformat()}] gradle.requestedTasks:{test_type} tag:github tag:trunk'
     
     def process_chunk(
         self,
@@ -768,13 +768,14 @@ class TestAnalyzer:
         
         return cleared_tests
 
-def get_develocity_class_link(class_name: str, threshold_days: int) -> str:
+def get_develocity_class_link(class_name: str, threshold_days: int, test_type: str = None) -> str:
     """
     Generate Develocity link for a test class
     
     Args:
         class_name: Name of the test class
         threshold_days: Number of days to look back in search
+        test_type: Type of test (e.g., "quarantinedTest", "test")
     """
     base_url = "https://ge.apache.org/scans/tests"
     params = {
@@ -784,9 +785,13 @@ def get_develocity_class_link(class_name: str, threshold_days: int) -> str:
         "search.relativeStartTime": f"P{threshold_days}D",
         "tests.container": class_name
     }
+    
+    if test_type:
+        params["search.tasks"] = test_type
+        
     return f"{base_url}?{'&'.join(f'{k}={requests.utils.quote(str(v))}' for k, v in params.items())}"
 
-def get_develocity_method_link(class_name: str, method_name: str, threshold_days: int) -> str:
+def get_develocity_method_link(class_name: str, method_name: str, threshold_days: int, test_type: str = None) -> str:
     """
     Generate Develocity link for a test method
     
@@ -794,6 +799,7 @@ def get_develocity_method_link(class_name: str, method_name: str, threshold_days
         class_name: Name of the test class
         method_name: Name of the test method
         threshold_days: Number of days to look back in search
+        test_type: Type of test (e.g., "quarantinedTest", "test")
     """
     base_url = "https://ge.apache.org/scans/tests"
     
@@ -809,9 +815,13 @@ def get_develocity_method_link(class_name: str, method_name: str, threshold_days
         "tests.container": class_name,
         "tests.test": method_name
     }
+    
+    if test_type:
+        params["search.tasks"] = test_type
+        
     return f"{base_url}?{'&'.join(f'{k}={requests.utils.quote(str(v))}' for k, v in params.items())}"
 
-def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_days: int):
+def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_days: int, test_type: str = None):
     """Print a summary of the most problematic tests"""
     print("\n## Most Problematic Tests")
     if not problematic_tests:
@@ -827,7 +837,7 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
     for test_name, details in sorted(problematic_tests.items(), 
                                    key=lambda x: x[1]['failure_rate'],
                                    reverse=True):
-        class_link = get_develocity_class_link(test_name, threshold_days)
+        class_link = get_develocity_class_link(test_name, threshold_days, test_type=test_type)
         print(f"<tr><td colspan=\"4\">{test_name}</td><td><a href=\"{class_link}\">↗️</a></td></tr>")
         
         for test_case in sorted(details['test_cases'],
@@ -836,7 +846,7 @@ def print_most_problematic_tests(problematic_tests: Dict[str, Dict], threshold_d
                               reverse=True):
             method_name = test_case.name.split('.')[-1]
             if method_name != 'N/A':
-                method_link = get_develocity_method_link(test_name, test_case.name, threshold_days)
+                method_link = get_develocity_method_link(test_name, test_case.name, threshold_days, test_type="quarantinedTest")
                 total_runs = test_case.outcome_distribution.total
                 failure_rate = (test_case.outcome_distribution.failed + test_case.outcome_distribution.flaky) / total_runs if total_runs > 0 else 0
                 print(f"<tr><td></td><td>{method_name}</td>"
@@ -925,7 +935,7 @@ def print_flaky_regressions(flaky_regressions: Dict[str, Dict], threshold_days: 
     
     print("</details>")
 
-def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
+def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int, test_type: str = None):
     """Print tests that are ready to be unquarantined"""
     print("\n## Cleared Tests (Ready for Unquarantine)")
     if not cleared_tests:
@@ -945,7 +955,7 @@ def print_cleared_tests(cleared_tests: Dict[str, Dict], threshold_days: int):
     for test_name, details in sorted(cleared_tests.items(),
                                    key=lambda x: x[1]['success_rate'],
                                    reverse=True):
-        class_link = get_develocity_class_link(test_name, threshold_days)
+        class_link = get_develocity_class_link(test_name, threshold_days, test_type=test_type)
         print(f"<tr><td colspan=\"5\">{test_name}</td><td><a href=\"{class_link}\">↗️</a></td></tr>")
         print(f"<tr><td></td><td>Class Overall</td>"
               f"<td>{details['success_rate']:.2%}</td>"
@@ -1054,9 +1064,9 @@ def main():
         print(f"This report was run on {datetime.now(pytz.UTC).strftime('%Y-%m-%d %H:%M:%S')} UTC")
         
         # Print each section
-        print_most_problematic_tests(problematic_tests, QUARANTINE_THRESHOLD_DAYS)
+        print_most_problematic_tests(problematic_tests, QUARANTINE_THRESHOLD_DAYS, test_type="quarantinedTest")
         print_flaky_regressions(flaky_regressions, QUARANTINE_THRESHOLD_DAYS)
-        print_cleared_tests(cleared_tests, QUARANTINE_THRESHOLD_DAYS)
+        print_cleared_tests(cleared_tests, QUARANTINE_THRESHOLD_DAYS, test_type="quarantinedTest")
 
     except Exception as e:
         logger.exception("Error occurred during report generation")

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -168,8 +168,8 @@ class TestAnalyzer:
         
         # Initialize cache providers
         self.cache_providers = [
-            # GitHubActionsCacheProvider(),
-            # LocalCacheProvider()
+            GitHubActionsCacheProvider(),
+            LocalCacheProvider()
         ]
         self.build_cache = None
         self._load_cache()
@@ -1119,10 +1119,9 @@ def main():
 if __name__ == "__main__":
     # Configure logging
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=logging.INFO,
         format='%(asctime)s - %(levelname)s - %(message)s',
         handlers=[
-            logging.FileHandler("flaky_test_report.log"),
             logging.StreamHandler()
         ]
     )

--- a/.github/scripts/develocity_reports.py
+++ b/.github/scripts/develocity_reports.py
@@ -781,7 +781,7 @@ def get_develocity_class_link(class_name: str, threshold_days: int, test_type: s
     params = {
         "search.rootProjectNames": "kafka",
         "search.tags": "github,trunk",
-        "search.timeZoneId": "America/New_York",
+        "search.timeZoneId": "UTC",
         "search.relativeStartTime": f"P{threshold_days}D",
         "tests.container": class_name
     }
@@ -810,7 +810,7 @@ def get_develocity_method_link(class_name: str, method_name: str, threshold_days
     params = {
         "search.rootProjectNames": "kafka",
         "search.tags": "github,trunk",
-        "search.timeZoneId": "America/New_York",
+        "search.timeZoneId": "UTC",
         "search.relativeStartTime": f"P{threshold_days}D",
         "tests.container": class_name,
         "tests.test": method_name


### PR DESCRIPTION
Added script to find the commit that would have caused the flakiness.

### Flaky Pattern Detection:

For each test execution in chronological order:

- When a FAILED or FLAKY status is encountered, opens a window of size M
- Counts failures/flaky occurrences within that window
- If count ≥ N, marks this as a potential flaky pattern
- Records detailed information about the pattern including:
  - Initial failing commit
  - Build information
  - All test executions within the window

### Example
Given:
- Window size (M) = 6
- Required failures (N) = 2

Timeline:
[PASS] -> [PASS] -> [FAIL] -> [PASS] -> [FAIL] -> [PASS] -> [PASS]
                     ^
                     |
                     Window starts here
                     
Window Analysis:
[FAIL], [PASS], [FAIL], [PASS], [PASS] = 2 failures in 5 executions
Result: Pattern detected (2 failures ≥ N within window of size 6)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
