### PR TITLE
HOTFIX: fix failed case RemoteLogManagerTest#testStopPartitionsWithDeletion

### DIFF
--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2150,9 +2150,9 @@ public class RemoteLogManagerTest {
         partitions.add(new StopPartition(followerTopicIdPartition.topicPartition(), true, true, true));
 
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition)))
-                .thenReturn(listRemoteLogSegmentMetadata(leaderTopicIdPartition, 5, 100, 1024, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED).iterator());
+            .thenAnswer(invocation -> listRemoteLogSegmentMetadata(leaderTopicIdPartition, 5, 100, 1024, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED).iterator());
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(followerTopicIdPartition)))
-                .thenReturn(listRemoteLogSegmentMetadata(followerTopicIdPartition, 3, 100, 1024, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED).iterator());
+            .thenAnswer(invocation -> listRemoteLogSegmentMetadata(followerTopicIdPartition, 3, 100, 1024, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED).iterator());
         CompletableFuture<Void> dummyFuture = new CompletableFuture<>();
         dummyFuture.complete(null);
         when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any()))


### PR DESCRIPTION
Not sure which commit makes the case fail. The CI result of my PR fails with `RemoteLogManagerTest#testStopPartitionsWithDeletion`. The trunk branch can also reproduce this.

* https://github.com/apache/kafka/actions/runs/12702931506/job/35410037095?pr=18461

The root cause is that following functions call `RemoteLogMetadataManager#listRemoteLogSegments`. It returns iterator. If one of function go through iterator first, another can't get expected result. I change `thenReturn` to `thenAnswer` to avoid the issue.

* RLMExpirationTask#cleanupExpiredRemoteLogSegments
* RemoteLogManager#deleteRemoteLogPartition

```
> ./gradlew clean :core:test --tests "kafka.log.remote.RemoteLogManagerTest.testStopPartitionsWithDeletion"
> Task :core:test

Gradle Test Run :core:test > Gradle Test Executor 7 > RemoteLogManagerTest > testStopPartitionsWithDeletion() PASSED
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
