### PR TITLE
KAFKA-18399: Remove ZooKeeper from KafkaApis (3/N): USER_SCRAM_CREDENTIALS

### DIFF
--- a/core/src/main/scala/kafka/server/MetadataSupport.scala
+++ b/core/src/main/scala/kafka/server/MetadataSupport.scala
@@ -58,16 +58,11 @@ sealed trait MetadataSupport {
 
   def canForward(): Boolean
 
-  def maybeForward(
+  def forward(
     request: RequestChannel.Request,
-    handler: RequestChannel.Request => Unit,
     responseCallback: Option[AbstractResponse] => Unit
   ): Unit = {
-    if (!request.isForwarded && canForward()) {
-      forwardingManager.get.forwardRequest(request, responseCallback)
-    } else {
-      handler(request)
-    }
+    forwardingManager.get.forwardRequest(request, responseCallback)
   }
 }
 


### PR DESCRIPTION
JIRA: KAFKA-18399
This is a part of KAFKA-18399 and it's focus on clean up `ALTER_USER_SCRAM_CREDENTIALS` and `DESCRIBE_USER_SCRAM_CREDENTIALS`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
