### PR TITLE
KAFKA-18363 Clean up Server config documents which contained zookeeper

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
@@ -54,9 +54,8 @@ public class QuotaConfig {
 
     public static final String CLIENT_QUOTA_CALLBACK_CLASS_CONFIG = "client.quota.callback.class";
     public static final String CLIENT_QUOTA_CALLBACK_CLASS_DOC = "The fully qualified name of a class that implements the ClientQuotaCallback interface, " +
-            "which is used to determine quota limits applied to client requests. By default, the &lt;user&gt; and &lt;client-id&gt; " +
-            "quotas that are stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal " +
-            "of the session and the client-id of the request is applied.";
+            "which is used to determine quota limits applied to client requests. " +
+            "For any given request, the most specific quota that matches the user principal of the session and the client-id of the request is applied.";
 
     public static final String LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG = "leader.replication.throttled.replicas";
     public static final String LEADER_REPLICATION_THROTTLED_REPLICAS_DOC = "A list of replicas for which log replication should be throttled on " +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -77,7 +77,7 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
-                    " use to connect, such as in cloud environments. In environments using ZooKeeper, these addresses are published to ZooKeeper." +
+                    " use to connect, such as in cloud environments." +
                     " In Kraft mode, the address would be published to and managed by kraft controller, the brokers would pull these data from controller as needed." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -78,7 +78,7 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
                     " use to connect, such as in cloud environments." +
-                    " In Kraft mode, the address would be published to and managed by kraft controller, the brokers would pull these data from controller as needed." +
+                    " The address would be published to and managed by the KRaft controller, the brokers pull these data from the controller as needed." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -78,7 +78,7 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
                     " use to connect, such as in cloud environments." +
-                    " The address would be published to and managed by the KRaft controller, the brokers pull these data from the controller as needed." +
+                    " The address are published to and managed by the KRaft controller, the brokers pull these data from the controller as needed." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +

--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -78,7 +78,7 @@ public class SocketServerConfigs {
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +
                     " The config is useful where the actual listener configuration <code>%s</code> does not represent the addresses that clients should" +
                     " use to connect, such as in cloud environments." +
-                    " The address are published to and managed by the KRaft controller, the brokers pull these data from the controller as needed." +
+                    " The addresses are published to and managed by the controller, the brokers pull these data from the controller as needed." +
                     " In IaaS environments, this may need to be different from the interface to which the broker binds." +
                     " If this is not set, the value for <code>%1$1s</code> will be used." +
                     " Unlike <code>%1$1s</code>, it is not valid to advertise the 0.0.0.0 meta-address.%n" +

--- a/server/src/main/java/org/apache/kafka/server/config/KRaftConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/KRaftConfigs.java
@@ -35,29 +35,27 @@ import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 public class KRaftConfigs {
     /** KRaft mode configs */
     public static final String PROCESS_ROLES_CONFIG = "process.roles";
-    public static final String PROCESS_ROLES_DOC = "The roles that this process plays: 'broker', 'controller', or 'broker,controller' if it is both. " +
-            "This configuration is only applicable for clusters in KRaft (Kafka Raft) mode (instead of ZooKeeper). Leave this config undefined or empty for ZooKeeper clusters.";
-
+    public static final String PROCESS_ROLES_DOC = "The roles that this process plays: 'broker', 'controller', or 'broker,controller' if it is both. ";
+    
     public static final String INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_CONFIG = "initial.broker.registration.timeout.ms";
     public static final int INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_DEFAULT = 60000;
     public static final String INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_DOC = "When initially registering with the controller quorum, the number of milliseconds to wait before declaring failure and exiting the broker process.";
 
     public static final String BROKER_HEARTBEAT_INTERVAL_MS_CONFIG = "broker.heartbeat.interval.ms";
     public static final int BROKER_HEARTBEAT_INTERVAL_MS_DEFAULT = 2000;
-    public static final String BROKER_HEARTBEAT_INTERVAL_MS_DOC = "The length of time in milliseconds between broker heartbeats. Used when running in KRaft mode.";
+    public static final String BROKER_HEARTBEAT_INTERVAL_MS_DOC = "The length of time in milliseconds between broker heartbeats.";
 
     public static final String BROKER_SESSION_TIMEOUT_MS_CONFIG = "broker.session.timeout.ms";
     public static final int BROKER_SESSION_TIMEOUT_MS_DEFAULT = 9000;
-    public static final String BROKER_SESSION_TIMEOUT_MS_DOC = "The length of time in milliseconds that a broker lease lasts if no heartbeats are made. Used when running in KRaft mode.";
+    public static final String BROKER_SESSION_TIMEOUT_MS_DOC = "The length of time in milliseconds that a broker lease lasts if no heartbeats are made.";
 
 
     public static final String NODE_ID_CONFIG = "node.id";
     public static final int EMPTY_NODE_ID = -1;
-    public static final String NODE_ID_DOC = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty. " +
-            "This is required configuration when running in KRaft mode.";
+    public static final String NODE_ID_DOC = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty.";
 
     public static final String METADATA_LOG_DIR_CONFIG = "metadata.log.dir";
-    public static final String METADATA_LOG_DIR_DOC = "This configuration determines where we put the metadata log for clusters in KRaft mode. " +
+    public static final String METADATA_LOG_DIR_DOC = "This configuration determines where we put the metadata log. " +
             "If it is not set, the metadata log is placed in the first log directory from log.dirs.";
 
     public static final String METADATA_SNAPSHOT_MAX_INTERVAL_MS_CONFIG = "metadata.log.max.snapshot.interval.ms";
@@ -78,8 +76,7 @@ public class KRaftConfigs {
 
     public static final String CONTROLLER_LISTENER_NAMES_CONFIG = "controller.listener.names";
     public static final String CONTROLLER_LISTENER_NAMES_DOC = "A comma-separated list of the names of the listeners used by the controller. This is required " +
-            "if running in KRaft mode. When communicating with the controller quorum, the broker will always use the first listener in this list.\n " +
-            "Note: The ZooKeeper-based controller should not set this configuration.";
+            "in KRaft mode. When communicating with the controller quorum, the broker will always use the first listener in this list.";
 
     public static final String SASL_MECHANISM_CONTROLLER_PROTOCOL_CONFIG = "sasl.mechanism.controller.protocol";
     public static final String SASL_MECHANISM_CONTROLLER_PROTOCOL_DOC = "SASL mechanism used for communication with controllers. Default is GSSAPI.";

--- a/server/src/main/java/org/apache/kafka/server/config/KRaftConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/KRaftConfigs.java
@@ -52,7 +52,8 @@ public class KRaftConfigs {
 
     public static final String NODE_ID_CONFIG = "node.id";
     public static final int EMPTY_NODE_ID = -1;
-    public static final String NODE_ID_DOC = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty.";
+    public static final String NODE_ID_DOC = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty. " +
+            "This is required configuration when running in KRaft mode.";
 
     public static final String METADATA_LOG_DIR_CONFIG = "metadata.log.dir";
     public static final String METADATA_LOG_DIR_DOC = "This configuration determines where we put the metadata log. " +
@@ -76,7 +77,7 @@ public class KRaftConfigs {
 
     public static final String CONTROLLER_LISTENER_NAMES_CONFIG = "controller.listener.names";
     public static final String CONTROLLER_LISTENER_NAMES_DOC = "A comma-separated list of the names of the listeners used by the controller. This is required " +
-            "in KRaft mode. When communicating with the controller quorum, the broker will always use the first listener in this list.";
+            "when communicating with the controller quorum, the broker will always use the first listener in this list.";
 
     public static final String SASL_MECHANISM_CONTROLLER_PROTOCOL_CONFIG = "sasl.mechanism.controller.protocol";
     public static final String SASL_MECHANISM_CONTROLLER_PROTOCOL_DOC = "SASL mechanism used for communication with controllers. Default is GSSAPI.";

--- a/server/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -46,9 +46,7 @@ public class ServerConfigs {
 
     public static final String BROKER_ID_CONFIG = "broker.id";
     public static final int BROKER_ID_DEFAULT = -1;
-    public static final String BROKER_ID_DOC = "The broker id for this server. If unset, a unique broker id will be generated." +
-            "To avoid conflicts between ZooKeeper generated broker id's and user configured broker id's, generated broker ids " +
-            "start from " + RESERVED_BROKER_MAX_ID_CONFIG + " + 1.";
+    public static final String BROKER_ID_DOC = "The broker id for this server. If unset, a unique broker id will be generated.";
 
     public static final String MESSAGE_MAX_BYTES_CONFIG = "message.max.bytes";
     public static final String MESSAGE_MAX_BYTES_DOC = TopicConfig.MAX_MESSAGE_BYTES_DOC +

--- a/server/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -46,7 +46,7 @@ public class ServerConfigs {
 
     public static final String BROKER_ID_CONFIG = "broker.id";
     public static final int BROKER_ID_DEFAULT = -1;
-    public static final String BROKER_ID_DOC = "The broker id for this server. If unset, a unique broker id will be generated.";
+    public static final String BROKER_ID_DOC = "The broker id for this server.";
 
     public static final String MESSAGE_MAX_BYTES_CONFIG = "message.max.bytes";
     public static final String MESSAGE_MAX_BYTES_DOC = TopicConfig.MAX_MESSAGE_BYTES_DOC +


### PR DESCRIPTION
These document in my local machine.

![CleanShot 2024-12-29 at 20 56 35](https://github.com/user-attachments/assets/ae106dd9-1e8d-40ce-93ae-560fad9d254e)
![CleanShot 2024-12-29 at 20 57 35@2x](https://github.com/user-attachments/assets/05c38844-4b9b-4701-9dbe-3894910f3a79)
![CleanShot 2024-12-29 at 20 58 11@2x](https://github.com/user-attachments/assets/0e4734e1-c968-46b9-ac35-ef4c3eabccbe)
![CleanShot 2024-12-29 at 20 58 38@2x](https://github.com/user-attachments/assets/bd535a42-c571-44c6-8cd1-1f84b76ae999)
![CleanShot 2024-12-29 at 20 59 03@2x](https://github.com/user-attachments/assets/8742782b-02f6-4dcc-92b5-a0747fa11813)
![CleanShot 2024-12-29 at 20 59 30@2x](https://github.com/user-attachments/assets/60be4d90-ff72-4db2-a346-f2687ce8a9d4)
![CleanShot 2024-12-29 at 20 59 54@2x](https://github.com/user-attachments/assets/87159f46-4a26-4f1b-8960-7f5500c8140d)
![CleanShot 2024-12-29 at 21 00 21@2x](https://github.com/user-attachments/assets/371d4b5d-0f21-4817-b747-c8844ce9369f)
![CleanShot 2024-12-29 at 21 00 54@2x](https://github.com/user-attachments/assets/3d4d3d4d-508e-478b-89f0-9e6c84fb5058)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
