### PR TITLE
KAFKA-18484; Improve exception handling during coordinator unload

### DIFF
--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -3209,8 +3209,8 @@ public class CoordinatorRuntimeTest {
         // Commit the first and second record.
         writer.commit(TP, 2);
 
-        // Write #1's completion throws an exception. The coordinator should fail write #2 and the
-        // current batch.
+        // Write #1's completion throws an exception after completing its future.
+        // The coordinator should fail write #2 and the current batch.
         assertTrue(write1.isDone());
         assertTrue(write2.isDone());
         assertTrue(write3.isDone());

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -96,6 +96,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -1114,6 +1115,58 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleUnloadOperation(TP, OptionalInt.of(0));
         assertEquals(ACTIVE, ctx.state);
         assertEquals(10, ctx.epoch);
+    }
+
+    @Test
+    public void testScheduleUnloadingWithException() {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = mock(MockPartitionWriter.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(supplier)
+                .withCoordinatorRuntimeMetrics(metrics)
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(new StringSerializer())
+                .withExecutorService(mock(ExecutorService.class))
+                .build();
+
+        doThrow(new KafkaException("error")).when(coordinator).onUnloaded();
+        when(builder.withSnapshotRegistry(any())).thenReturn(builder);
+        when(builder.withLogContext(any())).thenReturn(builder);
+        when(builder.withTime(any())).thenReturn(builder);
+        when(builder.withTimer(any())).thenReturn(builder);
+        when(builder.withCoordinatorMetrics(any())).thenReturn(builder);
+        when(builder.withTopicPartition(any())).thenReturn(builder);
+        when(builder.withExecutor(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(coordinator);
+        when(supplier.get()).thenReturn(builder);
+
+        // Loads the coordinator. It directly transitions to active.
+        runtime.scheduleLoadOperation(TP, 10);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        assertEquals(ACTIVE, ctx.state);
+        assertEquals(10, ctx.epoch);
+
+        // Schedule the unloading.
+        runtime.scheduleUnloadOperation(TP, OptionalInt.of(ctx.epoch + 1));
+        assertEquals(CLOSED, ctx.state);
+
+        // Verify that onUnloaded is called.
+        verify(coordinator, times(1)).onUnloaded();
+
+        // Getting the coordinator context fails because it no longer exists.
+        assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
     }
 
     @Test

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -1165,6 +1165,9 @@ public class CoordinatorRuntimeTest {
         // Verify that onUnloaded is called.
         verify(coordinator, times(1)).onUnloaded();
 
+        // Verify that partition metrics are updated.
+        verify(metrics, times(1)).recordPartitionStateChange(ACTIVE, CLOSED);
+
         // Getting the coordinator context fails because it no longer exists.
         assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
     }

--- a/server-common/src/main/java/org/apache/kafka/deferred/DeferredEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/deferred/DeferredEventQueue.java
@@ -74,6 +74,9 @@ public class DeferredEventQueue {
     /**
      * Fail all deferred events with the provided exception.
      *
+     * When this method returns, the queue is guaranteed to be empty. Any exceptions thrown by
+     * deferred events are caught and not propagated.
+     *
      * @param exception     The exception to fail the entries with.
      */
     public void failAll(Exception exception) {
@@ -82,7 +85,11 @@ public class DeferredEventQueue {
             Entry<Long, List<DeferredEvent>> entry = iter.next();
             for (DeferredEvent event : entry.getValue()) {
                 log.info("failAll({}): failing {}.", exception.getClass().getSimpleName(), event);
-                event.complete(exception);
+                try {
+                    event.complete(exception);
+                } catch (Throwable e) {
+                    log.error("failAll({}): {} threw an exception.", exception.getClass().getSimpleName(), event, e);
+                }
             }
             iter.remove();
         }


### PR DESCRIPTION
* Ensure that coordinator contexts are removed even if they throw an
  exception during unload, otherwise the next load will fail.
* Ensure that the active partition count metric is decremented even when
  coordinator unload throws an exception.
* Guard against the coordinator getting stuck due to deferred events
  throwing exceptions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
