### PR TITLE
KAFKA-18371  TopicBasedRemoteLogMetadataManagerConfig exposes sensitive configuration data in logs

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -33,6 +34,7 @@ import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 import static org.apache.kafka.common.config.ConfigDef.Type.SHORT;
+import static org.apache.kafka.common.utils.ConfigUtils.configMapToRedactedString;
 
 /**
  * This class defines the configuration of topic based {@link org.apache.kafka.server.log.remote.storage.RemoteLogMetadataManager} implementation.
@@ -227,9 +229,9 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                 ", metadataTopicReplicationFactor=" + metadataTopicReplicationFactor +
                 ", initializationRetryMaxTimeoutMs=" + initializationRetryMaxTimeoutMs +
                 ", initializationRetryIntervalMs=" + initializationRetryIntervalMs +
-                ", commonProps=" + commonProps +
-                ", consumerProps=" + consumerProps +
-                ", producerProps=" + producerProps +
+                ", commonProps=" + configMapToRedactedString(commonProps, AdminClientConfig.configDef()) +
+                ", consumerProps=" + configMapToRedactedString(consumerProps, ConsumerConfig.configDef()) +
+                ", producerProps=" + configMapToRedactedString(producerProps, ProducerConfig.configDef()) +
                 '}';
     }
 


### PR DESCRIPTION
This change addresses issue described in [KAFKA-18371](https://issues.apache.org/jira/browse/KAFKA-18371)

It was noticed that sensitive information is printed as clear text while using default TopicBasedRemoteLogMetadataManagerConfig implementation. Example:
`
2024-12-20 14:52:56,805] INFO Successfully configured topic-based RLMM with config: TopicBasedRemoteLogMetadataManagerConfig{clientIdPrefix='__remote_log_metadata_client_6', metadataTopicPartitionsCount=50, consumeWaitMs=120000, metadataTopicRetentionMs=-1, metadataTopicReplicationFactor=3, initializationRetryMaxTimeoutMs=120000, initializationRetryIntervalMs=100, commonProps={request.timeout.ms=10000, ssl.client.auth=none, ssl.keystore.location=/etc/eystore.p12, bootstrap.servers=server1:9094, security.protocol=SASL_SSL, password=CLEARTEXT, ssl.truststore.location=/etc/cacerts, ssl.keystore.password=CLEARTEXT, sasl.mechanism=SCRAM-SHA-512, ssl.key.password=CLEARTEXT, sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="username" password="CLEARTEXT";, ssl.truststore.password=CLEARTEXT, …
`
- updated toString method of TopicBasedRemoteLogMetadataManagerConfig to check configuration keys for being sensitive
- Verified that produced logs has masking applied according to existing rules. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
