### PR TITLE
MINOR: Remove unnecessary `<` from Errant Record Reporter section

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -766,7 +766,7 @@ public List&lt;SourceRecord&gt; poll() throws InterruptedException {
 
     <p>When <a href="#connect_errorreporting">error reporting</a> is enabled for a connector, the connector can use an <code>ErrantRecordReporter</code> to report problems with individual records sent to a sink connector. The following example shows how a connector's <code>SinkTask</code> subclass might obtain and use the <code>ErrantRecordReporter</code>, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:</p>
 
-    <<pre class="line-numbers"><code class="language-java">private ErrantRecordReporter reporter;
+    <pre class="line-numbers"><code class="language-java">private ErrantRecordReporter reporter;
 
 @Override
 public void start(Map&lt;String, String&gt; props) {


### PR DESCRIPTION
There is a unnecessary  `<` in  Errant Record Reporter section:
![image](https://github.com/user-attachments/assets/3cc2fb14-6886-429a-bb10-a004173ea8f2)
![image](https://github.com/user-attachments/assets/f8451e35-18f7-40a3-ade1-d8420e02683e)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
