### PR TITLE
KAFKA-18298;KAFKA-18297: Partially fix flaky test testConsumerGroupsDeprecatedConsumerGroupState and testConsumerGroups

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1864,17 +1864,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -1883,6 +1886,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                stopLatch.countDown()
               }
             }
           }
@@ -1894,7 +1899,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2012,6 +2017,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
           val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
           assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
+
+          // Stop the consumer threads before removing the group members to prevent rejoining.
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
 
           // Test consumer group deletion
           var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
@@ -2230,17 +2239,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -2249,6 +2261,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                stopLatch.countDown()
               }
             }
           }
@@ -2260,7 +2274,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2398,6 +2412,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
           val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
           assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
+
+          // Stop the consumer threads before removing the group members to prevent rejoining.
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
 
           // Test consumer group deletion
           var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)


### PR DESCRIPTION
It's related to KAFKA-18298 and KAFKA-18297.

To prevent members from rejoining after being removed, stop poll() in ConsumerThread before removing group members.


This PR fixed below flaky errors with ClassicConsumer tests: (It doesn't fix AsyncConsumer beacuase the rejoin was triggered by consumer heartbeat.)
1. **PlaintextAdminIntegrationTest#testConsumerGroups**
  a.  `org.opentest4j.AssertionFailedError: expected: <2> but was: <3>` ([Report](https://ge.apache.org/s/lt3lpviv45cns/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroups(String%2C%20String)%5B1%5D?top-execution=1))
  b.  `org.opentest4j.AssertionFailedError: expected: <true> but was: <false>` ([Report](https://ge.apache.org/s/jlxo446xalpoa/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroups(String%2C%20String)%5B1%5D?top-execution=1))
2. **PlaintextAdminIntegrationTest#testConsumerGroupsDeprecatedConsumerGroupState**
  a.  `org.opentest4j.AssertionFailedError: expected: <2> but was: <3>` ([Report](https://ge.apache.org/s/ndoj6s2stb446/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroupsDeprecatedConsumerGroupState(String%2C%20String)%5B1%5D?top-execution=1))
  b. `org.opentest4j.AssertionFailedError: expected: <true> but was: <false>` ([Report](https://ge.apache.org/s/kh3jze2tc5qeu/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroupsDeprecatedConsumerGroupState(String%2C%20String)%5B1%5D?top-execution=1))

**Note**: This PR only fixed the flaky with ClassicConsumer. To fix the same error in AsyncConsumer, there should be a method to prevent consumer's heartbeat(rejoin) after group members being removed. **it seems impossible in the current AsyncConsumer implementation**.

**Note**:  The flaky can be reproduced with[ this patch](https://issues.apache.org/jira/secure/attachment/13073949/0001-Reproduce-KAFKA-18298-and-KAFKA-18297-in-ClassicConsumer.patch). (Uncomment the sleep 1 sec)

**Co-authored-by**: TaiJuWu (tjwu1217@gmail.com)



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
