### PR TITLE
KAFKA-18274: Failed to restart controller in testing due to closed socket channel [2/2]

### DIFF
--- a/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
+++ b/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
@@ -54,7 +54,11 @@ public class PreboundSocketFactoryManager implements AutoCloseable {
                 if (socketChannel.isOpen()) {
                     return socketChannel;
                 }
-                // bind the server socket with same port
+                // When restarting components(e.g. controllers, brokers) in tests, we want to reuse the same
+                // port that was previously allocated to maintain consistent addressing
+                // so the client can reconnect to the same port.
+                // Since those components would close the socket when they are restarted,
+                // we need to rebind the socket to the same port.
                 socketAddress = new InetSocketAddress(socketAddress.getHostString(), socketChannel.socket().getLocalPort());
                 socketChannel = ServerSocketFactory.INSTANCE.openServerSocket(
                         listenerName,

--- a/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
+++ b/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
@@ -49,7 +49,16 @@ public class PreboundSocketFactoryManager implements AutoCloseable {
             ServerSocketChannel socketChannel = getSocketForListenerAndMarkAsUsed(
                 nodeId,
                 listenerName);
-            if (socketChannel != null) {
+            if (socketChannel != null && socketChannel.isOpen()) {
+                return socketChannel;
+            } else if (socketChannel != null) {
+                // bind the server socket with same port
+                socketAddress = new InetSocketAddress(socketAddress.getHostString(), socketChannel.socket().getLocalPort());
+                socketChannel = ServerSocketFactory.INSTANCE.openServerSocket(
+                        listenerName,
+                        socketAddress,
+                        listenBacklogSize,
+                        recvBufferSize);
                 return socketChannel;
             }
             return ServerSocketFactory.INSTANCE.openServerSocket(

--- a/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
+++ b/test-common/src/main/java/org/apache/kafka/common/test/PreboundSocketFactoryManager.java
@@ -49,9 +49,11 @@ public class PreboundSocketFactoryManager implements AutoCloseable {
             ServerSocketChannel socketChannel = getSocketForListenerAndMarkAsUsed(
                 nodeId,
                 listenerName);
-            if (socketChannel != null && socketChannel.isOpen()) {
-                return socketChannel;
-            } else if (socketChannel != null) {
+
+            if (socketChannel != null) {
+                if (socketChannel.isOpen()) {
+                    return socketChannel;
+                }
                 // bind the server socket with same port
                 socketAddress = new InetSocketAddress(socketAddress.getHostString(), socketChannel.socket().getLocalPort());
                 socketChannel = ServerSocketFactory.INSTANCE.openServerSocket(

--- a/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
@@ -348,7 +348,7 @@ public class ClusterTestExtensionsTest {
     }
 
     @ClusterTest(types = {Type.KRAFT})
-    public void testKRaftIsolatedControllerRestart(ClusterInstance cluster) throws ExecutionException, InterruptedException {
+    public void testControllerRestart(ClusterInstance cluster) throws ExecutionException, InterruptedException {
         try (Admin admin = cluster.admin()) {
 
             ControllerServer controller = cluster.controllers().values().iterator().next();

--- a/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-api/src/test/java/org/apache/kafka/common/test/api/ClusterTestExtensionsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.common.test.api;
 
+import kafka.server.ControllerServer;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -341,6 +343,20 @@ public class ClusterTestExtensionsTest {
     public void testControllerListenerName(ClusterInstance cluster) throws ExecutionException, InterruptedException {
         assertEquals("FOO", cluster.controllerListenerName().get().value());
         try (Admin admin = cluster.admin(Map.of(), true)) {
+            assertEquals(1, admin.describeMetadataQuorum().quorumInfo().get().nodes().size());
+        }
+    }
+
+    @ClusterTest(types = {Type.KRAFT})
+    public void testKRaftIsolatedControllerRestart(ClusterInstance cluster) throws ExecutionException, InterruptedException {
+        try (Admin admin = cluster.admin()) {
+
+            ControllerServer controller = cluster.controllers().values().iterator().next();
+            controller.shutdown();
+            controller.awaitShutdown();
+
+            controller.startup();
+
             assertEquals(1, admin.describeMetadataQuorum().quorumInfo().get().nodes().size());
         }
     }


### PR DESCRIPTION
Enable controller to restart with the same port in ClusterTest.

## Tests

In the newly added test `testKRaftIsolatedControllerRestart`, if we don't have the corresponding changes in `PreboundSocketFactoryManager` then the admin will keep retrying connect to the restarted controller, cause the controller's port has changed.

```
[2024-12-28 06:01:46,521] INFO [broker-0-to-controller-forwarding-channel-manager]: Recorded new KRaft controller, from now on will use node localhost:43227 (id: 3000 rack: null isFenced: false) (kafka.server.NodeToControllerRequestThread:66)
[2024-12-28 06:01:46,546] INFO [RaftManager id=0] Node 3000 disconnected. (org.apache.kafka.clients.NetworkClient:1073)
[2024-12-28 06:01:46,546] WARN [RaftManager id=0] Connection to node 3000 (localhost/127.0.0.1:43227) could not be established. Node may not be available. (org.apache.kafka.clients.NetworkClient:899)
[2024-12-28 06:01:46,547] INFO [controller-3000-to-controller-registration-channel-manager]: Recorded new KRaft controller, from now on will use node localhost:43227 (id: 3000 rack: null isFenced: false) (kafka.server.NodeToControllerRequestThread:66)
[2024-12-28 06:01:46,548] INFO [NodeToControllerChannelManager id=3000 name=registration] Node 3000 disconnected. (org.apache.kafka.clients.NetworkClient:1073)
...
// repeated same log messages
```