### PR TITLE
KAFKA-18418: Use CDL to block the thread termination to avoid flaky tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -1362,6 +1362,7 @@ public class KafkaStreamsTest {
         when(mockConfig.getKafkaClientSupplier()).thenReturn(supplier);
 
         try (final KafkaStreams ignored = new KafkaStreamsWithTerminableThread(getBuilderWithSource().build(), mockConfig)) {
+            // no-op
         }
         // It's called once in above when mock
         verify(mockConfig, times(2)).getKafkaClientSupplier();
@@ -1398,6 +1399,7 @@ public class KafkaStreamsTest {
         final StreamsConfig mockConfig = spy(config);
 
         try (final KafkaStreams ignored = new KafkaStreamsWithTerminableThread(getBuilderWithSource().build(), mockConfig, supplier)) {
+            // no-op
         }
         // It's called once in above when mock
         verify(mockConfig, times(0)).getKafkaClientSupplier();


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

This PR fixes [KAFKA-18418](https://issues.apache.org/jira/browse/KAFKA-18418). KafkaStreamsTest uses `Thread.sleep` to prevent threads from terminating. This introduces flaky tests if the sleep duration is not long enough. This patch fixes the issue by replacing the `Thread.sleep` with a `CountDownLatch`. The `CountDownLatch` will be released after assertions are validated. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

I tested the proposed fix against the patch: https://github.com/aoli-al/kafka/commit/aced4f1430139c315809cceca26558416140883d and verified that all tests have passed. I also tested the new code using [Fray](https://github.com/cmu-pasta/fray) (the tool that found the bug), and Fray did not report any bug using the POS strategy after 10 minutes.  

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
