### PR TITLE
MINOR: fix KafkaStreams archtype docs

### DIFF
--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -47,7 +47,7 @@
 -DarchetypeArtifactId=streams-quickstart-java \
 -DarchetypeVersion={{fullDotVersion}} \
 -DgroupId=streams.examples \
--DartifactId=streams-quickstart\
+-DartifactId=streams-quickstart \
 -Dversion=0.1 \
 -Dpackage=myapps</code></pre>
     <p>


### PR DESCRIPTION
Introduced in https://github.com/apache/kafka/commit/364bc3c5c42b7854265d6f3a051217643a5e67a3 which accidentally removed the space by accident. Fix should be back-ported to 3.7.

W/o the space, the command when copied from the docs become `mvn ... -DartifactId=streams-quickstart-Dversion=0.1 ...` ie, the two parameters are not separated but `streams-quickstart-Dversion=0.1` becomes the value of `-DartifactId=`.