### PR TITLE
MINOR: Remove javadoc of non-exist parameter.

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -151,9 +151,7 @@ class KRaftMetadataCache(
    * @param topicName                   The name of the topic.
    * @param listenerName                The listener name.
    * @param startIndex                  The smallest index of the partitions to be included in the result.
-   * @param upperIndex                  The upper limit of the index of the partitions to be included in the result.
-   *                                    Note that, the upper index can be larger than the largest partition index in
-   *                                    this topic.
+   *                                    
    * @return                            A collection of topic partition metadata and next partition index (-1 means
    *                                    no next partition).
    */
@@ -271,7 +269,7 @@ class KRaftMetadataCache(
    *
    * @param topics                        The iterator of topics and their corresponding first partition id to fetch.
    * @param listenerName                  The listener name.
-   * @param firstTopicPartitionStartIndex The start partition index for the first topic
+   * @param topicPartitionStartIndex      The start partition index for the first topic
    * @param maximumNumberOfPartitions     The max number of partitions to return.
    * @param ignoreTopicsWithExceptions    Whether ignore the topics with exception.
    */


### PR DESCRIPTION
The parameter `upperIndex` never exists. We should remove its javadoc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
