### PR TITLE
KAFKA-18521: Cleanup NodeApiVersions zkMigrationEnabled field

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1047,7 +1047,6 @@ public class NetworkClient implements KafkaClient {
         NodeApiVersions nodeVersionInfo = new NodeApiVersions(
             apiVersionsResponse.data().apiKeys(),
             apiVersionsResponse.data().supportedFeatures(),
-            apiVersionsResponse.data().zkMigrationReady(),
             apiVersionsResponse.data().finalizedFeatures(),
             apiVersionsResponse.data().finalizedFeaturesEpoch());
         apiVersions.update(node, nodeVersionInfo);

--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -49,8 +49,6 @@ public class NodeApiVersions {
 
     private final Map<String, SupportedVersionRange> supportedFeatures;
 
-    private final boolean zkMigrationEnabled;
-
     private final Map<String, Short> finalizedFeatures;
 
     private final long finalizedFeaturesEpoch;
@@ -83,7 +81,7 @@ public class NodeApiVersions {
             }
             if (!exists) apiVersions.add(ApiVersionsResponse.toApiVersion(apiKey));
         }
-        return new NodeApiVersions(apiVersions, Collections.emptyList(), false, Collections.emptyList(), -1);
+        return new NodeApiVersions(apiVersions, Collections.emptyList(), Collections.emptyList(), -1);
     }
 
 
@@ -104,16 +102,14 @@ public class NodeApiVersions {
 
     public NodeApiVersions(
             Collection<ApiVersion> nodeApiVersions,
-            Collection<SupportedFeatureKey> nodeSupportedFeatures,
-            boolean zkMigrationEnabled
+            Collection<SupportedFeatureKey> nodeSupportedFeatures
     ) {
-        this(nodeApiVersions, nodeSupportedFeatures, zkMigrationEnabled, Collections.emptyList(), -1);
+        this(nodeApiVersions, nodeSupportedFeatures, Collections.emptyList(), -1);
     }
 
     public NodeApiVersions(
             Collection<ApiVersion> nodeApiVersions,
             Collection<SupportedFeatureKey> nodeSupportedFeatures,
-            boolean zkMigrationEnabled,
             Collection<ApiVersionsResponseData.FinalizedFeatureKey> nodeFinalizedFeatures,
             long finalizedFeaturesEpoch
     ) {
@@ -133,8 +129,6 @@ public class NodeApiVersions {
                     new SupportedVersionRange(supportedFeature.minVersion(), supportedFeature.maxVersion()));
         }
         this.supportedFeatures = Collections.unmodifiableMap(supportedFeaturesBuilder);
-        this.zkMigrationEnabled = zkMigrationEnabled;
-
         this.finalizedFeaturesEpoch = finalizedFeaturesEpoch;
         this.finalizedFeatures = new HashMap<>();
         for (ApiVersionsResponseData.FinalizedFeatureKey finalizedFeature : nodeFinalizedFeatures) {
@@ -262,10 +256,6 @@ public class NodeApiVersions {
 
     public Map<String, SupportedVersionRange> supportedFeatures() {
         return supportedFeatures;
-    }
-
-    public boolean zkMigrationEnabled() {
-        return zkMigrationEnabled;
     }
 
     public Map<String, Short> finalizedFeatures() {

--- a/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
@@ -37,7 +37,6 @@ public class ApiVersionsTest {
                     .setName("transaction.version")
                     .setMaxVersion((short) 2)
                     .setMinVersion((short) 0)),
-                false,
                 Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                     .setName("transaction.version")
                     .setMaxVersionLevel((short) 2)
@@ -53,7 +52,6 @@ public class ApiVersionsTest {
                     .setName("transaction.version")
                     .setMaxVersion((short) 2)
                     .setMinVersion((short) 0)),
-                false,
                 Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                     .setName("transaction.version")
                     .setMaxVersionLevel((short) 1)

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -44,7 +44,7 @@ public class NodeApiVersionsTest {
 
     @Test
     public void testUnsupportedVersionsToString() {
-        NodeApiVersions versions = new NodeApiVersions(new ApiVersionCollection(), Collections.emptyList(), false);
+        NodeApiVersions versions = new NodeApiVersions(new ApiVersionCollection(), Collections.emptyList());
         StringBuilder bld = new StringBuilder();
         String prefix = "(";
         for (ApiKeys apiKey : ApiKeys.clientApis()) {
@@ -73,7 +73,7 @@ public class NodeApiVersionsTest {
                         .setMaxVersion((short) 10001));
             } else versionList.add(ApiVersionsResponse.toApiVersion(apiKey));
         }
-        NodeApiVersions versions = new NodeApiVersions(versionList, Collections.emptyList(), false);
+        NodeApiVersions versions = new NodeApiVersions(versionList, Collections.emptyList());
         StringBuilder bld = new StringBuilder();
         String prefix = "(";
         for (ApiKeys apiKey : ApiKeys.values()) {
@@ -130,7 +130,7 @@ public class NodeApiVersionsTest {
 
     @Test
     public void testUsableVersionCalculationNoKnownVersions() {
-        NodeApiVersions versions = new NodeApiVersions(new ApiVersionCollection(), Collections.emptyList(), false);
+        NodeApiVersions versions = new NodeApiVersions(new ApiVersionCollection(), Collections.emptyList());
         assertThrows(UnsupportedVersionException.class,
             () -> versions.latestUsableVersion(ApiKeys.FETCH));
     }
@@ -152,7 +152,7 @@ public class NodeApiVersionsTest {
                 .setApiKey((short) 100)
                 .setMinVersion((short) 0)
                 .setMaxVersion((short) 1));
-        NodeApiVersions versions = new NodeApiVersions(versionList, Collections.emptyList(), false);
+        NodeApiVersions versions = new NodeApiVersions(versionList, Collections.emptyList());
         for (ApiKeys apiKey: ApiKeys.apisForListener(scope)) {
             assertEquals(apiKey.latestVersion(), versions.latestUsableVersion(apiKey));
         }
@@ -162,7 +162,7 @@ public class NodeApiVersionsTest {
     @EnumSource(ApiMessageType.ListenerType.class)
     public void testConstructionFromApiVersionsResponse(ApiMessageType.ListenerType scope) {
         ApiVersionsResponse apiVersionsResponse = TestUtils.defaultApiVersionsResponse(scope);
-        NodeApiVersions versions = new NodeApiVersions(apiVersionsResponse.data().apiKeys(), Collections.emptyList(), false);
+        NodeApiVersions versions = new NodeApiVersions(apiVersionsResponse.data().apiKeys(), Collections.emptyList());
 
         for (ApiVersion apiVersionKey : apiVersionsResponse.data().apiKeys()) {
             ApiVersion apiVersion = versions.apiVersion(ApiKeys.forId(apiVersionKey.apiKey()));

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -180,7 +180,6 @@ public class NodeApiVersionsTest {
                 .setName("transaction.version")
                 .setMaxVersion((short) 2)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel((short) 2)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1634,7 +1634,6 @@ public class KafkaProducerTest {
                 .setName("transaction.version")
                 .setMaxVersion((short) 2)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel((short) 2)
@@ -1701,7 +1700,6 @@ public class KafkaProducerTest {
                 .setName("transaction.version")
                 .setMaxVersion((short) 2)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel((short) 2)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -182,7 +182,6 @@ public class TransactionManagerTest {
                 .setName("transaction.version")
                 .setMaxVersion(transactionV2Enabled ? (short) 2 : (short) 1)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel(transactionV2Enabled ? (short) 2 : (short) 1)
@@ -930,7 +929,6 @@ public class TransactionManagerTest {
                 .setName("transaction.version")
                 .setMaxVersion((short) 2)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel((short) 2)
@@ -1035,7 +1033,6 @@ public class TransactionManagerTest {
                 .setName("transaction.version")
                 .setMaxVersion((short) 1)
                 .setMinVersion((short) 0)),
-            false,
             Arrays.asList(new ApiVersionsResponseData.FinalizedFeatureKey()
                 .setName("transaction.version")
                 .setMaxVersionLevel((short) 1)
@@ -2972,7 +2969,6 @@ public class TransactionManagerTest {
                     .setMinVersion((short) 0)
                     .setMaxVersion((short) 7)),
                 Collections.emptyList(),
-                false,
                 Collections.emptyList(),
                 0));
 
@@ -3267,7 +3263,6 @@ public class TransactionManagerTest {
                         .setMinVersion((short) 0)
                         .setMaxVersion((short) 7)),
                 Collections.emptyList(),
-                false,
                 Collections.emptyList(),
                 0));
 
@@ -3328,7 +3323,6 @@ public class TransactionManagerTest {
                      .setMinVersion((short) 0)
                      .setMaxVersion((short) 4)),
                 Collections.emptyList(),
-                false,
                 Collections.emptyList(),
                 0));
 

--- a/tools/src/main/java/org/apache/kafka/tools/BrokerApiVersionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/BrokerApiVersionsCommand.java
@@ -249,7 +249,7 @@ public class BrokerApiVersionsCommand {
                 if (error.exception() != null) {
                     future.completeExceptionally(error.exception());
                 } else {
-                    future.complete(new NodeApiVersions(response.data().apiKeys(), response.data().supportedFeatures(), response.data().zkMigrationReady()));
+                    future.complete(new NodeApiVersions(response.data().apiKeys(), response.data().supportedFeatures()));
                 }
             } catch (Exception e) {
                 future.completeExceptionally(e);

--- a/tools/src/test/java/org/apache/kafka/tools/BrokerApiVersionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/BrokerApiVersionsCommandTest.java
@@ -60,8 +60,7 @@ public class BrokerApiVersionsCommandTest {
 
         NodeApiVersions nodeApiVersions = new NodeApiVersions(
                 ApiVersionsResponse.collectApis(ApiKeys.clientApis(), true),
-                Collections.emptyList(),
-                false);
+                Collections.emptyList());
         Iterator<ApiKeys> apiKeysIter = ApiKeys.clientApis().iterator();
         while (apiKeysIter.hasNext()) {
             ApiKeys apiKey = apiKeysIter.next();


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18521

After we remove zk migration in code base https://github.com/apache/kafka/pull/18016, we also need to clean up `NodeApiVersions.zkMigrationEnabled` this field which never read in code base.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
