### PR TITLE
KAFKA-18479: RocksDBTimeOrderedKeyValueBuffer not initialized correctly (#18490)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1269,8 +1269,14 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 throw new IllegalArgumentException("KTable must be versioned to use a grace period in a stream table join.");
             }
             bufferStoreName = Optional.of(name + "-Buffer");
-            final RocksDBTimeOrderedKeyValueBuffer.Builder<Object, Object> storeBuilder =
-                    new RocksDBTimeOrderedKeyValueBuffer.Builder<>(bufferStoreName.get(), joined.gracePeriod(), name);
+            final RocksDBTimeOrderedKeyValueBuffer.Builder<K, V> storeBuilder =
+                    new RocksDBTimeOrderedKeyValueBuffer.Builder<>(
+                        bufferStoreName.get(),
+                        joinedInternal.keySerde() != null ? joinedInternal.keySerde() : keySerde,
+                        joinedInternal.valueSerde() != null ? joinedInternal.valueSerde() : valueSerde,
+                        joined.gracePeriod(),
+                        name
+                    );
             builder.addStateStore(new StoreBuilderWrapper(storeBuilder));
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -65,13 +65,23 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyVal
     public static class Builder<K, V> implements StoreBuilder<TimeOrderedKeyValueBuffer<K, V, V>> {
 
         private final String storeName;
+        private final Serde<K> keySerde;
+        private final Serde<V> valueSerde;
         private boolean loggingEnabled = true;
         private Map<String, String> logConfig = new HashMap<>();
         private final Duration grace;
         private final String topic;
 
-        public Builder(final String storeName, final Duration grace, final String topic) {
+        public Builder(
+            final String storeName,
+            final Serde<K> keySerde,
+            final Serde<V> valueSerde,
+            final Duration grace,
+            final String topic
+        ) {
             this.storeName = storeName;
+            this.keySerde = keySerde;
+            this.valueSerde = valueSerde;
             this.grace = grace;
             this.topic = topic;
         }
@@ -116,6 +126,8 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyVal
         public TimeOrderedKeyValueBuffer<K, V, V> build() {
             return new RocksDBTimeOrderedKeyValueBuffer<>(
                 new RocksDBTimeOrderedKeyValueBytesStoreSupplier(storeName).get(),
+                keySerde,
+                valueSerde,
                 grace,
                 topic,
                 loggingEnabled);
@@ -139,10 +151,14 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyVal
 
 
     public RocksDBTimeOrderedKeyValueBuffer(final RocksDBTimeOrderedKeyValueBytesStore store,
+                                            final Serde<K> keySerde,
+                                            final Serde<V> valueSerde,
                                             final Duration gracePeriod,
                                             final String topic,
                                             final boolean loggingEnabled) {
         this.store = store;
+        this.keySerde = keySerde;
+        this.valueSerde = valueSerde;
         this.gracePeriod = gracePeriod.toMillis();
         minTimestamp = store.minTimestamp();
         minValid = false;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -56,7 +56,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
 
     @Before
     public void prepareTopology() throws InterruptedException {
-        super.prepareEnvironment();
+        super.prepareEnvironment(true);
 
         appID = "stream-stream-join-integration-test";
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
@@ -57,7 +57,7 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
 
     @Before
     public void prepareTopology() throws InterruptedException {
-        super.prepareEnvironment();
+        super.prepareEnvironment(true);
 
         appID = "stream-table-join-integration-test";
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -56,7 +56,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
 
     @Before
     public void prepareTopology() throws InterruptedException {
-        super.prepareEnvironment();
+        super.prepareEnvironment(true);
 
         appID = "table-table-join-integration-test";
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
@@ -57,18 +58,16 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Before
     public void setUp() {
-        when(serdeGetter.keySerde()).thenReturn(new Serdes.StringSerde());
-        when(serdeGetter.valueSerde()).thenReturn(new Serdes.StringSerde());
         final Metrics metrics = new Metrics();
         offset = 0;
         streamsMetrics = new StreamsMetricsImpl(metrics, "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
         context = new MockInternalNewProcessorContext<>(StreamsTestUtils.getStreamsConfig(), new TaskId(0, 0), TestUtils.tempDirectory());
     }
 
-    private void createBuffer(final Duration grace) {
+    private void createBuffer(final Duration grace, final Serde<String> serde) {
         final RocksDBTimeOrderedKeyValueBytesStore store = new RocksDBTimeOrderedKeyValueBytesStoreSupplier("testing").get();
 
-        buffer = new RocksDBTimeOrderedKeyValueBuffer<>(store, grace, "testing", false);
+        buffer = new RocksDBTimeOrderedKeyValueBuffer<>(store, serde, serde, grace, "testing", false);
         buffer.setSerdesIfNull(serdeGetter);
         buffer.init((StateStoreContext) context, store);
     }
@@ -81,14 +80,16 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldReturnIfRecordWasAdded() {
-        createBuffer(Duration.ofMillis(1));
+        when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
+        when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
+        createBuffer(Duration.ofMillis(1), null);
         assertThat(pipeRecord("K", "V", 2L), equalTo(true));
         assertThat(pipeRecord("K", "V", 0L), equalTo(false));
     }
 
     @Test
     public void shouldPutInBufferAndUpdateFields() {
-        createBuffer(Duration.ofMinutes(1));
+        createBuffer(Duration.ofMinutes(1), Serdes.String());
         assertNumSizeAndTimestamp(buffer, 0, Long.MAX_VALUE, 0);
         pipeRecord("1", "0", 0L);
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
@@ -98,7 +99,7 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldAddAndEvictRecord() {
-        createBuffer(Duration.ZERO);
+        createBuffer(Duration.ZERO, Serdes.String());
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("1", "0", 0L);
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
@@ -109,7 +110,9 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldAddAndEvictRecordTwice() {
-        createBuffer(Duration.ZERO);
+        when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
+        when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
+        createBuffer(Duration.ZERO, null);
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("1", "0", 0L);
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
@@ -125,7 +128,7 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldAddAndEvictRecordTwiceWithNonZeroGrace() {
-        createBuffer(Duration.ofMillis(1));
+        createBuffer(Duration.ofMillis(1), Serdes.String());
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("1", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
@@ -139,7 +142,9 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldAddRecordsTwiceAndEvictRecordsOnce() {
-        createBuffer(Duration.ZERO);
+        when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
+        when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
+        createBuffer(Duration.ZERO, null);
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("1", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 1, r -> count.getAndIncrement());
@@ -151,7 +156,9 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldDropLateRecords() {
-        createBuffer(Duration.ZERO);
+        when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
+        when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
+        createBuffer(Duration.ZERO, null);
         pipeRecord("1", "0", 1L);
         assertNumSizeAndTimestamp(buffer, 1, 1, 42);
         pipeRecord("2", "0", 0L);
@@ -160,7 +167,7 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldDropLateRecordsWithNonZeroGrace() {
-        createBuffer(Duration.ofMillis(1));
+        createBuffer(Duration.ofMillis(1), Serdes.String());
         pipeRecord("1", "0", 2L);
         assertNumSizeAndTimestamp(buffer, 1, 2, 42);
         pipeRecord("2", "0", 1L);
@@ -171,7 +178,9 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
 
     @Test
     public void shouldHandleCollidingKeys() {
-        createBuffer(Duration.ofMillis(1));
+        when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
+        when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
+        createBuffer(Duration.ofMillis(1), null);
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("2", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());


### PR DESCRIPTION
RocksDBTimeOrderedKeyValueBuffer is not initialize with serdes provides via Joined, but always uses serdes from StreamsConfig.

Reviewers: Bill Bejeck <bill@confluent.io>

Cherry-pick of https://github.com/apache/kafka/pull/18490 to `3.8` branch.