### PR TITLE
KAFKA-18469;KAFKA-18036: AsyncConsumer should request metadata update if ListOffsetRequest encounters a retriable error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -578,6 +578,7 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
                     listOffsetsRequestState.globalResult.complete(listOffsetResult);
                 } else {
                     requestsToRetry.add(listOffsetsRequestState);
+                    metadata.requestUpdate(false);
                 }
             } else {
                 log.debug("ListOffsets request failed with error", error);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -86,7 +86,6 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     private final SubscriptionState subscriptionState;
 
     private final Set<ListOffsetsRequestState> requestsToRetry;
-    private final Set<ListOffsetsRequestState> requestsToRetryOnMetadataUpdate;
     private final List<NetworkClientDelegate.UnsentRequest> requestsToSend;
     private final int requestTimeoutMs;
     private final Time time;
@@ -133,7 +132,6 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
         this.isolationLevel = isolationLevel;
         this.log = logContext.logger(getClass());
         this.requestsToRetry = new HashSet<>();
-        this.requestsToRetryOnMetadataUpdate = new HashSet<>();
         this.requestsToSend = new ArrayList<>();
         this.subscriptionState = subscriptionState;
         this.time = time;
@@ -144,7 +142,7 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
                 time, retryBackoffMs, apiVersions);
         // Register the cluster metadata update callback. Note this only relies on the
-        // requestsToRetryOnMetadataUpdate initialized above, and won't be invoked until all managers are
+        // requestsToRetry initialized above, and won't be invoked until all managers are
         // initialized and the network thread started.
         this.metadata.addClusterUpdateListener(this);
         this.commitRequestManager = commitRequestManager;
@@ -169,8 +167,6 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     @Override
     public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
         // Copy the outgoing request list and clear it.
-        maybeRetryListOffsetsRequests(false);
-
         List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>(requestsToSend);
         requestsToSend.clear();
         return new NetworkClientDelegate.PollResult(unsentRequests);
@@ -525,28 +521,17 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
                     timestampsToSearch, requireTimestamps, listOffsetsRequestState);
             requestsToSend.addAll(unsentRequests);
         } catch (StaleMetadataException e) {
-            requestsToRetryOnMetadataUpdate.add(listOffsetsRequestState);
+            requestsToRetry.add(listOffsetsRequestState);
         }
     }
 
     @Override
     public void onUpdate(ClusterResource clusterResource) {
-        // Retry requests on metadata update
-        maybeRetryListOffsetsRequests(true);
-    }
-
-    private void maybeRetryListOffsetsRequests(boolean onMetadataUpdate) {
-        // Process a copy of the list to avoid errors, given that the list of requestsToRetry
-        // may be modified from the fetchOffsetsByTimes call if any of the requests being retried fails
-        List<ListOffsetsRequestState> requestsToProcess;
-        if (onMetadataUpdate) {
-            requestsToProcess = new ArrayList<>(requestsToRetryOnMetadataUpdate);
-            requestsToRetryOnMetadataUpdate.clear();
-        } else {
-            requestsToProcess = new ArrayList<>(requestsToRetry);
-            requestsToRetry.clear();
-        }
-
+        // Retry requests that were awaiting a metadata update. Process a copy of the list to
+        // avoid errors, given that the list of requestsToRetry may be modified from the
+        // fetchOffsetsByTimes call if any of the requests being retried fails
+        List<ListOffsetsRequestState> requestsToProcess = new ArrayList<>(requestsToRetry);
+        requestsToRetry.clear();
         requestsToProcess.forEach(requestState -> {
             Map<TopicPartition, Long> timestampsToSearch =
                     new HashMap<>(requestState.remainingToSearch);
@@ -929,11 +914,6 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     // Visible for testing
     int requestsToRetry() {
         return requestsToRetry.size();
-    }
-
-    // Visible for testing
-    int requestsToRetryOnMetadataUpdate() {
-        return requestsToRetryOnMetadataUpdate.size();
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -86,6 +86,7 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     private final SubscriptionState subscriptionState;
 
     private final Set<ListOffsetsRequestState> requestsToRetry;
+    private final Set<ListOffsetsRequestState> requestsToRetryOnMetadataUpdate;
     private final List<NetworkClientDelegate.UnsentRequest> requestsToSend;
     private final int requestTimeoutMs;
     private final Time time;
@@ -132,6 +133,7 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
         this.isolationLevel = isolationLevel;
         this.log = logContext.logger(getClass());
         this.requestsToRetry = new HashSet<>();
+        this.requestsToRetryOnMetadataUpdate = new HashSet<>();
         this.requestsToSend = new ArrayList<>();
         this.subscriptionState = subscriptionState;
         this.time = time;
@@ -142,7 +144,7 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
                 time, retryBackoffMs, apiVersions);
         // Register the cluster metadata update callback. Note this only relies on the
-        // requestsToRetry initialized above, and won't be invoked until all managers are
+        // requestsToRetryOnMetadataUpdate initialized above, and won't be invoked until all managers are
         // initialized and the network thread started.
         this.metadata.addClusterUpdateListener(this);
         this.commitRequestManager = commitRequestManager;
@@ -167,6 +169,8 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     @Override
     public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
         // Copy the outgoing request list and clear it.
+        maybeRetryListOffsetsRequests(false);
+
         List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>(requestsToSend);
         requestsToSend.clear();
         return new NetworkClientDelegate.PollResult(unsentRequests);
@@ -521,17 +525,28 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
                     timestampsToSearch, requireTimestamps, listOffsetsRequestState);
             requestsToSend.addAll(unsentRequests);
         } catch (StaleMetadataException e) {
-            requestsToRetry.add(listOffsetsRequestState);
+            requestsToRetryOnMetadataUpdate.add(listOffsetsRequestState);
         }
     }
 
     @Override
     public void onUpdate(ClusterResource clusterResource) {
-        // Retry requests that were awaiting a metadata update. Process a copy of the list to
-        // avoid errors, given that the list of requestsToRetry may be modified from the
-        // fetchOffsetsByTimes call if any of the requests being retried fails
-        List<ListOffsetsRequestState> requestsToProcess = new ArrayList<>(requestsToRetry);
-        requestsToRetry.clear();
+        // Retry requests on metadata update
+        maybeRetryListOffsetsRequests(true);
+    }
+
+    private void maybeRetryListOffsetsRequests(boolean onMetadataUpdate) {
+        // Process a copy of the list to avoid errors, given that the list of requestsToRetry
+        // may be modified from the fetchOffsetsByTimes call if any of the requests being retried fails
+        List<ListOffsetsRequestState> requestsToProcess;
+        if (onMetadataUpdate) {
+            requestsToProcess = new ArrayList<>(requestsToRetryOnMetadataUpdate);
+            requestsToRetryOnMetadataUpdate.clear();
+        } else {
+            requestsToProcess = new ArrayList<>(requestsToRetry);
+            requestsToRetry.clear();
+        }
+
         requestsToProcess.forEach(requestState -> {
             Map<TopicPartition, Long> timestampsToSearch =
                     new HashMap<>(requestState.remainingToSearch);
@@ -914,6 +929,11 @@ public final class OffsetsRequestManager implements RequestManager, ClusterResou
     // Visible for testing
     int requestsToRetry() {
         return requestsToRetry.size();
+    }
+
+    // Visible for testing
+    int requestsToRetryOnMetadataUpdate() {
+        return requestsToRetryOnMetadataUpdate.size();
     }
 
     // Visible for testing

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -134,6 +134,7 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets = Collections.singletonMap(
                 TEST_PARTITION_1,
@@ -152,7 +153,8 @@ public class OffsetsRequestManagerTest {
             requestManager.fetchOffsets(timestampsToSearch, false);
 
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(1, requestManager.requestsToRetryOnMetadataUpdate());
         verify(metadata).requestUpdate(true);
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
         assertEquals(0, res.unsentRequests.size());
@@ -178,6 +180,7 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets = timestampsToSearch.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
@@ -192,12 +195,14 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(0, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         NetworkClientDelegate.PollResult pollResult = requestManager.poll(time.milliseconds());
         assertTrue(pollResult.unsentRequests.isEmpty());
 
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         assertTrue(result.isDone());
         assertFalse(result.isCompletedExceptionally());
@@ -216,6 +221,7 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         List<ListOffsetsResponseData.ListOffsetsTopicResponse> topicResponses = Collections.singletonList(
                 mockUnknownOffsetResponse(TEST_PARTITION_1));
@@ -240,7 +246,8 @@ public class OffsetsRequestManagerTest {
         CompletableFuture<Map<TopicPartition, OffsetAndTimestampInternal>> fetchOffsetsFuture =
             requestManager.fetchOffsets(timestampsToSearch, false);
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(1, requestManager.requestsToRetryOnMetadataUpdate());
         verify(metadata).requestUpdate(true);
 
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -271,6 +278,7 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent to single broker
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -284,17 +292,24 @@ public class OffsetsRequestManagerTest {
                 Collections.singletonMap(TEST_PARTITION_1, error));
         clientResponse.onComplete();
         assertFalse(fetchOffsetsFuture.isDone());
-        assertEquals(1, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
-        // Cluster metadata update. Failed requests should be retried and succeed
+        // Cluster metadata update won't retry requests in requestsToRetry
         mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
         requestManager.onUpdate(new ClusterResource(""));
-        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
+        // Following poll should send the retry request and get a successful response
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets =
                 Collections.singletonMap(TEST_PARTITION_1, new OffsetAndTimestampInternal(5L, -1, Optional.empty()));
         verifySuccessfulPollAndResponseReceived(fetchOffsetsFuture, expectedOffsets);
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -320,6 +335,7 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent to single broker
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -360,6 +376,7 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(2, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Requests successfully sent to both brokers
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -382,15 +399,20 @@ public class OffsetsRequestManagerTest {
         clientResponse2.onComplete();
 
         assertFalse(fetchOffsetsFuture.isDone());
+        assertEquals(0, requestManager.requestsToSend());
         assertEquals(1, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
-        // Cluster metadata update. Failed requests should be retried
+        // Cluster metadata update won't retry requests in requestsToRetry
         mockSuccessfulRequest(partitionLeaders);
         requestManager.onUpdate(new ClusterResource(""));
-        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
-        // Following poll should send the request and get a successful response
+        // Following poll should send the retry request and get a successful response
         NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
         verifySuccessfulPollAwaitingResponse(retriedPoll);
         NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
@@ -418,6 +440,7 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -432,6 +455,7 @@ public class OffsetsRequestManagerTest {
         verifyRequestCompletedWithErrorResponse(fetchOffsetsFuture, TopicAuthorizationException.class);
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -447,6 +471,7 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -464,6 +489,7 @@ public class OffsetsRequestManagerTest {
         // Request completed with error. Nothing pending to be sent or retried
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -480,6 +506,7 @@ public class OffsetsRequestManagerTest {
 
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -500,6 +527,7 @@ public class OffsetsRequestManagerTest {
 
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -286,6 +286,8 @@ public class OffsetsRequestManagerTest {
         assertFalse(fetchOffsetsFuture.isDone());
         assertEquals(1, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        // A retriable error should be followed by a metadata update request
+        verify(metadata).requestUpdate(false);
 
         // Cluster metadata update. Failed requests should be retried and succeed
         mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -386,6 +386,8 @@ public class OffsetsRequestManagerTest {
         assertFalse(fetchOffsetsFuture.isDone());
         assertEquals(1, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
+        // A retriable error should be followed by a metadata update request
+        verify(metadata).requestUpdate(false);
 
         // Cluster metadata update. Failed requests should be retried
         mockSuccessfulRequest(partitionLeaders);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -134,7 +134,6 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets = Collections.singletonMap(
                 TEST_PARTITION_1,
@@ -153,8 +152,7 @@ public class OffsetsRequestManagerTest {
             requestManager.fetchOffsets(timestampsToSearch, false);
 
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(1, requestManager.requestsToRetryOnMetadataUpdate());
+        assertEquals(1, requestManager.requestsToRetry());
         verify(metadata).requestUpdate(true);
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
         assertEquals(0, res.unsentRequests.size());
@@ -180,7 +178,6 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets = timestampsToSearch.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
@@ -195,14 +192,12 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(0, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         NetworkClientDelegate.PollResult pollResult = requestManager.poll(time.milliseconds());
         assertTrue(pollResult.unsentRequests.isEmpty());
 
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         assertTrue(result.isDone());
         assertFalse(result.isCompletedExceptionally());
@@ -221,7 +216,6 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         List<ListOffsetsResponseData.ListOffsetsTopicResponse> topicResponses = Collections.singletonList(
                 mockUnknownOffsetResponse(TEST_PARTITION_1));
@@ -246,8 +240,7 @@ public class OffsetsRequestManagerTest {
         CompletableFuture<Map<TopicPartition, OffsetAndTimestampInternal>> fetchOffsetsFuture =
             requestManager.fetchOffsets(timestampsToSearch, false);
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(1, requestManager.requestsToRetryOnMetadataUpdate());
+        assertEquals(1, requestManager.requestsToRetry());
         verify(metadata).requestUpdate(true);
 
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -278,7 +271,6 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent to single broker
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -292,24 +284,17 @@ public class OffsetsRequestManagerTest {
                 Collections.singletonMap(TEST_PARTITION_1, error));
         clientResponse.onComplete();
         assertFalse(fetchOffsetsFuture.isDone());
-        assertEquals(0, requestManager.requestsToSend());
         assertEquals(1, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
+        assertEquals(0, requestManager.requestsToSend());
 
-        // Cluster metadata update won't retry requests in requestsToRetry
+        // Cluster metadata update. Failed requests should be retried and succeed
         mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
         requestManager.onUpdate(new ClusterResource(""));
-        assertEquals(0, requestManager.requestsToSend());
-        assertEquals(1, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
+        assertEquals(1, requestManager.requestsToSend());
 
-        // Following poll should send the retry request and get a successful response
         Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets =
                 Collections.singletonMap(TEST_PARTITION_1, new OffsetAndTimestampInternal(5L, -1, Optional.empty()));
         verifySuccessfulPollAndResponseReceived(fetchOffsetsFuture, expectedOffsets);
-        assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -335,7 +320,6 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent to single broker
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -376,7 +360,6 @@ public class OffsetsRequestManagerTest {
                 false);
         assertEquals(2, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Requests successfully sent to both brokers
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -399,20 +382,15 @@ public class OffsetsRequestManagerTest {
         clientResponse2.onComplete();
 
         assertFalse(fetchOffsetsFuture.isDone());
-        assertEquals(0, requestManager.requestsToSend());
         assertEquals(1, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
-        // Cluster metadata update won't retry requests in requestsToRetry
+        // Cluster metadata update. Failed requests should be retried
         mockSuccessfulRequest(partitionLeaders);
         requestManager.onUpdate(new ClusterResource(""));
-        assertEquals(0, requestManager.requestsToSend());
-        assertEquals(1, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
+        assertEquals(1, requestManager.requestsToSend());
 
-        // Following poll should send the retry request and get a successful response
+        // Following poll should send the request and get a successful response
         NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
         verifySuccessfulPollAwaitingResponse(retriedPoll);
         NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
@@ -440,7 +418,6 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -455,7 +432,6 @@ public class OffsetsRequestManagerTest {
         verifyRequestCompletedWithErrorResponse(fetchOffsetsFuture, TopicAuthorizationException.class);
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -471,7 +447,6 @@ public class OffsetsRequestManagerTest {
                         false);
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -489,7 +464,6 @@ public class OffsetsRequestManagerTest {
         // Request completed with error. Nothing pending to be sent or retried
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test
@@ -506,7 +480,6 @@ public class OffsetsRequestManagerTest {
 
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
 
         // Request successfully sent
         NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
@@ -527,7 +500,6 @@ public class OffsetsRequestManagerTest {
 
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetryOnMetadataUpdate());
     }
 
     @Test


### PR DESCRIPTION
This is related to KAFKA-18469.
AsynConsumer will trigger a metadata update if ListOffsetRequest gets a retriable error.

This issue is the root cause of the flaky test KAFKA-18036. Can be validated through this command:
```
I=0; while ./gradlew :storage:test --tests TransactionsWithTieredStoreTest.testReadCommittedConsumerShouldNotSeeUndecidedData  --rerun --fail-fast; do  (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done
```
After this PR applied, this test passes without error in 200 loop. (It was failed within 20 loops)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
