### PR TITLE
KAFKA-18440: Admin does not convert the AuthorizationException to fatal error in using bootstrap controllers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestUtils.java
@@ -16,6 +16,13 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.MismatchedEndpointTypeException;
+import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnsupportedEndpointTypeException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Message;
@@ -76,5 +83,15 @@ public final class RequestUtils {
 
         writable.flip();
         return writable.buffer();
+    }
+
+    public static boolean isFatalException(Throwable e) {
+        return e instanceof AuthenticationException ||
+            e instanceof AuthorizationException ||
+            e instanceof MismatchedEndpointTypeException ||
+            e instanceof SecurityDisabledException ||
+            e instanceof UnsupportedVersionException ||
+            e instanceof UnsupportedEndpointTypeException ||
+            e instanceof UnsupportedForMessageFormatException;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.clients.admin.internals;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 
@@ -94,6 +95,16 @@ public class AdminMetadataManagerTest {
         mgr.updateFailed(new AuthenticationException("Authentication failed"));
         assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
         assertThrows(AuthenticationException.class, mgr::isReady);
+        mgr.update(mockCluster(), time.milliseconds());
+        assertTrue(mgr.isReady());
+    }
+
+    @Test
+    public void testAuthorizationFailure() {
+        mgr.transitionToUpdatePending(time.milliseconds());
+        mgr.updateFailed(new AuthorizationException("Authorization failed"));
+        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertThrows(AuthorizationException.class, mgr::isReady);
         mgr.update(mockCluster(), time.milliseconds());
         assertTrue(mgr.isReady());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.MismatchedEndpointTypeException;
+import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnsupportedEndpointTypeException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequestUtilsTest {
+    @Test
+    public void testIsFatalException() {
+        assertTrue(RequestUtils.isFatalException(new AuthenticationException("")));
+        assertTrue(RequestUtils.isFatalException(new AuthorizationException("")));
+        assertTrue(RequestUtils.isFatalException(new MismatchedEndpointTypeException("")));
+        assertTrue(RequestUtils.isFatalException(new SecurityDisabledException("")));
+        assertTrue(RequestUtils.isFatalException(new UnsupportedEndpointTypeException("")));
+        assertTrue(RequestUtils.isFatalException(new UnsupportedForMessageFormatException("")));
+        assertTrue(RequestUtils.isFatalException(new UnsupportedVersionException("")));
+
+        // retriable exceptions
+        assertFalse(RequestUtils.isFatalException(new DisconnectException("")));
+    }
+}


### PR DESCRIPTION
Admin use DescribeClusterRequest to build metadata when using bootstrap controllers, and controller APIs may return ClusterAuthorizationException when users have no "ALTER" permission (see https://github.com/apache/kafka/pull/14306#discussion_r1312367762).

However, admin does not convert the authorized exception to fatal exception (https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java#L276), so it keeps sending the request to controller until timeout.

* unit test: AdminMetadataManagerTest#testAuthorizationFailure
* integration test: ClusterTestExtensionsTest#testSaslPlaintext

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
