### PR TITLE
KAFKA-18437: Correct version of ShareUpdateRecord value

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinator.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinator.java
@@ -35,7 +35,7 @@ public interface ShareCoordinator {
     short SHARE_SNAPSHOT_RECORD_KEY_VERSION = 0;
     short SHARE_SNAPSHOT_RECORD_VALUE_VERSION = 0;
     short SHARE_UPDATE_RECORD_KEY_VERSION = 1;
-    short SHARE_UPDATE_RECORD_VALUE_VERSION = 1;
+    short SHARE_UPDATE_RECORD_VALUE_VERSION = 0;
 
     /**
      * Return the partition index for the given key.

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordSerde.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordSerde.java
@@ -29,9 +29,9 @@ public class ShareCoordinatorRecordSerde extends CoordinatorRecordSerde {
     @Override
     protected ApiMessage apiMessageKeyFor(short recordVersion) {
         switch (recordVersion) {
-            case ShareCoordinator.SHARE_SNAPSHOT_RECORD_KEY_VERSION:
+            case 0:
                 return new ShareSnapshotKey();
-            case ShareCoordinator.SHARE_UPDATE_RECORD_KEY_VERSION:
+            case 1:
                 return new ShareUpdateKey();
             default:
                 throw new CoordinatorLoader.UnknownRecordTypeException(recordVersion);
@@ -41,9 +41,9 @@ public class ShareCoordinatorRecordSerde extends CoordinatorRecordSerde {
     @Override
     protected ApiMessage apiMessageValueFor(short recordVersion) {
         switch (recordVersion) {
-            case ShareCoordinator.SHARE_SNAPSHOT_RECORD_VALUE_VERSION:
+            case 0:
                 return new ShareSnapshotValue();
-            case ShareCoordinator.SHARE_UPDATE_RECORD_VALUE_VERSION:
+            case 1:
                 return new ShareUpdateValue();
             default:
                 throw new CoordinatorLoader.UnknownRecordTypeException(recordVersion);


### PR DESCRIPTION
The versions of coordinator record keys are hijacked to distinguish between the record types. Coordinator record values are always version 0.

The JSON schema definition of ShareUpdateRecord uses version 0, but the version number used when constructing the record was version 1.

This patch applies to AK 4.0 only because this code has been superseded and the error was already been fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
