### PR TITLE
MINOR: fix document bash should use `.sh` and fix the unknown file `controller_static.properties`

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3753,7 +3753,7 @@ Feature: metadata.version       SupportedMinVersion: 3.0-IV1    SupportedMaxVers
   this flag when formatting brokers -- only when formatting controllers.)<p>
 
 <pre><code class="language-bash">
-  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller_static.properties
+  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
   Cannot set kraft.version to 1 unless KIP-853 configuration is present. Try removing the --feature flag for kraft.version.
 </code></pre><p>
 

--- a/docs/streams/developer-guide/app-reset-tool.html
+++ b/docs/streams/developer-guide/app-reset-tool.html
@@ -67,7 +67,7 @@
             <h2>Step 1: Run the application reset tool<a class="headerlink" href="#step-1-run-the-application-reset-tool" title="Permalink to this headline"></a></h2>
             <p>Invoke the application reset tool from the command line</p>
             <p>Warning! This tool makes irreversible changes to your application. It is strongly recommended that you run this once with <code class="docutils literal"><span class="pre">--dry-run</span></code> to preview your changes before making them.</p>
-            <pre><code class="language-bash">$ bin/kafka-streams-application-reset</code></pre>
+            <pre><code class="language-bash">$ bin/kafka-streams-application-reset.sh</code></pre>
             <p>The tool accepts the following parameters:</p>
             <pre><code class="language-text">Option (* = required)                 Description
 ---------------------                 -----------


### PR DESCRIPTION
In document the shell command base dir is in Kafka, so we should make all command is `bin/<tools>.sh`
In kafka repo doesn't have `controller_static.properties` this file, this would misunderstanding user, I change to use controller.properties

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
