### PR TITLE
MINOR: Replace deprecated RichOptional.asScala with toScala

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -380,7 +380,7 @@ class KRaftMetadataCache(
   }
 
   override def getBrokerNodes(listenerName: ListenerName): Seq[Node] = {
-    _currentImage.cluster().brokers().values().asScala.flatMap(_.node(listenerName.value()).asScala).toSeq
+    _currentImage.cluster().brokers().values().asScala.flatMap(_.node(listenerName.value()).toScala).toSeq
   }
 
   // Does NOT include offline replica metadata


### PR DESCRIPTION
as title, `asScala` is deprecated and it's recommended to use `toScala`

reference: https://www.scala-lang.org/api/2.13.0/scala/jdk/OptionConverters$$RichOptional.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
