### PR TITLE
KAFKA-18558: Added check before adding previously subscribed partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -203,15 +203,17 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                             if (acknowledgementsToSend != null) {
                                 metricsManager.recordAcknowledgementSent(acknowledgementsToSend.size());
                                 fetchAcknowledgementsInFlight.put(tip, acknowledgementsToSend);
+
+                                sessionHandler.addPartitionToFetch(tip, acknowledgementsToSend);
+                                handlerMap.put(node, sessionHandler);
+
+                                partitionsToForgetMap.putIfAbsent(node, new ArrayList<>());
+                                partitionsToForgetMap.get(node).add(tip);
+
+                                topicNamesMap.putIfAbsent(new IdAndPartition(tip.topicId(), tip.partition()), tip.topic());
+                                fetchedPartitions.add(tip);
+                                log.debug("Added fetch request for previously subscribed partition {} to node {}", tip, node.id());
                             }
-
-                            sessionHandler.addPartitionToFetch(tip, acknowledgementsToSend);
-                            partitionsToForgetMap.putIfAbsent(node, new ArrayList<>());
-                            partitionsToForgetMap.get(node).add(tip);
-
-                            topicNamesMap.putIfAbsent(new IdAndPartition(tip.topicId(), tip.partition()), tip.topic());
-                            fetchedPartitions.add(tip);
-                            log.debug("Added fetch request for previously subscribed partition {} to node {}", tip, node.id());
                         }
                     }
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -60,6 +60,7 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.requests.ShareAcknowledgeResponse;
+import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -849,6 +850,13 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.commitAsync(Collections.singletonMap(tip0, acknowledgements));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+
+        client.prepareResponse(fullAcknowledgeResponse(tip1, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+
+        // We should send a fetch to the newly subscribed partition.
+        assertEquals(1, sendFetches());
+
     }
 
     @Test
@@ -879,6 +887,137 @@ public class ShareConsumeRequestManagerTest {
         assertFalse(shareConsumeRequestManager.hasCompletedFetches());
         assertEquals(3.0,
                 metrics.metrics().get(metrics.metricInstance(shareFetchMetricsRegistry.acknowledgementSendTotal)).metricValue());
+    }
+
+    @Test
+    public void testShareFetchWithSubscriptionChangeMultipleNodes() {
+        buildRequestManager();
+
+        subscriptions.subscribeToShareGroup(Collections.singleton(topicName));
+        Set<TopicPartition> partitions = new HashSet<>();
+        partitions.add(tp0);
+        partitions.add(tp1);
+        subscriptions.assignFromSubscribed(Collections.singletonList(tp0));
+
+        client.updateMetadata(
+                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
+                        tp -> validLeaderEpoch, topicIds, false));
+        Node nodeId0 = metadata.fetch().nodeById(0);
+        Node nodeId1 = metadata.fetch().nodeById(1);
+        Node tp0Leader = metadata.fetch().leaderFor(tp0);
+        Node tp1Leader = metadata.fetch().leaderFor(tp1);
+
+        assertEquals(nodeId0, tp0Leader);
+        assertEquals(nodeId1, tp1Leader);
+
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, records, emptyAcquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        acknowledgements.add(0L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(1L, AcknowledgeType.RELEASE);
+        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+
+        // Send acknowledgements via ShareFetch
+        shareConsumeRequestManager.fetch(Collections.singletonMap(tip0, acknowledgements));
+        fetchRecords();
+        // Subscription changes.
+        subscriptions.assignFromSubscribed(Collections.singletonList(tp1));
+
+        client.updateMetadata(
+                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
+                        tp -> validLeaderEpoch, topicIds, false));
+        nodeId0 = metadata.fetch().nodeById(0);
+        nodeId1 = metadata.fetch().nodeById(1);
+        tp0Leader = metadata.fetch().leaderFor(tp0);
+        tp1Leader = metadata.fetch().leaderFor(tp1);
+
+        assertEquals(nodeId0, tp0Leader);
+        assertEquals(nodeId1, tp1Leader);
+
+        NetworkClientDelegate.PollResult pollResult = shareConsumeRequestManager.sendFetchesReturnPollResult();
+        assertEquals(2, pollResult.unsentRequests.size());
+
+        ShareFetchRequest.Builder builder1 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
+        assertEquals(1, builder1.data().topics().size());
+        assertEquals(tip0.topicId(), builder1.data().topics().get(0).topicId());
+        assertEquals(1, builder1.data().topics().get(0).partitions().size());
+        assertEquals(0, builder1.data().topics().get(0).partitions().get(0).partitionIndex());
+        assertEquals(1, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().size());
+        assertEquals(0L, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).firstOffset());
+        assertEquals(2L, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).lastOffset());
+
+        assertEquals(1, builder1.data().forgottenTopicsData().size());
+        assertEquals(tip0.topicId(), builder1.data().forgottenTopicsData().get(0).topicId());
+        assertEquals(1, builder1.data().forgottenTopicsData().get(0).partitions().size());
+        assertEquals(0, builder1.data().forgottenTopicsData().get(0).partitions().get(0));
+
+        ShareFetchRequest.Builder builder2 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(1).requestBuilder();
+        assertEquals(1, builder2.data().topics().size());
+        assertEquals(tip1.topicId(), builder2.data().topics().get(0).topicId());
+        assertEquals(1, builder2.data().topics().get(0).partitions().size());
+        assertEquals(1, builder2.data().topics().get(0).partitions().get(0).partitionIndex());
+    }
+
+    @Test
+    public void testShareFetchWithSubscriptionChangeMultipleNodesEmptyAcknowledgements() {
+        buildRequestManager();
+
+        subscriptions.subscribeToShareGroup(Collections.singleton(topicName));
+        subscriptions.assignFromSubscribed(Collections.singletonList(tp0));
+
+        client.updateMetadata(
+                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
+                        tp -> validLeaderEpoch, topicIds, false));
+        Node nodeId0 = metadata.fetch().nodeById(0);
+        Node nodeId1 = metadata.fetch().nodeById(1);
+        Node tp0Leader = metadata.fetch().leaderFor(tp0);
+        Node tp1Leader = metadata.fetch().leaderFor(tp1);
+
+        assertEquals(nodeId0, tp0Leader);
+        assertEquals(nodeId1, tp1Leader);
+
+        // Send the first ShareFetch
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        // Prepare an empty response
+        client.prepareResponse(fullFetchResponse(tip0, records, emptyAcquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        fetchRecords();
+
+        // Change the subscription.
+        subscriptions.assignFromSubscribed(Collections.singletonList(tp1));
+
+        client.updateMetadata(
+                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
+                        tp -> validLeaderEpoch, topicIds, false));
+        nodeId0 = metadata.fetch().nodeById(0);
+        nodeId1 = metadata.fetch().nodeById(1);
+        tp0Leader = metadata.fetch().leaderFor(tp0);
+        tp1Leader = metadata.fetch().leaderFor(tp1);
+
+        assertEquals(nodeId0, tp0Leader);
+        assertEquals(nodeId1, tp1Leader);
+
+        // Now we will be sending the request to node1 only as leader for tip1 is node1.
+        // We do not build the request for tip0 as there are no acknowledgements to send.
+        NetworkClientDelegate.PollResult pollResult = shareConsumeRequestManager.sendFetchesReturnPollResult();
+        assertEquals(1, pollResult.unsentRequests.size());
+
+        ShareFetchRequest.Builder builder = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
+
+        assertEquals(1, builder.data().topics().size());
+        assertEquals(tip1.topicId(), builder.data().topics().get(0).topicId());
+        assertEquals(1, builder.data().topics().get(0).partitions().size());
+        assertEquals(1, builder.data().topics().get(0).partitions().get(0).partitionIndex());
+        assertEquals(0, builder.data().forgottenTopicsData().size());
     }
 
     @Test
@@ -1807,6 +1946,13 @@ public class ShareConsumeRequestManagerTest {
             NetworkClientDelegate.PollResult pollResult = poll(time.milliseconds());
             networkClientDelegate.addAll(pollResult.unsentRequests);
             return pollResult.unsentRequests.size();
+        }
+
+        private NetworkClientDelegate.PollResult sendFetchesReturnPollResult() {
+            fetch(new HashMap<>());
+            NetworkClientDelegate.PollResult pollResult = poll(time.milliseconds());
+            networkClientDelegate.addAll(pollResult.unsentRequests);
+            return pollResult;
         }
 
         private int sendAcknowledgements() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -931,7 +931,19 @@ public class ShareConsumeRequestManagerTest {
         NetworkClientDelegate.PollResult pollResult = shareConsumeRequestManager.sendFetchesReturnPollResult();
         assertEquals(2, pollResult.unsentRequests.size());
 
-        ShareFetchRequest.Builder builder1 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
+        ShareFetchRequest.Builder builder1, builder2;
+        if (pollResult.unsentRequests.get(0).node().get() == nodeId0) {
+            builder1 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
+            builder2 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(1).requestBuilder();
+            assertEquals(nodeId1, pollResult.unsentRequests.get(1).node().get());
+        } else {
+            builder1 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(1).requestBuilder();
+            builder2 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
+            assertEquals(nodeId0, pollResult.unsentRequests.get(1).node().get());
+            assertEquals(nodeId1, pollResult.unsentRequests.get(0).node().get());
+        }
+
+        // Verify the builder data for node0.
         assertEquals(1, builder1.data().topics().size());
         assertEquals(tip0.topicId(), builder1.data().topics().get(0).topicId());
         assertEquals(1, builder1.data().topics().get(0).partitions().size());
@@ -945,7 +957,7 @@ public class ShareConsumeRequestManagerTest {
         assertEquals(1, builder1.data().forgottenTopicsData().get(0).partitions().size());
         assertEquals(0, builder1.data().forgottenTopicsData().get(0).partitions().get(0));
 
-        ShareFetchRequest.Builder builder2 = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(1).requestBuilder();
+        // Verify the builder data for node1.
         assertEquals(1, builder2.data().topics().size());
         assertEquals(tip1.topicId(), builder2.data().topics().get(0).topicId());
         assertEquals(1, builder2.data().topics().get(0).partitions().size());
@@ -989,6 +1001,7 @@ public class ShareConsumeRequestManagerTest {
         // We do not build the request for tip0 as there are no acknowledgements to send.
         NetworkClientDelegate.PollResult pollResult = shareConsumeRequestManager.sendFetchesReturnPollResult();
         assertEquals(1, pollResult.unsentRequests.size());
+        assertEquals(nodeId1, pollResult.unsentRequests.get(0).node().get());
 
         ShareFetchRequest.Builder builder = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -928,17 +928,6 @@ public class ShareConsumeRequestManagerTest {
         // Subscription changes.
         subscriptions.assignFromSubscribed(Collections.singletonList(tp1));
 
-        client.updateMetadata(
-                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
-                        tp -> validLeaderEpoch, topicIds, false));
-        nodeId0 = metadata.fetch().nodeById(0);
-        nodeId1 = metadata.fetch().nodeById(1);
-        tp0Leader = metadata.fetch().leaderFor(tp0);
-        tp1Leader = metadata.fetch().leaderFor(tp1);
-
-        assertEquals(nodeId0, tp0Leader);
-        assertEquals(nodeId1, tp1Leader);
-
         NetworkClientDelegate.PollResult pollResult = shareConsumeRequestManager.sendFetchesReturnPollResult();
         assertEquals(2, pollResult.unsentRequests.size());
 
@@ -995,16 +984,6 @@ public class ShareConsumeRequestManagerTest {
         // Change the subscription.
         subscriptions.assignFromSubscribed(Collections.singletonList(tp1));
 
-        client.updateMetadata(
-                RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 2),
-                        tp -> validLeaderEpoch, topicIds, false));
-        nodeId0 = metadata.fetch().nodeById(0);
-        nodeId1 = metadata.fetch().nodeById(1);
-        tp0Leader = metadata.fetch().leaderFor(tp0);
-        tp1Leader = metadata.fetch().leaderFor(tp1);
-
-        assertEquals(nodeId0, tp0Leader);
-        assertEquals(nodeId1, tp1Leader);
 
         // Now we will be sending the request to node1 only as leader for tip1 is node1.
         // We do not build the request for tip0 as there are no acknowledgements to send.


### PR DESCRIPTION
*What*
Currently in a `ShareFetchRequest`, we include partitions from a previous subscription even if we do not have any acknowledgements to send. This is unnecessary and it means we will just include the partition both in `FetchTopics` and in `ForgottenTopics` with no acknowledgements. 
This PR fixes this bug and adds tests to verify the change. 
Also for the multi-broker scenario, we were not updating `handlerMap` when we updated the `sessionHandlers` with the previously subscribed partitions. This bug is also fixed in this PR.