### PR TITLE
KAFKA-17915: Convert remaining Kafka Client system tests to use KRaft

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -53,12 +53,6 @@ def run_command(node, cmd, ssh_log_file):
             print(e, flush=True)
             raise
 
-def for_test(test_context):
-    default_version = 'dev'
-    arg_name = 'broker_version'
-    version_string = default_version if not test_context.injected_args else test_context.injected_args.get(arg_name, default_version)
-    return KafkaVersion(version_string)
-
 class ClientCompatibilityFeaturesTest(Test):
     """
     Tests clients for the presence or absence of specific features when communicating with brokers with various
@@ -77,7 +71,7 @@ class ClientCompatibilityFeaturesTest(Test):
             "partitions": 1, # Use only one partition to avoid worrying about ordering
             "replication-factor": 3
             }}
-        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics=self.topics, version=for_test(test_context))
+        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics=self.topics)
         # Always use the latest version of org.apache.kafka.tools.ClientCompatibilityTest
         # so store away the path to the DEV version before we set the Kafka version
         self.dev_script_path = self.kafka.path.script("kafka-run-class.sh", self.kafka.nodes[0])
@@ -133,6 +127,10 @@ class ClientCompatibilityFeaturesTest(Test):
     def run_compatibility_test(self, broker_version, metadata_quorum=quorum.zk):
         if self.zk:
             self.zk.start()
+        self.kafka.set_version(KafkaVersion(broker_version))
+        if metadata_quorum == quorum.isolated_kraft:
+            for node in self.kafka.controller_quorum.nodes:
+                node.version = KafkaVersion(broker_version)
         self.kafka.start()
         features = get_broker_features(broker_version)
         self.invoke_compatibility_program(features)

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -53,6 +53,11 @@ def run_command(node, cmd, ssh_log_file):
             print(e, flush=True)
             raise
 
+def for_test(test_context):
+    default_version = 'dev'
+    arg_name = 'broker_version'
+    version_string = default_version if not test_context.injected_args else test_context.injected_args.get(arg_name, default_version)
+    return KafkaVersion(version_string)
 
 class ClientCompatibilityFeaturesTest(Test):
     """
@@ -72,7 +77,7 @@ class ClientCompatibilityFeaturesTest(Test):
             "partitions": 1, # Use only one partition to avoid worrying about ordering
             "replication-factor": 3
             }}
-        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics=self.topics)
+        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics=self.topics, version=for_test(test_context))
         # Always use the latest version of org.apache.kafka.tools.ClientCompatibilityTest
         # so store away the path to the DEV version before we set the Kafka version
         self.dev_script_path = self.kafka.path.script("kafka-run-class.sh", self.kafka.nodes[0])
@@ -118,17 +123,16 @@ class ClientCompatibilityFeaturesTest(Test):
     @parametrize(broker_version=str(LATEST_3_0))
     @parametrize(broker_version=str(LATEST_3_1))
     @parametrize(broker_version=str(LATEST_3_2))
-    @parametrize(broker_version=str(LATEST_3_3))
-    @parametrize(broker_version=str(LATEST_3_4))
-    @parametrize(broker_version=str(LATEST_3_5))
-    @parametrize(broker_version=str(LATEST_3_6))
-    @parametrize(broker_version=str(LATEST_3_7))
-    @parametrize(broker_version=str(LATEST_3_8))
-    @parametrize(broker_version=str(LATEST_3_9))
+    @parametrize(broker_version=str(LATEST_3_3), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_4), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_5), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_6), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_7), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_8), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_9), metadata_quorum=quorum.isolated_kraft)
     def run_compatibility_test(self, broker_version, metadata_quorum=quorum.zk):
         if self.zk:
             self.zk.start()
-        self.kafka.set_version(KafkaVersion(broker_version))
         self.kafka.start()
         features = get_broker_features(broker_version)
         self.invoke_compatibility_program(features)

--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -27,12 +27,6 @@ from kafkatest.version import DEV_BRANCH, \
     LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
     LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, LATEST_3_7, LATEST_3_8, LATEST_3_9, KafkaVersion
 
-def for_test(test_context):
-    default_version = 'dev'
-    arg_name = 'broker_version'
-    version_string = default_version if not test_context.injected_args else test_context.injected_args.get(arg_name, default_version)
-    return KafkaVersion(version_string)
-
 class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     """
     These tests validate that we can use a new client to produce and consume from older brokers.
@@ -54,7 +48,6 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
                     "replication-factor": 2
                 }
             },
-            version=for_test(test_context)
         )
         self.num_partitions = 10
         self.timeout_sec = 60
@@ -93,6 +86,10 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     @parametrize(broker_version=str(LATEST_3_9), metadata_quorum=quorum.isolated_kraft)
     def test_produce_consume(self, broker_version, metadata_quorum=quorum.zk):
         print("running producer_consumer_compat with broker_version = %s" % broker_version, flush=True)
+        self.kafka.set_version(KafkaVersion(broker_version))
+        if metadata_quorum == quorum.isolated_kraft:
+            for node in self.kafka.controller_quorum.nodes:
+                node.version = KafkaVersion(broker_version)
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = self.kafka.security_protocol
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,

--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -27,6 +27,12 @@ from kafkatest.version import DEV_BRANCH, \
     LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, LATEST_2_8, \
     LATEST_3_0, LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, LATEST_3_6, LATEST_3_7, LATEST_3_8, LATEST_3_9, KafkaVersion
 
+def for_test(test_context):
+    default_version = 'dev'
+    arg_name = 'broker_version'
+    version_string = default_version if not test_context.injected_args else test_context.injected_args.get(arg_name, default_version)
+    return KafkaVersion(version_string)
+
 class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     """
     These tests validate that we can use a new client to produce and consume from older brokers.
@@ -38,9 +44,18 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
 
         self.topic = "test_topic"
         self.zk = ZookeeperService(test_context, num_nodes=3) if quorum.for_test(test_context) == quorum.zk else None
-        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic:{
-                                                                    "partitions": 10,
-                                                                    "replication-factor": 2}})
+        self.kafka = KafkaService(
+            test_context,
+            num_nodes=3,
+            zk=self.zk,
+            topics={
+                self.topic:{
+                    "partitions": 10,
+                    "replication-factor": 2
+                }
+            },
+            version=for_test(test_context)
+        )
         self.num_partitions = 10
         self.timeout_sec = 60
         self.producer_throughput = 1000
@@ -69,16 +84,15 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     @parametrize(broker_version=str(LATEST_3_0))
     @parametrize(broker_version=str(LATEST_3_1))
     @parametrize(broker_version=str(LATEST_3_2))
-    @parametrize(broker_version=str(LATEST_3_3))
-    @parametrize(broker_version=str(LATEST_3_4))
-    @parametrize(broker_version=str(LATEST_3_5))
-    @parametrize(broker_version=str(LATEST_3_6))
-    @parametrize(broker_version=str(LATEST_3_7))
-    @parametrize(broker_version=str(LATEST_3_8))
-    @parametrize(broker_version=str(LATEST_3_9))
+    @parametrize(broker_version=str(LATEST_3_3), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_4), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_5), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_6), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_7), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_8), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(broker_version=str(LATEST_3_9), metadata_quorum=quorum.isolated_kraft)
     def test_produce_consume(self, broker_version, metadata_quorum=quorum.zk):
         print("running producer_consumer_compat with broker_version = %s" % broker_version, flush=True)
-        self.kafka.set_version(KafkaVersion(broker_version))
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = self.kafka.security_protocol
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,

--- a/tests/kafkatest/tests/client/quota_test.py
+++ b/tests/kafkatest/tests/client/quota_test.py
@@ -17,8 +17,7 @@ from ducktape.tests.test import Test
 from ducktape.mark import matrix, parametrize
 from ducktape.mark.resource import cluster
 
-from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.services.kafka import KafkaService
+from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.performance import ProducerPerformanceService
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.version import DEV_BRANCH
@@ -108,8 +107,7 @@ class QuotaTest(Test):
         self.num_records = 50000
         self.record_size = 3000
 
-        self.zk = ZookeeperService(test_context, num_nodes=1)
-        self.kafka = KafkaService(test_context, num_nodes=1, zk=self.zk,
+        self.kafka = KafkaService(test_context, num_nodes=1, zk=None,
                                   security_protocol='SSL', authorizer_class_name='',
                                   interbroker_security_protocol='SSL',
                                   topics={self.topic: {'partitions': 6, 'replication-factor': 1, 'configs': {'min.insync.replicas': 1}}},
@@ -119,17 +117,14 @@ class QuotaTest(Test):
         self.num_producers = 1
         self.num_consumers = 2
 
-    def setUp(self):
-        self.zk.start()
-
     def min_cluster_size(self):
         """Override this since we're adding services outside of the constructor"""
         return super(QuotaTest, self).min_cluster_size() + self.num_producers + self.num_consumers
 
     @cluster(num_nodes=5)
-    @matrix(quota_type=[QuotaConfig.CLIENT_ID, QuotaConfig.USER, QuotaConfig.USER_CLIENT], override_quota=[True, False])
-    @parametrize(quota_type=QuotaConfig.CLIENT_ID, consumer_num=2)
-    def test_quota(self, quota_type, override_quota=True, producer_num=1, consumer_num=1):
+    @matrix(quota_type=[QuotaConfig.CLIENT_ID, QuotaConfig.USER, QuotaConfig.USER_CLIENT], override_quota=[True, False], metadata_quorum=[quorum.isolated_kraft])
+    @parametrize(quota_type=QuotaConfig.CLIENT_ID, consumer_num=2, metadata_quorum=quorum.isolated_kraft)
+    def test_quota(self, quota_type, override_quota=True, producer_num=1, consumer_num=1, metadata_quorum=quorum.isolated_kraft):
         self.kafka.start()
 
         self.quota_config = QuotaConfig(quota_type, override_quota, self.kafka)

--- a/tests/kafkatest/tests/client/quota_test.py
+++ b/tests/kafkatest/tests/client/quota_test.py
@@ -76,10 +76,9 @@ class QuotaConfig(object):
                 self.configure_quota(kafka, QuotaConfig.LARGE_QUOTA, QuotaConfig.LARGE_QUOTA, ['clients', None])
 
     def configure_quota(self, kafka, producer_byte_rate, consumer_byte_rate, entity_args):
-        force_use_zk_connection = not kafka.all_nodes_configs_command_uses_bootstrap_server()
         node = kafka.nodes[0]
         cmd = "%s --alter --add-config producer_byte_rate=%d,consumer_byte_rate=%d" % \
-              (kafka.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection), producer_byte_rate, consumer_byte_rate)
+              (kafka.kafka_configs_cmd_with_optional_security_settings(node, False), producer_byte_rate, consumer_byte_rate)
         cmd += " --entity-type " + entity_args[0] + self.entity_name_opt(entity_args[1])
         if len(entity_args) > 2:
             cmd += " --entity-type " + entity_args[2] + self.entity_name_opt(entity_args[3])


### PR DESCRIPTION
Convert `tests/kafkatest/tests/client/client_compatibility_features_test.py`, `tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py`, and  
`tests/kafkatest/tests/client/quota_test.py`to use KRaft.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
