### PR TITLE
KAFKA-18298;KAFKA-18297: Fix flaky testConsumerGroupsDeprecatedConsumerGroupState and testConsumerGroups in PlaintextAdminIntegrationTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2047,13 +2047,11 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
 
           // Test delete one correct static member
-          val removeOptions = new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1)))
-          removeOptions.reason("test remove")
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, removeOptions)
+          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
+            new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
 
           assertNull(removeMembersResult.all().get())
-          val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
-          assertNull(validMemberFuture.get())
+          assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
 
           // Delete all active members remaining (a static member)
           removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
@@ -2447,13 +2445,11 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
 
           // Test delete one correct static member
-          val removeOptions = new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1)))
-          removeOptions.reason("test remove")
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, removeOptions)
+          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
+            new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
 
           assertNull(removeMembersResult.all().get())
-          val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
-          assertNull(validMemberFuture.get())
+          assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
 
           // Delete all active members remaining (a static member)
           removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2198,7 +2198,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
             group.groupId == testGroupId &&
               group.state.get == ConsumerGroupState.STABLE &&
               group.groupState.get == GroupState.STABLE)
-            matching.size == 1
+          matching.size == 1
         }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
 
         TestUtils.waitUntilTrue(() => {
@@ -4113,5 +4113,4 @@ object PlaintextAdminIntegrationTest {
 
     assertEquals(LogConfig.DEFAULT_COMPRESSION_TYPE, configs.get(brokerResource).get(ServerConfigs.COMPRESSION_TYPE_CONFIG).value)
   }
-
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1852,9 +1852,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
       val defaultConsumerConfig = new Properties(consumerConfig)
       defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
       defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
 
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      val backgroundConsumerSet = new BackgroundConsumerSet(defaultConsumerConfig)
       groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
         val configOverrides = new Properties()
         if (groupInstanceId != "") {
@@ -2114,9 +2115,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
       val defaultConsumerConfig = new Properties(consumerConfig)
       defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
       defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
 
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      val backgroundConsumerSet = new BackgroundConsumerSet(defaultConsumerConfig)
       groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
         val configOverrides = new Properties()
         if (groupInstanceId != "") {
@@ -2314,12 +2316,13 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
       val defaultConsumerConfig = new Properties(consumerConfig)
       defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
       defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
       // We need to set internal.leave.group.on.close to validate dynamic member removal, but it only works for ClassicConsumer
       // After KIP-1092, we can control dynamic member removal for both ClassicConsumer and AsyncConsumer
       defaultConsumerConfig.setProperty("internal.leave.group.on.close", "false")
 
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      val backgroundConsumerSet = new BackgroundConsumerSet(defaultConsumerConfig)
       groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
         val configOverrides = new Properties()
         if (groupInstanceId != "") {
@@ -3959,14 +3962,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
 
-  class BackgroundConsumerSet(testGroupId: String, defaultConsumerConfig: Properties) {
+  class BackgroundConsumerSet(defaultConsumerConfig: Properties) {
     private val consumerSet: scala.collection.mutable.Set[Consumer[Array[Byte], Array[Byte]]] = scala.collection.mutable.Set.empty
     private val consumerThreads: scala.collection.mutable.Set[Thread] = scala.collection.mutable.Set.empty
     private var startLatch: CountDownLatch = new CountDownLatch(0)
     private var stopLatch: CountDownLatch = new CountDownLatch(0)
     private var consumerThreadRunning = new AtomicBoolean(false)
-
-    defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
 
     def addConsumer(topic: String, configOverrides: Properties = new Properties()): Unit = {
       val newConsumerConfig = defaultConsumerConfig.clone().asInstanceOf[Properties]

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1863,17 +1863,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -1882,6 +1885,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                consumer.close()
+                stopLatch.countDown()
               }
             }
           }
@@ -1893,7 +1899,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2026,6 +2032,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
             classOf[GroupNotEmptyException])
 
+          // Stop the consumer threads and close consumers
+          // dynamic member will be removed, leaving two static members in the group
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
+
+          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+          assertEquals(1, describeTestGroupResult.describedGroups().size())
+
+          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+          assertEquals(testGroupId, testGroupDescription.groupId)
+          assertFalse(testGroupDescription.isSimpleConsumerGroup)
+          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
+
           // Test delete one correct static member
           val removeOptions = new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1)))
           removeOptions.reason("test remove")
@@ -2035,17 +2055,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
           assertNull(validMemberFuture.get())
 
-          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(1, describeTestGroupResult.describedGroups().size())
-
-          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
-
-          assertEquals(testGroupId, testGroupDescription.groupId)
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
-
-          // Delete all active members remaining (a static member + a dynamic member)
+          // Delete all active members remaining (a static member)
           removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
           assertNull(removeMembersResult.all().get())
 
@@ -2229,17 +2239,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -2248,6 +2261,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                consumer.close()
+                stopLatch.countDown()
               }
             }
           }
@@ -2259,7 +2275,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2398,6 +2414,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
           assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
 
+          // Stop the consumer threads before removing the group members to prevent rejoining.
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
+
           // Test consumer group deletion
           var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
           assertEquals(2, deleteResult.deletedGroups().size())
@@ -2412,6 +2432,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
             classOf[GroupNotEmptyException])
 
+          // Stop the consumer threads and close consumers
+          // dynamic member will be removed, leaving two static members in the group
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
+
+          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+          assertEquals(1, describeTestGroupResult.describedGroups().size())
+
+          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+          assertEquals(testGroupId, testGroupDescription.groupId)
+          assertFalse(testGroupDescription.isSimpleConsumerGroup)
+          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
+
           // Test delete one correct static member
           val removeOptions = new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1)))
           removeOptions.reason("test remove")
@@ -2421,17 +2455,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
           assertNull(validMemberFuture.get())
 
-          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(1, describeTestGroupResult.describedGroups().size())
-
-          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
-
-          assertEquals(testGroupId, testGroupDescription.groupId)
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
-
-          // Delete all active members remaining (a static member + a dynamic member)
+          // Delete all active members remaining (a static member)
           removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
           assertNull(removeMembersResult.all().get())
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1847,12 +1847,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerThreadsManager = new BackgroundConsumerThreadsManager(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
         // Start consumer polling threads in the background
-        backgroundConsumerThreadsManager.startConsumerThreads()
+        backgroundConsumerSet.start()
 
         // Test that we can list the new group.
         TestUtils.waitUntilTrue(() => {
@@ -1988,7 +1988,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Stop the consumer threads and close consumers to prevent rejoining.
         // dynamic member will be removed, leaving two static members in the group
-        backgroundConsumerThreadsManager.stopConsumerThreads()
+        backgroundConsumerSet.stop()
 
         val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
           new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
@@ -2034,7 +2034,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
         }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        backgroundConsumerThreadsManager.stopQuietly()
+        backgroundConsumerSet.close()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -2166,12 +2166,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerThreadsManager = new BackgroundConsumerThreadsManager(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
         // Start consumer polling threads in the background
-        backgroundConsumerThreadsManager.startConsumerThreads()
+        backgroundConsumerSet.start()
 
         // Test that we can list the new group.
         TestUtils.waitUntilTrue(() => {
@@ -2327,7 +2327,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Stop the consumer threads and close consumers to prevent rejoining.
         // dynamic member will be removed, leaving two static members in the group
-        backgroundConsumerThreadsManager.stopConsumerThreads()
+        backgroundConsumerSet.stop()
 
         val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
           new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
@@ -2373,7 +2373,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
         }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        backgroundConsumerThreadsManager.stopQuietly()
+        backgroundConsumerSet.close()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -3910,7 +3910,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
 
-  class BackgroundConsumerThreadsManager(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
+  class BackgroundConsumerSet(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
     private val consumerSet: Set[Consumer[Array[Byte], Array[Byte]]] = groupInstanceSet.map { groupInstanceId =>
       createConsumer(configOverrides = createProperties(groupInstanceId))
     }
@@ -3919,17 +3919,17 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     private val stopLatch: CountDownLatch = new CountDownLatch(consumerSet.size)
     private val consumerThreadRunning = new AtomicBoolean(true)
 
-    def startConsumerThreads(): Unit = {
+    def start(): Unit = {
       consumerThreads.foreach(_.start())
       assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to start consumer threads in time")
     }
 
-    def stopConsumerThreads(): Unit = {
+    def stop(): Unit = {
       consumerThreadRunning.set(false)
       assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
     }
 
-    def stopQuietly(): Unit = {
+    def close(): Unit = {
       try {
         consumerThreads.foreach {
           consumerThread =>

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1847,12 +1847,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerThreadManager = new BackgroundConsumerThreadManager(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerThreadsManager = new BackgroundConsumerThreadsManager(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
         // Start consumer polling threads in the background
-        backgroundConsumerThreadManager.startConsumerThreads()
+        backgroundConsumerThreadsManager.startConsumerThreads()
 
         // Test that we can list the new group.
         TestUtils.waitUntilTrue(() => {
@@ -1988,7 +1988,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Stop the consumer threads and close consumers to prevent rejoining.
         // dynamic member will be removed, leaving two static members in the group
-        backgroundConsumerThreadManager.stopConsumerThreads()
+        backgroundConsumerThreadsManager.stopConsumerThreads()
 
         val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
           new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
@@ -2034,7 +2034,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
         }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        backgroundConsumerThreadManager.stopQuietly()
+        backgroundConsumerThreadsManager.stopQuietly()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -2166,12 +2166,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerThreadManager = new BackgroundConsumerThreadManager(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerThreadsManager = new BackgroundConsumerThreadsManager(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
         // Start consumer polling threads in the background
-        backgroundConsumerThreadManager.startConsumerThreads()
+        backgroundConsumerThreadsManager.startConsumerThreads()
 
         // Test that we can list the new group.
         TestUtils.waitUntilTrue(() => {
@@ -2327,7 +2327,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Stop the consumer threads and close consumers to prevent rejoining.
         // dynamic member will be removed, leaving two static members in the group
-        backgroundConsumerThreadManager.stopConsumerThreads()
+        backgroundConsumerThreadsManager.stopConsumerThreads()
 
         val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
           new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
@@ -2373,7 +2373,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
         }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        backgroundConsumerThreadManager.stopQuietly()
+        backgroundConsumerThreadsManager.stopQuietly()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -3910,7 +3910,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
 
-  class BackgroundConsumerThreadManager(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
+  class BackgroundConsumerThreadsManager(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
     private val consumerSet: Set[Consumer[Array[Byte], Array[Byte]]] = groupInstanceSet.map { groupInstanceId =>
       createConsumer(configOverrides = createProperties(groupInstanceId))
     }

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2274,7 +2274,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
    */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
-  def testConsumerGroupWithMembersRemoval(quorum: String, groupProtocol: String): Unit = {
+  def testConsumerGroupWithMemberRemoval(quorum: String, groupProtocol: String): Unit = {
     val config = createConfig
     client = Admin.create(config)
     try {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -25,7 +25,7 @@ import java.time.{Duration => JDuration}
 import java.util.Arrays.asList
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit}
-import java.util.{Collections, Optional, Properties}
+import java.util.{Collections, Locale, Optional, Properties}
 import java.{time, util}
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
@@ -1915,7 +1915,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Test that we can get information about the test consumer group.
         assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
-        var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
+        val testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
         if (groupType == GroupType.CLASSIC) {
           assertTrue(testGroupDescription.groupEpoch.isEmpty)
           assertTrue(testGroupDescription.targetAssignmentEpoch.isEmpty)
@@ -1976,78 +1976,6 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
         assertTrue(parts.containsKey(testTopicPart0))
         assertEquals(1, parts.get(testTopicPart0).offset())
-
-        // Test delete non-exist consumer instance
-        val invalidInstanceId = "invalid-instance-id"
-        var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
-          Collections.singleton(new MemberToRemove(invalidInstanceId))
-        ))
-
-        assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
-        val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
-        assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
-
-        // Test consumer group deletion
-        var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
-        assertEquals(2, deleteResult.deletedGroups().size())
-
-        // Deleting the fake group ID should get GroupIdNotFoundException.
-        assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
-        assertFutureThrows(deleteResult.deletedGroups().get(fakeGroupId),
-          classOf[GroupIdNotFoundException])
-
-        // Deleting the real group ID should get GroupNotEmptyException
-        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-        assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
-          classOf[GroupNotEmptyException])
-
-        // Stop the consumer threads and close consumers to prevent rejoining.
-        // dynamic member will be removed, leaving two static members in the group
-        backgroundConsumerSet.stop()
-
-        val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
-          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-        assertEquals(1, describeTestGroupResult.describedGroups().size())
-
-        testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
-        assertEquals(testGroupId, testGroupDescription.groupId)
-        assertFalse(testGroupDescription.isSimpleConsumerGroup)
-        assertEquals(groupInstanceSet.size - 1, testGroupDescription.members().size())
-
-        // Test delete one correct static member
-        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
-          new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
-
-        assertNull(removeMembersResult.all().get())
-        assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
-
-        // Delete all active members remaining (a static member)
-        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
-        assertNull(removeMembersResult.all().get())
-
-        // The group should contain no members now.
-        testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true)).describedGroups().get(testGroupId).get()
-        assertTrue(testGroupDescription.members().isEmpty)
-
-        // Consumer group deletion on empty group should succeed
-        deleteResult = client.deleteConsumerGroups(Seq(testGroupId).asJava)
-        assertEquals(1, deleteResult.deletedGroups().size())
-
-        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-        assertNull(deleteResult.deletedGroups().get(testGroupId).get())
-
-        // Test alterConsumerGroupOffsets
-        val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
-          Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
-        assertNull(alterConsumerGroupOffsetsResult.all().get())
-        assertNull(alterConsumerGroupOffsetsResult.partitionResult(testTopicPart0).get())
-
-        // Verify alterConsumerGroupOffsets success
-        TestUtils.waitUntilTrue(() => {
-          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
-          parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
-        }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
         backgroundConsumerSet.close()
       }
@@ -2279,7 +2207,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         // Test that we can get information about the test consumer group.
         assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
-        var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
+        val testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
 
         assertEquals(testGroupId, testGroupDescription.groupId())
         assertFalse(testGroupDescription.isSimpleConsumerGroup)
@@ -2330,13 +2258,86 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
         assertTrue(parts.containsKey(testTopicPart0))
         assertEquals(1, parts.get(testTopicPart0).offset())
+      } finally {
+        backgroundConsumerSet.close()
+      }
+    } finally {
+      Utils.closeQuietly(client, "adminClient")
+    }
+  }
+
+
+  /**
+   * Test the consumer group APIs for member removal.
+   */
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testConsumerGroupWithMembersRemoval(quorum: String, groupProtocol: String): Unit = {
+    val config = createConfig
+    client = Admin.create(config)
+    try {
+      // Verify that initially there are no consumer groups to list.
+      val list1 = client.listConsumerGroups()
+      assertEquals(0, list1.all().get().size())
+      assertEquals(0, list1.errors().get().size())
+      assertEquals(0, list1.valid().get().size())
+      val testTopicName = "test_topic"
+      val testTopicName1 = testTopicName + "1"
+      val testTopicName2 = testTopicName + "2"
+      val testNumPartitions = 2
+
+      client.createTopics(util.Arrays.asList(
+        new NewTopic(testTopicName, testNumPartitions, 1.toShort),
+        new NewTopic(testTopicName1, testNumPartitions, 1.toShort),
+        new NewTopic(testTopicName2, testNumPartitions, 1.toShort)
+      )).all().get()
+      waitForTopics(client, List(testTopicName, testTopicName1, testTopicName2), List())
+
+      val producer = createProducer()
+      try {
+        producer.send(new ProducerRecord(testTopicName, 0, null, null)).get()
+      } finally {
+        Utils.closeQuietly(producer, "producer")
+      }
+
+      val testGroupId = "test_group_id"
+      val testClientId = "test_client_id"
+      val testInstanceId1 = "test_instance_id_1"
+      val testInstanceId2 = "test_instance_id_2"
+      val fakeGroupId = "fake_group_id"
+
+      // contains two static members and one dynamic member
+      val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
+      val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
+
+      // We need to disable the auto commit because after the members got removed from group, the offset commit
+      // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
+      val defaultConsumerConfig = new Properties(consumerConfig)
+      defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+      // We need to set internal.leave.group.on.close to validate dynamic member removal, but it only works for ClassicConsumer
+      // After KIP-1092, we can control dynamic member removal for both ClassicConsumer and AsyncConsumer
+      defaultConsumerConfig.setProperty("internal.leave.group.on.close", "false")
+
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
+        val configOverrides = new Properties()
+        if (groupInstanceId != "") {
+          // static member
+          configOverrides.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+        }
+        backgroundConsumerSet.addConsumer(topic, configOverrides)
+      }
+
+      try {
+        // Start consumer polling threads in the background
+        backgroundConsumerSet.start()
 
         // Test delete non-exist consumer instance
         val invalidInstanceId = "invalid-instance-id"
         var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
           Collections.singleton(new MemberToRemove(invalidInstanceId))
         ))
-
         assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
         val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
         assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
@@ -2353,35 +2354,52 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         // Deleting the real group ID should get GroupNotEmptyException
         assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
         assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
-            classOf[GroupNotEmptyException])
+          classOf[GroupNotEmptyException])
 
-        // Stop the consumer threads and close consumers to prevent rejoining.
-        // dynamic member will be removed, leaving two static members in the group
+        // Stop the consumer threads and close consumers to prevent member rejoining.
         backgroundConsumerSet.stop()
 
-        val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+        // Check the members in the group after consumers have stopped
+        var describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
           new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
         assertEquals(1, describeTestGroupResult.describedGroups().size())
 
-        testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+        var testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
         assertEquals(testGroupId, testGroupDescription.groupId)
         assertFalse(testGroupDescription.isSimpleConsumerGroup)
-        assertEquals(groupInstanceSet.size - 1, testGroupDescription.members().size())
 
-        // Test delete one correct static member
+        // Although we set `internal.leave.group.on.close` in the consumer, it only works for ClassicConsumer.
+        // After KIP-1092, we can control dynamic member removal in consumer.close()
+        if (groupProtocol == GroupProtocol.CLASSIC.name.toLowerCase(Locale.ROOT)) {
+          assertEquals(3, testGroupDescription.members().size())
+        } else if (groupProtocol == GroupProtocol.CONSUMER.name.toLowerCase(Locale.ROOT)) {
+          assertEquals(2, testGroupDescription.members().size())
+        }
+
+        // Test delete one static member
         removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
           new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
 
         assertNull(removeMembersResult.all().get())
         assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
 
-        // Delete all active members remaining (a static member)
+        describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+        testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+
+        if (groupProtocol == GroupProtocol.CLASSIC.name.toLowerCase(Locale.ROOT)) {
+          assertEquals(2, testGroupDescription.members().size())
+        } else if (groupProtocol == GroupProtocol.CONSUMER.name.toLowerCase(Locale.ROOT)) {
+          assertEquals(1, testGroupDescription.members().size())
+        }
+
+        // Delete all active members remaining
         removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
         assertNull(removeMembersResult.all().get())
 
         // The group should contain no members now.
         testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true)).describedGroups().get(testGroupId).get()
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true)).describedGroups().get(testGroupId).get()
         assertTrue(testGroupDescription.members().isEmpty)
 
         // Consumer group deletion on empty group should succeed
@@ -2391,7 +2409,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
         assertNull(deleteResult.deletedGroups().get(testGroupId).get())
 
-        // Test alterConsumerGroupOffsets
+        // Test alterConsumerGroupOffsets when group is empty
+        val testTopicPart0 = new TopicPartition(testTopicName, 0)
         val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
           Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
         assertNull(alterConsumerGroupOffsetsResult.all().get())

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1847,13 +1847,22 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, new Properties(consumerConfig))
 
       // We need to disable the auto commit because after the members got removed from group, the offset commit
       // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
-      val configOverrides = new Properties()
-      configOverrides.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-      groupInstanceSet.zip(topicSet).foreach(zipped => backgroundConsumerSet.addConsumer(zipped._1, zipped._2, configOverrides))
+      val defaultConsumerConfig = new Properties(consumerConfig)
+      defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
+        val configOverrides = new Properties()
+        if(groupInstanceId != "") {
+          // static member
+          configOverrides.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+        }
+        backgroundConsumerSet.addConsumer(topic, configOverrides)
+      }
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
@@ -2172,13 +2181,22 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, new Properties(consumerConfig))
 
       // We need to disable the auto commit because after the members got removed from group, the offset commit
       // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
-      val configOverrides = new Properties()
-      configOverrides.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-      groupInstanceSet.zip(topicSet).foreach(zipped => backgroundConsumerSet.addConsumer(zipped._1, zipped._2, configOverrides))
+      val defaultConsumerConfig = new Properties(consumerConfig)
+      defaultConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
+      groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
+        val configOverrides = new Properties()
+        if(groupInstanceId != "") {
+          // static member
+          configOverrides.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+        }
+        backgroundConsumerSet.addConsumer(topic, configOverrides)
+      }
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
@@ -3922,7 +3940,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
 
-  class BackgroundConsumerSet(testGroupId: String, testClientId: String, defaultConsumerConfig: Properties) {
+  class BackgroundConsumerSet(testGroupId: String, defaultConsumerConfig: Properties) {
     private val consumerSet: scala.collection.mutable.Set[Consumer[Array[Byte], Array[Byte]]] = scala.collection.mutable.Set.empty
     private val consumerThreads: scala.collection.mutable.Set[Thread] = scala.collection.mutable.Set.empty
     private var startLatch: CountDownLatch = new CountDownLatch(0)
@@ -3930,14 +3948,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     private var consumerThreadRunning = new AtomicBoolean(false)
 
     defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
-    defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
 
-    def addConsumer(groupInstanceId: String, topic: String, configOverrides: Properties = new Properties()): Unit = {
+    def addConsumer(topic: String, configOverrides: Properties = new Properties()): Unit = {
       val newConsumerConfig = defaultConsumerConfig.clone().asInstanceOf[Properties]
-      if (groupInstanceId != "") {
-        // static member
-        newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
-      }
       newConsumerConfig.putAll(configOverrides)
 
       val consumer = createConsumer(configOverrides = newConsumerConfig)

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -3995,7 +3995,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
               }
             }
           } catch {
-            case _: InterruptException => // Suppress the output to stderr
+            case _: WakeupException => // ignore
+            case _: InterruptException => // ignore
           } finally {
             consumer.close()
             stopLatch.countDown()

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1857,7 +1857,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
       groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
         val configOverrides = new Properties()
-        if(groupInstanceId != "") {
+        if (groupInstanceId != "") {
           // static member
           configOverrides.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
         }
@@ -2191,7 +2191,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, defaultConsumerConfig)
       groupInstanceSet.zip(topicSet).foreach { case (groupInstanceId, topic) =>
         val configOverrides = new Properties()
-        if(groupInstanceId != "") {
+        if (groupInstanceId != "") {
           // static member
           configOverrides.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
         }
@@ -3968,21 +3968,15 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     }
 
     def stop(): Unit = {
+      consumerSet.foreach(_.wakeup())
       consumerThreadRunning.set(false)
       assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
     }
 
     def close(): Unit = {
-      try {
-        consumerThreads.foreach {
-          consumerThread =>
-            consumerThread.interrupt()
-            consumerThread.join()
-        }
-      }
-      finally{
-        consumerSet.foreach(consumer => Utils.closeQuietly(consumer, "consumer"))
-      }
+      // stop the consumers and wait for consumer threads stopped
+      stop()
+      consumerThreads.foreach(_.join())
     }
 
     private def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1847,7 +1847,13 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, new Properties(consumerConfig))
+
+      // We need to disable the auto commit because after the members got removed from group, the offset commit
+      // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
+      val configOverrides = new Properties()
+      configOverrides.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      groupInstanceSet.zip(topicSet).foreach(zipped => backgroundConsumerSet.addConsumer(zipped._1, zipped._2, configOverrides))
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
@@ -2166,7 +2172,13 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // contains two static members and one dynamic member
       val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, groupInstanceSet, topicSet)
+      val backgroundConsumerSet = new BackgroundConsumerSet(testGroupId, testClientId, new Properties(consumerConfig))
+
+      // We need to disable the auto commit because after the members got removed from group, the offset commit
+      // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
+      val configOverrides = new Properties()
+      configOverrides.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      groupInstanceSet.zip(topicSet).foreach(zipped => backgroundConsumerSet.addConsumer(zipped._1, zipped._2, configOverrides))
 
       try {
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
@@ -3910,16 +3922,34 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
 
-  class BackgroundConsumerSet(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
-    private val consumerSet: Set[Consumer[Array[Byte], Array[Byte]]] = groupInstanceSet.map { groupInstanceId =>
-      createConsumer(configOverrides = createProperties(groupInstanceId))
+  class BackgroundConsumerSet(testGroupId: String, testClientId: String, defaultConsumerConfig: Properties) {
+    private val consumerSet: scala.collection.mutable.Set[Consumer[Array[Byte], Array[Byte]]] = scala.collection.mutable.Set.empty
+    private val consumerThreads: scala.collection.mutable.Set[Thread] = scala.collection.mutable.Set.empty
+    private var startLatch: CountDownLatch = new CountDownLatch(0)
+    private var stopLatch: CountDownLatch = new CountDownLatch(0)
+    private var consumerThreadRunning = new AtomicBoolean(false)
+
+    defaultConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
+    defaultConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+
+    def addConsumer(groupInstanceId: String, topic: String, configOverrides: Properties = new Properties()): Unit = {
+      val newConsumerConfig = defaultConsumerConfig.clone().asInstanceOf[Properties]
+      if (groupInstanceId != "") {
+        // static member
+        newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+      }
+      newConsumerConfig.putAll(configOverrides)
+
+      val consumer = createConsumer(configOverrides = newConsumerConfig)
+      val consumerThread = createConsumerThread(consumer, topic)
+      consumerSet.add(consumer)
+      consumerThreads.add(consumerThread)
     }
-    private val consumerThreads = consumerSet.zip(topicSet).map(zipped => createConsumerThread(zipped._1, zipped._2))
-    private val startLatch: CountDownLatch = new CountDownLatch(consumerSet.size)
-    private val stopLatch: CountDownLatch = new CountDownLatch(consumerSet.size)
-    private val consumerThreadRunning = new AtomicBoolean(true)
 
     def start(): Unit = {
+      startLatch = new CountDownLatch(consumerSet.size)
+      stopLatch = new CountDownLatch(consumerSet.size)
+      consumerThreadRunning = new AtomicBoolean(true)
       consumerThreads.foreach(_.start())
       assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to start consumer threads in time")
     }
@@ -3938,23 +3968,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         }
       }
       finally{
-        consumerSet.zip(groupInstanceSet).foreach(zipped => Utils.closeQuietly(zipped._1, zipped._2))
+        consumerSet.foreach(consumer => Utils.closeQuietly(consumer, "consumer"))
       }
-    }
-
-    private def createProperties(groupInstanceId: String): Properties = {
-      val newConsumerConfig = new Properties(consumerConfig)
-      // We need to disable the auto commit because after the members got removed from group, the offset commit
-      // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
-      newConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-      newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
-      newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
-
-      // static member
-      if (groupInstanceId != "") {
-        newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
-      }
-      newConsumerConfig
     }
 
     private def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1838,258 +1838,203 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         Utils.closeQuietly(producer, "producer")
       }
 
-      val EMPTY_GROUP_INSTANCE_ID = ""
       val testGroupId = "test_group_id"
       val testClientId = "test_client_id"
       val testInstanceId1 = "test_instance_id_1"
       val testInstanceId2 = "test_instance_id_2"
       val fakeGroupId = "fake_group_id"
 
-      def createProperties(groupInstanceId: String): Properties = {
-        val newConsumerConfig = new Properties(consumerConfig)
-        // We need to disable the auto commit because after the members got removed from group, the offset commit
-        // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
-        newConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-        newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
-        newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
-        if (groupInstanceId != EMPTY_GROUP_INSTANCE_ID) {
-          newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
-        }
-        newConsumerConfig
-      }
-
       // contains two static members and one dynamic member
-      val groupInstanceSet = Set(testInstanceId1, testInstanceId2, EMPTY_GROUP_INSTANCE_ID)
-      val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
+      val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-
-      val startLatch = new CountDownLatch(consumerSet.size)
-      val stopLatch = new CountDownLatch(consumerSet.size)
-      val consumerThreadRunning = new AtomicBoolean(true)
+      val backgroundConsumerThreadManager = new BackgroundConsumerThreadManager(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
-        def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
-          new Thread {
-            override def run : Unit = {
-              consumer.subscribe(Collections.singleton(topic))
-              try {
-                while (consumerThreadRunning.get()) {
-                  consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
-                    startLatch.countDown()
-                  try {
-                    consumer.commitSync()
-                  } catch {
-                    case _: CommitFailedException => // Ignore and retry on next iteration.
-                  }
-                }
-              } catch {
-                case _: InterruptException => // Suppress the output to stderr
-              } finally {
-                consumer.close()
-                stopLatch.countDown()
-              }
-            }
-          }
-        }
-
-        // Start consumers in a thread that will subscribe to a new group.
-        val consumerThreads = consumerSet.zip(topicSet).map(zipped => createConsumerThread(zipped._1, zipped._2))
         val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
+        // Start consumer polling threads in the background
+        backgroundConsumerThreadManager.startConsumerThreads()
 
-        try {
-          consumerThreads.foreach(_.start())
-          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
-          // Test that we can list the new group.
-          TestUtils.waitUntilTrue(() => {
-            val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
-                group.groupId == testGroupId &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId")
-
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-                group.groupId == testGroupId &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in group type $groupType")
-
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
-              .inGroupStates(Set(GroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+        // Test that we can list the new group.
+        TestUtils.waitUntilTrue(() => {
+          val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
               group.groupId == testGroupId &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId")
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-                group.groupId == testGroupId &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in state Stable")
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in group type $groupType")
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.EMPTY).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(
-                _.groupId == testGroupId)
-            matching.isEmpty
-          }, s"Expected to find zero groups")
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
+            .inGroupStates(Set(GroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
 
-          val describeWithFakeGroupResult = client.describeConsumerGroups(Seq(testGroupId, fakeGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(2, describeWithFakeGroupResult.describedGroups().size())
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+              group.groupId == testGroupId &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in state Stable")
 
-          // Test that we can get information about the test consumer group.
-          assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
-          var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
-          if (groupType == GroupType.CLASSIC) {
-            assertTrue(testGroupDescription.groupEpoch.isEmpty)
-            assertTrue(testGroupDescription.targetAssignmentEpoch.isEmpty)
-          } else {
-            assertEquals(Optional.of(3), testGroupDescription.groupEpoch)
-            assertEquals(Optional.of(3), testGroupDescription.targetAssignmentEpoch)
-          }
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.EMPTY).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(
+              _.groupId == testGroupId)
+          matching.isEmpty
+        }, s"Expected to find zero groups")
 
-          assertEquals(testGroupId, testGroupDescription.groupId())
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(groupInstanceSet.size, testGroupDescription.members().size())
-          val members = testGroupDescription.members()
-          members.asScala.foreach { member =>
-            assertEquals(testClientId, member.clientId)
-            assertEquals(if (groupType == GroupType.CLASSIC) Optional.empty else Optional.of(true), member.upgraded)
-          }
-          val topicPartitionsByTopic = members.asScala.flatMap(_.assignment().topicPartitions().asScala).groupBy(_.topic())
-          topicSet.foreach { topic =>
-            val topicPartitions = topicPartitionsByTopic.getOrElse(topic, List.empty)
-            assertEquals(testNumPartitions, topicPartitions.size)
-          }
+        val describeWithFakeGroupResult = client.describeConsumerGroups(Seq(testGroupId, fakeGroupId).asJava,
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+        assertEquals(2, describeWithFakeGroupResult.describedGroups().size())
 
-          val expectedOperations = AclEntry.supportedOperations(ResourceType.GROUP)
-          assertEquals(expectedOperations, testGroupDescription.authorizedOperations())
-
-          // Test that the fake group throws GroupIdNotFoundException
-          assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(fakeGroupId))
-          assertFutureThrows(describeWithFakeGroupResult.describedGroups().get(fakeGroupId), classOf[GroupIdNotFoundException],
-            s"Group $fakeGroupId not found.")
-
-          // Test that all() also throws GroupIdNotFoundException
-          assertFutureThrows(describeWithFakeGroupResult.all(), classOf[GroupIdNotFoundException],
-            s"Group $fakeGroupId not found.")
-
-          val testTopicPart0 = new TopicPartition(testTopicName, 0)
-
-          // Test listConsumerGroupOffsets
-          TestUtils.waitUntilTrue(() => {
-            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
-            parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 1)
-          }, s"Expected the offset for partition 0 to eventually become 1.")
-
-          // Test listConsumerGroupOffsets with requireStable true
-          val options = new ListConsumerGroupOffsetsOptions().requireStable(true)
-          var parts = client.listConsumerGroupOffsets(testGroupId, options)
-            .partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec
-          val groupSpecs = Collections.singletonMap(testGroupId,
-            new ListConsumerGroupOffsetsSpec().topicPartitions(Collections.singleton(new TopicPartition(testTopicName, 0))))
-          parts = client.listConsumerGroupOffsets(groupSpecs).partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec and requireStable option
-          parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test delete non-exist consumer instance
-          val invalidInstanceId = "invalid-instance-id"
-          var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
-            Collections.singleton(new MemberToRemove(invalidInstanceId))
-          ))
-
-          assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
-          val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
-          assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
-
-          // Test consumer group deletion
-          var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
-          assertEquals(2, deleteResult.deletedGroups().size())
-
-          // Deleting the fake group ID should get GroupIdNotFoundException.
-          assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
-          assertFutureThrows(deleteResult.deletedGroups().get(fakeGroupId),
-            classOf[GroupIdNotFoundException])
-
-          // Deleting the real group ID should get GroupNotEmptyException
-          assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-          assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
-            classOf[GroupNotEmptyException])
-
-          // Stop the consumer threads and close consumers
-          // dynamic member will be removed, leaving two static members in the group
-          consumerThreadRunning.set(false)
-          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
-
-          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(1, describeTestGroupResult.describedGroups().size())
-
-          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
-          assertEquals(testGroupId, testGroupDescription.groupId)
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
-
-          // Test delete one correct static member
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
-            new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
-
-          assertNull(removeMembersResult.all().get())
-          assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
-
-          // Delete all active members remaining (a static member)
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
-          assertNull(removeMembersResult.all().get())
-
-          // The group should contain no members now.
-          testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-              .describedGroups().get(testGroupId).get()
-          assertTrue(testGroupDescription.members().isEmpty)
-
-          // Consumer group deletion on empty group should succeed
-          deleteResult = client.deleteConsumerGroups(Seq(testGroupId).asJava)
-          assertEquals(1, deleteResult.deletedGroups().size())
-
-          assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-          assertNull(deleteResult.deletedGroups().get(testGroupId).get())
-
-          // Test alterConsumerGroupOffsets
-          val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
-            Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
-          assertNull(alterConsumerGroupOffsetsResult.all().get())
-          assertNull(alterConsumerGroupOffsetsResult.partitionResult(testTopicPart0).get())
-
-          // Verify alterConsumerGroupOffsets success
-          TestUtils.waitUntilTrue(() => {
-            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
-            parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
-          }, s"Expected the offset for partition 0 to eventually become 0.")
-      } finally {
-        consumerThreads.foreach {
-          case consumerThread =>
-            consumerThread.interrupt()
-            consumerThread.join()
+        // Test that we can get information about the test consumer group.
+        assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
+        var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
+        if (groupType == GroupType.CLASSIC) {
+          assertTrue(testGroupDescription.groupEpoch.isEmpty)
+          assertTrue(testGroupDescription.targetAssignmentEpoch.isEmpty)
+        } else {
+          assertEquals(Optional.of(3), testGroupDescription.groupEpoch)
+          assertEquals(Optional.of(3), testGroupDescription.targetAssignmentEpoch)
         }
-      }
+
+        assertEquals(testGroupId, testGroupDescription.groupId())
+        assertFalse(testGroupDescription.isSimpleConsumerGroup)
+        assertEquals(groupInstanceSet.size, testGroupDescription.members().size())
+        val members = testGroupDescription.members()
+        members.asScala.foreach { member =>
+          assertEquals(testClientId, member.clientId)
+          assertEquals(if (groupType == GroupType.CLASSIC) Optional.empty else Optional.of(true), member.upgraded)
+        }
+        val topicPartitionsByTopic = members.asScala.flatMap(_.assignment().topicPartitions().asScala).groupBy(_.topic())
+        topicSet.foreach { topic =>
+          val topicPartitions = topicPartitionsByTopic.getOrElse(topic, List.empty)
+          assertEquals(testNumPartitions, topicPartitions.size)
+        }
+
+        val expectedOperations = AclEntry.supportedOperations(ResourceType.GROUP)
+        assertEquals(expectedOperations, testGroupDescription.authorizedOperations())
+
+        // Test that the fake group throws GroupIdNotFoundException
+        assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(fakeGroupId))
+        assertFutureThrows(describeWithFakeGroupResult.describedGroups().get(fakeGroupId), classOf[GroupIdNotFoundException],
+          s"Group $fakeGroupId not found.")
+
+        // Test that all() also throws GroupIdNotFoundException
+        assertFutureThrows(describeWithFakeGroupResult.all(), classOf[GroupIdNotFoundException],
+          s"Group $fakeGroupId not found.")
+
+        val testTopicPart0 = new TopicPartition(testTopicName, 0)
+
+        // Test listConsumerGroupOffsets
+        TestUtils.waitUntilTrue(() => {
+          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+          parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 1)
+        }, s"Expected the offset for partition 0 to eventually become 1.")
+
+        // Test listConsumerGroupOffsets with requireStable true
+        val options = new ListConsumerGroupOffsetsOptions().requireStable(true)
+        var parts = client.listConsumerGroupOffsets(testGroupId, options)
+          .partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
+
+        // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec
+        val groupSpecs = Collections.singletonMap(testGroupId,
+          new ListConsumerGroupOffsetsSpec().topicPartitions(Collections.singleton(new TopicPartition(testTopicName, 0))))
+        parts = client.listConsumerGroupOffsets(groupSpecs).partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
+
+        // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec and requireStable option
+        parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
+
+        // Test delete non-exist consumer instance
+        val invalidInstanceId = "invalid-instance-id"
+        var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
+          Collections.singleton(new MemberToRemove(invalidInstanceId))
+        ))
+
+        assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
+        val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
+        assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
+
+        // Test consumer group deletion
+        var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
+        assertEquals(2, deleteResult.deletedGroups().size())
+
+        // Deleting the fake group ID should get GroupIdNotFoundException.
+        assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
+        assertFutureThrows(deleteResult.deletedGroups().get(fakeGroupId),
+          classOf[GroupIdNotFoundException])
+
+        // Deleting the real group ID should get GroupNotEmptyException
+        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
+        assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
+          classOf[GroupNotEmptyException])
+
+        // Stop the consumer threads and close consumers to prevent rejoining.
+        // dynamic member will be removed, leaving two static members in the group
+        backgroundConsumerThreadManager.stopConsumerThreads()
+
+        val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+        assertEquals(1, describeTestGroupResult.describedGroups().size())
+
+        testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+        assertEquals(testGroupId, testGroupDescription.groupId)
+        assertFalse(testGroupDescription.isSimpleConsumerGroup)
+        assertEquals(groupInstanceSet.size - 1, testGroupDescription.members().size())
+
+        // Test delete one correct static member
+        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
+          new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
+
+        assertNull(removeMembersResult.all().get())
+        assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
+
+        // Delete all active members remaining (a static member)
+        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
+        assertNull(removeMembersResult.all().get())
+
+        // The group should contain no members now.
+        testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
+            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true)).describedGroups().get(testGroupId).get()
+        assertTrue(testGroupDescription.members().isEmpty)
+
+        // Consumer group deletion on empty group should succeed
+        deleteResult = client.deleteConsumerGroups(Seq(testGroupId).asJava)
+        assertEquals(1, deleteResult.deletedGroups().size())
+
+        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
+        assertNull(deleteResult.deletedGroups().get(testGroupId).get())
+
+        // Test alterConsumerGroupOffsets
+        val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
+          Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
+        assertNull(alterConsumerGroupOffsetsResult.all().get())
+        assertNull(alterConsumerGroupOffsetsResult.partitionResult(testTopicPart0).get())
+
+        // Verify alterConsumerGroupOffsets success
+        TestUtils.waitUntilTrue(() => {
+          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+          parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
+        }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        consumerSet.zip(groupInstanceSet).foreach(zipped => Utils.closeQuietly(zipped._1, zipped._2))
+        backgroundConsumerThreadManager.stopQuietly()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -2212,282 +2157,223 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         Utils.closeQuietly(producer, "producer")
       }
 
-      val EMPTY_GROUP_INSTANCE_ID = ""
       val testGroupId = "test_group_id"
       val testClientId = "test_client_id"
       val testInstanceId1 = "test_instance_id_1"
       val testInstanceId2 = "test_instance_id_2"
       val fakeGroupId = "fake_group_id"
 
-      def createProperties(groupInstanceId: String): Properties = {
-        val newConsumerConfig = new Properties(consumerConfig)
-        // We need to disable the auto commit because after the members got removed from group, the offset commit
-        // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
-        newConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-        newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
-        newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
-        if (groupInstanceId != EMPTY_GROUP_INSTANCE_ID) {
-          newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
-        }
-        newConsumerConfig
-      }
-
       // contains two static members and one dynamic member
-      val groupInstanceSet = Set(testInstanceId1, testInstanceId2, EMPTY_GROUP_INSTANCE_ID)
-      val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
+      val groupInstanceSet = Set(testInstanceId1, testInstanceId2, "")
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
-
-      val startLatch = new CountDownLatch(consumerSet.size)
-      val stopLatch = new CountDownLatch(consumerSet.size)
-      val consumerThreadRunning = new AtomicBoolean(true)
+      val backgroundConsumerThreadManager = new BackgroundConsumerThreadManager(testGroupId, testClientId, groupInstanceSet, topicSet)
 
       try {
-        def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
-          new Thread {
-            override def run : Unit = {
-              consumer.subscribe(Collections.singleton(topic))
-              try {
-                while (consumerThreadRunning.get()) {
-                  consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
-                    startLatch.countDown()
-                  try {
-                    consumer.commitSync()
-                  } catch {
-                    case _: CommitFailedException => // Ignore and retry on next iteration.
-                  }
-                }
-              } catch {
-                case _: InterruptException => // Suppress the output to stderr
-              } finally {
-                consumer.close()
-                stopLatch.countDown()
-              }
-            }
-          }
+        val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
+        // Start consumer polling threads in the background
+        backgroundConsumerThreadManager.startConsumerThreads()
+
+        // Test that we can list the new group.
+        TestUtils.waitUntilTrue(() => {
+          val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in group type $groupType")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
+            .inStates(Set(ConsumerGroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+            matching.size == 1
+        }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
+            .inGroupStates(Set(GroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inStates(Set(ConsumerGroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in state Stable")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.STABLE).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
+            group.groupId == testGroupId &&
+              group.state.get == ConsumerGroupState.STABLE &&
+              group.groupState.get == GroupState.STABLE)
+          matching.size == 1
+        }, s"Expected to be able to list $testGroupId in state Stable")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inStates(Set(ConsumerGroupState.EMPTY).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(
+            _.groupId == testGroupId)
+          matching.isEmpty
+        }, s"Expected to find zero groups")
+
+        TestUtils.waitUntilTrue(() => {
+          val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.EMPTY).asJava)
+          val matching = client.listConsumerGroups(options).all.get.asScala.filter(
+            _.groupId == testGroupId)
+          matching.isEmpty
+        }, s"Expected to find zero groups")
+
+        val describeWithFakeGroupResult = client.describeConsumerGroups(Seq(testGroupId, fakeGroupId).asJava,
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+        assertEquals(2, describeWithFakeGroupResult.describedGroups().size())
+
+        // Test that we can get information about the test consumer group.
+        assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
+        var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
+
+        assertEquals(testGroupId, testGroupDescription.groupId())
+        assertFalse(testGroupDescription.isSimpleConsumerGroup)
+        assertEquals(groupInstanceSet.size, testGroupDescription.members().size())
+        val members = testGroupDescription.members()
+        members.asScala.foreach(member => assertEquals(testClientId, member.clientId()))
+        val topicPartitionsByTopic = members.asScala.flatMap(_.assignment().topicPartitions().asScala).groupBy(_.topic())
+        topicSet.foreach { topic =>
+          val topicPartitions = topicPartitionsByTopic.getOrElse(topic, List.empty)
+          assertEquals(testNumPartitions, topicPartitions.size)
         }
 
-        // Start consumers in a thread that will subscribe to a new group.
-        val consumerThreads = consumerSet.zip(topicSet).map(zipped => createConsumerThread(zipped._1, zipped._2))
-        val groupType = if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name)) GroupType.CONSUMER else GroupType.CLASSIC
+        val expectedOperations = AclEntry.supportedOperations(ResourceType.GROUP)
+        assertEquals(expectedOperations, testGroupDescription.authorizedOperations())
 
-        try {
-          consumerThreads.foreach(_.start())
-          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
-          // Test that we can list the new group.
-          TestUtils.waitUntilTrue(() => {
-            val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId")
+        // Test that the fake group throws GroupIdNotFoundException
+        assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(fakeGroupId))
+        assertFutureThrows(describeWithFakeGroupResult.describedGroups().get(fakeGroupId),
+          classOf[GroupIdNotFoundException], s"Group $fakeGroupId not found.")
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in group type $groupType")
+        // Test that all() also throws GroupIdNotFoundException
+        assertFutureThrows(describeWithFakeGroupResult.all(),
+          classOf[GroupIdNotFoundException], s"Group $fakeGroupId not found.")
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
-              .inStates(Set(ConsumerGroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
+        val testTopicPart0 = new TopicPartition(testTopicName, 0)
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().withTypes(Set(groupType).asJava)
-              .inGroupStates(Set(GroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in group type $groupType and state Stable")
+        // Test listConsumerGroupOffsets
+        TestUtils.waitUntilTrue(() => {
+          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+          parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 1)
+        }, s"Expected the offset for partition 0 to eventually become 1.")
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inStates(Set(ConsumerGroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in state Stable")
+        // Test listConsumerGroupOffsets with requireStable true
+        val options = new ListConsumerGroupOffsetsOptions().requireStable(true)
+        var parts = client.listConsumerGroupOffsets(testGroupId, options)
+          .partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.STABLE).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(group =>
-              group.groupId == testGroupId &&
-                group.state.get == ConsumerGroupState.STABLE &&
-                group.groupState.get == GroupState.STABLE)
-            matching.size == 1
-          }, s"Expected to be able to list $testGroupId in state Stable")
+        // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec
+        val groupSpecs = Collections.singletonMap(testGroupId,
+          new ListConsumerGroupOffsetsSpec().topicPartitions(Collections.singleton(new TopicPartition(testTopicName, 0))))
+        parts = client.listConsumerGroupOffsets(groupSpecs).partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inStates(Set(ConsumerGroupState.EMPTY).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(
-              _.groupId == testGroupId)
-            matching.isEmpty
-          }, s"Expected to find zero groups")
+        // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec and requireStable option
+        parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
+        assertTrue(parts.containsKey(testTopicPart0))
+        assertEquals(1, parts.get(testTopicPart0).offset())
 
-          TestUtils.waitUntilTrue(() => {
-            val options = new ListConsumerGroupsOptions().inGroupStates(Set(GroupState.EMPTY).asJava)
-            val matching = client.listConsumerGroups(options).all.get.asScala.filter(
-              _.groupId == testGroupId)
-            matching.isEmpty
-          }, s"Expected to find zero groups")
+        // Test delete non-exist consumer instance
+        val invalidInstanceId = "invalid-instance-id"
+        var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
+          Collections.singleton(new MemberToRemove(invalidInstanceId))
+        ))
 
-          val describeWithFakeGroupResult = client.describeConsumerGroups(Seq(testGroupId, fakeGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(2, describeWithFakeGroupResult.describedGroups().size())
+        assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
+        val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
+        assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
 
-          // Test that we can get information about the test consumer group.
-          assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(testGroupId))
-          var testGroupDescription = describeWithFakeGroupResult.describedGroups().get(testGroupId).get()
+        // Test consumer group deletion
+        var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
+        assertEquals(2, deleteResult.deletedGroups().size())
 
-          assertEquals(testGroupId, testGroupDescription.groupId())
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(groupInstanceSet.size, testGroupDescription.members().size())
-          val members = testGroupDescription.members()
-          members.asScala.foreach(member => assertEquals(testClientId, member.clientId()))
-          val topicPartitionsByTopic = members.asScala.flatMap(_.assignment().topicPartitions().asScala).groupBy(_.topic())
-          topicSet.foreach { topic =>
-            val topicPartitions = topicPartitionsByTopic.getOrElse(topic, List.empty)
-            assertEquals(testNumPartitions, topicPartitions.size)
-          }
+        // Deleting the fake group ID should get GroupIdNotFoundException.
+        assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
+        assertFutureThrows(deleteResult.deletedGroups().get(fakeGroupId),
+          classOf[GroupIdNotFoundException])
 
-          val expectedOperations = AclEntry.supportedOperations(ResourceType.GROUP)
-          assertEquals(expectedOperations, testGroupDescription.authorizedOperations())
-
-          // Test that the fake group throws GroupIdNotFoundException
-          assertTrue(describeWithFakeGroupResult.describedGroups().containsKey(fakeGroupId))
-          assertFutureThrows(describeWithFakeGroupResult.describedGroups().get(fakeGroupId),
-            classOf[GroupIdNotFoundException], s"Group $fakeGroupId not found.")
-
-          // Test that all() also throws GroupIdNotFoundException
-          assertFutureThrows(describeWithFakeGroupResult.all(),
-            classOf[GroupIdNotFoundException], s"Group $fakeGroupId not found.")
-
-          val testTopicPart0 = new TopicPartition(testTopicName, 0)
-
-          // Test listConsumerGroupOffsets
-          TestUtils.waitUntilTrue(() => {
-            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
-            parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 1)
-          }, s"Expected the offset for partition 0 to eventually become 1.")
-
-          // Test listConsumerGroupOffsets with requireStable true
-          val options = new ListConsumerGroupOffsetsOptions().requireStable(true)
-          var parts = client.listConsumerGroupOffsets(testGroupId, options)
-            .partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec
-          val groupSpecs = Collections.singletonMap(testGroupId,
-            new ListConsumerGroupOffsetsSpec().topicPartitions(Collections.singleton(new TopicPartition(testTopicName, 0))))
-          parts = client.listConsumerGroupOffsets(groupSpecs).partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test listConsumerGroupOffsets with listConsumerGroupOffsetsSpec and requireStable option
-          parts = client.listConsumerGroupOffsets(groupSpecs, options).partitionsToOffsetAndMetadata().get()
-          assertTrue(parts.containsKey(testTopicPart0))
-          assertEquals(1, parts.get(testTopicPart0).offset())
-
-          // Test delete non-exist consumer instance
-          val invalidInstanceId = "invalid-instance-id"
-          var removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions(
-            Collections.singleton(new MemberToRemove(invalidInstanceId))
-          ))
-
-          assertFutureThrows(removeMembersResult.all, classOf[UnknownMemberIdException])
-          val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
-          assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
-
-          // Stop the consumer threads before removing the group members to prevent rejoining.
-          consumerThreadRunning.set(false)
-          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
-
-          // Test consumer group deletion
-          var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
-          assertEquals(2, deleteResult.deletedGroups().size())
-
-          // Deleting the fake group ID should get GroupIdNotFoundException.
-          assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
-          assertFutureThrows(deleteResult.deletedGroups().get(fakeGroupId),
-            classOf[GroupIdNotFoundException])
-
-          // Deleting the real group ID should get GroupNotEmptyException
-          assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-          assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
+        // Deleting the real group ID should get GroupNotEmptyException
+        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
+        assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
             classOf[GroupNotEmptyException])
 
-          // Stop the consumer threads and close consumers
-          // dynamic member will be removed, leaving two static members in the group
-          consumerThreadRunning.set(false)
-          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
+        // Stop the consumer threads and close consumers to prevent rejoining.
+        // dynamic member will be removed, leaving two static members in the group
+        backgroundConsumerThreadManager.stopConsumerThreads()
 
-          val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
-            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-          assertEquals(1, describeTestGroupResult.describedGroups().size())
+        val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
+          new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
+        assertEquals(1, describeTestGroupResult.describedGroups().size())
 
-          testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
-          assertEquals(testGroupId, testGroupDescription.groupId)
-          assertFalse(testGroupDescription.isSimpleConsumerGroup)
-          assertEquals(consumerSet.size - 1, testGroupDescription.members().size())
+        testGroupDescription = describeTestGroupResult.describedGroups().get(testGroupId).get()
+        assertEquals(testGroupId, testGroupDescription.groupId)
+        assertFalse(testGroupDescription.isSimpleConsumerGroup)
+        assertEquals(groupInstanceSet.size - 1, testGroupDescription.members().size())
 
-          // Test delete one correct static member
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
-            new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
+        // Test delete one correct static member
+        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId,
+          new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1))))
 
-          assertNull(removeMembersResult.all().get())
-          assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
+        assertNull(removeMembersResult.all().get())
+        assertNull(removeMembersResult.memberResult(new MemberToRemove(testInstanceId1)).get())
 
-          // Delete all active members remaining (a static member)
-          removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
-          assertNull(removeMembersResult.all().get())
+        // Delete all active members remaining (a static member)
+        removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
+        assertNull(removeMembersResult.all().get())
 
-          // The group should contain no members now.
-          testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
-              new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
-            .describedGroups().get(testGroupId).get()
-          assertTrue(testGroupDescription.members().isEmpty)
+        // The group should contain no members now.
+        testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,
+            new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true)).describedGroups().get(testGroupId).get()
+        assertTrue(testGroupDescription.members().isEmpty)
 
-          // Consumer group deletion on empty group should succeed
-          deleteResult = client.deleteConsumerGroups(Seq(testGroupId).asJava)
-          assertEquals(1, deleteResult.deletedGroups().size())
+        // Consumer group deletion on empty group should succeed
+        deleteResult = client.deleteConsumerGroups(Seq(testGroupId).asJava)
+        assertEquals(1, deleteResult.deletedGroups().size())
 
-          assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
-          assertNull(deleteResult.deletedGroups().get(testGroupId).get())
+        assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
+        assertNull(deleteResult.deletedGroups().get(testGroupId).get())
 
-          // Test alterConsumerGroupOffsets
-          val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
-            Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
-          assertNull(alterConsumerGroupOffsetsResult.all().get())
-          assertNull(alterConsumerGroupOffsetsResult.partitionResult(testTopicPart0).get())
+        // Test alterConsumerGroupOffsets
+        val alterConsumerGroupOffsetsResult = client.alterConsumerGroupOffsets(testGroupId,
+          Collections.singletonMap(testTopicPart0, new OffsetAndMetadata(0L)))
+        assertNull(alterConsumerGroupOffsetsResult.all().get())
+        assertNull(alterConsumerGroupOffsetsResult.partitionResult(testTopicPart0).get())
 
-          // Verify alterConsumerGroupOffsets success
-          TestUtils.waitUntilTrue(() => {
-            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
-            parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
-          }, s"Expected the offset for partition 0 to eventually become 0.")
-        } finally {
-          consumerThreads.foreach {
-            case consumerThread =>
-              consumerThread.interrupt()
-              consumerThread.join()
-          }
-        }
+        // Verify alterConsumerGroupOffsets success
+        TestUtils.waitUntilTrue(() => {
+          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+          parts.containsKey(testTopicPart0) && (parts.get(testTopicPart0).offset() == 0)
+        }, s"Expected the offset for partition 0 to eventually become 0.")
       } finally {
-        consumerSet.zip(groupInstanceSet).foreach(zipped => Utils.closeQuietly(zipped._1, zipped._2))
+        backgroundConsumerThreadManager.stopQuietly()
       }
     } finally {
       Utils.closeQuietly(client, "adminClient")
@@ -4023,6 +3909,79 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       ConfigSource.DYNAMIC_TOPIC_CONFIG, false, false, Collections.emptyList(), null, null),
       topicConfigs.get(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG))
   }
+
+  class BackgroundConsumerThreadManager(testGroupId: String, testClientId: String, groupInstanceSet: Set[String], topicSet: Set[String]){
+    private val consumerSet: Set[Consumer[Array[Byte], Array[Byte]]] = groupInstanceSet.map { groupInstanceId =>
+      createConsumer(configOverrides = createProperties(groupInstanceId))
+    }
+    private val consumerThreads = consumerSet.zip(topicSet).map(zipped => createConsumerThread(zipped._1, zipped._2))
+    private val startLatch: CountDownLatch = new CountDownLatch(consumerSet.size)
+    private val stopLatch: CountDownLatch = new CountDownLatch(consumerSet.size)
+    private val consumerThreadRunning = new AtomicBoolean(true)
+
+    def startConsumerThreads(): Unit = {
+      consumerThreads.foreach(_.start())
+      assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to start consumer threads in time")
+    }
+
+    def stopConsumerThreads(): Unit = {
+      consumerThreadRunning.set(false)
+      assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS), "Failed to stop consumer threads in time")
+    }
+
+    def stopQuietly(): Unit = {
+      try {
+        consumerThreads.foreach {
+          consumerThread =>
+            consumerThread.interrupt()
+            consumerThread.join()
+        }
+      }
+      finally{
+        consumerSet.zip(groupInstanceSet).foreach(zipped => Utils.closeQuietly(zipped._1, zipped._2))
+      }
+    }
+
+    private def createProperties(groupInstanceId: String): Properties = {
+      val newConsumerConfig = new Properties(consumerConfig)
+      // We need to disable the auto commit because after the members got removed from group, the offset commit
+      // will cause the member rejoining and the test will be flaky (check ConsumerCoordinator#OffsetCommitResponseHandler)
+      newConsumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
+      newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+
+      // static member
+      if (groupInstanceId != "") {
+        newConsumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+      }
+      newConsumerConfig
+    }
+
+    private def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
+      new Thread {
+        override def run : Unit = {
+          consumer.subscribe(Collections.singleton(topic))
+          try {
+            while (consumerThreadRunning.get()) {
+              consumer.poll(JDuration.ofSeconds(5))
+              if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                startLatch.countDown()
+              try {
+                consumer.commitSync()
+              } catch {
+                case _: CommitFailedException => // Ignore and retry on next iteration.
+              }
+            }
+          } catch {
+            case _: InterruptException => // Suppress the output to stderr
+          } finally {
+            consumer.close()
+            stopLatch.countDown()
+          }
+        }
+      }
+    }
+  }
 }
 
 object PlaintextAdminIntegrationTest {
@@ -4154,4 +4113,5 @@ object PlaintextAdminIntegrationTest {
 
     assertEquals(LogConfig.DEFAULT_COMPRESSION_TYPE, configs.get(brokerResource).get(ServerConfigs.COMPRESSION_TYPE_CONFIG).value)
   }
+
 }


### PR DESCRIPTION
It's related to KAFKA-18298 and KAFKA-18297.

The root cause of the flaky tests is member rejoin after member removal.

To prevent members from rejoining after being removed, before removing group members, calling `consumers.close` in ConsumerThread . This fix also extract the flaky member removal test  to new test `testConsumerGroupWithMemberRemoval`.

Flow of member removal test: 
1. Set 2 static consumer + 1 dynamic consumer
2. Close all consumers.
3. remove one static member
4. remove remaining members
 
Before KIP-1092, the member count is different between ClassicConsumer/AsyncConsumer. (AsyncConsumer will remove dynamic member after consumer closed.)

To get more details, please refer to the discussion under KAFKA-18297 and this PR:
- discussion : [Link](https://issues.apache.org/jira/browse/KAFKA-18297?focusedCommentId=17912537&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17912537)
- review: https://github.com/apache/kafka/pull/18513#pullrequestreview-2589110367


This PR fixed below flaky errors:
1. **PlaintextAdminIntegrationTest#testConsumerGroups**
  a.  `org.opentest4j.AssertionFailedError: expected: <2> but was: <3>` ([Report](https://ge.apache.org/s/lt3lpviv45cns/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroups(String%2C%20String)%5B1%5D?top-execution=1))
  b.  `org.opentest4j.AssertionFailedError: expected: <true> but was: <false>` ([Report](https://ge.apache.org/s/jlxo446xalpoa/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroups(String%2C%20String)%5B1%5D?top-execution=1))
8. **PlaintextAdminIntegrationTest#testConsumerGroupsDeprecatedConsumerGroupState**
  a.  `org.opentest4j.AssertionFailedError: expected: <2> but was: <3>` ([Report](https://ge.apache.org/s/ndoj6s2stb446/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroupsDeprecatedConsumerGroupState(String%2C%20String)%5B1%5D?top-execution=1))
  b. `org.opentest4j.AssertionFailedError: expected: <true> but was: <false>` ([Report](https://ge.apache.org/s/kh3jze2tc5qeu/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroupsDeprecatedConsumerGroupState(String%2C%20String)%5B1%5D?top-execution=1))

Test command: (No error within 100 loops in my local env)
```
N=100; I=0; while [ $I -lt $N ] && ./gradlew core:test --tests PlaintextAdminIntegrationTest.testConsumerGroupsDeprecatedConsumerGroupState --tests PlaintextAdminIntegrationTest.testConsumerGroups --tests PlaintextAdminIntegrationTest.testConsumerGroupWithMemberRemoval --rerun --fail-fast; do (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done
```


**Note**:  The flaky can be reproduced with[ this patch](https://issues.apache.org/jira/secure/attachment/13073949/0001-Reproduce-KAFKA-18298-and-KAFKA-18297-in-ClassicConsumer.patch). (Uncomment the sleep 1 sec)

**Co-authored-by**: TaiJuWu (tjwu1217@gmail.com)



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
