### PR TITLE
MINOR: Added flaky references for a few tests.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1782,7 +1782,7 @@ public class KafkaAdminClientTest {
         }
     }
 
-    // @Flaky("KAFKA-18550")
+    // @Flaky("KAFKA-18441")
     @Test
     public void testAdminClientApisAuthenticationFailure() {
         Cluster cluster = mockBootstrapCluster();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1782,6 +1782,7 @@ public class KafkaAdminClientTest {
         }
     }
 
+    // @Flaky("KAFKA-18550")
     @Test
     public void testAdminClientApisAuthenticationFailure() {
         Cluster cluster = mockBootstrapCluster();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
@@ -22,4 +22,6 @@ public class EagerConsumerCoordinatorTest extends ConsumerCoordinatorTest {
     public EagerConsumerCoordinatorTest() {
         super(ConsumerPartitionAssignor.RebalanceProtocol.EAGER);
     }
+
+    // @Flaky("KAFKA-18551") -> testOutdatedCoordinatorAssignment (in super class)
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
@@ -23,5 +23,5 @@ public class EagerConsumerCoordinatorTest extends ConsumerCoordinatorTest {
         super(ConsumerPartitionAssignor.RebalanceProtocol.EAGER);
     }
 
-    // @Flaky("KAFKA-18551") -> testOutdatedCoordinatorAssignment (in super class)
+    // @Flaky("KAFKA-15900") -> testOutdatedCoordinatorAssignment (in super class)
 }

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -42,6 +42,8 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
     quotaTestClients.waitForQuotaUpdate(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
   }
 
+  // @Flaky("KAFKA-8073") -> testThrottledProducerConsumer (in super class)
+
   @AfterEach
   override def tearDown(): Unit = {
     super.tearDown()


### PR DESCRIPTION
Following tests were found to be flaky over multiple runs on local and confirmed by develocity (details in the jiras)

KafkaAdminClientTest > testAdminClientApisAuthenticationFailure() - https://issues.apache.org/jira/browse/KAFKA-18441
EagerConsumerCoordinatorTest > testOutdatedCoordinatorAssignment() - https://issues.apache.org/jira/browse/KAFKA-15900
UserQuotaTest > testThrottledProducerConsumer(String, String).quorum=kraft.groupProtocol=classic - https://issues.apache.org/jira/browse/KAFKA-8073

*Note:* Some tests are in `clients` module which does not have any other project dependencies. The flaky annotation is part of `test-common` and hence they are not explicitly marked `@Flaky`. Instead I've added comments to create breadcrumb trail without disrupting the code. 

The exact test for `UserQuotaTest` is in its superclass so not possible to add the annotation. 
