### PR TITLE
[KAFKA-18442] Remove broken upgrade-downgrade-upgrade path.

### DIFF
--- a/tests/kafkatest/tests/core/kraft_upgrade_test.py
+++ b/tests/kafkatest/tests/core/kraft_upgrade_test.py
@@ -176,13 +176,13 @@ class TestKRaftUpgrade(ProduceConsumeValidateTest):
         self.run_upgrade(from_kafka_version)
 
     @cluster(num_nodes=5)
-    @matrix(from_kafka_version=[str(LATEST_3_3), str(LATEST_3_4), str(LATEST_3_5), str(LATEST_3_6), str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(DEV_BRANCH)],
+    @matrix(from_kafka_version=[str(LATEST_3_4), str(LATEST_3_5), str(LATEST_3_6), str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(DEV_BRANCH)],
             metadata_quorum=[combined_kraft])
     def test_combined_mode_upgrade_downgrade(self, from_kafka_version, metadata_quorum, use_new_coordinator=False):
         self.run_upgrade_downgrade(from_kafka_version)
 
     @cluster(num_nodes=8)
-    @matrix(from_kafka_version=[str(LATEST_3_3), str(LATEST_3_4), str(LATEST_3_5), str(LATEST_3_6), str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(DEV_BRANCH)],
+    @matrix(from_kafka_version=[str(LATEST_3_4), str(LATEST_3_5), str(LATEST_3_6), str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(DEV_BRANCH)],
             metadata_quorum=[isolated_kraft])
     def test_isolated_mode_upgrade_downgrade(self, from_kafka_version, metadata_quorum, use_new_coordinator=False):
         self.run_upgrade_downgrade(from_kafka_version)


### PR DESCRIPTION
Fixes broken system tests. 

This has likely been broken for at least a year but may have only been detected now when [new tests](https://github.com/confluentinc/ce-kafka/pull/17847) where added. 

The test does the following:
1. starts kafka in older version of kafka
2. upgrades kafka to newest (stopping, starting)
3. downgrades to old version again (stopping, starting)

All while sending off verifiable producer/consumer to make sure all messages are read. 

The test suite only fails for kafka-3.3.2 at the starting phase of step 3. According to logs, the test suite fails because of:

```
kafka.common.InconsistentBrokerMetadataException: BrokerMetadata is not consistent across log.dirs. This could happen if multiple brokers shared a log directory (log.dirs) or partial data was manually copied from another broker. Found:
- /mnt/kafka/kafka-metadata-logs -> {node.id=1, directory.id=ItAoMTrsidYVfoRnX3gsAA, version=1, cluster.id=I2eXt9rvSnyhct8BYmW6-w}
- /mnt/kafka/kafka-data-logs-2 -> {node.id=1, directory.id=MiQDnIX6WuYL0NdMaLOsRQ, version=1, cluster.id=I2eXt9rvSnyhct8BYmW6-w}
- /mnt/kafka/kafka-data-logs-1 -> {node.id=1, directory.id=F1m5lsdOIsGtTpTYT0Ao9g, version=1, cluster.id=I2eXt9rvSnyhct8BYmW6-w}

	at kafka.server.BrokerMetadataCheckpoint$.getBrokerMetadataAndOfflineDirs(BrokerMetadataCheckpoint.scala:194)
	at kafka.server.KafkaRaftServer$.initializeLogDirs(KafkaRaftServer.scala:184)
	at kafka.server.KafkaRaftServer.<init>(KafkaRaftServer.scala:61)
	at kafka.Kafka$.buildServer(Kafka.scala:79)
	at kafka.Kafka$.main(Kafka.scala:87)
	at kafka.Kafka.main(Kafka.scala)

```

This is only broken in 3.3.2 version of Kafka [BrokerMetatadataCheckpoint.scala](https://github.com/apache/kafka/blob/c9c03dd7ef9ff4edf2596e905cabececc72a9e9d/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala#L186). In 3.3.2 kafka loads information about metadata directories via `metadata.properties` files and expects that the properties are duplicated for all log directories.  We crash with a fatal error if they are non-duplicate which at that time would mean that another instance of kafka was using the same log directories. 

However, at some point before [#14628](https://github.com/apache/kafka/pull/14628) we dropped the requirement that the `metadata.properties` files is duplicate in each directory since they will now contain a non-unique `directory.id` field for each dir. This has no effect on versions of kafka running `kraft` mode, greater than 3.4.x (they care only about uniqueness of node.id and cluster.id) but does affect 3.3.2 since it expects every `metadata.properties` file to be the same or else. 

If we assume that this has been broken for a while and there is not a forward compat requirement, I propose removing this specific test version. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
