### PR TITLE
KAFKA-18311: Internal Topic Manager (5/5)

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopicMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopicMetadata.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Immutable topic metadata, representing the current state of a topic in the broker.
  *
- * @param id             The topic id.
+ * @param id             The topic ID.
  * @param name           The topic name.
  * @param numPartitions  The number of partitions.
  * @param partitionRacks Map of every partition ID to a set of its rack IDs, if they exist. If rack information is unavailable for all
@@ -35,12 +35,10 @@ import java.util.Set;
  */
 public record TopicMetadata(Uuid id, String name, int numPartitions, Map<Integer, Set<String>> partitionRacks) {
 
-    public TopicMetadata(
-        Uuid id,
-        String name,
-        int numPartitions,
-        Map<Integer, Set<String>> partitionRacks
-    ) {
+    public TopicMetadata(Uuid id,
+                         String name,
+                         int numPartitions,
+                         Map<Integer, Set<String>> partitionRacks) {
         this.id = Objects.requireNonNull(id);
         if (Uuid.ZERO_UUID.equals(id)) {
             throw new IllegalArgumentException("Topic id cannot be ZERO_UUID.");
@@ -50,15 +48,13 @@ public record TopicMetadata(Uuid id, String name, int numPartitions, Map<Integer
             throw new IllegalArgumentException("Topic name cannot be empty.");
         }
         this.numPartitions = numPartitions;
-        if (numPartitions < 0) {
-            throw new IllegalArgumentException("Number of partitions cannot be negative.");
+        if (numPartitions <= 0) {
+            throw new IllegalArgumentException("Number of partitions must be positive.");
         }
         this.partitionRacks = Objects.requireNonNull(partitionRacks);
     }
 
-    public static TopicMetadata fromRecord(
-        StreamsGroupPartitionMetadataValue.TopicMetadata record
-    ) {
+    public static TopicMetadata fromRecord(StreamsGroupPartitionMetadataValue.TopicMetadata record) {
         // Converting the data type from a list stored in the record to a map for the topic metadata.
         Map<Integer, Set<String>> partitionRacks = new HashMap<>();
         for (StreamsGroupPartitionMetadataValue.PartitionMetadata partitionMetadata : record.partitionMetadata()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopicMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopicMetadata.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupPartitionMetadataValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Immutable topic metadata, representing the current state of a topic in the broker.
+ *
+ * @param id             The topic id.
+ * @param name           The topic name.
+ * @param numPartitions  The number of partitions.
+ * @param partitionRacks Map of every partition ID to a set of its rack IDs, if they exist. If rack information is unavailable for all
+ *                       partitions, this is an empty map.
+ */
+public record TopicMetadata(Uuid id, String name, int numPartitions, Map<Integer, Set<String>> partitionRacks) {
+
+    public TopicMetadata(
+        Uuid id,
+        String name,
+        int numPartitions,
+        Map<Integer, Set<String>> partitionRacks
+    ) {
+        this.id = Objects.requireNonNull(id);
+        if (Uuid.ZERO_UUID.equals(id)) {
+            throw new IllegalArgumentException("Topic id cannot be ZERO_UUID.");
+        }
+        this.name = Objects.requireNonNull(name);
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Topic name cannot be empty.");
+        }
+        this.numPartitions = numPartitions;
+        if (numPartitions < 0) {
+            throw new IllegalArgumentException("Number of partitions cannot be negative.");
+        }
+        this.partitionRacks = Objects.requireNonNull(partitionRacks);
+    }
+
+    public static TopicMetadata fromRecord(
+        StreamsGroupPartitionMetadataValue.TopicMetadata record
+    ) {
+        // Converting the data type from a list stored in the record to a map for the topic metadata.
+        Map<Integer, Set<String>> partitionRacks = new HashMap<>();
+        for (StreamsGroupPartitionMetadataValue.PartitionMetadata partitionMetadata : record.partitionMetadata()) {
+            partitionRacks.put(
+                partitionMetadata.partition(),
+                Set.copyOf(partitionMetadata.racks())
+            );
+        }
+
+        return new TopicMetadata(
+            record.topicId(),
+            record.topicName(),
+            record.numPartitions(),
+            partitionRacks);
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
@@ -65,6 +65,8 @@ public class ChangelogTopics {
     /**
      * Determines the number of partitions for each non-source changelog topic in the requested topology.
      *
+     * @throws IllegalStateException If a source topic does not have a partition count defined through topicPartitionCountProvider.
+     *
      * @return the map of all non-source changelog topics for the requested topology to their required number of partitions.
      */
     public Map<String, Integer> setup() {
@@ -94,7 +96,7 @@ public class ChangelogTopics {
     private int getPartitionCountOrFail(String topic) {
         final OptionalInt topicPartitionCount = topicPartitionCountProvider.apply(topic);
         if (topicPartitionCount.isEmpty()) {
-            throw TopicConfigurationException.missingSourceTopics("No partition count for source topic " + topic);
+            throw new IllegalStateException("No partition count for source topic " + topic);
         }
         return topicPartitionCount.getAsInt();
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
@@ -148,8 +148,13 @@ public class InternalTopicManager {
 
         decidedPartitionCountsForInternalTopics.putAll(repartitionTopics.setup());
 
-        enforceCopartitioning(topology, copartitionGroupsBySubtopology, log,
-            decidedPartitionCountsForInternalTopics, copartitionedTopicsEnforcer);
+        enforceCopartitioning(
+            topology,
+            copartitionGroupsBySubtopology,
+            log,
+            decidedPartitionCountsForInternalTopics,
+            copartitionedTopicsEnforcer
+        );
 
         decidedPartitionCountsForInternalTopics.putAll(changelogTopics.setup());
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
@@ -148,6 +148,19 @@ public class InternalTopicManager {
 
         decidedPartitionCountsForInternalTopics.putAll(repartitionTopics.setup());
 
+        enforceCopartitioning(topology, copartitionGroupsBySubtopology, log,
+            decidedPartitionCountsForInternalTopics, copartitionedTopicsEnforcer);
+
+        decidedPartitionCountsForInternalTopics.putAll(changelogTopics.setup());
+
+        return decidedPartitionCountsForInternalTopics;
+    }
+
+    private static void enforceCopartitioning(final StreamsTopology topology,
+                                              final Map<String, Collection<Set<String>>> copartitionGroupsBySubtopology,
+                                              final Logger log,
+                                              final Map<String, Integer> decidedPartitionCountsForInternalTopics,
+                                              final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer) {
         final Set<String> fixedRepartitionTopics =
             topology.subtopologies().values().stream().flatMap(x ->
                 x.repartitionSourceTopics().stream().filter(y -> y.partitions() != 0)
@@ -170,10 +183,6 @@ public class InternalTopicManager {
                 }
             }
         }
-
-        decidedPartitionCountsForInternalTopics.putAll(changelogTopics.setup());
-
-        return decidedPartitionCountsForInternalTopics;
     }
 
     private static Map<String, CreatableTopic> missingInternalTopics(Map<String, ConfiguredSubtopology> subtopologyMap,
@@ -241,9 +250,8 @@ public class InternalTopicManager {
         return creatableTopic;
     }
 
-    private static ConfiguredSubtopology fromPersistedSubtopology(
-        final StreamsGroupTopologyValue.Subtopology subtopology,
-        Map<String, Integer> decidedPartitionCountsForInternalTopics
+    private static ConfiguredSubtopology fromPersistedSubtopology(final StreamsGroupTopologyValue.Subtopology subtopology,
+                                                                  final Map<String, Integer> decidedPartitionCountsForInternalTopics
     ) {
         return new ConfiguredSubtopology(
             new HashSet<>(subtopology.sourceTopics()),
@@ -257,9 +265,8 @@ public class InternalTopicManager {
         );
     }
 
-    private static ConfiguredInternalTopic fromPersistedTopicInfo(
-        final StreamsGroupTopologyValue.TopicInfo topicInfo,
-        Map<String, Integer> decidedPartitionCountsForInternalTopics) {
+    private static ConfiguredInternalTopic fromPersistedTopicInfo(final StreamsGroupTopologyValue.TopicInfo topicInfo,
+                                                                  final Map<String, Integer> decidedPartitionCountsForInternalTopics) {
         if (topicInfo.partitions() == 0 && !decidedPartitionCountsForInternalTopics.containsKey(topicInfo.name())) {
             throw new IllegalStateException("Number of partitions must be set for topic " + topicInfo.name());
         }
@@ -277,7 +284,8 @@ public class InternalTopicManager {
     }
 
     private static Collection<Set<String>> copartitionGroupsFromPersistedSubtopology(
-        final StreamsGroupTopologyValue.Subtopology subtopology) {
+        final StreamsGroupTopologyValue.Subtopology subtopology
+    ) {
         return subtopology.copartitionGroups().stream().map(copartitionGroup ->
             Stream.concat(
                 copartitionGroup.sourceTopics().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManager.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.streams.StreamsTopology;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Responsible for configuring internal topics for a given topology.
+ */
+public class InternalTopicManager {
+
+    /**
+     * Configures the internal topics for the given topology. Given a topology and the topic metadata, this method determines the number of
+     * partitions for all internal topics and returns a {@link ConfiguredTopology} object.
+     *
+     * @param logContext    The log context.
+     * @param topology      The topology.
+     * @param topicMetadata The topic metadata.
+     * @return The configured topology.
+     */
+    public static ConfiguredTopology configureTopics(LogContext logContext,
+                                                     StreamsTopology topology,
+                                                     Map<String, TopicMetadata> topicMetadata) {
+        final Logger log = logContext.logger(InternalTopicManager.class);
+        final Collection<StreamsGroupTopologyValue.Subtopology> subtopologies = topology.subtopologies().values();
+
+        final Map<String, Collection<Set<String>>> copartitionGroupsBySubtopology =
+            subtopologies.stream()
+                .collect(Collectors.toMap(
+                    StreamsGroupTopologyValue.Subtopology::subtopologyId,
+                    InternalTopicManager::copartitionGroupsFromPersistedSubtopology)
+                );
+
+        try {
+            Optional<TopicConfigurationException> topicConfigurationException = Optional.empty();
+
+            throwOnMissingSourceTopics(topology, topicMetadata);
+
+            Map<String, Integer> decidedPartitionCountsForInternalTopics =
+                decidePartitionCounts(logContext, topology, topicMetadata, copartitionGroupsBySubtopology, log);
+
+            final Map<String, ConfiguredSubtopology> configuredSubtopologies =
+                subtopologies.stream()
+                    .collect(Collectors.toMap(
+                        StreamsGroupTopologyValue.Subtopology::subtopologyId,
+                        x -> fromPersistedSubtopology(x, decidedPartitionCountsForInternalTopics))
+                    );
+
+            Map<String, CreatableTopic> internalTopicsToCreate = missingInternalTopics(configuredSubtopologies, topicMetadata);
+            if (!internalTopicsToCreate.isEmpty()) {
+                topicConfigurationException = Optional.of(TopicConfigurationException.missingInternalTopics(
+                    "Internal topics are missing: " + internalTopicsToCreate.keySet()
+                ));
+                log.info("Valid topic configuration found, but internal topics are missing for topology epoch {}: {}",
+                    topology.topologyEpoch(), topicConfigurationException.get().toString());
+            } else {
+                log.info("Valid topic configuration found, topology epoch {} is now initialized.", topology.topologyEpoch());
+            }
+
+            return new ConfiguredTopology(
+                topology.topologyEpoch(),
+                Optional.of(configuredSubtopologies),
+                internalTopicsToCreate,
+                topicConfigurationException
+            );
+
+        } catch (TopicConfigurationException e) {
+            log.warn("Topic configuration failed for topology epoch {}: {} ",
+                topology.topologyEpoch(), e.toString());
+            return new ConfiguredTopology(
+                topology.topologyEpoch(),
+                Optional.empty(),
+                Map.of(),
+                Optional.of(e)
+            );
+        }
+    }
+
+    private static void throwOnMissingSourceTopics(final StreamsTopology topology,
+                                                   final Map<String, TopicMetadata> topicMetadata) {
+        TreeSet<String> sortedMissingTopics = new TreeSet<>();
+        for (StreamsGroupTopologyValue.Subtopology subtopology : topology.subtopologies().values()) {
+            for (String sourceTopic : subtopology.sourceTopics()) {
+                if (!topicMetadata.containsKey(sourceTopic)) {
+                    sortedMissingTopics.add(sourceTopic);
+                }
+            }
+        }
+        if (!sortedMissingTopics.isEmpty()) {
+            throw TopicConfigurationException.missingSourceTopics(
+                "Source topics " + String.join(", ", sortedMissingTopics) + " are missing.");
+        }
+    }
+
+    private static Map<String, Integer> decidePartitionCounts(final LogContext logContext,
+                                                              final StreamsTopology topology,
+                                                              final Map<String, TopicMetadata> topicMetadata,
+                                                              final Map<String, Collection<Set<String>>> copartitionGroupsBySubtopology,
+                                                              final Logger log) {
+        final Map<String, Integer> decidedPartitionCountsForInternalTopics = new HashMap<>();
+        final Function<String, OptionalInt> topicPartitionCountProvider =
+            topic -> getPartitionCount(topicMetadata, topic, decidedPartitionCountsForInternalTopics);
+        final RepartitionTopics repartitionTopics = new RepartitionTopics(
+            logContext,
+            topology.subtopologies().values(),
+            topicPartitionCountProvider);
+        final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer = new CopartitionedTopicsEnforcer(
+            logContext,
+            topicPartitionCountProvider);
+        final ChangelogTopics changelogTopics = new ChangelogTopics(logContext,
+            topology.subtopologies().values(),
+            topicPartitionCountProvider);
+
+        decidedPartitionCountsForInternalTopics.putAll(repartitionTopics.setup());
+
+        final Set<String> fixedRepartitionTopics =
+            topology.subtopologies().values().stream().flatMap(x ->
+                x.repartitionSourceTopics().stream().filter(y -> y.partitions() != 0)
+            ).map(StreamsGroupTopologyValue.TopicInfo::name).collect(Collectors.toSet());
+        final Set<String> flexibleRepartitionTopics =
+            topology.subtopologies().values().stream().flatMap(x ->
+                x.repartitionSourceTopics().stream().filter(y -> y.partitions() == 0)
+            ).map(StreamsGroupTopologyValue.TopicInfo::name).collect(Collectors.toSet());
+
+        if (fixedRepartitionTopics.isEmpty() && flexibleRepartitionTopics.isEmpty()) {
+            log.info("Skipping the repartition topic validation since there are no repartition topics.");
+        } else {
+            // ensure the co-partitioning topics within the group have the same number of partitions,
+            // and enforce the number of partitions for those repartition topics to be the same if they
+            // are co-partitioned as well.
+            for (Collection<Set<String>> copartitionGroups : copartitionGroupsBySubtopology.values()) {
+                for (Set<String> copartitionGroup : copartitionGroups) {
+                    decidedPartitionCountsForInternalTopics.putAll(
+                        copartitionedTopicsEnforcer.enforce(copartitionGroup, fixedRepartitionTopics, flexibleRepartitionTopics));
+                }
+            }
+        }
+
+        decidedPartitionCountsForInternalTopics.putAll(changelogTopics.setup());
+
+        return decidedPartitionCountsForInternalTopics;
+    }
+
+    private static Map<String, CreatableTopic> missingInternalTopics(Map<String, ConfiguredSubtopology> subtopologyMap,
+                                                                     Map<String, TopicMetadata> topicMetadata) {
+
+        final Map<String, CreatableTopic> topicsToCreate = new HashMap<>();
+        for (ConfiguredSubtopology subtopology : subtopologyMap.values()) {
+            subtopology.repartitionSourceTopics().values()
+                .forEach(x -> topicsToCreate.put(x.name(), toCreatableTopic(x)));
+            subtopology.stateChangelogTopics().values()
+                .forEach(x -> topicsToCreate.put(x.name(), toCreatableTopic(x)));
+        }
+        for (Map.Entry<String, TopicMetadata> topic : topicMetadata.entrySet()) {
+            final TopicMetadata existingTopic = topic.getValue();
+            final CreatableTopic expectedTopic = topicsToCreate.remove(topic.getKey());
+            if (expectedTopic != null) {
+                if (existingTopic.numPartitions() != expectedTopic.numPartitions()) {
+                    throw TopicConfigurationException.incorrectlyPartitionedTopics("Existing topic " + topic.getKey() + " has different"
+                        + " number of partitions: expected " + expectedTopic.numPartitions() + ", found " + existingTopic.numPartitions());
+                }
+            }
+        }
+        return topicsToCreate;
+    }
+
+    private static OptionalInt getPartitionCount(Map<String, TopicMetadata> topicMetadata,
+                                                 String topic,
+                                                 Map<String, Integer> decidedPartitionCountsForInternalTopics) {
+        final TopicMetadata metadata = topicMetadata.get(topic);
+        if (metadata == null) {
+            if (decidedPartitionCountsForInternalTopics.containsKey(topic)) {
+                return OptionalInt.of(decidedPartitionCountsForInternalTopics.get(topic));
+            } else {
+                return OptionalInt.empty();
+            }
+        } else {
+            return OptionalInt.of(metadata.numPartitions());
+        }
+    }
+
+    private static CreatableTopic toCreatableTopic(final ConfiguredInternalTopic config) {
+
+        final CreatableTopic creatableTopic = new CreatableTopic();
+
+        creatableTopic.setName(config.name());
+        creatableTopic.setNumPartitions(config.numberOfPartitions());
+
+        if (config.replicationFactor().isPresent() && config.replicationFactor().get() != 0) {
+            creatableTopic.setReplicationFactor(config.replicationFactor().get());
+        } else {
+            creatableTopic.setReplicationFactor((short) -1);
+        }
+
+        final CreatableTopicConfigCollection topicConfigs = new CreatableTopicConfigCollection();
+
+        config.topicConfigs().forEach((k, v) -> {
+            final CreatableTopicConfig topicConfig = new CreatableTopicConfig();
+            topicConfig.setName(k);
+            topicConfig.setValue(v);
+            topicConfigs.add(topicConfig);
+        });
+
+        creatableTopic.setConfigs(topicConfigs);
+
+        return creatableTopic;
+    }
+
+    private static ConfiguredSubtopology fromPersistedSubtopology(
+        final StreamsGroupTopologyValue.Subtopology subtopology,
+        Map<String, Integer> decidedPartitionCountsForInternalTopics
+    ) {
+        return new ConfiguredSubtopology(
+            new HashSet<>(subtopology.sourceTopics()),
+            subtopology.repartitionSourceTopics().stream()
+                .map(x -> fromPersistedTopicInfo(x, decidedPartitionCountsForInternalTopics))
+                .collect(Collectors.toMap(ConfiguredInternalTopic::name, x -> x)),
+            new HashSet<>(subtopology.repartitionSinkTopics()),
+            subtopology.stateChangelogTopics().stream()
+                .map(x -> fromPersistedTopicInfo(x, decidedPartitionCountsForInternalTopics))
+                .collect(Collectors.toMap(ConfiguredInternalTopic::name, x -> x))
+        );
+    }
+
+    private static ConfiguredInternalTopic fromPersistedTopicInfo(
+        final StreamsGroupTopologyValue.TopicInfo topicInfo,
+        Map<String, Integer> decidedPartitionCountsForInternalTopics) {
+        if (topicInfo.partitions() == 0 && !decidedPartitionCountsForInternalTopics.containsKey(topicInfo.name())) {
+            throw new IllegalStateException("Number of partitions must be set for topic " + topicInfo.name());
+        }
+
+        return new ConfiguredInternalTopic(
+            topicInfo.name(),
+            topicInfo.partitions() == 0 ? decidedPartitionCountsForInternalTopics.get(topicInfo.name()) : topicInfo.partitions(),
+            topicInfo.replicationFactor() == 0 ? Optional.empty()
+                : Optional.of(topicInfo.replicationFactor()),
+            topicInfo.topicConfigs() != null ? topicInfo.topicConfigs().stream()
+                .collect(Collectors.toMap(StreamsGroupTopologyValue.TopicConfig::key,
+                    StreamsGroupTopologyValue.TopicConfig::value))
+                : Collections.emptyMap()
+        );
+    }
+
+    private static Collection<Set<String>> copartitionGroupsFromPersistedSubtopology(
+        final StreamsGroupTopologyValue.Subtopology subtopology) {
+        return subtopology.copartitionGroups().stream().map(copartitionGroup ->
+            Stream.concat(
+                copartitionGroup.sourceTopics().stream()
+                    .map(i -> subtopology.sourceTopics().get(i)),
+                copartitionGroup.repartitionSourceTopics().stream()
+                    .map(i -> subtopology.repartitionSourceTopics().get(i).name())
+            ).collect(Collectors.toSet())
+        ).collect(Collectors.toList());
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopics.java
@@ -48,7 +48,7 @@ public class RepartitionTopics {
      * @param logContext                   The context for emitting log messages.
      * @param subtopologies                The subtopologies for the requested topology.
      * @param topicPartitionCountProvider  Returns the number of partitions for a given topic, representing the current state of the
-     *                                     broker.
+     *                                     broker. This class requires the number of partition for all source topics to be defined.
      */
     public RepartitionTopics(final LogContext logContext,
                              final Collection<Subtopology> subtopologies,
@@ -63,8 +63,7 @@ public class RepartitionTopics {
      *
      * @return the map of repartition topics for the requested topology to their required number of partitions.
      *
-     * @throws TopicConfigurationException if no valid configuration can be found given the broker state, for example, if a source topic
-     *         is missing.
+     * @throws IllegalStateException if the number of partitions for a source topic is not defined by topicPartitionCountProvider.
      * @throws StreamsInvalidTopologyException if the number of partitions for all repartition topics cannot be determined, e.g.
      *         because of loops, or if a repartition source topic is not a sink topic of any subtopology.
      */
@@ -77,7 +76,7 @@ public class RepartitionTopics {
         }
 
         if (!missingSourceTopicsForTopology.isEmpty()) {
-            throw TopicConfigurationException.missingSourceTopics(String.format("Missing source topics: %s",
+            throw new IllegalStateException(String.format("Missing source topics: %s",
                 String.join(", ", missingSourceTopicsForTopology)));
         }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopicMetadataTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopicMetadataTest.java
@@ -26,10 +26,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TopicMetadataTest {
+
+    @Test
+    public void testConstructor() {
+        assertDoesNotThrow(() ->
+            new TopicMetadata(Uuid.randomUuid(), "valid-topic", 3, new HashMap<>()));
+    }
 
     @Test
     public void testConstructorWithZeroUuid() {
@@ -58,10 +65,17 @@ public class TopicMetadataTest {
     }
 
     @Test
+    public void testConstructorWithZeroNumPartitions() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+            new TopicMetadata(Uuid.randomUuid(), "valid-topic", 0, new HashMap<>()));
+        assertEquals("Number of partitions must be positive.", exception.getMessage());
+    }
+
+    @Test
     public void testConstructorWithNegativeNumPartitions() {
         Exception exception = assertThrows(IllegalArgumentException.class, () ->
             new TopicMetadata(Uuid.randomUuid(), "valid-topic", -1, new HashMap<>()));
-        assertEquals("Number of partitions cannot be negative.", exception.getMessage());
+        assertEquals("Number of partitions must be positive.", exception.getMessage());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopicMetadataTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopicMetadataTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupPartitionMetadataValue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TopicMetadataTest {
+
+    @Test
+    public void testConstructorWithZeroUuid() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+            new TopicMetadata(Uuid.ZERO_UUID, "valid-topic", 3, new HashMap<>()));
+        assertEquals("Topic id cannot be ZERO_UUID.", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithNullUuid() {
+        assertThrows(NullPointerException.class, () ->
+            new TopicMetadata(null, "valid-topic", 3, new HashMap<>()));
+    }
+
+    @Test
+    public void testConstructorWithNullName() {
+        assertThrows(NullPointerException.class, () ->
+            new TopicMetadata(Uuid.randomUuid(), null, 3, new HashMap<>()));
+    }
+
+    @Test
+    public void testConstructorWithEmptyName() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+            new TopicMetadata(Uuid.randomUuid(), "", 3, new HashMap<>()));
+        assertEquals("Topic name cannot be empty.", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithNegativeNumPartitions() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+            new TopicMetadata(Uuid.randomUuid(), "valid-topic", -1, new HashMap<>()));
+        assertEquals("Number of partitions cannot be negative.", exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithNullPartitionRacks() {
+        assertThrows(NullPointerException.class, () ->
+            new TopicMetadata(Uuid.randomUuid(), "valid-topic", 3, null));
+    }
+
+    @Test
+    public void testFromRecord() {
+        StreamsGroupPartitionMetadataValue.TopicMetadata record = new StreamsGroupPartitionMetadataValue.TopicMetadata()
+            .setTopicId(Uuid.randomUuid())
+            .setTopicName("test-topic")
+            .setNumPartitions(3)
+            .setPartitionMetadata(List.of(
+                new StreamsGroupPartitionMetadataValue.PartitionMetadata()
+                    .setPartition(0)
+                    .setRacks(List.of("rack1", "rack2")),
+                new StreamsGroupPartitionMetadataValue.PartitionMetadata()
+                    .setPartition(1)
+                    .setRacks(List.of("rack3")),
+                new StreamsGroupPartitionMetadataValue.PartitionMetadata()
+                    .setPartition(2)
+                    .setRacks(List.of("rack4", "rack5"))
+            ));
+
+        TopicMetadata topicMetadata = TopicMetadata.fromRecord(record);
+
+        assertEquals(record.topicId(), topicMetadata.id());
+        assertEquals(record.topicName(), topicMetadata.name());
+        assertEquals(record.numPartitions(), topicMetadata.numPartitions());
+
+        Map<Integer, Set<String>> expectedPartitionRacks = new HashMap<>();
+        expectedPartitionRacks.put(0, Set.of("rack1", "rack2"));
+        expectedPartitionRacks.put(1, Set.of("rack3"));
+        expectedPartitionRacks.put(2, Set.of("rack4", "rack5"));
+
+        assertEquals(expectedPartitionRacks, topicMetadata.partitionRacks());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopologyTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopologyTest.java
@@ -53,7 +53,7 @@ public class ConfiguredTopologyTest {
         assertThrows(NullPointerException.class,
             () -> new ConfiguredTopology(
                 0,
-                Collections.emptyMap(),
+                Optional.of(Map.of()),
                 null,
                 Optional.empty()
             )
@@ -65,7 +65,7 @@ public class ConfiguredTopologyTest {
         assertThrows(NullPointerException.class,
             () -> new ConfiguredTopology(
                 0,
-                Collections.emptyMap(),
+                Optional.empty(),
                 Collections.emptyMap(),
                 null
             )
@@ -77,7 +77,7 @@ public class ConfiguredTopologyTest {
         assertThrows(IllegalArgumentException.class,
             () -> new ConfiguredTopology(
                 -1,
-                Collections.emptyMap(),
+                Optional.of(Map.of()),
                 Collections.emptyMap(),
                 Optional.empty()
             )
@@ -85,13 +85,26 @@ public class ConfiguredTopologyTest {
     }
 
     @Test
+    public void testNoExceptionButNoSubtopologies() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> new ConfiguredTopology(
+                1,
+                Optional.empty(),
+                Collections.emptyMap(),
+                Optional.empty()
+            )
+        );
+        assertEquals(ex.getMessage(), "Subtopologies must be present if topicConfigurationException is empty.");
+    }
+
+    @Test
     public void testIsReady() {
         ConfiguredTopology readyTopology = new ConfiguredTopology(
-            1, new HashMap<>(), new HashMap<>(), Optional.empty());
+            1, Optional.of(Map.of()), new HashMap<>(), Optional.empty());
         assertTrue(readyTopology.isReady());
 
         ConfiguredTopology notReadyTopology = new ConfiguredTopology(
-            1, new HashMap<>(), new HashMap<>(), Optional.of(TopicConfigurationException.missingSourceTopics("missing")));
+            1, Optional.empty(), new HashMap<>(), Optional.of(TopicConfigurationException.missingSourceTopics("missing")));
         assertFalse(notReadyTopology.isReady());
     }
 
@@ -106,7 +119,7 @@ public class ConfiguredTopologyTest {
         Map<String, CreatableTopic> internalTopicsToBeCreated = new HashMap<>();
         Optional<TopicConfigurationException> topicConfigurationException = Optional.empty();
         ConfiguredTopology configuredTopology = new ConfiguredTopology(
-            topologyEpoch, subtopologies, internalTopicsToBeCreated, topicConfigurationException);
+            topologyEpoch, Optional.of(subtopologies), internalTopicsToBeCreated, topicConfigurationException);
 
         StreamsGroupDescribeResponseData.Topology topology = configuredTopology.asStreamsGroupDescribeTopology();
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/CopartitionedTopicsEnforcerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/CopartitionedTopicsEnforcerTest.java
@@ -48,19 +48,18 @@ public class CopartitionedTopicsEnforcerTest {
     }
 
     @Test
-    public void shouldThrowTopicConfigurationExceptionIfNoPartitionsFoundForCoPartitionedTopic() {
+    public void shouldThrowIllegalStateExceptionIfNoPartitionsFoundForCoPartitionedTopic() {
         final Map<String, Integer> topicPartitionCounts = Collections.emptyMap();
         final CopartitionedTopicsEnforcer enforcer =
             new CopartitionedTopicsEnforcer(LOG_CONTEXT, topicPartitionProvider(topicPartitionCounts));
 
-        final TopicConfigurationException ex = assertThrows(TopicConfigurationException.class, () ->
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
             enforcer.enforce(
                 Set.of(SOURCE_TOPIC_1),
                 Set.of(),
                 Set.of()
             ));
-        assertEquals(Status.MISSING_SOURCE_TOPICS, ex.status());
-        assertEquals(String.format("Following topics are missing: [%s]", SOURCE_TOPIC_1), ex.getMessage());
+        assertEquals(String.format("Number of partitions is not set for topic: %s", SOURCE_TOPIC_1), ex.getMessage());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/InternalTopicManagerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfig;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
+import org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
+import org.apache.kafka.coordinator.group.streams.StreamsTopology;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InternalTopicManagerTest {
+
+    public static final String SOURCE_TOPIC_1 = "source_topic1";
+    public static final String SOURCE_TOPIC_2 = "source_topic2";
+    public static final String REPARTITION_TOPIC = "repartition_topic";
+    public static final String STATE_CHANGELOG_TOPIC_1 = "state_changelog_topic1";
+    public static final String STATE_CHANGELOG_TOPIC_2 = "state_changelog_topic2";
+    public static final String SUBTOPOLOGY_1 = "subtopology1";
+    public static final String SUBTOPOLOGY_2 = "subtopology2";
+    public static final String CONFIG_KEY = "cleanup.policy";
+    public static final String CONFIG_VALUE = "compact";
+
+    @Test
+    void testConfigureTopicsSetsConfigurationExceptionWhenSourceTopicIsMissing() {
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put(SOURCE_TOPIC_1, new TopicMetadata(Uuid.randomUuid(), SOURCE_TOPIC_1, 2, Collections.emptyMap()));
+        // SOURCE_TOPIC_2 is missing from topicMetadata
+        StreamsTopology topology = makeTestTopology();
+
+        final ConfiguredTopology configuredTopology = InternalTopicManager.configureTopics(new LogContext(), topology, topicMetadata);
+
+        assertEquals(Optional.empty(), configuredTopology.subtopologies());
+        assertTrue(configuredTopology.topicConfigurationException().isPresent());
+        assertEquals(Status.MISSING_SOURCE_TOPICS, configuredTopology.topicConfigurationException().get().status());
+        assertEquals(String.format("Source topics %s are missing.", SOURCE_TOPIC_2), configuredTopology.topicConfigurationException().get().getMessage());
+    }
+
+    @Test
+    void testConfigureTopics() {
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put(SOURCE_TOPIC_1, new TopicMetadata(Uuid.randomUuid(), SOURCE_TOPIC_1, 2, Collections.emptyMap()));
+        topicMetadata.put(SOURCE_TOPIC_2, new TopicMetadata(Uuid.randomUuid(), SOURCE_TOPIC_2, 2, Collections.emptyMap()));
+        topicMetadata.put(STATE_CHANGELOG_TOPIC_2,
+            new TopicMetadata(Uuid.randomUuid(), STATE_CHANGELOG_TOPIC_2, 2, Collections.emptyMap()));
+        StreamsTopology topology = makeTestTopology();
+
+        ConfiguredTopology configuredTopology = InternalTopicManager.configureTopics(new LogContext(), topology, topicMetadata);
+        final Map<String, CreatableTopic> internalTopicsToBeCreated = configuredTopology.internalTopicsToBeCreated();
+
+        assertEquals(2, internalTopicsToBeCreated.size());
+        assertEquals(
+            new CreatableTopic()
+                .setName(REPARTITION_TOPIC)
+                .setNumPartitions(2)
+                .setReplicationFactor((short) 3),
+            internalTopicsToBeCreated.get(REPARTITION_TOPIC)
+        );
+        assertEquals(
+            new CreatableTopic()
+                .setName(STATE_CHANGELOG_TOPIC_1)
+                .setNumPartitions(2)
+                .setReplicationFactor((short) -1)
+                .setConfigs(
+                    new CreatableTopicConfigCollection(
+                        Collections.singletonList(new CreatableTopicConfig().setName(CONFIG_KEY).setValue(CONFIG_VALUE)).iterator())
+                ),
+            internalTopicsToBeCreated.get(STATE_CHANGELOG_TOPIC_1));
+
+        Optional<Map<String, ConfiguredSubtopology>> expectedConfiguredTopology = Optional.of(makeExpectedConfiguredSubtopologies());
+        assertEquals(expectedConfiguredTopology, configuredTopology.subtopologies());
+    }
+
+    private static Map<String, ConfiguredSubtopology> makeExpectedConfiguredSubtopologies() {
+        return mkMap(
+            mkEntry(SUBTOPOLOGY_1,
+                new ConfiguredSubtopology(
+                    Set.of(SOURCE_TOPIC_1),
+                    Map.of(),
+                    Set.of(REPARTITION_TOPIC),
+                    Map.of(STATE_CHANGELOG_TOPIC_1,
+                        new ConfiguredInternalTopic(
+                            STATE_CHANGELOG_TOPIC_1,
+                            2,
+                            Optional.empty(),
+                            Map.of(CONFIG_KEY, CONFIG_VALUE)
+                        ))
+                )
+            ),
+            mkEntry(SUBTOPOLOGY_2,
+                new ConfiguredSubtopology(
+                    Set.of(SOURCE_TOPIC_2),
+                    Map.of(REPARTITION_TOPIC,
+                        new ConfiguredInternalTopic(REPARTITION_TOPIC,
+                            2,
+                            Optional.of((short) 3),
+                            Collections.emptyMap()
+                        )
+                    ),
+                    Set.of(),
+                    Map.of(STATE_CHANGELOG_TOPIC_2,
+                        new ConfiguredInternalTopic(STATE_CHANGELOG_TOPIC_2,
+                            2,
+                            Optional.empty(),
+                            Collections.emptyMap()
+                        )))
+            )
+        );
+    }
+
+    private static StreamsTopology makeTestTopology() {
+        // Create a subtopology source -> repartition
+        Subtopology subtopology1 = new Subtopology()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setSourceTopics(Collections.singletonList(SOURCE_TOPIC_1))
+            .setRepartitionSinkTopics(Collections.singletonList(REPARTITION_TOPIC))
+            .setStateChangelogTopics(Collections.singletonList(
+                new StreamsGroupTopologyValue.TopicInfo()
+                    .setName(STATE_CHANGELOG_TOPIC_1)
+                    .setTopicConfigs(Collections.singletonList(
+                        new StreamsGroupTopologyValue.TopicConfig()
+                            .setKey(CONFIG_KEY)
+                            .setValue(CONFIG_VALUE)
+                    ))
+            ));
+        // Create a subtopology repartition/source2 -> sink (copartitioned)
+        Subtopology subtopology2 = new Subtopology()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setSourceTopics(Collections.singletonList(SOURCE_TOPIC_2))
+            .setRepartitionSourceTopics(Collections.singletonList(
+                new StreamsGroupTopologyValue.TopicInfo()
+                    .setName(REPARTITION_TOPIC)
+                    .setReplicationFactor((short) 3)
+            ))
+            .setStateChangelogTopics(Collections.singletonList(
+                new StreamsGroupTopologyValue.TopicInfo()
+                    .setName(STATE_CHANGELOG_TOPIC_2)
+            ))
+            .setCopartitionGroups(Collections.singletonList(
+                new StreamsGroupTopologyValue.CopartitionGroup()
+                    .setSourceTopics(Collections.singletonList((short) 0))
+                    .setRepartitionSourceTopics(Collections.singletonList((short) 0))
+            ));
+
+        return new StreamsTopology(3, Map.of(SUBTOPOLOGY_1, subtopology1, SUBTOPOLOGY_2, subtopology2));
+    }
+
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/RepartitionTopicsTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.coordinator.group.streams.topics;
 
 import org.apache.kafka.common.errors.StreamsInvalidTopologyException;
-import org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.Subtopology;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue.TopicInfo;
@@ -72,7 +71,7 @@ public class RepartitionTopicsTest {
     }
 
     @Test
-    public void shouldThrowStreamsMissingSourceTopicsExceptionIfMissingSourceTopics() {
+    public void shouldThrowIllegalStateExceptionIfMissingSourceTopics() {
         final Subtopology subtopology1 = new Subtopology()
             .setSubtopologyId("subtopology1")
             .setSourceTopics(List.of(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2))
@@ -88,10 +87,9 @@ public class RepartitionTopicsTest {
             topicPartitionCountProvider
         );
 
-        final TopicConfigurationException exception = assertThrows(TopicConfigurationException.class,
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
             repartitionTopics::setup);
 
-        assertEquals(Status.MISSING_SOURCE_TOPICS, exception.status());
         assertEquals("Missing source topics: source1", exception.getMessage());
     }
 


### PR DESCRIPTION
The internal topic manager takes a requested topology and returns a configured topology, as well as any internal topics that need to be created.

Shares with the client-side "InternalTopicManager" the name only.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
