### PR TITLE
MINOR: Replace deprecated MemberDescription calls in test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
@@ -41,20 +41,31 @@ public class MemberDescriptionTest {
                                                           INSTANCE_ID,
                                                           CLIENT_ID,
                                                           HOST,
-                                                          ASSIGNMENT);
+                                                          ASSIGNMENT,
+                                                          Optional.empty(),
+                                                          Optional.empty(),
+                                                          Optional.empty());
     }
 
     @Test
     public void testEqualsWithoutGroupInstanceId() {
         MemberDescription dynamicMemberDescription = new MemberDescription(MEMBER_ID,
+                                                                           Optional.empty(),
                                                                            CLIENT_ID,
                                                                            HOST,
-                                                                           ASSIGNMENT);
+                                                                           ASSIGNMENT,
+                                                                           Optional.empty(),
+                                                                           Optional.empty(),
+                                                                           Optional.empty());
 
         MemberDescription identityDescription = new MemberDescription(MEMBER_ID,
+                                                                      Optional.empty(),
                                                                       CLIENT_ID,
                                                                       HOST,
-                                                                      ASSIGNMENT);
+                                                                      ASSIGNMENT,
+                                                                      Optional.empty(),
+                                                                      Optional.empty(),
+                                                                      Optional.empty());
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, dynamicMemberDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), dynamicMemberDescription.hashCode());
@@ -74,7 +85,10 @@ public class MemberDescriptionTest {
                                                                       INSTANCE_ID,
                                                                       CLIENT_ID,
                                                                       HOST,
-                                                                      ASSIGNMENT);
+                                                                      ASSIGNMENT,
+                                                                      Optional.empty(),
+                                                                      Optional.empty(),
+                                                                      Optional.empty());
 
         assertEquals(STATIC_MEMBER_DESCRIPTION, identityDescription);
         assertEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), identityDescription.hashCode());
@@ -86,7 +100,10 @@ public class MemberDescriptionTest {
                                                                        INSTANCE_ID,
                                                                        CLIENT_ID,
                                                                        HOST,
-                                                                       ASSIGNMENT);
+                                                                       ASSIGNMENT,
+                                                                       Optional.empty(),
+                                                                       Optional.empty(),
+                                                                       Optional.empty());
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, newMemberDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newMemberDescription.hashCode());
@@ -95,7 +112,10 @@ public class MemberDescriptionTest {
                                                                          Optional.of("new_instance"),
                                                                          CLIENT_ID,
                                                                          HOST,
-                                                                         ASSIGNMENT);
+                                                                         ASSIGNMENT,
+                                                                         Optional.empty(),
+                                                                         Optional.empty(),
+                                                                         Optional.empty());
 
         assertNotEquals(STATIC_MEMBER_DESCRIPTION, newInstanceDescription);
         assertNotEquals(STATIC_MEMBER_DESCRIPTION.hashCode(), newInstanceDescription.hashCode());


### PR DESCRIPTION
`MemberDescriptionTest` makes several constructor calls that will be deprecated from `4.0` on.  This patch replaces these calls to the supported one.

Testing:
1. Re-run MemberDescriptionTest to rule out regression: `./gradlew clients:test --tests MemberDescriptionTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
