### PR TITLE
KAFKA-18556: Remove JaasModule#zkDigestModule, JaasTestUtils#zkSections and its usage

### DIFF
--- a/core/src/test/java/kafka/security/JaasModule.java
+++ b/core/src/test/java/kafka/security/JaasModule.java
@@ -23,15 +23,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class JaasModule {
-    public static JaasModule zkDigestModule(boolean debug, Map<String, String> entries) {
-        String name = "org.apache.zookeeper.server.auth.DigestLoginModule";
-        return new JaasModule(
-            name,
-            debug,
-            entries
-        );
-    }
-
     public static JaasModule krb5LoginModule(boolean useKeyTab, boolean storeKey, String keyTab, String principal, boolean debug, Optional<String> serviceName, boolean isIbmSecurity) {
         String name = isIbmSecurity ? "com.ibm.security.auth.module.Krb5LoginModule" : "com.sun.security.auth.module.Krb5LoginModule";
 

--- a/core/src/test/java/kafka/security/JaasTestUtils.java
+++ b/core/src/test/java/kafka/security/JaasTestUtils.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -71,12 +70,6 @@ public class JaasTestUtils {
     }
 
     private static final boolean IS_IBM_SECURITY = Java.isIbmJdk() && !Java.isIbmJdkSemeru();
-
-    private static final String ZK_SERVER_CONTEXT_NAME = "Server";
-    private static final String ZK_CLIENT_CONTEXT_NAME = "Client";
-    private static final String ZK_USER_SUPER_PASSWD = "adminpasswd";
-    private static final String ZK_USER = "fpj";
-    private static final String ZK_USER_PASSWORD = "fpjsecret";
 
     public static final String KAFKA_SERVER_CONTEXT_NAME = "KafkaServer";
     public static final String KAFKA_SERVER_PRINCIPAL_UNQUALIFIED_NAME = "kafka";
@@ -170,20 +163,6 @@ public class JaasTestUtils {
         Map<String, String> tokenProps = new HashMap<>();
         tokenProps.put("tokenauth", "true");
         return JaasModule.scramLoginModule(tokenId, password, false, tokenProps).toString();
-    }
-
-    public static List<JaasSection> zkSections() {
-        Map<String, String> zkServerEntries = new HashMap<>();
-        zkServerEntries.put("user_super", ZK_USER_SUPER_PASSWD);
-        zkServerEntries.put("user_" + ZK_USER, ZK_USER_PASSWORD);
-        JaasSection zkServerSection = new JaasSection(ZK_SERVER_CONTEXT_NAME, Collections.singletonList(JaasModule.zkDigestModule(false, zkServerEntries)));
-
-        Map<String, String> zkClientEntries = new HashMap<>();
-        zkClientEntries.put("username", ZK_USER);
-        zkClientEntries.put("password", ZK_USER_PASSWORD);
-        JaasSection zkClientSection = new JaasSection(ZK_CLIENT_CONTEXT_NAME, Collections.singletonList(JaasModule.zkDigestModule(false, zkClientEntries)));
-
-        return Arrays.asList(zkServerSection, zkClientSection);
     }
 
     public static JaasSection kafkaServerSection(String contextName, List<String> mechanisms, Optional<File> keytabLocation) {

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -104,14 +104,8 @@ trait SaslSetup {
       (kafkaServerSaslMechanisms.contains("GSSAPI") || kafkaClientSaslMechanism.contains("GSSAPI"))
     if (hasKerberos)
       maybeCreateEmptyKeytabFiles()
-    mode match {
-      case ZkSasl => JaasTestUtils.zkSections.asScala
-      case KafkaSasl =>
-        Seq(JaasTestUtils.kafkaServerSection(kafkaServerEntryName, kafkaServerSaslMechanisms.asJava, serverKeytabFile.toJava),
-          JaasTestUtils.kafkaClientSection(kafkaClientSaslMechanism.toJava, clientKeytabFile.toJava))
-      case Both => Seq(JaasTestUtils.kafkaServerSection(kafkaServerEntryName, kafkaServerSaslMechanisms.asJava, serverKeytabFile.toJava),
-        JaasTestUtils.kafkaClientSection(kafkaClientSaslMechanism.toJava, clientKeytabFile.toJava)) ++ JaasTestUtils.zkSections.asScala
-    }
+    Seq(JaasTestUtils.kafkaServerSection(kafkaServerEntryName, kafkaServerSaslMechanisms.asJava, serverKeytabFile.toJava),
+      JaasTestUtils.kafkaClientSection(kafkaClientSaslMechanism.toJava, clientKeytabFile.toJava))
   }
 
   private def writeJaasConfigurationToFile(jaasSections: Seq[JaasSection]): Unit = {

--- a/core/src/test/scala/integration/kafka/server/MultipleListenersWithAdditionalJaasContextTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MultipleListenersWithAdditionalJaasContextTest.scala
@@ -32,8 +32,7 @@ class MultipleListenersWithAdditionalJaasContextTest extends MultipleListenersWi
 
   override def staticJaasSections: Seq[JaasSection] = {
     val (serverKeytabFile, _) = maybeCreateEmptyKeytabFiles()
-    JaasTestUtils.zkSections.asScala :+
-      JaasTestUtils.kafkaServerSection("secure_external.KafkaServer", kafkaServerSaslMechanisms(SecureExternal).asJava, Some(serverKeytabFile).toJava)
+    Seq(JaasTestUtils.kafkaServerSection("secure_external.KafkaServer", kafkaServerSaslMechanisms(SecureExternal).asJava, Some(serverKeytabFile).toJava))
   }
 
   override protected def dynamicJaasSections: Properties = {


### PR DESCRIPTION
JIRA: KAFKA-18556
We should clean up JaasModule and JaasTestUtils since we are removing zk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
