### PR TITLE
KAFKA-18744: reuse LoginCallbackHandler on kerberos re-login

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/AbstractLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/AbstractLogin.java
@@ -76,6 +76,10 @@ public abstract class AbstractLogin implements Login {
         return configuration;
     }
 
+    protected AuthenticateCallbackHandler getLoginCallbackHandler() {
+        return this.loginCallbackHandler;
+    }
+
     /**
      * Callback handler for creating login context. Login callback handlers
      * should support the callbacks required for the login modules used by

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -370,7 +370,7 @@ public class KerberosLogin extends AbstractLogin {
             }
             //login and also update the subject field of this instance to
             //have the new credentials (pass it to the LoginContext constructor)
-            loginContext = new LoginContext(contextName(), subject, null, configuration());
+            loginContext = new LoginContext(contextName(), subject, getLoginCallbackHandler(), configuration());
             log.info("Initiating re-login for {}", principal);
             login(loginContext);
         }


### PR DESCRIPTION
When I add sasl.login.callback.handler.class it is used for initial login but not used when ticket is about to expire

Add small ticket_lifetime in krb5.conf, for example ticket_lifetime = 3m and wait kerberos relogin

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
