### PR TITLE
KAFKA-18340 Change Dockerfile to use log4j2 yaml instead log4j properties

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -56,7 +56,8 @@ ARG build_date
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \
       org.label-schema.build-date="${build_date}" \
-      org.label-schema.vcs-url="https://github.com/apache/kafka"
+      org.label-schema.vcs-url="https://github.com/apache/kafka" \
+      maintainer="Apache Kafka"
       
 MAINTAINER Apache Kafka
 

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -58,8 +58,6 @@ LABEL org.label-schema.name="kafka" \
       org.label-schema.build-date="${build_date}" \
       org.label-schema.vcs-url="https://github.com/apache/kafka" \
       maintainer="Apache Kafka"
-      
-MAINTAINER Apache Kafka
 
 RUN set -eux ; \
     apk update ; \

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -56,8 +56,9 @@ ARG build_date
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \
       org.label-schema.build-date="${build_date}" \
-      org.label-schema.vcs-url="https://github.com/apache/kafka" \
-      maintainer="Apache Kafka"
+      org.label-schema.vcs-url="https://github.com/apache/kafka"
+      
+MAINTAINER Apache Kafka
 
 RUN set -eux ; \
     apk update ; \
@@ -76,8 +77,8 @@ RUN set -eux ; \
     chown appuser:appuser -R /usr/logs /opt/kafka /mnt/shared/config; \
     chown appuser:root -R /var/lib/kafka /etc/kafka/secrets /etc/kafka; \
     chmod -R ug+w /etc/kafka /var/lib/kafka /etc/kafka/secrets; \
-    cp /opt/kafka/config/log4j.properties /etc/kafka/docker/log4j.properties; \
-    cp /opt/kafka/config/tools-log4j.properties /etc/kafka/docker/tools-log4j.properties; \
+    cp /opt/kafka/config/log4j2.yaml /etc/kafka/docker/log4j2.yaml; \
+    cp /opt/kafka/config/tools-log4j2.yaml /etc/kafka/docker/tools-log4j2.yaml; \
     cp /opt/kafka/config/kraft/reconfig-server.properties /etc/kafka/docker/server.properties; \
     rm kafka.tgz kafka.tgz.asc KEYS; \
     apk del wget gpg gpg-agent; \

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -51,8 +51,9 @@ ARG build_date
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \
       org.label-schema.build-date="${build_date}" \
-      org.label-schema.vcs-url="https://github.com/apache/kafka" \
-      maintainer="Apache Kafka"
+      org.label-schema.vcs-url="https://github.com/apache/kafka"
+      
+MAINTAINER Apache Kafka
 
 RUN apk update ; \
     apk add --no-cache gcompat ; \
@@ -64,8 +65,8 @@ RUN apk update ; \
 
 COPY --chown=appuser:root --from=build-native-image /app/kafka/kafka.Kafka /opt/kafka/
 COPY --chown=appuser:root --from=build-native-image /app/kafka/config/kraft/reconfig-server.properties /etc/kafka/docker/
-COPY --chown=appuser:root --from=build-native-image /app/kafka/config/log4j.properties /etc/kafka/docker/
-COPY --chown=appuser:root --from=build-native-image /app/kafka/config/tools-log4j.properties /etc/kafka/docker/
+COPY --chown=appuser:root --from=build-native-image /app/kafka/config/log4j2.yaml /etc/kafka/docker/
+COPY --chown=appuser:root --from=build-native-image /app/kafka/config/tools-log4j2.yaml /etc/kafka/docker/
 COPY --chown=appuser:root resources/common-scripts /etc/kafka/docker/
 COPY --chown=appuser:root launch /etc/kafka/docker/
 

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -51,9 +51,8 @@ ARG build_date
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \
       org.label-schema.build-date="${build_date}" \
-      org.label-schema.vcs-url="https://github.com/apache/kafka"
-      
-MAINTAINER Apache Kafka
+      org.label-schema.vcs-url="https://github.com/apache/kafka" \
+      maintainer="Apache Kafka"
 
 RUN apk update ; \
     apk add --no-cache gcompat ; \


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18340

We already upgrade log4j to log4j2, we should update our docker image to use log4j2 yaml file

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
