### PR TITLE
KAFKA-18311: Configuring repartition topics (3/N)

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams.topics;
 
+import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
@@ -29,7 +30,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for configuring the number of partitions in repartitioning topics. It computes a fix-point iteration, deriving the number of
@@ -59,9 +59,14 @@ public class RepartitionTopics {
     }
 
     /**
-     * Returns the set the number of partitions for each repartition topic.
+     * Returns the set of the number of partitions for each repartition topic.
      *
      * @return the map of repartition topics for the requested topology to their required number of partitions.
+     *
+     * @throws TopicConfigurationException if no valid configuration can be found given the broker state, for example, if a source topic
+     *         is missing.
+     * @throws StreamsInvalidTopologyException if the number of partitions for all repartition topics cannot be determined, e.g.
+     *         because of loops, or if a repartition source topic is not a sink topic of any subtopology.
      */
     public Map<String, Integer> setup() {
         final Set<String> missingSourceTopicsForTopology = new HashSet<>();
@@ -71,12 +76,21 @@ public class RepartitionTopics {
             missingSourceTopicsForTopology.addAll(missingSourceTopicsForSubtopology);
         }
 
-        if (missingSourceTopicsForTopology.isEmpty()) {
-            return computeRepartitionSourceTopicPartitionCount();
-        } else {
+        if (!missingSourceTopicsForTopology.isEmpty()) {
             throw TopicConfigurationException.missingSourceTopics(String.format("Missing source topics: %s",
                 String.join(", ", missingSourceTopicsForTopology)));
         }
+
+        final Map<String, Integer> repartitionTopicPartitionCount = computeRepartitionTopicPartitionCount();
+
+        for (final Subtopology subtopology : subtopologies) {
+            if (subtopology.repartitionSourceTopics().stream().anyMatch(repartitionTopic -> !repartitionTopicPartitionCount.containsKey(repartitionTopic.name()))) {
+                throw new StreamsInvalidTopologyException("Failed to compute number of partitions for all repartition topics, because "
+                    + "a repartition source topic is never used as a sink topic.");
+            }
+        }
+
+        return repartitionTopicPartitionCount;
     }
 
     private Set<String> computeMissingExternalSourceTopics(final Subtopology subtopology) {
@@ -91,21 +105,14 @@ public class RepartitionTopics {
     /**
      * Computes the number of partitions and returns it for each repartition topic.
      */
-    private Map<String, Integer> computeRepartitionSourceTopicPartitionCount() {
+    private Map<String, Integer> computeRepartitionTopicPartitionCount() {
         boolean partitionCountNeeded;
-        Map<String, Integer> repartitionSourceTopicPartitionCounts = new HashMap<>();
-        Map<String, Set<String>> repartitionSinkTopics =
-            subtopologies.stream().collect(
-                Collectors.toMap(
-                    Subtopology::subtopologyId,
-                    x -> new HashSet<>(x.repartitionSinkTopics())
-                )
-            );
+        Map<String, Integer> repartitionTopicPartitionCounts = new HashMap<>();
 
         for (final Subtopology subtopology : subtopologies) {
             for (final TopicInfo repartitionSourceTopic : subtopology.repartitionSourceTopics()) {
                 if (repartitionSourceTopic.partitions() != 0) {
-                    repartitionSourceTopicPartitionCounts.put(repartitionSourceTopic.name(), repartitionSourceTopic.partitions());
+                    repartitionTopicPartitionCounts.put(repartitionSourceTopic.name(), repartitionSourceTopic.partitions());
                 }
             }
         }
@@ -116,68 +123,54 @@ public class RepartitionTopics {
             boolean progressMadeThisIteration = false;
 
             for (final Subtopology subtopology : subtopologies) {
-                for (final TopicInfo repartitionSourceTopic : subtopology.repartitionSourceTopics()) {
-                    final Integer repartitionSourceTopicPartitionCount =
-                        repartitionSourceTopicPartitionCounts.get(repartitionSourceTopic.name());
-
-                    if (repartitionSourceTopicPartitionCount == null) {
+                for (final String repartitionSinkTopic : subtopology.repartitionSinkTopics()) {
+                    if (!repartitionTopicPartitionCounts.containsKey(repartitionSinkTopic)) {
                         final Integer numPartitions = computePartitionCount(
-                            repartitionSourceTopicPartitionCounts,
-                            repartitionSourceTopic.name(),
-                            repartitionSinkTopics
+                            repartitionTopicPartitionCounts,
+                            subtopology
                         );
 
                         if (numPartitions == null) {
                             partitionCountNeeded = true;
                             log.trace("Unable to determine number of partitions for {}, another iteration is needed",
-                                repartitionSourceTopic);
+                                repartitionSinkTopic);
                         } else {
                             log.trace("Determined number of partitions for {} to be {}",
-                                repartitionSourceTopic,
+                                repartitionSinkTopic,
                                 numPartitions);
-                            repartitionSourceTopicPartitionCounts.put(repartitionSourceTopic.name(), numPartitions);
+                            repartitionTopicPartitionCounts.put(repartitionSinkTopic, numPartitions);
                             progressMadeThisIteration = true;
                         }
                     }
                 }
             }
             if (!progressMadeThisIteration && partitionCountNeeded) {
-                throw TopicConfigurationException.missingSourceTopics("Failed to compute number of partitions for all " +
-                    "repartition topics, make sure all user input topics are created and all pattern subscriptions " +
-                    "match at least one topic in the cluster");
+                throw new StreamsInvalidTopologyException("Failed to compute number of partitions for all " +
+                    "repartition topics. There may be loops in the topology that cannot be resolved.");
             }
         } while (partitionCountNeeded);
 
-        return repartitionSourceTopicPartitionCounts;
+        return repartitionTopicPartitionCounts;
     }
 
-    private Integer computePartitionCount(final Map<String, Integer> repartitionSourceTopicPartitionCounts,
-                                          final String repartitionSourceTopic,
-                                          Map<String, Set<String>> repartitionSinkTopics) {
+    private Integer computePartitionCount(final Map<String, Integer> repartitionTopicPartitionCounts,
+                                          final Subtopology subtopology) {
         Integer partitionCount = null;
         // try set the number of partitions for this repartition topic if it is not set yet
-        for (final Subtopology subtopology : subtopologies) {
+        // use the maximum of all its source topic partitions as the number of partitions
 
-            if (repartitionSinkTopics.get(subtopology.subtopologyId()).contains(repartitionSourceTopic)) {
-                // if this topic is one of the sink topics of this topology,
-                // use the maximum of all its source topic partitions as the number of partitions
-                for (final String upstreamSourceTopic : subtopology.sourceTopics()) {
-                    // It is possible the sourceTopic is another internal topic, i.e,
-                    // map().join().join(map())
-                    Integer numPartitionsCandidate = repartitionSourceTopicPartitionCounts.get(upstreamSourceTopic);
-                    if (numPartitionsCandidate == null) {
-                        final OptionalInt actualPartitionCount = topicPartitionCountProvider.apply(upstreamSourceTopic);
-                        if (actualPartitionCount.isPresent()) {
-                            numPartitionsCandidate = actualPartitionCount.getAsInt();
-                        }
-                    }
-
-                    if (numPartitionsCandidate != null) {
-                        if (partitionCount == null || numPartitionsCandidate > partitionCount) {
-                            partitionCount = numPartitionsCandidate;
-                        }
-                    }
-                }
+        // It is possible that there is another internal topic, i.e,
+        // map().join().join(map())
+        for (final TopicInfo repartitionSourceTopic : subtopology.repartitionSourceTopics()) {
+            Integer numPartitionsCandidate = repartitionTopicPartitionCounts.get(repartitionSourceTopic.name());
+            if (numPartitionsCandidate != null && (partitionCount == null || numPartitionsCandidate > partitionCount)) {
+                partitionCount = numPartitionsCandidate;
+            }
+        }
+        for (final String externalSourceTopic : subtopology.sourceTopics()) {
+            final OptionalInt actualPartitionCount = topicPartitionCountProvider.apply(externalSourceTopic);
+            if (actualPartitionCount.isPresent() && (partitionCount == null || actualPartitionCount.getAsInt() > partitionCount)) {
+                partitionCount = actualPartitionCount.getAsInt();
             }
         }
         return partitionCount;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
+
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Responsible for configuring the number of partitions in repartitioning topics. It computes a fix-point iteration, deriving the number of
+ * partitions for each repartition topic based on the number of partitions of the source topics of the topology, if the number of
+ * partitions is not explicitly set in the topology.
+ */
+public class RepartitionTopics {
+
+    private final Logger log;
+    private final Collection<Subtopology> subtopologies;
+    private final Function<String, OptionalInt> topicPartitionCountProvider;
+
+    /**
+     * The constructor for the class.
+     *
+     * @param logContext                   The context for emitting log messages.
+     * @param subtopologies                The subtopologies for the requested topology.
+     * @param topicPartitionCountProvider  Returns the number of partitions for a given topic, representing the current state of the
+     *                                     broker.
+     */
+    public RepartitionTopics(final LogContext logContext,
+                             final Collection<Subtopology> subtopologies,
+                             final Function<String, OptionalInt> topicPartitionCountProvider) {
+        this.log = logContext.logger(getClass());
+        this.subtopologies = subtopologies;
+        this.topicPartitionCountProvider = topicPartitionCountProvider;
+    }
+
+    /**
+     * Returns the set the number of partitions for each repartition topic.
+     *
+     * @return the map of repartition topics for the requested topology to their required number of partitions.
+     */
+    public Map<String, Integer> setup() {
+        final Set<String> missingSourceTopicsForTopology = new HashSet<>();
+
+        for (final Subtopology subtopology : subtopologies) {
+            final Set<String> missingSourceTopicsForSubtopology = computeMissingExternalSourceTopics(subtopology);
+            missingSourceTopicsForTopology.addAll(missingSourceTopicsForSubtopology);
+        }
+
+        if (missingSourceTopicsForTopology.isEmpty()) {
+            return computeRepartitionSourceTopicPartitionCount();
+        } else {
+            throw TopicConfigurationException.missingSourceTopics(String.format("Missing source topics: %s",
+                String.join(", ", missingSourceTopicsForTopology)));
+        }
+    }
+
+    private Set<String> computeMissingExternalSourceTopics(final Subtopology subtopology) {
+        final Set<String> missingExternalSourceTopics = new HashSet<>(subtopology.sourceTopics());
+        for (final TopicInfo topicInfo : subtopology.repartitionSourceTopics()) {
+            missingExternalSourceTopics.remove(topicInfo.name());
+        }
+        missingExternalSourceTopics.removeIf(x -> topicPartitionCountProvider.apply(x).isPresent());
+        return missingExternalSourceTopics;
+    }
+
+    /**
+     * Computes the number of partitions and returns it for each repartition topic.
+     */
+    private Map<String, Integer> computeRepartitionSourceTopicPartitionCount() {
+        boolean partitionCountNeeded;
+        Map<String, Integer> repartitionSourceTopicPartitionCounts = new HashMap<>();
+        Map<String, Set<String>> repartitionSinkTopics =
+            subtopologies.stream().collect(
+                Collectors.toMap(
+                    Subtopology::subtopologyId,
+                    x -> new HashSet<>(x.repartitionSinkTopics())
+                )
+            );
+
+        for (final Subtopology subtopology : subtopologies) {
+            for (final TopicInfo repartitionSourceTopic : subtopology.repartitionSourceTopics()) {
+                if (repartitionSourceTopic.partitions() != 0) {
+                    repartitionSourceTopicPartitionCounts.put(repartitionSourceTopic.name(), repartitionSourceTopic.partitions());
+                }
+            }
+        }
+
+        do {
+            partitionCountNeeded = false;
+            // avoid infinitely looping without making any progress on unknown repartitions
+            boolean progressMadeThisIteration = false;
+
+            for (final Subtopology subtopology : subtopologies) {
+                for (final TopicInfo repartitionSourceTopic : subtopology.repartitionSourceTopics()) {
+                    final Integer repartitionSourceTopicPartitionCount =
+                        repartitionSourceTopicPartitionCounts.get(repartitionSourceTopic.name());
+
+                    if (repartitionSourceTopicPartitionCount == null) {
+                        final Integer numPartitions = computePartitionCount(
+                            repartitionSourceTopicPartitionCounts,
+                            repartitionSourceTopic.name(),
+                            repartitionSinkTopics.get(subtopology.subtopologyId())
+                        );
+
+                        if (numPartitions == null) {
+                            partitionCountNeeded = true;
+                            log.trace("Unable to determine number of partitions for {}, another iteration is needed",
+                                repartitionSourceTopic);
+                        } else {
+                            log.trace("Determined number of partitions for {} to be {}",
+                                repartitionSourceTopic,
+                                numPartitions);
+                            repartitionSourceTopicPartitionCounts.put(repartitionSourceTopic.name(), numPartitions);
+                            progressMadeThisIteration = true;
+                        }
+                    }
+                }
+            }
+            if (!progressMadeThisIteration && partitionCountNeeded) {
+                throw TopicConfigurationException.missingSourceTopics("Failed to compute number of partitions for all " +
+                    "repartition topics, make sure all user input topics are created and all pattern subscriptions " +
+                    "match at least one topic in the cluster");
+            }
+        } while (partitionCountNeeded);
+
+        return repartitionSourceTopicPartitionCounts;
+    }
+
+    private Integer computePartitionCount(final Map<String, Integer> repartitionSourceTopicPartitionCounts,
+                                          final String repartitionSourceTopic,
+                                          Set<String> repartitionSinkTopics) {
+        Integer partitionCount = null;
+        // try set the number of partitions for this repartition topic if it is not set yet
+        for (final Subtopology subtopology : subtopologies) {
+
+            if (repartitionSinkTopics.contains(repartitionSourceTopic)) {
+                // if this topic is one of the sink topics of this topology,
+                // use the maximum of all its source topic partitions as the number of partitions
+                for (final String upstreamSourceTopic : subtopology.sourceTopics()) {
+                    // It is possible the sourceTopic is another internal topic, i.e,
+                    // map().join().join(map())
+                    Integer numPartitionsCandidate = repartitionSourceTopicPartitionCounts.get(upstreamSourceTopic);
+                    if (numPartitionsCandidate == null) {
+                        final OptionalInt actualPartitionCount = topicPartitionCountProvider.apply(upstreamSourceTopic);
+                        if (actualPartitionCount.isPresent()) {
+                            numPartitionsCandidate = actualPartitionCount.getAsInt();
+                        }
+                    }
+
+                    if (numPartitionsCandidate != null) {
+                        if (partitionCount == null || numPartitionsCandidate > partitionCount) {
+                            partitionCount = numPartitionsCandidate;
+                        }
+                    }
+                }
+            }
+        }
+        return partitionCount;
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
@@ -124,7 +124,7 @@ public class RepartitionTopics {
                         final Integer numPartitions = computePartitionCount(
                             repartitionSourceTopicPartitionCounts,
                             repartitionSourceTopic.name(),
-                            repartitionSinkTopics.get(subtopology.subtopologyId())
+                            repartitionSinkTopics
                         );
 
                         if (numPartitions == null) {
@@ -153,12 +153,12 @@ public class RepartitionTopics {
 
     private Integer computePartitionCount(final Map<String, Integer> repartitionSourceTopicPartitionCounts,
                                           final String repartitionSourceTopic,
-                                          Set<String> repartitionSinkTopics) {
+                                          Map<String, Set<String>> repartitionSinkTopics) {
         Integer partitionCount = null;
         // try set the number of partitions for this repartition topic if it is not set yet
         for (final Subtopology subtopology : subtopologies) {
 
-            if (repartitionSinkTopics.contains(repartitionSourceTopic)) {
+            if (repartitionSinkTopics.get(subtopology.subtopologyId()).contains(repartitionSourceTopic)) {
                 // if this topic is one of the sink topics of this topology,
                 // use the maximum of all its source topic partitions as the number of partitions
                 for (final String upstreamSourceTopic : subtopology.sourceTopics()) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicConfig;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RepartitionTopicsTest {
+
+    private static final LogContext LOG_CONTEXT = new LogContext();
+    private static final String SOURCE_TOPIC_NAME1 = "source1";
+    private static final String SOURCE_TOPIC_NAME2 = "source2";
+    private static final String SINK_TOPIC_NAME1 = "sink1";
+    private static final String SINK_TOPIC_NAME2 = "sink2";
+    private static final String REPARTITION_TOPIC_NAME1 = "repartition1";
+    private static final String REPARTITION_TOPIC_NAME2 = "repartition2";
+    private static final String REPARTITION_WITHOUT_PARTITION_COUNT = "repartitionWithoutPartitionCount";
+    private static final TopicConfig TOPIC_CONFIG1 = new TopicConfig().setKey("config1").setValue("val1");
+    private static final TopicConfig TOPIC_CONFIG2 = new TopicConfig().setKey("config2").setValue("val2");
+    private static final TopicConfig TOPIC_CONFIG5 = new TopicConfig().setKey("config5").setValue("val5");
+    private static final TopicInfo REPARTITION_TOPIC_INFO1 = new TopicInfo()
+        .setName(REPARTITION_TOPIC_NAME1)
+        .setPartitions(4)
+        .setTopicConfigs(List.of(TOPIC_CONFIG1));
+    private static final Subtopology SUBTOPOLOGY2 = new Subtopology()
+        .setSubtopologyId("SUBTOPOLOGY2")
+        .setSourceTopics(Collections.singletonList(REPARTITION_TOPIC_NAME1))
+        .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME1))
+        .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC_INFO1))
+        .setStateChangelogTopics(Collections.emptyList());
+    private static final TopicInfo REPARTITION_TOPIC_INFO2 = new TopicInfo()
+        .setName(REPARTITION_TOPIC_NAME2)
+        .setPartitions(2)
+        .setTopicConfigs(List.of(TOPIC_CONFIG2));
+    private static final Subtopology SUBTOPOLOGY1 = new Subtopology()
+        .setSubtopologyId("SUBTOPOLOGY1")
+        .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2))
+        .setRepartitionSinkTopics(Collections.singletonList(REPARTITION_TOPIC_NAME1))
+        .setRepartitionSourceTopics(List.of(
+            REPARTITION_TOPIC_INFO1,
+            REPARTITION_TOPIC_INFO2
+        ))
+        .setStateChangelogTopics(Collections.emptyList());
+    private static final TopicInfo REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT = new TopicInfo()
+        .setName(REPARTITION_WITHOUT_PARTITION_COUNT)
+        .setTopicConfigs(List.of(TOPIC_CONFIG5));
+    private static final Subtopology SUBTOPOLOGY_WITHOUT_PARTITION_COUNT = new Subtopology()
+        .setSubtopologyId("SUBTOPOLOGY_WITHOUT_PARTITION_COUNT")
+        .setSourceTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT))
+        .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME2))
+        .setRepartitionSourceTopics(List.of(
+            REPARTITION_TOPIC_INFO1,
+            REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
+        ))
+        .setStateChangelogTopics(Collections.emptyList());
+    private static final Set<String> TOPICS = Set.of(
+        SOURCE_TOPIC_NAME1,
+        SOURCE_TOPIC_NAME2,
+        SINK_TOPIC_NAME1,
+        SINK_TOPIC_NAME2,
+        REPARTITION_TOPIC_NAME1,
+        REPARTITION_TOPIC_NAME2
+    );
+
+    @Test
+    public void shouldSetupRepartitionTopics() {
+        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY2);
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        Map<String, Integer> setup = repartitionTopics.setup();
+
+        assertEquals(
+            mkMap(
+                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
+                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions())
+            ),
+            setup
+        );
+    }
+
+    @Test
+    public void shouldThrowStreamsMissingSourceTopicsExceptionIfMissingSourceTopics() {
+        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY2);
+        Function<String, OptionalInt> topicPartitionCountProvider =
+            s -> Objects.equals(s, SOURCE_TOPIC_NAME1) ? OptionalInt.empty() :
+                (TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty());
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        final TopicConfigurationException exception = assertThrows(TopicConfigurationException.class,
+            repartitionTopics::setup);
+
+        assertNotNull(exception);
+        assertEquals(Status.MISSING_SOURCE_TOPICS, exception.status());
+        assertEquals("Missing source topics: source1", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowStreamsMissingSourceTopicsExceptionIfPartitionCountCannotBeComputedForAllRepartitionTopics() {
+        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY_WITHOUT_PARTITION_COUNT);
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        TopicConfigurationException exception = assertThrows(TopicConfigurationException.class, repartitionTopics::setup);
+
+        assertEquals(Status.MISSING_SOURCE_TOPICS, exception.status());
+        assertEquals(
+            "Failed to compute number of partitions for all repartition topics, make sure all user input topics are created "
+                + "and all pattern subscriptions match at least one topic in the cluster",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    public void shouldSetRepartitionTopicPartitionCountFromUpstreamExternalSourceTopic() {
+        final Subtopology subtopology = new Subtopology()
+            .setSubtopologyId("SUBTOPOLOGY0")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME2))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSourceTopics(List.of(
+                REPARTITION_TOPIC_INFO1,
+                REPARTITION_TOPIC_INFO2,
+                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
+            ))
+            .setStateChangelogTopics(Collections.emptyList());
+        List<Subtopology> subtopologyToSubtopology = List.of(
+            subtopology,
+            SUBTOPOLOGY_WITHOUT_PARTITION_COUNT
+        );
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        Map<String, Integer> setup = repartitionTopics.setup();
+
+        assertEquals(mkMap(
+            mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
+            mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
+            mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, 4)
+        ), setup);
+    }
+
+    @Test
+    public void shouldSetRepartitionTopicPartitionCountFromUpstreamInternalRepartitionSourceTopic() {
+        final Subtopology subtopology = new Subtopology()
+            .setSubtopologyId("SUBTOPOLOGY0")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME1))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME2, REPARTITION_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSourceTopics(List.of(
+                REPARTITION_TOPIC_INFO1,
+                REPARTITION_TOPIC_INFO2,
+                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
+            ))
+            .setStateChangelogTopics(Collections.emptyList());
+        List<Subtopology> subtopologyToSubtopology = List.of(subtopology, SUBTOPOLOGY_WITHOUT_PARTITION_COUNT);
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        Map<String, Integer> setup = repartitionTopics.setup();
+
+        assertEquals(
+            mkMap(
+                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
+                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
+                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, 4)
+            ),
+            setup
+        );
+    }
+
+    @Test
+    public void shouldNotSetupRepartitionTopicsWhenTopologyDoesNotContainAnyRepartitionTopics() {
+        final Subtopology subtopology = new Subtopology()
+            .setSubtopologyId("SUBTOPOLOGY0")
+            .setSourceTopics(Collections.singletonList(SOURCE_TOPIC_NAME1))
+            .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME1))
+            .setRepartitionSourceTopics(Collections.emptyList())
+            .setStateChangelogTopics(Collections.emptyList());
+        List<Subtopology> subtopologyToSubtopology = List.of(subtopology);
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        Map<String, Integer> setup = repartitionTopics.setup();
+
+        assertEquals(Collections.emptyMap(), setup);
+    }
+
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
@@ -155,7 +155,7 @@ public class RepartitionTopicsTest {
         assertEquals(Map.of(
             REPARTITION_TOPIC1.name(), REPARTITION_TOPIC1.partitions(),
             REPARTITION_TOPIC2.name(), REPARTITION_TOPIC2.partitions(),
-            REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name(), 3
+            REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name(), sourceTopicPartitionCounts(SOURCE_TOPIC_NAME1).getAsInt()
         ), setup);
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
@@ -47,7 +47,7 @@ public class RepartitionTopicsTest {
     private static final String SINK_TOPIC_NAME2 = "sink2";
     private static final String REPARTITION_TOPIC_NAME1 = "repartition1";
     private static final String REPARTITION_TOPIC_NAME2 = "repartition2";
-    private static final String REPARTITION_WITHOUT_PARTITION_COUNT = "repartitionWithoutPartitionCount";
+    private static final String REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT = "repartitionWithoutPartitionCount";
     private static final TopicConfig TOPIC_CONFIG1 = new TopicConfig().setKey("config1").setValue("val1");
     private static final TopicConfig TOPIC_CONFIG2 = new TopicConfig().setKey("config2").setValue("val2");
     private static final TopicConfig TOPIC_CONFIG5 = new TopicConfig().setKey("config5").setValue("val5");
@@ -75,11 +75,11 @@ public class RepartitionTopicsTest {
         ))
         .setStateChangelogTopics(Collections.emptyList());
     private static final TopicInfo REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT = new TopicInfo()
-        .setName(REPARTITION_WITHOUT_PARTITION_COUNT)
+        .setName(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT)
         .setTopicConfigs(List.of(TOPIC_CONFIG5));
     private static final Subtopology SUBTOPOLOGY_WITHOUT_PARTITION_COUNT = new Subtopology()
         .setSubtopologyId("SUBTOPOLOGY_WITHOUT_PARTITION_COUNT")
-        .setSourceTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT))
+        .setSourceTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
         .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME2))
         .setRepartitionSourceTopics(List.of(
             REPARTITION_TOPIC_INFO1,
@@ -161,7 +161,7 @@ public class RepartitionTopicsTest {
         final Subtopology subtopology = new Subtopology()
             .setSubtopologyId("SUBTOPOLOGY0")
             .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME2))
-            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
             .setRepartitionSourceTopics(List.of(
                 REPARTITION_TOPIC_INFO1,
                 REPARTITION_TOPIC_INFO2,
@@ -184,7 +184,7 @@ public class RepartitionTopicsTest {
         assertEquals(mkMap(
             mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
             mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
-            mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, 4)
+            mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 3)
         ), setup);
     }
 
@@ -193,7 +193,7 @@ public class RepartitionTopicsTest {
         final Subtopology subtopology = new Subtopology()
             .setSubtopologyId("SUBTOPOLOGY0")
             .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME1))
-            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME2, REPARTITION_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
             .setRepartitionSourceTopics(List.of(
                 REPARTITION_TOPIC_INFO1,
                 REPARTITION_TOPIC_INFO2,
@@ -214,7 +214,36 @@ public class RepartitionTopicsTest {
             mkMap(
                 mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
                 mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
-                mkEntry(REPARTITION_WITHOUT_PARTITION_COUNT, 4)
+                mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 4)
+            ),
+            setup
+        );
+    }
+
+    @Test
+    public void shouldSetRepartitionTopicPartitionCountFromUpstreamSourceTopicMultipleSubtopologies() {
+        final Subtopology subtopology0 = new Subtopology()
+            .setSubtopologyId("SUBTOPOLOGY0")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT));
+        final Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId("SUBTOPOLOGY1")
+            .setRepartitionSourceTopics(List.of(
+                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
+            ));
+        List<Subtopology> subtopologyToSubtopology = List.of(subtopology0, subtopology1);
+        Function<String, OptionalInt> topicPartitionCountProvider = s -> Objects.equals(s, SOURCE_TOPIC_NAME1) ? OptionalInt.of(3) : OptionalInt.empty();
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            subtopologyToSubtopology,
+            topicPartitionCountProvider
+        );
+
+        Map<String, Integer> setup = repartitionTopics.setup();
+
+        assertEquals(
+            mkMap(
+                mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 3)
             ),
             setup
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.coordinator.group.streams.topics;
 
+import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
 import org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicConfig;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
 
 import org.junit.jupiter.api.Test;
@@ -29,13 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
-import java.util.Set;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RepartitionTopicsTest {
@@ -43,115 +39,97 @@ public class RepartitionTopicsTest {
     private static final LogContext LOG_CONTEXT = new LogContext();
     private static final String SOURCE_TOPIC_NAME1 = "source1";
     private static final String SOURCE_TOPIC_NAME2 = "source2";
-    private static final String SINK_TOPIC_NAME1 = "sink1";
-    private static final String SINK_TOPIC_NAME2 = "sink2";
-    private static final String REPARTITION_TOPIC_NAME1 = "repartition1";
-    private static final String REPARTITION_TOPIC_NAME2 = "repartition2";
-    private static final String REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT = "repartitionWithoutPartitionCount";
-    private static final TopicConfig TOPIC_CONFIG1 = new TopicConfig().setKey("config1").setValue("val1");
-    private static final TopicConfig TOPIC_CONFIG2 = new TopicConfig().setKey("config2").setValue("val2");
-    private static final TopicConfig TOPIC_CONFIG5 = new TopicConfig().setKey("config5").setValue("val5");
-    private static final TopicInfo REPARTITION_TOPIC_INFO1 = new TopicInfo()
-        .setName(REPARTITION_TOPIC_NAME1)
-        .setPartitions(4)
-        .setTopicConfigs(List.of(TOPIC_CONFIG1));
-    private static final Subtopology SUBTOPOLOGY2 = new Subtopology()
-        .setSubtopologyId("SUBTOPOLOGY2")
-        .setSourceTopics(Collections.singletonList(REPARTITION_TOPIC_NAME1))
-        .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME1))
-        .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC_INFO1))
-        .setStateChangelogTopics(Collections.emptyList());
-    private static final TopicInfo REPARTITION_TOPIC_INFO2 = new TopicInfo()
-        .setName(REPARTITION_TOPIC_NAME2)
-        .setPartitions(2)
-        .setTopicConfigs(List.of(TOPIC_CONFIG2));
-    private static final Subtopology SUBTOPOLOGY1 = new Subtopology()
-        .setSubtopologyId("SUBTOPOLOGY1")
-        .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2))
-        .setRepartitionSinkTopics(Collections.singletonList(REPARTITION_TOPIC_NAME1))
-        .setRepartitionSourceTopics(List.of(
-            REPARTITION_TOPIC_INFO1,
-            REPARTITION_TOPIC_INFO2
-        ))
-        .setStateChangelogTopics(Collections.emptyList());
-    private static final TopicInfo REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT = new TopicInfo()
-        .setName(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT)
-        .setTopicConfigs(List.of(TOPIC_CONFIG5));
-    private static final Subtopology SUBTOPOLOGY_WITHOUT_PARTITION_COUNT = new Subtopology()
-        .setSubtopologyId("SUBTOPOLOGY_WITHOUT_PARTITION_COUNT")
-        .setSourceTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
-        .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME2))
-        .setRepartitionSourceTopics(List.of(
-            REPARTITION_TOPIC_INFO1,
-            REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
-        ))
-        .setStateChangelogTopics(Collections.emptyList());
-    private static final Set<String> TOPICS = Set.of(
-        SOURCE_TOPIC_NAME1,
-        SOURCE_TOPIC_NAME2,
-        SINK_TOPIC_NAME1,
-        SINK_TOPIC_NAME2,
-        REPARTITION_TOPIC_NAME1,
-        REPARTITION_TOPIC_NAME2
-    );
+    private static final TopicInfo REPARTITION_TOPIC1 = new TopicInfo().setName("repartition1").setPartitions(4);
+    private static final TopicInfo REPARTITION_TOPIC2 = new TopicInfo().setName("repartition2").setPartitions(2);
+    private static final TopicInfo REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT = new TopicInfo().setName("repartitionWithoutPartitionCount");
+
+    private static OptionalInt sourceTopicPartitionCounts(final String topicName) {
+        return SOURCE_TOPIC_NAME1.equals(topicName) || SOURCE_TOPIC_NAME2.equals(topicName) ? OptionalInt.of(3) : OptionalInt.empty();
+    }
 
     @Test
     public void shouldSetupRepartitionTopics() {
-        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY2);
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+        final Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId("subtopology1")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC1.name()));
+        final Subtopology subtopology2 = new Subtopology()
+            .setSubtopologyId("subtopology2")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC1));
+        final List<Subtopology> subtopologies = List.of(subtopology1, subtopology2);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
+            subtopologies,
+            RepartitionTopicsTest::sourceTopicPartitionCounts
         );
 
-        Map<String, Integer> setup = repartitionTopics.setup();
+        final Map<String, Integer> setup = repartitionTopics.setup();
 
         assertEquals(
-            mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions())
-            ),
+            Map.of(REPARTITION_TOPIC1.name(), REPARTITION_TOPIC1.partitions()),
             setup
         );
     }
 
     @Test
     public void shouldThrowStreamsMissingSourceTopicsExceptionIfMissingSourceTopics() {
-        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY2);
-        Function<String, OptionalInt> topicPartitionCountProvider =
-            s -> Objects.equals(s, SOURCE_TOPIC_NAME1) ? OptionalInt.empty() :
-                (TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty());
+        final Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId("subtopology1")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC1.name()));
+        final Subtopology subtopology2 = new Subtopology()
+            .setSubtopologyId("subtopology2")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC1));
+        final Function<String, OptionalInt> topicPartitionCountProvider =
+            s -> Objects.equals(s, SOURCE_TOPIC_NAME1) ? OptionalInt.empty() : sourceTopicPartitionCounts(s);
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
+            List.of(subtopology1, subtopology2),
             topicPartitionCountProvider
         );
 
         final TopicConfigurationException exception = assertThrows(TopicConfigurationException.class,
             repartitionTopics::setup);
 
-        assertNotNull(exception);
         assertEquals(Status.MISSING_SOURCE_TOPICS, exception.status());
         assertEquals("Missing source topics: source1", exception.getMessage());
     }
 
     @Test
-    public void shouldThrowStreamsMissingSourceTopicsExceptionIfPartitionCountCannotBeComputedForAllRepartitionTopics() {
-        List<Subtopology> subtopologyToSubtopology = List.of(SUBTOPOLOGY1, SUBTOPOLOGY_WITHOUT_PARTITION_COUNT);
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+    public void shouldThrowStreamsInvalidTopologyExceptionIfPartitionCountCannotBeComputedForAllRepartitionTopicsDueToLoops() {
+        final Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId("subtopology1")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name()));
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
+            List.of(subtopology1),
+            RepartitionTopicsTest::sourceTopicPartitionCounts
         );
 
-        TopicConfigurationException exception = assertThrows(TopicConfigurationException.class, repartitionTopics::setup);
+        final StreamsInvalidTopologyException exception = assertThrows(StreamsInvalidTopologyException.class, repartitionTopics::setup);
 
-        assertEquals(Status.MISSING_SOURCE_TOPICS, exception.status());
         assertEquals(
-            "Failed to compute number of partitions for all repartition topics, make sure all user input topics are created "
-                + "and all pattern subscriptions match at least one topic in the cluster",
+            "Failed to compute number of partitions for all repartition topics. There may be loops in the topology that cannot be resolved.",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    public void shouldThrowStreamsInvalidTopologyExceptionIfPartitionCountCannotBeComputedForAllRepartitionTopicsDueToMissingSinks() {
+        final Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId("subtopology1")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT));
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            LOG_CONTEXT,
+            List.of(subtopology1),
+            RepartitionTopicsTest::sourceTopicPartitionCounts
+        );
+
+        final StreamsInvalidTopologyException exception = assertThrows(StreamsInvalidTopologyException.class, repartitionTopics::setup);
+
+        assertEquals(
+            "Failed to compute number of partitions for all repartition topics, because a repartition source topic is never used as a sink topic.",
             exception.getMessage()
         );
     }
@@ -159,91 +137,51 @@ public class RepartitionTopicsTest {
     @Test
     public void shouldSetRepartitionTopicPartitionCountFromUpstreamExternalSourceTopic() {
         final Subtopology subtopology = new Subtopology()
-            .setSubtopologyId("SUBTOPOLOGY0")
-            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME2))
-            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
-            .setRepartitionSourceTopics(List.of(
-                REPARTITION_TOPIC_INFO1,
-                REPARTITION_TOPIC_INFO2,
-                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
-            ))
-            .setStateChangelogTopics(Collections.emptyList());
-        List<Subtopology> subtopologyToSubtopology = List.of(
-            subtopology,
-            SUBTOPOLOGY_WITHOUT_PARTITION_COUNT
-        );
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+            .setSubtopologyId("subtopology0")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC1.name(), REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name()))
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC2));
+        final Subtopology subtopologyWithoutPartitionCount = new Subtopology()
+            .setSubtopologyId("subtopologyWithoutPartitionCount")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC1, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT));
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
+            List.of(subtopology, subtopologyWithoutPartitionCount),
+            RepartitionTopicsTest::sourceTopicPartitionCounts
         );
 
-        Map<String, Integer> setup = repartitionTopics.setup();
+        final Map<String, Integer> setup = repartitionTopics.setup();
 
-        assertEquals(mkMap(
-            mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
-            mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
-            mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 3)
+        assertEquals(Map.of(
+            REPARTITION_TOPIC1.name(), REPARTITION_TOPIC1.partitions(),
+            REPARTITION_TOPIC2.name(), REPARTITION_TOPIC2.partitions(),
+            REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name(), 3
         ), setup);
     }
 
     @Test
     public void shouldSetRepartitionTopicPartitionCountFromUpstreamInternalRepartitionSourceTopic() {
         final Subtopology subtopology = new Subtopology()
-            .setSubtopologyId("SUBTOPOLOGY0")
-            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, REPARTITION_TOPIC_NAME1))
-            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
-            .setRepartitionSourceTopics(List.of(
-                REPARTITION_TOPIC_INFO1,
-                REPARTITION_TOPIC_INFO2,
-                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
-            ))
-            .setStateChangelogTopics(Collections.emptyList());
-        List<Subtopology> subtopologyToSubtopology = List.of(subtopology, SUBTOPOLOGY_WITHOUT_PARTITION_COUNT);
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
-        final RepartitionTopics repartitionTopics = new RepartitionTopics(
-            LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
-        );
-
-        Map<String, Integer> setup = repartitionTopics.setup();
-
-        assertEquals(
-            mkMap(
-                mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_INFO1.partitions()),
-                mkEntry(REPARTITION_TOPIC_NAME2, REPARTITION_TOPIC_INFO2.partitions()),
-                mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 4)
-            ),
-            setup
-        );
-    }
-
-    @Test
-    public void shouldSetRepartitionTopicPartitionCountFromUpstreamSourceTopicMultipleSubtopologies() {
-        final Subtopology subtopology0 = new Subtopology()
-            .setSubtopologyId("SUBTOPOLOGY0")
+            .setSubtopologyId("subtopology0")
             .setSourceTopics(List.of(SOURCE_TOPIC_NAME1))
-            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT));
-        final Subtopology subtopology1 = new Subtopology()
-            .setSubtopologyId("SUBTOPOLOGY1")
-            .setRepartitionSourceTopics(List.of(
-                REPARTITION_TOPIC_INFO_WITHOUT_PARTITION_COUNT
-            ));
-        List<Subtopology> subtopologyToSubtopology = List.of(subtopology0, subtopology1);
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> Objects.equals(s, SOURCE_TOPIC_NAME1) ? OptionalInt.of(3) : OptionalInt.empty();
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC1))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name()));
+        final Subtopology subtopologyWithoutPartitionCount = new Subtopology()
+            .setSubtopologyId("subtopologyWithoutPartitionCount")
+            .setRepartitionSourceTopics(List.of(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT))
+            .setRepartitionSinkTopics(List.of(REPARTITION_TOPIC1.name()));
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
+            List.of(subtopology, subtopologyWithoutPartitionCount),
+            RepartitionTopicsTest::sourceTopicPartitionCounts
         );
 
-        Map<String, Integer> setup = repartitionTopics.setup();
+        final Map<String, Integer> setup = repartitionTopics.setup();
 
         assertEquals(
-            mkMap(
-                mkEntry(REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT, 3)
+            Map.of(
+                REPARTITION_TOPIC1.name(), REPARTITION_TOPIC1.partitions(),
+                REPARTITION_TOPIC_WITHOUT_PARTITION_COUNT.name(), REPARTITION_TOPIC1.partitions()
             ),
             setup
         );
@@ -252,20 +190,15 @@ public class RepartitionTopicsTest {
     @Test
     public void shouldNotSetupRepartitionTopicsWhenTopologyDoesNotContainAnyRepartitionTopics() {
         final Subtopology subtopology = new Subtopology()
-            .setSubtopologyId("SUBTOPOLOGY0")
-            .setSourceTopics(Collections.singletonList(SOURCE_TOPIC_NAME1))
-            .setRepartitionSinkTopics(Collections.singletonList(SINK_TOPIC_NAME1))
-            .setRepartitionSourceTopics(Collections.emptyList())
-            .setStateChangelogTopics(Collections.emptyList());
-        List<Subtopology> subtopologyToSubtopology = List.of(subtopology);
-        Function<String, OptionalInt> topicPartitionCountProvider = s -> TOPICS.contains(s) ? OptionalInt.of(3) : OptionalInt.empty();
+            .setSubtopologyId("subtopology0")
+            .setSourceTopics(List.of(SOURCE_TOPIC_NAME1));
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
             LOG_CONTEXT,
-            subtopologyToSubtopology,
-            topicPartitionCountProvider
+            List.of(subtopology),
+            RepartitionTopicsTest::sourceTopicPartitionCounts
         );
 
-        Map<String, Integer> setup = repartitionTopics.setup();
+        final Map<String, Integer> setup = repartitionTopics.setup();
 
         assertEquals(Collections.emptyMap(), setup);
     }


### PR DESCRIPTION
A simplified port of "RepartitionTopics" from the client-side to the group coordinator.

Compared to the client-side version, the implementation uses immutable data structures, and returns the computed number of partitions instead of modifying mutable data structures and calling the admin client.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
