### PR TITLE
MINOR: Fix newlines not working in LISTENERS_DOC

### DIFF
--- a/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
+++ b/server/src/main/java/org/apache/kafka/network/SocketServerConfigs.java
@@ -65,17 +65,15 @@ public class SocketServerConfigs {
 
     public static final String LISTENERS_CONFIG = "listeners";
     public static final String LISTENERS_DEFAULT = "PLAINTEXT://:9092";
-    public static final String LISTENERS_DOC = "Listener List - Comma-separated list of URIs we will listen on and the listener names." +
-            String.format(" If the listener name is not a security protocol, <code>%s</code> must also be set.%n", LISTENER_SECURITY_PROTOCOL_MAP_CONFIG) +
-            " Listener names and port numbers must be unique unless %n" +
-            " one listener is an IPv4 address and the other listener is %n" +
-            " an IPv6 address (for the same port).%n" +
-            " Specify hostname as 0.0.0.0 to bind to all interfaces.%n" +
-            " Leave hostname empty to bind to default interface.%n" +
-            " Examples of legal listener lists:%n" +
-            " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>%n" +
-            " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>%n" +
-            " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>%n";
+    public static final String LISTENERS_DOC = String.format("Listener List - Comma-separated list of URIs we will listen on and the listener names." +
+                    " If the listener name is not a security protocol, <code>%s</code> must also be set.%n" +
+                    " Listener names and port numbers must be unique unless one listener is an IPv4 address and the other listener is an IPv6 address (for the same port).%n" +
+                    " Specify hostname as 0.0.0.0 to bind to all interfaces.%n" +
+                    " Leave hostname empty to bind to default interface.%n" +
+                    " Examples of legal listener lists:%n" +
+                    " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>%n" +
+                    " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>%n" +
+                    " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>%n", LISTENER_SECURITY_PROTOCOL_MAP_CONFIG);
 
     public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
     public static final String ADVERTISED_LISTENERS_DOC = String.format("Specifies the listener addresses that the Kafka brokers will advertise to clients and other brokers." +


### PR DESCRIPTION
Fix newlines not working with `%n` in LISTENERS_DOC

Following the Kafka site preview below:

Before
![Screenshot 2025-01-05 140840](https://github.com/user-attachments/assets/ccc9b3c6-10d4-4e64-8abf-4c54f95bfac0)

After
![Screenshot 2025-01-05 162419](https://github.com/user-attachments/assets/0811c89e-b7b7-453c-a97d-989f69ec802f)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
