### PR TITLE
MINOR: Remove recordVersion param from javadoc

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -48,7 +48,6 @@ public class UnifiedLog {
      * @param segments                The segments of the log whose producer state is being rebuilt
      * @param logStartOffset          The log start offset
      * @param lastOffset              The last offset upto which the producer state needs to be rebuilt
-     * @param recordVersion           The record version
      * @param time                    The time instance used for checking the clock
      * @param reloadFromCleanShutdown True if the producer state is being built after a clean shutdown, false otherwise.
      * @param logPrefix               The logging prefix


### PR DESCRIPTION
In [commit](https://github.com/apache/kafka/pull/18267/files#diff-af233f6e6dbc2b6ffab6657cac49c8f425d0a6063c7be1a567a37e50d46a11f6L61) the `RecordVersion` parameter has been removed, but it remains in the javadoc.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
