### PR TITLE
MINOR: Fix streams_reational_smoke_test.py

### DIFF
--- a/tests/kafkatest/tests/streams/streams_relational_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_relational_smoke_test.py
@@ -22,6 +22,7 @@ from kafkatest.services.kafka.util import get_log4j_config_param, get_log4j_conf
 from kafkatest.services.streams import StreamsTestBaseService
 from kafkatest.tests.kafka_test import KafkaTest
 from kafkatest.version import LATEST_4_0
+from kafkatest.version import get_version
 
 
 class StreamsRelationalSmokeTestService(StreamsTestBaseService):
@@ -35,7 +36,7 @@ class StreamsRelationalSmokeTestService(StreamsTestBaseService):
         self.mode = mode
         self.nodeId = nodeId
         self.processing_guarantee = processing_guarantee
-        self.log4j_template = "log4j2_template.yaml" if (self.node.version >= LATEST_4_0) else "log4j_template.properties"
+        self.log4j_template = "log4j2_template.yaml" if (get_version(self.node) >= LATEST_4_0) else "log4j_template.properties"
 
     def start_cmd(self, node):
         return "( export KAFKA_LOG4J_OPTS=\"%(log4j_param)s%(log4j)s\"; " \
@@ -58,7 +59,7 @@ class StreamsRelationalSmokeTestService(StreamsTestBaseService):
     def start_node(self, node):
         node.account.mkdirs(self.PERSISTENT_ROOT)
         node.account.create_file(get_log4j_config_for_tools(node),
-                                 self.render("log4j2_template.yaml" if node.version >= LATEST_4_0 else "log4j_template.properties",
+                                 self.render("log4j2_template.yaml" if get_version(node) >= LATEST_4_0 else "log4j_template.properties",
                                              log_file=self.LOG_FILE))
 
         self.logger.info("Starting process on " + str(node.account))


### PR DESCRIPTION
A prior commit introduced checking for the version of a node related to move to log4j2 but it was causing an error
`AttributeError("'ClusterNode' object has no attribute 'version'")` This PR uses the `get_version` method from `version.py` which checks if the `Node` has a version attribute preventing an error.

Ran the system test locally and kicked off a system test build

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
