### PR TITLE
KAFKA-18449: Add share group state configs to reconfig-server.properties.

### DIFF
--- a/config/kraft/reconfig-server.properties
+++ b/config/kraft/reconfig-server.properties
@@ -82,9 +82,11 @@ num.partitions=1
 num.recovery.threads.per.data.dir=1
 
 ############################# Internal Topic Settings  #############################
-# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"
 # For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
 offsets.topic.replication.factor=1
+share.coordinator.state.topic.replication.factor=1
+share.coordinator.state.topic.min.isr=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1
 

--- a/config/kraft/server.properties
+++ b/config/kraft/server.properties
@@ -82,15 +82,13 @@ num.partitions=1
 num.recovery.threads.per.data.dir=1
 
 ############################# Internal Topic Settings  #############################
-# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"
 # For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
 offsets.topic.replication.factor=1
-transaction.state.log.replication.factor=1
-transaction.state.log.min.isr=1
-
-# Share state topic settings
 share.coordinator.state.topic.replication.factor=1
 share.coordinator.state.topic.min.isr=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
 
 ############################# Log Flush Policy #############################
 


### PR DESCRIPTION
*What*
Share-group state configs have previously been added to `config/kraft/server.properties`. They also need to be added to `config/kraft/reconfig-server.properties`.
This is a cherrypick PR from trunk to 4.0.