### PR TITLE
KAFKA-18026: KIP-1112, configure all StoreBuilder & StoreFactory layers

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ConfigurableStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ConfigurableStore.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.StreamsConfig;
+
+public interface ConfigurableStore {
+
+    void configure(final StreamsConfig config);
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
@@ -34,6 +35,7 @@ import java.util.Set;
  */
 public class StoreBuilderWrapper implements StoreFactory {
 
+
     private final StoreBuilder<?> builder;
     private final Set<String> connectedProcessorNames = new HashSet<>();
 
@@ -47,6 +49,13 @@ public class StoreBuilderWrapper implements StoreFactory {
 
     private StoreBuilderWrapper(final StoreBuilder<?> builder) {
         this.builder = builder;
+    }
+
+    @Override
+    public void configure(final StreamsConfig config) {
+        if (builder instanceof ConfigurableStore) {
+            ((ConfigurableStore) builder).configure(config);
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -46,9 +46,7 @@ import java.util.Set;
  *     to {@link org.apache.kafka.streams.StreamsBuilder#StreamsBuilder(TopologyConfig)}</li>
  * </ul>
  */
-public interface StoreFactory {
-
-    void configure(final StreamsConfig config);
+public interface StoreFactory extends ConfigurableStore {
 
     StoreBuilder<?> builder();
 
@@ -74,7 +72,7 @@ public interface StoreFactory {
 
     boolean isCompatibleWith(StoreFactory storeFactory);
 
-    class FactoryWrappingStoreBuilder<T extends StateStore> implements StoreBuilder<T> {
+    class FactoryWrappingStoreBuilder<T extends StateStore> implements StoreBuilder<T>, ConfigurableStore {
 
         private final StoreFactory storeFactory;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -48,9 +48,7 @@ import java.util.Set;
  */
 public interface StoreFactory {
 
-    default void configure(final StreamsConfig config) {
-        // do nothing
-    }
+    void configure(final StreamsConfig config);
 
     StoreBuilder<?> builder();
 
@@ -86,6 +84,10 @@ public interface StoreFactory {
 
         public StoreFactory storeFactory() {
             return storeFactory;
+        }
+
+        public void configure(final StreamsConfig config) {
+            storeFactory.configure(config);
         }
 
         @Override


### PR DESCRIPTION
Because of how we have to wrap StoreFactory and StoreBuilder layers on top of each other for various parts of the topology building process, we need to make sure both of these are capable of configuration and will check for & delegate to an underlying layer if it exists