### PR TITLE
KAFKA-18211: Override class loaders for class graph scanning in connect.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
@@ -78,22 +78,9 @@ public class ReflectionScanner extends PluginScanner {
 
     @Override
     protected PluginScanResult scanPlugins(PluginSource source) {
-        // By default, java and classgraph uses parent first classloading, hence if a plugin is loaded by the classpath
-        // loader, and then by an isolated plugin loader, the default precedence will always load the classpath version.
-        // This breaks isolation and hence connect uses isolated plugin loaders, which are child first classloaders.
-        // Therefore, we override the classloader order to be child first, so that the isolated plugin loader is used first.
-        // In addition, we need to explicitly specify the full classloader order, to force classgraph to scan classes in
-        // the class path. This does not happen by default as it uses reflections to obtain access to classpath URLs from
-        // the application classloader, which can fail with illegal access exceptions.
-        List<ClassLoader> classLoaderOrder = new ArrayList<>();
-        ClassLoader cl = source.loader();
-        while (cl != null) {
-            classLoaderOrder.add(cl);
-            cl = cl.getParent();
-        }
         ClassGraph classGraphBuilder = new ClassGraph()
             .addClassLoader(source.loader())
-                .overrideClassLoaders(classLoaderOrder.toArray(new ClassLoader[0]))
+                .overrideClassLoaders(classLoaderOrder(source))
                 .enableExternalClasses()
                 .enableClassInfo();
         try (ScanResult classGraph = classGraphBuilder.scan()) {
@@ -119,6 +106,23 @@ public class ReflectionScanner extends PluginScanner {
     @SuppressWarnings({"unchecked"})
     private SortedSet<PluginDesc<Transformation<?>>> getTransformationPluginDesc(PluginSource source, ScanResult classGraph) {
         return (SortedSet<PluginDesc<Transformation<?>>>) (SortedSet<?>) getPluginDesc(classGraph, PluginType.TRANSFORMATION, source);
+    }
+
+    private ClassLoader[] classLoaderOrder(PluginSource source) {
+        // By default, java and classgraph uses parent first classloading, hence if a plugin is loaded by the classpath
+        // loader, and then by an isolated plugin loader, the default precedence will always load the classpath version.
+        // This breaks isolation and hence connect uses isolated plugin loaders, which are child first classloaders.
+        // Therefore, we override the classloader order to be child first, so that the isolated plugin loader is used first.
+        // In addition, we need to explicitly specify the full classloader order, to force classgraph to scan classes in
+        // the class path. This does not happen by default as it uses reflections to obtain access to classpath URLs from
+        // the application classloader, which can fail with illegal access exceptions.
+        List<ClassLoader> classLoaderOrder = new ArrayList<>();
+        ClassLoader cl = source.loader();
+        while (cl != null) {
+            classLoaderOrder.add(cl);
+            cl = cl.getParent();
+        }
+        return classLoaderOrder.toArray(new ClassLoader[0]);
     }
 
     @SuppressWarnings({"unchecked"})

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
@@ -29,7 +29,9 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -76,8 +78,21 @@ public class ReflectionScanner extends PluginScanner {
 
     @Override
     protected PluginScanResult scanPlugins(PluginSource source) {
+        // By default, java and classgraph uses parent first classloading, hence if a plugin is loaded by the classpath
+        // loader, and then by an isolated plugin loader, the default precedence will always load the classpath version.
+        // This breaks isolation and hence connect uses isolated plugin loaders, which are child first classloaders.
+        // Therefore, we override the classloader order to be child first, so that the isolated plugin loader is used first.
+        // In addition, we need to explicitly specify the full classloader order, as classgraph only scans the classes available
+        // in the classloaders and not the entire parent chain. Due to this reason if a plugin is extending a class present
+        // in classpath/application it will not be able to find the parent class unless we explicitly specify the classloader order.
+        List<ClassLoader> classLoaderOrder = new ArrayList<>();
+        ClassLoader cl = source.loader();
+        while (cl != null) {
+            classLoaderOrder.add(cl);
+            cl = cl.getParent();
+        }
         ClassGraph classGraphBuilder = new ClassGraph()
-                .overrideClassLoaders(source.loader())
+                .overrideClassLoaders(classLoaderOrder.toArray(new ClassLoader[0]))
                 .enableExternalClasses()
                 .enableClassInfo();
         try (ScanResult classGraph = classGraphBuilder.scan()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
@@ -77,7 +77,7 @@ public class ReflectionScanner extends PluginScanner {
     @Override
     protected PluginScanResult scanPlugins(PluginSource source) {
         ClassGraph classGraphBuilder = new ClassGraph()
-                .addClassLoader(source.loader())
+                .overrideClassLoaders(source.loader())
                 .enableExternalClasses()
                 .enableClassInfo();
         try (ScanResult classGraph = classGraphBuilder.scan()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
@@ -82,9 +82,9 @@ public class ReflectionScanner extends PluginScanner {
         // loader, and then by an isolated plugin loader, the default precedence will always load the classpath version.
         // This breaks isolation and hence connect uses isolated plugin loaders, which are child first classloaders.
         // Therefore, we override the classloader order to be child first, so that the isolated plugin loader is used first.
-        // In addition, we need to explicitly specify the full classloader order, as classgraph only scans the classes available
-        // in the classloaders and not the entire parent chain. Due to this reason if a plugin is extending a class present
-        // in classpath/application it will not be able to find the parent class unless we explicitly specify the classloader order.
+        // In addition, we need to explicitly specify the full classloader order, to force classgraph to scan classes in
+        // the class path. This does not happen by default as it uses reflections to obtain access to classpath URLs from
+        // the application classloader, which can fail with illegal access exceptions.
         List<ClassLoader> classLoaderOrder = new ArrayList<>();
         ClassLoader cl = source.loader();
         while (cl != null) {
@@ -92,6 +92,7 @@ public class ReflectionScanner extends PluginScanner {
             cl = cl.getParent();
         }
         ClassGraph classGraphBuilder = new ClassGraph()
+            .addClassLoader(source.loader())
                 .overrideClassLoaders(classLoaderOrder.toArray(new ClassLoader[0]))
                 .enableExternalClasses()
                 .enableClassInfo();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/ReflectionScanner.java
@@ -79,7 +79,6 @@ public class ReflectionScanner extends PluginScanner {
     @Override
     protected PluginScanResult scanPlugins(PluginSource source) {
         ClassGraph classGraphBuilder = new ClassGraph()
-            .addClassLoader(source.loader())
                 .overrideClassLoaders(classLoaderOrder(source))
                 .enableExternalClasses()
                 .enableClassInfo();
@@ -109,13 +108,11 @@ public class ReflectionScanner extends PluginScanner {
     }
 
     private ClassLoader[] classLoaderOrder(PluginSource source) {
-        // By default, java and classgraph uses parent first classloading, hence if a plugin is loaded by the classpath
-        // loader, and then by an isolated plugin loader, the default precedence will always load the classpath version.
-        // This breaks isolation and hence connect uses isolated plugin loaders, which are child first classloaders.
-        // Therefore, we override the classloader order to be child first, so that the isolated plugin loader is used first.
-        // In addition, we need to explicitly specify the full classloader order, to force classgraph to scan classes in
-        // the class path. This does not happen by default as it uses reflections to obtain access to classpath URLs from
-        // the application classloader, which can fail with illegal access exceptions.
+        // Classgraph will first scan all the class URLs from the provided classloader chain and use said chain during classloading.
+        // We compute and provide the classloader chain starting from the isolated PluginClassLoader to ensure that it adheres
+        // to the child first delegation model used in connect. In addition, classgraph can fail to find URLs from the
+        // application classloader as it uses an illegal reflections access. Providing the entire chain of classloaders
+        // which included the application classloader forces classpath URLs to be scanned separately.
         List<ClassLoader> classLoaderOrder = new ArrayList<>();
         ClassLoader cl = source.loader();
         while (cl != null) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.connect.json.JsonConverter;
+
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.connect.storage.Converter;
+
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.runtime.isolation;
 
+import org.apache.kafka.connect.json.JsonConverter;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,6 +32,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -135,6 +137,17 @@ public class PluginScannerTest {
                 TestPlugins.pluginPath(TestPlugins.TestPlugin.READ_VERSION_FROM_RESOURCE_V1));
         assertFalse(versionedPluginResult.isEmpty());
         versionedPluginResult.forEach(pluginDesc -> assertEquals("1.0.0", pluginDesc.version()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testClasspathPluginIsAlsoLoadedInIsolation(PluginScanner scanner) {
+        // json converter is part of the classpath by default
+        String jsonConverterLocation = JsonConverter.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        PluginScanResult result = scan(scanner, Collections.singleton(Path.of(jsonConverterLocation)));
+        assertFalse(result.converters().isEmpty());
+        result.converters().stream().filter(pluginDesc -> pluginDesc.className().equals(JsonConverter.class.getName()))
+            .forEach(pluginDesc -> assertInstanceOf(PluginClassLoader.class, pluginDesc.loader()));
     }
 
     private PluginScanResult scan(PluginScanner scanner, Set<Path> pluginLocations) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.kafka.connect.runtime.isolation;
 
-import org.apache.kafka.connect.json.JsonConverter;
 
+import org.apache.kafka.connect.json.JsonConverter;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -143,9 +143,8 @@ public class PluginScannerTest {
     @ParameterizedTest
     @MethodSource("parameters")
     public void testClasspathPluginIsAlsoLoadedInIsolation(PluginScanner scanner) {
-        // json converter is part of the classpath by default
-        String jsonConverterLocation = JsonConverter.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        PluginScanResult result = scan(scanner, Collections.singleton(Path.of(jsonConverterLocation)));
+        Set<Path> isolatedClassPathPlugin = TestPlugins.pluginPath(TestPlugins.TestPlugin.CLASSPATH_CONVERTER);
+        PluginScanResult result = scan(scanner, isolatedClassPathPlugin);
         assertFalse(result.converters().isEmpty());
         result.converters().stream().filter(pluginDesc -> pluginDesc.className().equals(JsonConverter.class.getName()))
             .forEach(pluginDesc -> assertInstanceOf(PluginClassLoader.class, pluginDesc.loader()));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginScannerTest.java
@@ -17,8 +17,7 @@
 
 package org.apache.kafka.connect.runtime.isolation;
 
-
-import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.Converter;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -145,9 +145,11 @@ public class PluginScannerTest {
     public void testClasspathPluginIsAlsoLoadedInIsolation(PluginScanner scanner) {
         Set<Path> isolatedClassPathPlugin = TestPlugins.pluginPath(TestPlugins.TestPlugin.CLASSPATH_CONVERTER);
         PluginScanResult result = scan(scanner, isolatedClassPathPlugin);
-        assertFalse(result.converters().isEmpty());
-        result.converters().stream().filter(pluginDesc -> pluginDesc.className().equals(JsonConverter.class.getName()))
-            .forEach(pluginDesc -> assertInstanceOf(PluginClassLoader.class, pluginDesc.loader()));
+        Optional<PluginDesc<Converter>> pluginDesc = result.converters().stream()
+            .filter(desc -> desc.className().equals(TestPlugins.TestPlugin.CLASSPATH_CONVERTER.className()))
+            .findFirst();
+        assertTrue(pluginDesc.isPresent());
+        assertInstanceOf(PluginClassLoader.class, pluginDesc.get().loader());
     }
 
     private PluginScanResult scan(PluginScanner scanner, Set<Path> pluginLocations) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
@@ -256,7 +256,7 @@ public class TestPlugins {
         /**
          * A plugin which is part of the classpath by default. This packages it as a separate jar which is used to test plugin isolation from the classpath plugin.
          */
-        CLASSPATH_CONVERTER(TestPackage.CLASSPATH_CONVERTER, "org.apache.kafka.connect.converters.ByteArrayConverter");
+        CLASSPATH_CONVERTER(TestPackage.CLASSPATH_CONVERTER, "org.apache.kafka.connect.converters.ByteArrayConverter", false);
 
         private final TestPackage testPackage;
         private final String className;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
@@ -85,7 +85,8 @@ public class TestPlugins {
         SAMPLING_CONVERTER("sampling-converter"),
         SAMPLING_HEADER_CONVERTER("sampling-header-converter"),
         SERVICE_LOADER("service-loader"),
-        SUBCLASS_OF_CLASSPATH("subclass-of-classpath");
+        SUBCLASS_OF_CLASSPATH("subclass-of-classpath"),
+        CLASSPATH_CONVERTER("classpath-converter");
 
         private final String resourceDir;
         private final Predicate<String> removeRuntimeClasses;
@@ -251,7 +252,11 @@ public class TestPlugins {
         /**
          * A ServiceLoader discovered plugin which subclasses another plugin which is present on the classpath
          */
-        SUBCLASS_OF_CLASSPATH_OVERRIDE_POLICY(TestPackage.SUBCLASS_OF_CLASSPATH, "test.plugins.SubclassOfClasspathOverridePolicy");
+        SUBCLASS_OF_CLASSPATH_OVERRIDE_POLICY(TestPackage.SUBCLASS_OF_CLASSPATH, "test.plugins.SubclassOfClasspathOverridePolicy"),
+        /**
+         * A plugin which is part of the classpath by default. This packages it as a separate jar which is used to test plugin isolation from the classpath plugin.
+         */
+        CLASSPATH_CONVERTER(TestPackage.CLASSPATH_CONVERTER, "org.apache.kafka.connect.converters.ByteArrayConverter");
 
         private final TestPackage testPackage;
         private final String className;

--- a/connect/runtime/src/test/resources/test-plugins/classpath-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/src/test/resources/test-plugins/classpath-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.converters.ByteArrayConverter
+

--- a/connect/runtime/src/test/resources/test-plugins/classpath-converter/org/apache/kafka/connect/converters/ByteArrayConverter.java
+++ b/connect/runtime/src/test/resources/test-plugins/classpath-converter/org/apache/kafka/connect/converters/ByteArrayConverter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.converters;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.HeaderConverter;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+public class ByteArrayConverter implements Converter, HeaderConverter, Versioned {
+
+    private static final ConfigDef CONFIG_DEF = ConverterConfig.newConfigDef();
+    @Override
+    public String version() {
+        return AppInfoParser.getVersion();
+    }
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        if (schema != null && schema.type() != Schema.Type.BYTES)
+            throw new DataException("Invalid schema type for ByteArrayConverter: " + schema.type().toString());
+
+        if (value != null && !(value instanceof byte[]) && !(value instanceof ByteBuffer))
+            throw new DataException("ByteArrayConverter is not compatible with objects of type " + value.getClass());
+
+        return value instanceof ByteBuffer ? getBytesFromByteBuffer((ByteBuffer) value) : (byte[]) value;
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        return new SchemaAndValue(Schema.OPTIONAL_BYTES_SCHEMA, value);
+    }
+
+    @Override
+    public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+        return fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+        return toConnectData(topic, value);
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    private byte[] getBytesFromByteBuffer(ByteBuffer byteBuffer) {
+        if (byteBuffer == null) {
+            return null;
+        }
+
+        byteBuffer.rewind();
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes);
+        return bytes;
+    }
+}


### PR DESCRIPTION
Addresses the issue highlighted in https://issues.apache.org/jira/browse/KAFKA-18211

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
