### PR TITLE
KAFKA-16368: Constraints update for segment.index.bytes

### DIFF
--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -102,7 +102,7 @@ class AbstractPartitionTest {
   def createLogProperties(overrides: Map[String, String]): Properties = {
     val logProps = new Properties()
     logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, 512: java.lang.Integer)
-    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1000: java.lang.Integer)
+    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1024: java.lang.Integer)
     logProps.put(TopicConfig.RETENTION_MS_CONFIG, 999: java.lang.Integer)
     overrides.foreach { case (k, v) => logProps.put(k, v) }
     logProps

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -365,7 +365,7 @@ class PartitionLockTest extends Logging {
   private def createLogProperties(overrides: Map[String, String]): Properties = {
     val logProps = new Properties()
     logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, 512: java.lang.Integer)
-    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1000: java.lang.Integer)
+    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1024: java.lang.Integer)
     logProps.put(TopicConfig.RETENTION_MS_CONFIG, 999: java.lang.Integer)
     overrides.foreach { case (k, v) => logProps.put(k, v) }
     logProps

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1808,7 +1808,7 @@ class LogCleanerTest extends Logging {
     val map = new FakeOffsetMap(1000)
     val logProps = new Properties()
     logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, 120: java.lang.Integer)
-    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 120: java.lang.Integer)
+    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1024: java.lang.Integer)
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
     val logConfig = new LogConfig(logProps)
     val log = makeLog(config = logConfig)

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -811,7 +811,7 @@ class LogLoaderTest {
     Files.createFile(bogusTimeIndex2.toPath)
 
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds)
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, indexIntervalBytes = 1)
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, indexIntervalBytes = 1)
     val log = createLog(logDir, logConfig)
 
     // Force the segment to access the index files because we are doing index lazy loading.
@@ -841,7 +841,7 @@ class LogLoaderTest {
   def testReopenThenTruncate(): Unit = {
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds)
     // create a log
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, indexIntervalBytes = 10000)
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, indexIntervalBytes = 10000)
     var log = createLog(logDir, logConfig)
 
     // add enough messages to roll over several segments then close and re-open and attempt to truncate
@@ -860,7 +860,7 @@ class LogLoaderTest {
   @Test
   def testOpenDeletesObsoleteFiles(): Unit = {
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds - 1000)
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, retentionMs = 999)
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, retentionMs = 999)
     var log = createLog(logDir, logConfig)
 
     // append some messages to create some segments

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -2364,7 +2364,7 @@ class UnifiedLogTest {
   def testAsyncDelete(): Unit = {
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds - 1000L)
     val asyncDeleteMs = 1000
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, indexIntervalBytes = 10000,
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, indexIntervalBytes = 10000,
                                     retentionMs = 999, fileDeleteDelayMs = asyncDeleteMs)
     val log = createLog(logDir, logConfig)
 
@@ -2657,7 +2657,7 @@ class UnifiedLogTest {
   @Test
   def testDeleteOldSegments(): Unit = {
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds - 1000)
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, retentionMs = 999)
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, retentionMs = 999)
     val log = createLog(logDir, logConfig)
 
     // append some messages to create some segments
@@ -2707,7 +2707,7 @@ class UnifiedLogTest {
   @Test
   def testLogDeletionAfterClose(): Unit = {
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds - 1000)
-    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, retentionMs = 999)
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1024, retentionMs = 999)
     val log = createLog(logDir, logConfig)
 
     // append some messages to create some segments
@@ -3543,7 +3543,7 @@ class UnifiedLogTest {
   def testSegmentDeletionWithHighWatermarkInitialization(): Unit = {
     val logConfig = LogTestUtils.createLogConfig(
       segmentBytes = 512,
-      segmentIndexBytes = 1000,
+      segmentIndexBytes = 1024,
       retentionMs = 999
     )
     val log = createLog(logDir, logConfig)
@@ -3567,7 +3567,7 @@ class UnifiedLogTest {
   def testCannotDeleteSegmentsAtOrAboveHighWatermark(): Unit = {
     val logConfig = LogTestUtils.createLogConfig(
       segmentBytes = 512,
-      segmentIndexBytes = 1000,
+      segmentIndexBytes = 1024,
       retentionMs = 999
     )
     val log = createLog(logDir, logConfig)
@@ -3610,7 +3610,7 @@ class UnifiedLogTest {
   def testCannotIncrementLogStartOffsetPastHighWatermark(): Unit = {
     val logConfig = LogTestUtils.createLogConfig(
       segmentBytes = 512,
-      segmentIndexBytes = 1000,
+      segmentIndexBytes = 1024,
       retentionMs = 999
     )
     val log = createLog(logDir, logConfig)
@@ -4123,7 +4123,7 @@ class UnifiedLogTest {
 
   @Test
   def testActiveSegmentDeletionDueToRetentionTimeBreachWithRemoteStorage(): Unit = {
-    val logConfig = LogTestUtils.createLogConfig(indexIntervalBytes = 1, segmentIndexBytes = 12,
+    val logConfig = LogTestUtils.createLogConfig(indexIntervalBytes = 1, segmentIndexBytes = 1024,
       retentionMs = 3, localRetentionMs = 1, fileDeleteDelayMs = 0, remoteLogStorageEnable = true)
     val log = createLog(logDir, logConfig, remoteStorageSystemEnable = true)
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -202,7 +202,7 @@ public class LogConfig extends AbstractConfig {
                 .define(TopicConfig.SEGMENT_MS_CONFIG, LONG, DEFAULT_SEGMENT_MS, atLeast(1), MEDIUM, TopicConfig.SEGMENT_MS_DOC)
                 .define(TopicConfig.SEGMENT_JITTER_MS_CONFIG, LONG, DEFAULT_SEGMENT_JITTER_MS, atLeast(0), MEDIUM,
                         TopicConfig.SEGMENT_JITTER_MS_DOC)
-                .define(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, INT, ServerLogConfigs.LOG_INDEX_SIZE_MAX_BYTES_DEFAULT, atLeast(4), MEDIUM,
+                .define(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, INT, ServerLogConfigs.LOG_INDEX_SIZE_MAX_BYTES_DEFAULT, atLeast(1024), MEDIUM,
                         TopicConfig.SEGMENT_INDEX_BYTES_DOC)
                 .define(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, LONG, ServerLogConfigs.LOG_FLUSH_INTERVAL_MESSAGES_DEFAULT, atLeast(1), MEDIUM,
                         TopicConfig.FLUSH_MESSAGES_INTERVAL_DOC)

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -619,7 +619,7 @@ public class LogSegmentTest {
         File tempDir = TestUtils.tempDirectory();
         Map<String, Object> configMap = new HashMap<>();
         configMap.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, 10);
-        configMap.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1000);
+        configMap.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1024);
         configMap.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, 0);
         LogConfig logConfig = new LogConfig(configMap);
         try (LogSegment seg = LogSegment.open(tempDir, 40, logConfig, Time.SYSTEM, false,
@@ -643,7 +643,7 @@ public class LogSegmentTest {
         // Set up the log configuration
         Map<String, Object> configMap = new HashMap<>();
         configMap.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, 10);
-        configMap.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1000);
+        configMap.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1024);
         configMap.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, 0);
         LogConfig logConfig = new LogConfig(configMap);
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/TieredStorageTestUtils.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/TieredStorageTestUtils.java
@@ -178,6 +178,8 @@ public class TieredStorageTestUtils {
         // a "small" number of records (i.e. such that the average record size times the number of records is
         // much less than the segment size), the number of records which hold in a segment is the multiple of 12
         // defined below.
+
+        // TODO: WIP - Need to consider options for dealing with this segment roll approach not being valid for this PR.
         topicProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, String.valueOf(12 * maxRecordBatchPerSegment));
         // To verify records physically absent from Kafka's storage can be consumed via the second tier storage, we
         // want to delete log segments as soon as possible. When tiered storage is active, an inactive log


### PR DESCRIPTION
KIP-1030: Update minimum for segment.index.bytes / log.index.size.max.bytes to 1KB.

WIP: Need to resolve issues with TieredStorageTestHarness using index.size to roll segments.
