### PR TITLE
KAFKA-18391 Skip running "Flaky Test Report" job on forks

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   flaky-test-report:
     name: Flaky Test Report
+    if : github.event.repository.fork == 'false'
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves [KAFKA-18391](https://issues.apache.org/jira/browse/KAFKA-18391)

Skip running "Flaky Test Report" job on forks

*Prevents jobs that fail outside main repository to be run on forks*

![image](https://github.com/user-attachments/assets/2063d7cc-08aa-4b39-98ab-d46f0be4d8bc)



Testing with changes applied:
![image](https://github.com/user-attachments/assets/7c9ae75d-d625-4d81-991e-230231f2e691)



### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)

