### PR TITLE
Use `instanceof` pattern to avoid explicit cast

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
@@ -160,8 +160,7 @@ public class SchemaProjector {
         assert source.type().isPrimitive();
         assert target.type().isPrimitive();
         Object result;
-        if (isPromotable(source.type(), target.type()) && record instanceof Number) {
-            Number numberRecord = (Number) record;
+        if (isPromotable(source.type(), target.type()) && record instanceof Number numberRecord) {
             switch (target.type()) {
                 case INT8:
                     result = numberRecord.byteValue();

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -584,8 +584,7 @@ public class Values {
             SchemaAndValue parsed = parseString(value.toString());
             value = parsed.value();
         }
-        if (value instanceof java.util.Date) {
-            java.util.Date date = (java.util.Date) value;
+        if (value instanceof java.util.Date date) {
             if (fromSchema != null) {
                 String fromSchemaName = fromSchema.name();
                 if (Date.LOGICAL_NAME.equals(fromSchemaName)) {
@@ -655,8 +654,7 @@ public class Values {
      */
     protected static long asLong(Object value, Schema fromSchema, Throwable error) {
         try {
-            if (value instanceof Number) {
-                Number number = (Number) value;
+            if (value instanceof Number number) {
                 return number.longValue();
             }
             if (value instanceof String) {
@@ -695,8 +693,7 @@ public class Values {
      */
     protected static double asDouble(Object value, Schema schema, Throwable error) {
         try {
-            if (value instanceof Number) {
-                Number number = (Number) value;
+            if (value instanceof Number number) {
                 return number.doubleValue();
             }
             if (value instanceof String) {
@@ -733,18 +730,15 @@ public class Values {
         } else if (value instanceof ByteBuffer) {
             byte[] bytes = Utils.readBytes((ByteBuffer) value);
             append(sb, bytes, embedded);
-        } else if (value instanceof List) {
-            List<?> list = (List<?>) value;
+        } else if (value instanceof List<?> list) {
             sb.append('[');
             appendIterable(sb, list.iterator());
             sb.append(']');
-        } else if (value instanceof Map) {
-            Map<?, ?> map = (Map<?, ?>) value;
+        } else if (value instanceof Map<?, ?> map) {
             sb.append('{');
             appendIterable(sb, map.entrySet().iterator());
             sb.append('}');
-        } else if (value instanceof Struct) {
-            Struct struct = (Struct) value;
+        } else if (value instanceof Struct struct) {
             Schema schema = struct.schema();
             boolean first = true;
             sb.append('{');
@@ -759,13 +753,11 @@ public class Values {
                 append(sb, struct.get(field), true);
             }
             sb.append('}');
-        } else if (value instanceof Map.Entry) {
-            Map.Entry<?, ?> entry = (Map.Entry<?, ?>) value;
+        } else if (value instanceof Map.Entry<?, ?> entry) {
             append(sb, entry.getKey(), true);
             sb.append(':');
             append(sb, entry.getValue(), true);
-        } else if (value instanceof java.util.Date) {
-            java.util.Date dateValue = (java.util.Date) value;
+        } else if (value instanceof java.util.Date dateValue) {
             String formatted = dateFormatFor(dateValue).format(dateValue);
             sb.append(formatted);
         } else {

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeader.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeader.java
@@ -81,8 +81,7 @@ class ConnectHeader implements Header {
         if (obj == this) {
             return true;
         }
-        if (obj instanceof Header) {
-            Header that = (Header) obj;
+        if (obj instanceof Header that) {
             return Objects.equals(this.key, that.key()) && Objects.equals(this.schema(), that.schema()) && Objects.equals(this.value(),
                                                                                                                           that.value());
         }

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -55,8 +55,7 @@ public class ConnectHeaders implements Headers {
         if (original == null) {
             return;
         }
-        if (original instanceof ConnectHeaders) {
-            ConnectHeaders originalHeaders = (ConnectHeaders) original;
+        if (original instanceof ConnectHeaders originalHeaders) {
             if (!originalHeaders.isEmpty()) {
                 headers = new LinkedList<>(originalHeaders.headers);
             }
@@ -343,8 +342,7 @@ public class ConnectHeaders implements Headers {
         if (obj == this) {
             return true;
         }
-        if (obj instanceof Headers) {
-            Headers that = (Headers) obj;
+        if (obj instanceof Headers that) {
             Iterator<Header> thisIter = this.iterator();
             Iterator<Header> thatIter = that.iterator();
             while (thisIter.hasNext() && thatIter.hasNext()) {

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -149,10 +149,9 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
         LOGICAL_CONVERTERS.put(Decimal.LOGICAL_NAME, new LogicalTypeConverter() {
             @Override
             public JsonNode toJson(final Schema schema, final Object value, final JsonConverterConfig config) {
-                if (!(value instanceof BigDecimal))
+                if (!(value instanceof BigDecimal decimal))
                     throw new DataException("Invalid type for Decimal, expected BigDecimal but was " + value.getClass());
 
-                final BigDecimal decimal = (BigDecimal) value;
                 switch (config.decimalFormat()) {
                     case NUMERIC:
                         return JSON_NODE_FACTORY.numberNode(decimal);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncWriter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncWriter.java
@@ -186,8 +186,7 @@ class OffsetSyncWriter implements AutoCloseable {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof PartitionState)) return false;
-            PartitionState that = (PartitionState) o;
+            if (!(o instanceof PartitionState that)) return false;
             return previousUpstreamOffset == that.previousUpstreamOffset &&
                     previousDownstreamOffset == that.previousDownstreamOffset &&
                     lastSyncDownstreamOffset == that.lastSyncDownstreamOffset &&

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -222,8 +222,7 @@ public class ConnectMetrics {
         public boolean equals(Object obj) {
             if (obj == this)
                 return true;
-            if (obj instanceof MetricGroupId) {
-                MetricGroupId that = (MetricGroupId) obj;
+            if (obj instanceof MetricGroupId that) {
                 return this.groupName.equals(that.groupName) && this.tags.equals(that.tags);
             }
             return false;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -584,11 +584,10 @@ public class ConnectorConfig extends AbstractConfig {
 
             LinkedHashSet<?> uniqueAliases = new LinkedHashSet<>((List<?>) aliases);
             for (Object o : uniqueAliases) {
-                if (!(o instanceof String)) {
+                if (!(o instanceof String alias)) {
                     throw new ConfigException("Item in " + aliasConfig + " property is not of "
                             + "type String");
                 }
-                String alias = (String) o;
                 final String prefix = aliasConfig + "." + alias + ".";
                 final String group = aliasGroup + ": " + alias;
                 int orderInGroup = 0;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
@@ -248,10 +248,9 @@ public final class SourceConnectorConfig extends ConnectorConfig {
         short defaultGroupReplicationFactor = defaultGroupConfig.getShort(defaultGroupPrefix + REPLICATION_FACTOR_CONFIG);
         int defaultGroupPartitions = defaultGroupConfig.getInt(defaultGroupPrefix + PARTITIONS_CONFIG);
         topicCreationGroups.stream().distinct().forEach(group -> {
-            if (!(group instanceof String)) {
+            if (!(group instanceof String alias)) {
                 throw new ConfigException("Item in " + TOPIC_CREATION_GROUPS_CONFIG + " property is not of type String");
             }
-            String alias = (String) group;
             String prefix = TOPIC_CREATION_PREFIX + alias + ".";
             String configGroup = TOPIC_CREATION_GROUP + ": " + alias;
             newDef.embed(prefix, configGroup, 0,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TopicStatus.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TopicStatus.java
@@ -93,10 +93,9 @@ public class TopicStatus {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TopicStatus)) {
+        if (!(o instanceof TopicStatus that)) {
             return false;
         }
-        TopicStatus that = (TopicStatus) o;
         return task == that.task &&
                 discoverTimestamp == that.discoverTimestamp &&
                 topic.equals(that.topic) &&

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2193,8 +2193,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     boolean isPossibleExpiredKeyException(long initialRequestTime, Throwable error) {
-        if (error instanceof ConnectRestException) {
-            ConnectRestException connectError = (ConnectRestException) error;
+        if (error instanceof ConnectRestException connectError) {
             return connectError.statusCode() == Response.Status.FORBIDDEN.getStatusCode()
                 && initialRequestTime + TimeUnit.MINUTES.toMillis(1) >= time.milliseconds();
         }
@@ -2565,9 +2564,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof DistributedHerderRequest))
+            if (!(o instanceof DistributedHerderRequest other))
                 return false;
-            DistributedHerderRequest other = (DistributedHerderRequest) o;
             return compareTo(other) == 0;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -440,8 +440,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof LeaderState)) return false;
-            LeaderState that = (LeaderState) o;
+            if (!(o instanceof LeaderState that)) return false;
             return Objects.equals(allMembers, that.allMembers)
                     && Objects.equals(connectorOwners, that.connectorOwners)
                     && Objects.equals(taskOwners, that.taskOwners);
@@ -644,10 +643,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof WorkerLoad)) {
+            if (!(o instanceof WorkerLoad that)) {
                 return false;
             }
-            WorkerLoad that = (WorkerLoad) o;
             return worker.equals(that.worker) &&
                     connectors.equals(that.connectors) &&
                     tasks.equals(that.tasks);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
@@ -103,10 +103,9 @@ public class PluginDesc<T> implements Comparable<PluginDesc<?>> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof PluginDesc)) {
+        if (!(o instanceof PluginDesc<?> that)) {
             return false;
         }
-        PluginDesc<?> that = (PluginDesc<?>) o;
         return Objects.equals(klass, that.klass) &&
                 Objects.equals(version, that.version) &&
                 type == that.type;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -675,8 +675,7 @@ public class Plugins {
         }
         try (LoaderSwap loaderSwap = withClassLoader(klass.getClassLoader())) {
             plugin = newPlugin(klass);
-            if (plugin instanceof Versioned) {
-                Versioned versionedPlugin = (Versioned) plugin;
+            if (plugin instanceof Versioned versionedPlugin) {
                 if (Utils.isBlank(versionedPlugin.version())) {
                     throw new ConnectException("Version not defined for '" + klassName + "'");
                 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
@@ -307,11 +307,10 @@ public abstract class RestServerConfig extends AbstractConfig {
     private static class ListenersValidator implements ConfigDef.Validator {
         @Override
         public void ensureValid(String name, Object value) {
-            if (!(value instanceof List)) {
+            if (!(value instanceof List<?> items)) {
                 throw new ConfigException("Invalid value type for listeners (expected list of URLs , ex: http://localhost:8080,https://localhost:8443).");
             }
 
-            List<?> items = (List<?>) value;
             if (items.isEmpty()) {
                 throw new ConfigException("Invalid value for listeners, at least one URL is expected, ex: http://localhost:8080,https://localhost:8443.");
             }
@@ -339,11 +338,10 @@ public abstract class RestServerConfig extends AbstractConfig {
                 return;
             }
 
-            if (!(value instanceof List)) {
+            if (!(value instanceof List<?> items)) {
                 throw new ConfigException("Invalid value type for admin.listeners (expected list).");
             }
 
-            List<?> items = (List<?>) value;
             if (items.isEmpty()) {
                 return;
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffset.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffset.java
@@ -64,10 +64,9 @@ public class ConnectorOffset {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof ConnectorOffset)) {
+        if (!(obj instanceof ConnectorOffset that)) {
             return false;
         }
-        ConnectorOffset that = (ConnectorOffset) obj;
         return Objects.equals(this.partition, that.partition) &&
                 Objects.equals(this.offset, that.offset);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
@@ -77,10 +77,9 @@ public class ConnectorOffsets {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof ConnectorOffsets)) {
+        if (!(obj instanceof ConnectorOffsets that)) {
             return false;
         }
-        ConnectorOffsets that = (ConnectorOffsets) obj;
         return Objects.equals(this.offsets, that.offsets);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorStateInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorStateInfo.java
@@ -124,9 +124,8 @@ public class ConnectorStateInfo {
         public boolean equals(Object o) {
             if (o == this)
                 return true;
-            if (!(o instanceof TaskState))
+            if (!(o instanceof TaskState other))
                 return false;
-            TaskState other = (TaskState) o;
             return compareTo(other) == 0;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/Message.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/Message.java
@@ -47,10 +47,9 @@ public class Message {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Message)) {
+        if (!(obj instanceof Message that)) {
             return false;
         }
-        Message that = (Message) obj;
         return Objects.equals(this.message, that.message);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
@@ -42,8 +42,7 @@ public class ConnectExceptionMapper implements ExceptionMapper<Exception> {
     public Response toResponse(Exception exception) {
         log.debug("Uncaught exception in REST call to /{}", uriInfo.getPath(), exception);
 
-        if (exception instanceof ConnectRestException) {
-            ConnectRestException restException = (ConnectRestException) exception;
+        if (exception instanceof ConnectRestException restException) {
             return Response.status(restException.statusCode())
                     .entity(new ErrorMessage(restException.errorCode(), restException.getMessage()))
                     .build();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -624,9 +624,8 @@ public final class StandaloneHerder extends AbstractHerder {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof StandaloneHerderRequest))
+            if (!(o instanceof StandaloneHerderRequest other))
                 return false;
-            StandaloneHerderRequest other = (StandaloneHerderRequest) o;
             return seq == other.seq;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -109,7 +109,7 @@ public class OffsetUtils {
             return;
         }
 
-        if (!(keyList.get(0) instanceof String)) {
+        if (!(keyList.get(0) instanceof String connectorName)) {
             log.warn("Ignoring offset partition key with an unexpected format for the first element in the partition key list. " +
                     "Expected type: {}, actual type: {}", String.class.getName(), className(keyList.get(0)));
             return;
@@ -123,7 +123,6 @@ public class OffsetUtils {
             return;
         }
 
-        String connectorName = (String) keyList.get(0);
         Map<String, Object> partition = (Map<String, Object>) keyList.get(1);
         connectorPartitions.computeIfAbsent(connectorName, ignored -> new HashSet<>());
         if (offsetValue == null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicCreationGroup.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicCreationGroup.java
@@ -122,10 +122,9 @@ public class TopicCreationGroup {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TopicCreationGroup)) {
+        if (!(o instanceof TopicCreationGroup that)) {
             return false;
         }
-        TopicCreationGroup that = (TopicCreationGroup) o;
         return Objects.equals(name, that.name)
                 && numPartitions == that.numPartitions
                 && replicationFactor == that.replicationFactor

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -1777,8 +1777,7 @@ public class WorkerTest {
 
         List<MetricsReporter> list = worker.metrics().metrics().reporters();
         for (MetricsReporter reporter : list) {
-            if (reporter instanceof MockMetricsReporter) {
-                MockMetricsReporter mockMetricsReporter = (MockMetricsReporter) reporter;
+            if (reporter instanceof MockMetricsReporter mockMetricsReporter) {
                 //verify connect cluster is set in MetricsContext
                 assertEquals(CLUSTER_ID, mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
             }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
@@ -78,9 +78,8 @@ public class WorkerGroupMemberTest {
         boolean foundJmxReporter = false;
         assertEquals(2, member.metrics().reporters().size());
         for (MetricsReporter reporter : member.metrics().reporters()) {
-            if (reporter instanceof MockConnectMetrics.MockMetricsReporter) {
+            if (reporter instanceof MockConnectMetrics.MockMetricsReporter mockMetricsReporter) {
                 foundMockReporter = true;
-                MockConnectMetrics.MockMetricsReporter mockMetricsReporter = (MockConnectMetrics.MockMetricsReporter) reporter;
                 assertEquals("cluster-1", mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
                 assertEquals("group-1", mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_GROUP_ID));
             }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
@@ -114,10 +114,9 @@ public class WorkerHandle {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof WorkerHandle)) {
+        if (!(o instanceof WorkerHandle that)) {
             return false;
         }
-        WorkerHandle that = (WorkerHandle) o;
         return Objects.equals(workerName, that.workerName) &&
                 Objects.equals(worker, that.worker);
     }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -386,14 +386,11 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     }
 
     private static String castToString(Object value) {
-        if (value instanceof java.util.Date) {
-            java.util.Date dateValue = (java.util.Date) value;
+        if (value instanceof java.util.Date dateValue) {
             return Values.dateFormatFor(dateValue).format(dateValue);
-        } else if (value instanceof ByteBuffer) {
-            ByteBuffer byteBuffer = (ByteBuffer) value;
+        } else if (value instanceof ByteBuffer byteBuffer) {
             return Base64.getEncoder().encodeToString(Utils.readBytes(byteBuffer));
-        } else if (value instanceof byte[]) {
-            byte[] rawBytes = (byte[]) value;
+        } else if (value instanceof byte[] rawBytes) {
             return Base64.getEncoder().encodeToString(rawBytes);
         } else {
             return value.toString();

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
@@ -179,8 +179,7 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
      * a copy of the key or value object with updated references to the new schema.
      */
     protected Object updateSchemaIn(Object keyOrValue, Schema updatedSchema) {
-        if (keyOrValue instanceof Struct) {
-            Struct origStruct = (Struct) keyOrValue;
+        if (keyOrValue instanceof Struct origStruct) {
             Struct newStruct = new Struct(updatedSchema);
             for (Field field : updatedSchema.fields()) {
                 // assume both schemas have exact same fields with same names and schemas ...

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
@@ -164,9 +164,8 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
         TRANSLATORS.put(TYPE_UNIX, new TimestampTranslator() {
             @Override
             public Date toRaw(Config config, Object orig) {
-                if (!(orig instanceof Long))
+                if (!(orig instanceof Long unixTime))
                     throw new DataException("Expected Unix timestamp to be a Long, but found " + orig.getClass());
-                Long unixTime = (Long) orig;
                 switch (config.unixPrecision) {
                     case UNIX_PRECISION_SECONDS:
                         return Timestamp.toLogical(Timestamp.SCHEMA, TimeUnit.SECONDS.toMillis(unixTime));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -160,14 +160,12 @@ class RangeSet implements Set<Integer> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Set)) return false;
+        if (!(o instanceof Set<?> otherSet)) return false;
 
-        if (o instanceof RangeSet) {
-            RangeSet other = (RangeSet) o;
+        if (o instanceof RangeSet other) {
             return this.from == other.from && this.to == other.to;
         }
 
-        Set<?> otherSet = (Set<?>) o;
         if (otherSet.size() != this.size()) return false;
 
         for (int i = from; i < to; i++) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/TopicIds.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/TopicIds.java
@@ -190,8 +190,7 @@ public class TopicIds implements Set<Uuid> {
 
     @Override
     public boolean contains(Object o) {
-        if (o instanceof Uuid) {
-            Uuid topicId = (Uuid) o;
+        if (o instanceof Uuid topicId) {
             String topicName = resolver.name(topicId);
             if (topicName == null) return false;
             return topicNames.contains(topicName);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/UnionSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/UnionSet.java
@@ -188,9 +188,8 @@ public class UnionSet<T> implements Set<T> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Set)) return false;
+        if (!(o instanceof Set<?> set)) return false;
 
-        Set<?> set = (Set<?>) o;
         if (set.size() != size()) return false;
         return containsAll(set);
     }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ImplicitLinkedHashCollectionBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ImplicitLinkedHashCollectionBenchmark.java
@@ -83,8 +83,7 @@ public class ImplicitLinkedHashCollectionBenchmark {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof TestElement)) return false;
-            TestElement other = (TestElement) o;
+            if (!(o instanceof TestElement other)) return false;
             return value.equals(other.value);
         }
     }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
@@ -419,8 +419,7 @@ public class TestPurgatoryPerformance {
 
         @Override
         public int compareTo(Delayed o) {
-            if (o instanceof Scheduled) {
-                Scheduled other = (Scheduled) o;
+            if (o instanceof Scheduled other) {
                 if (operation.completesAt < other.operation.completesAt)
                     return -1;
                 else if (operation.completesAt > other.operation.completesAt)

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerControlStates.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerControlStates.java
@@ -44,8 +44,7 @@ class BrokerControlStates {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof BrokerControlStates)) return false;
-        BrokerControlStates other = (BrokerControlStates) o;
+        if (!(o instanceof BrokerControlStates other)) return false;
         return other.current == current && other.next == next;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerIdAndEpoch.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerIdAndEpoch.java
@@ -41,8 +41,7 @@ public class BrokerIdAndEpoch {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || (!(o instanceof BrokerIdAndEpoch))) return false;
-        BrokerIdAndEpoch other = (BrokerIdAndEpoch) o;
+        if (o == null || (!(o instanceof BrokerIdAndEpoch other))) return false;
         return id == other.id && epoch == other.epoch;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentReplicas.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentReplicas.java
@@ -152,8 +152,7 @@ class PartitionReassignmentReplicas {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PartitionReassignmentReplicas)) return false;
-        PartitionReassignmentReplicas other = (PartitionReassignmentReplicas) o;
+        if (!(o instanceof PartitionReassignmentReplicas other)) return false;
         return removing.equals(other.removing) &&
             adding.equals(other.adding) &&
             replicas.equals(other.replicas);

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
@@ -86,8 +86,7 @@ class PartitionReassignmentRevert {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PartitionReassignmentRevert)) return false;
-        PartitionReassignmentRevert other = (PartitionReassignmentRevert) o;
+        if (!(o instanceof PartitionReassignmentRevert other)) return false;
         return replicas.equals(other.replicas) &&
             isr.equals(other.isr) &&
             unclean == other.unclean;

--- a/metadata/src/main/java/org/apache/kafka/image/AclsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/AclsImage.java
@@ -69,8 +69,7 @@ public final class AclsImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof AclsImage)) return false;
-        AclsImage other = (AclsImage) o;
+        if (!(o instanceof AclsImage other)) return false;
         return acls.equals(other.acls);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -102,8 +102,7 @@ public final class ClientQuotaImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ClientQuotaImage)) return false;
-        ClientQuotaImage other = (ClientQuotaImage) o;
+        if (!(o instanceof ClientQuotaImage other)) return false;
         return quotas.equals(other.quotas);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
@@ -176,8 +176,7 @@ public final class ClientQuotasImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ClientQuotasImage)) return false;
-        ClientQuotasImage other = (ClientQuotasImage) o;
+        if (!(o instanceof ClientQuotasImage other)) return false;
         return entities.equals(other.entities);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
@@ -100,8 +100,7 @@ public final class ClusterImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ClusterImage)) return false;
-        ClusterImage other = (ClusterImage) o;
+        if (!(o instanceof ClusterImage other)) return false;
         return brokers.equals(other.brokers) &&
             controllers.equals(other.controllers);
     }

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
@@ -85,8 +85,7 @@ public final class ConfigurationImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ConfigurationImage)) return false;
-        ConfigurationImage other = (ConfigurationImage) o;
+        if (!(o instanceof ConfigurationImage other)) return false;
         return data.equals(other.data);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
@@ -84,8 +84,7 @@ public final class ConfigurationsImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ConfigurationsImage)) return false;
-        ConfigurationsImage other = (ConfigurationsImage) o;
+        if (!(o instanceof ConfigurationsImage other)) return false;
         return data.equals(other.data);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
@@ -116,8 +116,7 @@ public final class FeaturesImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof FeaturesImage)) return false;
-        FeaturesImage other = (FeaturesImage) o;
+        if (!(o instanceof FeaturesImage other)) return false;
         return finalizedVersions.equals(other.finalizedVersions) &&
             metadataVersion.equals(other.metadataVersion);
     }

--- a/metadata/src/main/java/org/apache/kafka/image/ProducerIdsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ProducerIdsImage.java
@@ -61,8 +61,7 @@ public final class ProducerIdsImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ProducerIdsImage)) return false;
-        ProducerIdsImage other = (ProducerIdsImage) o;
+        if (!(o instanceof ProducerIdsImage other)) return false;
         return nextProducerId == other.nextProducerId;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -74,8 +74,7 @@ public final class TopicImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TopicImage)) return false;
-        TopicImage other = (TopicImage) o;
+        if (!(o instanceof TopicImage other)) return false;
         return name.equals(other.name) &&
             id.equals(other.id) &&
             partitions.equals(other.partitions);

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
@@ -87,8 +87,7 @@ public final class TopicsImage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TopicsImage)) return false;
-        TopicsImage other = (TopicsImage) o;
+        if (!(o instanceof TopicsImage other)) return false;
         return topicsById.equals(other.topicsById) &&
             topicsByName.equals(other.topicsByName);
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerHeartbeatReply.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerHeartbeatReply.java
@@ -74,8 +74,7 @@ public class BrokerHeartbeatReply {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof BrokerHeartbeatReply)) return false;
-        BrokerHeartbeatReply other = (BrokerHeartbeatReply) o;
+        if (!(o instanceof BrokerHeartbeatReply other)) return false;
         return other.isCaughtUp == isCaughtUp &&
             other.isFenced == isFenced &&
             other.inControlledShutdown == inControlledShutdown &&

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -342,8 +342,7 @@ public class BrokerRegistration {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof BrokerRegistration)) return false;
-        BrokerRegistration other = (BrokerRegistration) o;
+        if (!(o instanceof BrokerRegistration other)) return false;
         return other.id == id &&
             other.epoch == epoch &&
             other.incarnationId.equals(incarnationId) &&

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistrationReply.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistrationReply.java
@@ -38,8 +38,7 @@ public class BrokerRegistrationReply {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof BrokerRegistrationReply)) return false;
-        BrokerRegistrationReply other = (BrokerRegistrationReply) o;
+        if (!(o instanceof BrokerRegistrationReply other)) return false;
         return other.epoch == epoch;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/ControllerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/ControllerRegistration.java
@@ -203,8 +203,7 @@ public class ControllerRegistration {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ControllerRegistration)) return false;
-        ControllerRegistration other = (ControllerRegistration) o;
+        if (!(o instanceof ControllerRegistration other)) return false;
         return other.id == id &&
             other.incarnationId.equals(incarnationId) &&
             other.zkMigrationReady == zkMigrationReady &&

--- a/metadata/src/main/java/org/apache/kafka/metadata/FinalizedControllerFeatures.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/FinalizedControllerFeatures.java
@@ -63,8 +63,7 @@ public class FinalizedControllerFeatures {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof FinalizedControllerFeatures)) return false;
-        FinalizedControllerFeatures other = (FinalizedControllerFeatures) o;
+        if (!(o instanceof FinalizedControllerFeatures other)) return false;
         return featureMap.equals(other.featureMap) && epoch == other.epoch;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -432,8 +432,7 @@ public class PartitionRegistration {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PartitionRegistration)) return false;
-        PartitionRegistration other = (PartitionRegistration) o;
+        if (!(o instanceof PartitionRegistration other)) return false;
         return Arrays.equals(replicas, other.replicas) &&
             Arrays.equals(directories, other.directories) &&
             Arrays.equals(isr, other.isr) &&

--- a/metadata/src/main/java/org/apache/kafka/metadata/VersionRange.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/VersionRange.java
@@ -70,8 +70,7 @@ public class VersionRange {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof VersionRange)) return false;
-        VersionRange other = (VersionRange) o;
+        if (!(o instanceof VersionRange other)) return false;
         return other.min == min && other.max == max;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapMetadata.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapMetadata.java
@@ -97,8 +97,7 @@ public class BootstrapMetadata {
     }
 
     public static Optional<MetadataVersion> recordToMetadataVersion(ApiMessage record) {
-        if (record instanceof FeatureLevelRecord) {
-            FeatureLevelRecord featureLevel = (FeatureLevelRecord) record;
+        if (record instanceof FeatureLevelRecord featureLevel) {
             if (featureLevel.name().equals(MetadataVersion.FEATURE_NAME)) {
                 return Optional.of(MetadataVersion.fromFeatureLevel(featureLevel.featureLevel()));
             }
@@ -137,8 +136,7 @@ public class BootstrapMetadata {
     public short featureLevel(String featureName) {
         short result = 0;
         for (ApiMessageAndVersion record : records) {
-            if (record.message() instanceof FeatureLevelRecord) {
-                FeatureLevelRecord message = (FeatureLevelRecord) record.message();
+            if (record.message() instanceof FeatureLevelRecord message) {
                 if (message.name().equals(featureName)) {
                     result = message.featureLevel();
                 }
@@ -151,8 +149,7 @@ public class BootstrapMetadata {
         List<ApiMessageAndVersion> newRecords = new ArrayList<>();
         int i = 0;
         while (i < records.size()) {
-            if (records.get(i).message() instanceof FeatureLevelRecord) {
-                FeatureLevelRecord record = (FeatureLevelRecord) records.get(i).message();
+            if (records.get(i).message() instanceof FeatureLevelRecord record) {
                 if (record.name().equals(featureName)) {
                     FeatureLevelRecord newRecord = record.duplicate();
                     newRecord.setFeatureLevel(level);

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -43,8 +43,7 @@ public class TopicAssignment {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TopicAssignment)) return false;
-        TopicAssignment other = (TopicAssignment) o;
+        if (!(o instanceof TopicAssignment other)) return false;
         return assignments.equals(other.assignments);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/UsableBroker.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/UsableBroker.java
@@ -54,8 +54,7 @@ public class UsableBroker {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof UsableBroker)) return false;
-        UsableBroker other = (UsableBroker) o;
+        if (!(o instanceof UsableBroker other)) return false;
         return other.id == id && other.rack.equals(rack) && other.fenced == fenced;
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
@@ -276,8 +276,7 @@ public class RecordTestUtils {
     public static void deepSortRecords(Object o) throws Exception {
         if (o == null) {
             return;
-        } else if (o instanceof List) {
-            List<?> list = (List<?>) o;
+        } else if (o instanceof List<?> list) {
             for (Object entry : list) {
                 if (entry != null) {
                     if (Number.class.isAssignableFrom(entry.getClass())) {
@@ -287,8 +286,7 @@ public class RecordTestUtils {
                 }
             }
             list.sort(Comparator.comparing(Object::toString));
-        } else if (o instanceof ImplicitLinkedHashCollection) {
-            ImplicitLinkedHashCollection<?> coll = (ImplicitLinkedHashCollection<?>) o;
+        } else if (o instanceof ImplicitLinkedHashCollection<?> coll) {
             for (Object entry : coll) {
                 deepSortRecords(entry);
             }

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -96,8 +96,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof LeaderChangeBatch)) return false;
-            LeaderChangeBatch other = (LeaderChangeBatch) o;
+            if (!(o instanceof LeaderChangeBatch other)) return false;
             return other.newLeader.equals(newLeader);
         }
 
@@ -135,8 +134,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof LocalRecordBatch)) return false;
-            LocalRecordBatch other = (LocalRecordBatch) o;
+            if (!(o instanceof LocalRecordBatch other)) return false;
 
             return leaderEpoch == other.leaderEpoch &&
                 appendTimestamp == other.appendTimestamp &&
@@ -261,8 +259,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
             long nextEndOffset = prevOffset + batch.size();
             log.debug("append(batch={}, nextEndOffset={})", batch, nextEndOffset);
             batches.put(nextEndOffset, batch);
-            if (batch instanceof LeaderChangeBatch) {
-                LeaderChangeBatch leaderChangeBatch = (LeaderChangeBatch) batch;
+            if (batch instanceof LeaderChangeBatch leaderChangeBatch) {
                 leader = leaderChangeBatch.newLeader;
             }
             for (LocalLogManager logManager : logManagers.values()) {
@@ -373,8 +370,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                 .values()
                 .stream()
                 .flatMapToInt(batch -> {
-                    if (batch instanceof LocalRecordBatch) {
-                        LocalRecordBatch localBatch = (LocalRecordBatch) batch;
+                    if (batch instanceof LocalRecordBatch localBatch) {
                         return localBatch.records.stream().mapToInt(record -> messageSize(record, objectCache));
                     } else {
                         return IntStream.empty();
@@ -398,8 +394,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
         public synchronized List<ApiMessageAndVersion> allRecords() {
             List<ApiMessageAndVersion> allRecords = new ArrayList<>();
             for (LocalBatch batch : batches.values()) {
-                if (batch instanceof LocalRecordBatch) {
-                    LocalRecordBatch recordBatch = (LocalRecordBatch) batch;
+                if (batch instanceof LocalRecordBatch recordBatch) {
                     allRecords.addAll(recordBatch.records);
                 }
             }
@@ -554,8 +549,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                                 nodeId, numEntriesFound, entryOffset, maxReadOffset);
                             break;
                         }
-                        if (entry.getValue() instanceof LeaderChangeBatch) {
-                            LeaderChangeBatch batch = (LeaderChangeBatch) entry.getValue();
+                        if (entry.getValue() instanceof LeaderChangeBatch batch) {
                             log.trace("Node {}: handling LeaderChange to {}.",
                                 nodeId, batch.newLeader);
                             // Only notify the listener if it equals the shared leader state
@@ -572,8 +566,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                                         nodeId, batch.newLeader, sharedLeader);
                                 listenerData.setOffset(entryOffset);
                             }
-                        } else if (entry.getValue() instanceof LocalRecordBatch) {
-                            LocalRecordBatch batch = (LocalRecordBatch) entry.getValue();
+                        } else if (entry.getValue() instanceof LocalRecordBatch batch) {
                             log.trace("Node {}: handling LocalRecordBatch with offset {}.",
                                 nodeId, entryOffset);
                             ObjectSerializationCache objectCache = new ObjectSerializationCache();

--- a/raft/src/main/java/org/apache/kafka/raft/FileQuorumStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FileQuorumStateStore.java
@@ -95,11 +95,10 @@ public class FileQuorumStateStore implements QuorumStateStore {
             final ObjectMapper objectMapper = new ObjectMapper();
             JsonNode readNode = objectMapper.readTree(line);
 
-            if (!(readNode instanceof ObjectNode)) {
+            if (!(readNode instanceof ObjectNode dataObject)) {
                 throw new IOException("Deserialized node " + readNode +
                     " is not an object node");
             }
-            final ObjectNode dataObject = (ObjectNode) readNode;
 
             JsonNode dataVersionNode = dataObject.get(DATA_VERSION);
             if (dataVersionNode == null) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2630,11 +2630,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private void handleInboundMessage(RaftMessage message, long currentTimeMs) {
         logger.trace("Received inbound message {}", message);
 
-        if (message instanceof RaftRequest.Inbound) {
-            RaftRequest.Inbound request = (RaftRequest.Inbound) message;
+        if (message instanceof RaftRequest.Inbound request) {
             handleRequest(request, currentTimeMs);
-        } else if (message instanceof RaftResponse.Inbound) {
-            RaftResponse.Inbound response = (RaftResponse.Inbound) message;
+        } else if (message instanceof RaftResponse.Inbound response) {
             if (requestManager.isResponseExpected(response.source(), response.correlationId())) {
                 handleResponse(response, currentTimeMs);
             } else {
@@ -3496,8 +3494,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (kafkaRaftMetrics != null) {
             kafkaRaftMetrics.close();
         }
-        if (memoryPool instanceof BatchMemoryPool) {
-            BatchMemoryPool batchMemoryPool = (BatchMemoryPool) memoryPool;
+        if (memoryPool instanceof BatchMemoryPool batchMemoryPool) {
             batchMemoryPool.releaseRetained();
         }
     }

--- a/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
@@ -51,8 +51,7 @@ public class LogOffsetMetadata {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof LogOffsetMetadata) {
-            LogOffsetMetadata other = (LogOffsetMetadata) obj;
+        if (obj instanceof LogOffsetMetadata other) {
             return this.offset == other.offset &&
                    this.metadata.equals(other.metadata);
         } else {

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -793,8 +793,7 @@ public final class RaftClientTestContext {
     ) {
         List<RaftRequest.Outbound> voteRequests = new ArrayList<>();
         for (RaftRequest.Outbound raftMessage : channel.drainSendQueue()) {
-            if (raftMessage.data() instanceof VoteRequestData) {
-                VoteRequestData request = (VoteRequestData) raftMessage.data();
+            if (raftMessage.data() instanceof VoteRequestData request) {
                 VoteRequestData.PartitionData partitionRequest = unwrap(request);
 
                 assertEquals(epoch, partitionRequest.replicaEpoch());
@@ -1247,8 +1246,7 @@ public final class RaftClientTestContext {
             .map(list -> list.stream().map(ReplicaKey::id).collect(Collectors.toList()));
 
         for (RaftRequest.Outbound raftMessage : channel.drainSendQueue()) {
-            if (raftMessage.data() instanceof EndQuorumEpochRequestData) {
-                EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) raftMessage.data();
+            if (raftMessage.data() instanceof EndQuorumEpochRequestData request) {
 
                 EndQuorumEpochRequestData.PartitionData partitionRequest =
                     request.topics().get(0).partitions().get(0);

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -958,8 +958,7 @@ public class RaftEventSimulationTest {
          */
         @Override
         public boolean acceptOutbound(RaftMessage message) {
-            if (message instanceof RaftRequest.Outbound) {
-                RaftRequest.Outbound request = (RaftRequest.Outbound) message;
+            if (message instanceof RaftRequest.Outbound request) {
                 InetSocketAddress destination = InetSocketAddress.createUnresolved(
                     request.destination().host(),
                     request.destination().port()

--- a/server-common/src/main/java/org/apache/kafka/server/common/TopicIdPartition.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/TopicIdPartition.java
@@ -48,8 +48,7 @@ public final class TopicIdPartition {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TopicIdPartition)) return false;
-        TopicIdPartition other = (TopicIdPartition) o;
+        if (!(o instanceof TopicIdPartition other)) return false;
         return other.topicId.equals(topicId) && other.partitionId == partitionId;
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
@@ -65,8 +65,7 @@ public class FutureUtils {
             timeout.setStackTrace(t.getStackTrace());
             throw timeout;
         } catch (Throwable t)  {
-            if (t instanceof ExecutionException) {
-                ExecutionException executionException = (ExecutionException) t;
+            if (t instanceof ExecutionException executionException) {
                 t = executionException.getCause();
             }
             log.error("{}Received a fatal error while waiting for {}", prefix, action, t);

--- a/server-common/src/main/java/org/apache/kafka/server/util/TranslatedValueMapView.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/TranslatedValueMapView.java
@@ -43,8 +43,7 @@ public final class TranslatedValueMapView<K, V, B> extends AbstractMap<K, V> {
         @SuppressWarnings("rawtypes")
         @Override
         public boolean contains(Object o) {
-            if (!(o instanceof Entry)) return false;
-            Entry other = (Entry) o;
+            if (!(o instanceof Entry other)) return false;
             if (!underlyingMap.containsKey(other.getKey())) return false;
             B value = underlyingMap.get(other.getKey());
             V translatedValue = valueMapping.apply(value);

--- a/server-common/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
@@ -150,8 +150,7 @@ class BaseHashTable<T> {
         Object object = elements[slot];
         if (object == null) {
             return null;
-        } else if (object instanceof Object[]) {
-            Object[] curArray = (Object[]) object;
+        } else if (object instanceof Object[] curArray) {
             for (int i = 0; i < curArray.length; i++) {
                 if (curArray[i].equals(key)) {
                     size--;
@@ -191,8 +190,7 @@ class BaseHashTable<T> {
                 Object cur = elements[newSlot];
                 if (cur == null) {
                     elements[newSlot] = object;
-                } else if (cur instanceof Object[]) {
-                    Object[] curArray = (Object[]) cur;
+                } else if (cur instanceof Object[] curArray) {
                     Object[] newArray = new Object[curArray.length + 1];
                     System.arraycopy(curArray, 0, newArray, 0, curArray.length);
                     newArray[curArray.length] = object;
@@ -225,8 +223,7 @@ class BaseHashTable<T> {
     static <T> void unpackSlot(List<T> out, Object[] elements, int slot) {
         Object value = elements[slot];
         if (value != null) {
-            if (value instanceof Object[]) {
-                Object[] array = (Object[]) value;
+            if (value instanceof Object[] array) {
                 for (Object object : array) {
                     out.add((T) object);
                 }
@@ -244,8 +241,7 @@ class BaseHashTable<T> {
             bld.append(String.format("%n%d: ", i));
             if (slotObject == null) {
                 bld.append("null");
-            } else if (slotObject instanceof Object[]) {
-                Object[] array = (Object[]) slotObject;
+            } else if (slotObject instanceof Object[] array) {
                 String prefix = "";
                 for (Object object : array) {
                     bld.append(prefix);

--- a/server-common/src/main/java/org/apache/kafka/timeline/TimelineHashMap.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/TimelineHashMap.java
@@ -386,9 +386,8 @@ public class TimelineHashMap<K, V>
     public boolean equals(Object o) {
         if (o == this)
             return true;
-        if (!(o instanceof Map))
+        if (!(o instanceof Map<?, ?> m))
             return false;
-        Map<?, ?> m = (Map<?, ?>) o;
         if (m.size() != size())
             return false;
         try {

--- a/server-common/src/main/java/org/apache/kafka/timeline/TimelineHashSet.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/TimelineHashSet.java
@@ -241,9 +241,8 @@ public class TimelineHashSet<T>
     public boolean equals(Object o) {
         if (o == this)
             return true;
-        if (!(o instanceof Set))
+        if (!(o instanceof Collection<?> c))
             return false;
-        Collection<?> c = (Collection<?>) o;
         if (c.size() != size())
             return false;
         try {

--- a/server-common/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
@@ -110,8 +110,7 @@ public final class TimelineInteger implements Revertable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TimelineInteger)) return false;
-        TimelineInteger other = (TimelineInteger) o;
+        if (!(o instanceof TimelineInteger other)) return false;
         return value == other.value;
     }
 

--- a/server-common/src/main/java/org/apache/kafka/timeline/TimelineLong.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/TimelineLong.java
@@ -110,8 +110,7 @@ public final class TimelineLong implements Revertable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TimelineLong)) return false;
-        TimelineLong other = (TimelineLong) o;
+        if (!(o instanceof TimelineLong other)) return false;
         return value == other.value;
     }
 

--- a/server-common/src/main/java/org/apache/kafka/timeline/TimelineObject.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/TimelineObject.java
@@ -109,8 +109,7 @@ public final class TimelineObject<T> implements Revertable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TimelineObject)) return false;
-        TimelineObject other = (TimelineObject) o;
+        if (!(o instanceof TimelineObject other)) return false;
         return value.equals(other.value);
     }
 

--- a/server-common/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
+++ b/server-common/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
@@ -74,10 +74,9 @@ public class SnapshottableHashTableTest {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof TestElement)) {
+            if (!(o instanceof TestElement other)) {
                 return false;
             }
-            TestElement other = (TestElement) o;
             return other.i == i;
         }
 

--- a/server/src/main/java/org/apache/kafka/server/Assignment.java
+++ b/server/src/main/java/org/apache/kafka/server/Assignment.java
@@ -98,8 +98,7 @@ final class Assignment {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || (!(o instanceof Assignment))) return false;
-        Assignment other = (Assignment) o;
+        if (o == null || (!(o instanceof Assignment other))) return false;
         return topicIdPartition.equals(other.topicIdPartition) &&
             directoryId.equals(other.directoryId) &&
             submissionTimeNs == other.submissionTimeNs &&

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombiner.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombiner.java
@@ -390,8 +390,7 @@ public class PersisterStateBatchCombiner {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof MergeCandidatePair)) return false;
-            MergeCandidatePair that = (MergeCandidatePair) o;
+            if (!(o instanceof MergeCandidatePair that)) return false;
             return Objects.equals(prev, that.prev) && Objects.equals(candidate, that.candidate);
         }
 

--- a/shell/src/main/java/org/apache/kafka/shell/command/CatCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/CatCommandHandler.java
@@ -121,8 +121,7 @@ public final class CatCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof CatCommandHandler)) return false;
-        CatCommandHandler o = (CatCommandHandler) other;
+        if (!(other instanceof CatCommandHandler o)) return false;
         return Objects.equals(o.targets, targets);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/CdCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/CdCommandHandler.java
@@ -112,8 +112,7 @@ public final class CdCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof CdCommandHandler)) return false;
-        CdCommandHandler o = (CdCommandHandler) other;
+        if (!(other instanceof CdCommandHandler o)) return false;
         return o.target.equals(target);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/ErroneousCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ErroneousCommandHandler.java
@@ -50,8 +50,7 @@ public final class ErroneousCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ErroneousCommandHandler)) return false;
-        ErroneousCommandHandler o = (ErroneousCommandHandler) other;
+        if (!(other instanceof ErroneousCommandHandler o)) return false;
         return Objects.equals(o.message, message);
     }
 

--- a/shell/src/main/java/org/apache/kafka/shell/command/FindCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/FindCommandHandler.java
@@ -127,8 +127,7 @@ public final class FindCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof FindCommandHandler)) return false;
-        FindCommandHandler o = (FindCommandHandler) other;
+        if (!(other instanceof FindCommandHandler o)) return false;
         return Objects.equals(o.paths, paths);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/HistoryCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/HistoryCommandHandler.java
@@ -110,8 +110,7 @@ public final class HistoryCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof HistoryCommandHandler)) return false;
-        HistoryCommandHandler o = (HistoryCommandHandler) other;
+        if (!(other instanceof HistoryCommandHandler o)) return false;
         return o.numEntriesToShow == numEntriesToShow;
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
@@ -268,8 +268,7 @@ public final class LsCommandHandler implements Commands.Handler {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof ColumnSchema)) return false;
-            ColumnSchema other = (ColumnSchema) o;
+            if (!(o instanceof ColumnSchema other)) return false;
             if (entriesPerColumn != other.entriesPerColumn) return false;
             return Arrays.equals(columnWidths, other.columnWidths);
         }
@@ -295,8 +294,7 @@ public final class LsCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof LsCommandHandler)) return false;
-        LsCommandHandler o = (LsCommandHandler) other;
+        if (!(other instanceof LsCommandHandler o)) return false;
         return Objects.equals(o.targets, targets);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
@@ -110,8 +110,7 @@ public final class ManCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ManCommandHandler)) return false;
-        ManCommandHandler o = (ManCommandHandler) other;
+        if (!(other instanceof ManCommandHandler o)) return false;
         return o.cmd.equals(cmd);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
@@ -117,8 +117,7 @@ public final class TreeCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof TreeCommandHandler)) return false;
-        TreeCommandHandler o = (TreeCommandHandler) other;
+        if (!(other instanceof TreeCommandHandler o)) return false;
         return Objects.equals(o.targets, targets);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/glob/GlobVisitor.java
+++ b/shell/src/main/java/org/apache/kafka/shell/glob/GlobVisitor.java
@@ -73,8 +73,7 @@ public final class GlobVisitor implements Consumer<MetadataShellState> {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof MetadataNodeInfo)) return false;
-            MetadataNodeInfo other = (MetadataNodeInfo) o;
+            if (!(o instanceof MetadataNodeInfo other)) return false;
             if (!Arrays.equals(path, other.path)) return false;
             return node.equals(other.node);
         }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentMetadataSnapshot.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentMetadataSnapshot.java
@@ -242,8 +242,7 @@ public class RemoteLogSegmentMetadataSnapshot extends RemoteLogMetadata {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof RemoteLogSegmentMetadataSnapshot)) return false;
-        RemoteLogSegmentMetadataSnapshot that = (RemoteLogSegmentMetadataSnapshot) o;
+        if (!(o instanceof RemoteLogSegmentMetadataSnapshot that)) return false;
         return startOffset == that.startOffset
                 && endOffset == that.endOffset
                 && maxTimestampMs == that.maxTimestampMs

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
@@ -175,8 +175,7 @@ public class LazyIndex<T extends AbstractIndex> implements Closeable {
             try {
                 if (indexWrapper instanceof IndexValue<?>)
                     return ((IndexValue<T>) indexWrapper).index;
-                else if (indexWrapper instanceof IndexFile) {
-                    IndexFile indexFile = (IndexFile) indexWrapper;
+                else if (indexWrapper instanceof IndexFile indexFile) {
                     IndexValue<T> indexValue = new IndexValue<>(loadIndex(indexFile.file));
                     indexWrapper = indexValue;
                     return indexValue.index;

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogValidatorTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogValidatorTest.java
@@ -2119,8 +2119,7 @@ public class LogValidatorTest {
     }
 
     private void maybeCheckBaseTimestamp(long expected, RecordBatch batch) {
-        if (batch instanceof DefaultRecordBatch) {
-            DefaultRecordBatch b = (DefaultRecordBatch) batch;
+        if (batch instanceof DefaultRecordBatch b) {
             assertEquals(expected, b.baseTimestamp(), "Unexpected base timestamp of batch " + batch);
         }
     }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
@@ -138,9 +138,7 @@ public abstract class TieredStorageTestHarness extends IntegrationTestHarness {
             if (broker.remoteLogManagerOpt().isDefined()) {
                 RemoteLogManager remoteLogManager = broker.remoteLogManagerOpt().get();
                 RemoteStorageManager storageManager = remoteLogManager.storageManager();
-                if (storageManager instanceof ClassLoaderAwareRemoteStorageManager) {
-                    ClassLoaderAwareRemoteStorageManager loaderAwareRSM =
-                            (ClassLoaderAwareRemoteStorageManager) storageManager;
+                if (storageManager instanceof ClassLoaderAwareRemoteStorageManager loaderAwareRSM) {
                     if (loaderAwareRSM.delegate() instanceof LocalTieredStorage) {
                         storages.add((LocalTieredStorage) loaderAwareRSM.delegate());
                     }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
@@ -136,8 +136,7 @@ public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosi
 
     @SuppressWarnings("unchecked")
     private SimpleRecord convert(Object recordCandidate) {
-        if (recordCandidate instanceof ProducerRecord) {
-            ProducerRecord<?, ?> record = (ProducerRecord<?, ?>) recordCandidate;
+        if (recordCandidate instanceof ProducerRecord<?, ?> record) {
             long timestamp = record.timestamp() != null ? record.timestamp() : RecordBatch.NO_TIMESTAMP;
             ByteBuffer keyBytes =
                     Utils.wrapNullable(keySerde.serializer().serialize(topicPartition.topic(), (K) record.key()));
@@ -145,16 +144,14 @@ public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosi
                     Utils.wrapNullable(valueSerde.serializer().serialize(topicPartition.topic(), (V) record.value()));
             Header[] headers = record.headers() != null ? record.headers().toArray() : Record.EMPTY_HEADERS;
             return new SimpleRecord(timestamp, keyBytes, valueBytes, headers);
-        } else if (recordCandidate instanceof ConsumerRecord) {
-            ConsumerRecord<?, ?> record = (ConsumerRecord<?, ?>) recordCandidate;
+        } else if (recordCandidate instanceof ConsumerRecord<?, ?> record) {
             ByteBuffer keyBytes =
                     Utils.wrapNullable(keySerde.serializer().serialize(topicPartition.topic(), (K) record.key()));
             ByteBuffer valueBytes =
                     Utils.wrapNullable(valueSerde.serializer().serialize(topicPartition.topic(), (V) record.value()));
             Header[] headers = record.headers() != null ? record.headers().toArray() : Record.EMPTY_HEADERS;
             return new SimpleRecord(record.timestamp(), keyBytes, valueBytes, headers);
-        } else if (recordCandidate instanceof Record) {
-            Record record = (Record) recordCandidate;
+        } else if (recordCandidate instanceof Record record) {
             return new SimpleRecord(record.timestamp(), record.key(), record.value(), record.headers());
         } else {
             return null;

--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -83,8 +83,7 @@ public class ConsoleProducer {
     RecordReader messageReader(ConsoleProducerOptions opts) throws Exception {
         Object objReader = Class.forName(opts.readerClass()).getDeclaredConstructor().newInstance();
 
-        if (objReader instanceof RecordReader) {
-            RecordReader reader = (RecordReader) objReader;
+        if (objReader instanceof RecordReader reader) {
             reader.configure(opts.readerProps());
 
             return reader;

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -187,9 +187,7 @@ public class GetOffsetShellTest {
         public boolean equals(Object o) {
             if (o == this) return true;
 
-            if (!(o instanceof Row)) return false;
-
-            Row r = (Row) o;
+            if (!(o instanceof Row r)) return false;
 
             return name.equals(r.name) && partition == r.partition && Objects.equals(offset, r.offset);
         }

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -371,8 +371,7 @@ public class CoordinatorClient {
                     System.out.printf("Task %s of type %s is %s. %s%n", taskId,
                         taskState.spec().getClass().getCanonicalName(),
                         taskState.stateType(), prettyPrintTaskInfo(taskState, localOffset));
-                    if (taskState instanceof TaskDone) {
-                        TaskDone taskDone = (TaskDone) taskState;
+                    if (taskState instanceof TaskDone taskDone) {
                         if ((taskDone.error() != null) && (!taskDone.error().isEmpty())) {
                             System.out.printf("Error: %s%n", taskDone.error());
                         }
@@ -491,15 +490,12 @@ public class CoordinatorClient {
     static String prettyPrintTaskInfo(TaskState taskState, ZoneOffset zoneOffset) {
         if (taskState instanceof TaskPending) {
             return "Will start at " + dateString(taskState.spec().startMs(), zoneOffset);
-        } else if (taskState instanceof TaskRunning) {
-            TaskRunning runState = (TaskRunning) taskState;
+        } else if (taskState instanceof TaskRunning runState) {
             return "Started " + dateString(runState.startedMs(), zoneOffset) +
                 "; will stop after " + durationString(taskState.spec().durationMs());
-        } else if (taskState instanceof TaskStopping) {
-            TaskStopping stoppingState = (TaskStopping) taskState;
+        } else if (taskState instanceof TaskStopping stoppingState) {
             return "Started " + dateString(stoppingState.startedMs(), zoneOffset);
-        } else if (taskState instanceof TaskDone) {
-            TaskDone doneState = (TaskDone) taskState;
+        } else if (taskState instanceof TaskDone doneState) {
             String status;
             if (doneState.error() == null || doneState.error().isEmpty()) {
                 if (doneState.cancelled()) {


### PR DESCRIPTION
This feature was introduced in Java 16.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
