### PR TITLE
MINOR: Remove Sanitizer document with zookeeper description

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
@@ -26,10 +26,9 @@ import javax.management.ObjectName;
 /**
  * Utility class for sanitizing/desanitizing/quoting values used in JMX metric names.
  * <p>
- * User principals and client-ids are URL-encoded using ({@link #sanitize(String)}.
- * User principals are URL-encoded in all metric names as well. All other metric tags 
- * including client-id are quoted if they contain special characters using 
- * {@link #jmxSanitize(String)} when registering in JMX.
+ * User principals are URL-encoded using ({@link #sanitize(String)} in all metric names.
+ * All other metric tags including client-id are quoted if they contain special characters 
+ * using {@link #jmxSanitize(String)} when registering in JMX.
  */
 public class Sanitizer {
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
@@ -24,14 +24,12 @@ import java.util.regex.Pattern;
 import javax.management.ObjectName;
 
 /**
- * Utility class for sanitizing/desanitizing/quoting values used in JMX metric names
- * or as ZooKeeper node name.
+ * Utility class for sanitizing/desanitizing/quoting values used in JMX metric names.
  * <p>
- * User principals and client-ids are URL-encoded using ({@link #sanitize(String)}
- * for use as ZooKeeper node names. User principals are URL-encoded in all metric
- * names as well. All other metric tags including client-id are quoted if they
- * contain special characters using {@link #jmxSanitize(String)} when
- * registering in JMX.
+ * User principals and client-ids are URL-encoded using ({@link #sanitize(String)}.
+ * User principals are URL-encoded in all metric names as well. All other metric tags 
+ * including client-id are quoted if they contain special characters using 
+ * {@link #jmxSanitize(String)} when registering in JMX.
  */
 public class Sanitizer {
 
@@ -43,8 +41,7 @@ public class Sanitizer {
     private static final Pattern MBEAN_PATTERN = Pattern.compile("[\\w-%\\. \t]*");
 
     /**
-     * Sanitize `name` for safe use as JMX metric name as well as ZooKeeper node name
-     * using URL-encoding.
+     * Sanitize `name` for safe use as JMX metric name.
      */
     public static String sanitize(String name) {
         String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8);
@@ -63,8 +60,7 @@ public class Sanitizer {
     }
 
     /**
-     * Desanitize name that was URL-encoded using {@link #sanitize(String)}. This
-     * is used to obtain the desanitized version of node names in ZooKeeper.
+     * Desanitize name that was URL-encoded using {@link #sanitize(String)}.
      */
     public static String desanitize(String name) {
         return URLDecoder.decode(name, StandardCharsets.UTF_8);


### PR DESCRIPTION
As we depreacate Zk in Kafka 4.0, we should clean the document with zk description.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
