### PR TITLE
MINOR: Use clear method to speed up removal

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -1755,10 +1755,7 @@ public class SharePartition {
             }
 
             if (lastKeyToRemove != -1) {
-                NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(firstKeyToRemove, true, lastKeyToRemove, true);
-                for (Long key : subMap.keySet()) {
-                    cachedState.remove(key);
-                }
+                cachedState.subMap(firstKeyToRemove, true, lastKeyToRemove, true).clear();
             }
         } finally {
             lock.writeLock().unlock();


### PR DESCRIPTION
In maybeUpdateCachedStateAndOffsets, we obtain the subMap according to firstKeyToRemove and lastKeyToRemove.
Then we iterate over the keys of subMap to remove the entries.

This PR makes the removal faster via clear method of the subMap.

Existing test cases pass.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
