### PR TITLE
MINOR: Replace deprecated `Project.buildDir` property in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1162,7 +1162,7 @@ project(':core') {
       if (versions.baseScala == '2.13') {
         scoverageScalaVersion = '2.13.9' // there's no newer 2.13 artifact, org.scoverage:scalac-scoverage-plugin_2.13.9:2.0.11 is the latest as of now
       }
-      reportDir = file("${rootProject.buildDir}/scoverage")
+      reportDir = file("${layout.buildDirectory.get().asFile.path}/scoverage")
       highlighting = false
       minimumRate = 0.0
     }


### PR DESCRIPTION
reference: https://docs.gradle.org/8.10.2/dsl/org.gradle.api.Project.html#org.gradle.api.Project:buildDir

`buidDir` is deprecated and will be removed in the next major version of Gradle. We should replace it with `getLayout().getBuildDirectory()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
