### PR TITLE
KAFKA-10409: Refactor Kakfa Streams RocksDB Iterators

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -192,7 +192,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                                                             final Bytes from,
                                                             final Bytes to,
                                                             final boolean forward) {
-            return new RocksDBDualCFRangeIterator(
+            return RocksDBDualCFRangeIterator.of(
                     from,
                     to,
                     accessor.newIterator(oldColumnFamily),
@@ -220,7 +220,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> all(final DBAccessor accessor, final boolean forward) {
-            return new RocksDBDualCFRangeIterator(
+            return RocksDBDualCFRangeIterator.of(
                     null,
                     null,
                     accessor.newIterator(oldColumnFamily),
@@ -233,7 +233,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor, final Bytes prefix) {
             final Bytes to = incrementWithoutOverflow(prefix);
-            return new RocksDBDualCFRangeIterator(
+            return RocksDBDualCFRangeIterator.of(
                     prefix,
                     to,
                     accessor.newIterator(oldColumnFamily),
@@ -321,6 +321,9 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
      *
      * <h3>Thread Safety:</h3>
      *
+     * <p>This iterator is not thread-safe. If access from multiple threads is required, external synchronization must
+     * be provided by the caller.</p>
+     *
      * <p>The iterator is thread-safe for sequential operations but should not be accessed concurrently from multiple
      * threads without external synchronization.</p>
      *
@@ -372,21 +375,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private final byte[] rawLastKey;
         private volatile boolean open = true;
 
-        /**
-         * Constructs a new {@code RocksDBDualCFRangeIterator}.
-         *
-         * <p>Initializes the RocksDB iterators for two column families (timestamped and non-timestamped) and sets up
-         * the range and direction for iteration.</p>
-         *
-         * @param from                  The starting key of the range. Can be {@code null} for an open range.
-         * @param to                    The ending key of the range. Can be {@code null} for an open range.
-         * @param noTimestampIterator   The iterator for the non-timestamped column family.
-         * @param withTimestampIterator The iterator for the timestamped column family.
-         * @param storeName             The name of the store associated with this iterator.
-         * @param forward               {@code true} for forward iteration; {@code false} for reverse iteration.
-         * @param toInclusive           Whether the upper boundary of the range is inclusive.
-         */
-        RocksDBDualCFRangeIterator(final Bytes from,
+        private RocksDBDualCFRangeIterator(final Bytes from,
                                    final Bytes to,
                                    final RocksIterator noTimestampIterator,
                                    final RocksIterator withTimestampIterator,
@@ -400,6 +389,41 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             this.withTimestampIterator = withTimestampIterator;
 
             this.rawLastKey = initializeIterators(from, to);
+        }
+
+        /**
+         * Creates a new {@code RocksDBDualCFRangeIterator}.
+         *
+         * <p>Initializes the RocksDB iterators for two column families (timestamped and non-timestamped) and sets up
+         * the range and direction for iteration.</p>
+         *
+         * @param from                  The starting key of the range. Can be {@code null} for an open range.
+         * @param to                    The ending key of the range. Can be {@code null} for an open range.
+         * @param noTimestampIterator   The iterator for the non-timestamped column family.
+         * @param withTimestampIterator The iterator for the timestamped column family.
+         * @param storeName             The name of the store associated with this iterator.
+         * @param forward               {@code true} for forward iteration; {@code false} for reverse iteration.
+         * @param toInclusive           Whether the upper boundary of the range is inclusive.
+         */
+        public static RocksDBDualCFRangeIterator of(final Bytes from,
+                                             final Bytes to,
+                                             final RocksIterator noTimestampIterator,
+                                             final RocksIterator withTimestampIterator,
+                                             final String storeName,
+                                             final boolean forward,
+                                             final boolean toInclusive) {
+            final RocksDBDualCFRangeIterator iterator =
+                new RocksDBDualCFRangeIterator(
+                    from,
+                    to,
+                    noTimestampIterator,
+                    withTimestampIterator,
+                    storeName,
+                    forward,
+                    toInclusive
+                );
+            iterator.initializeIterators(from, to);
+            return iterator;
         }
 
         /**
@@ -549,9 +573,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private boolean isInRange(final KeyValue<Bytes, byte[]> keyValue) {
             if (rawLastKey == null) return true; // Open-ended range
             final int comparison = comparator.compare(keyValue.key.get(), rawLastKey);
-            return forward
-                    ? comparison < 0 || (toInclusive && comparison == 0)
-                    : comparison > 0 || (toInclusive && comparison == 0);
+            return (toInclusive && comparison == 0) || (forward ? comparison < 0 : comparison > 0);
         }
 
         /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -275,6 +275,90 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
     }
 
+    /**
+     * A range-based iterator for RocksDB that merges results from two column families.
+     *
+     * <p>This iterator supports traversal over two RocksDB column families: one containing timestamped values and
+     * another containing non-timestamped values. It ensures that the keys from both column families are merged and
+     * sorted lexicographically, respecting the iteration order (forward or reverse) and the specified range
+     * boundaries.</p>
+     *
+     * <h2>Key Features</h2>
+     *
+     * <ul>
+     *     <li>Merges results from the "with-timestamp" and "no-timestamp" column families.</li>
+     *     <li>Supports range-based queries with open or closed boundaries.</li>
+     *     <li>Handles both forward and reverse iteration seamlessly.</li>
+     *     <li>Ensures correct handling of inclusive and exclusive upper boundaries.</li>
+     *     <li>Integrates efficiently with Kafka Streams state store mechanisms.</li>
+     * </ul>
+     *
+     * <h2>Usage</h2>
+     *
+     * <p>The iterator can be used for different types of range-based operations, such as:
+     * <ul>
+     *     <li>Iterating over all keys within a range.</li>
+     *     <li>Prefix-based scans (when combined with dynamically calculated range endpoints).</li>
+     *     <li>Open-ended range queries (e.g., from a given key to the end of the dataset).</li>
+     * </ul>
+     * </p>
+     *
+     * <h2>Implementation Details</h2>
+     *
+     * <p>The class extends {@link AbstractIterator} and implements {@link ManagedKeyValueIterator}. It uses RocksDB's
+     * native iterators for efficient traversal of keys within the specified range. Keys from the two column families
+     * are merged during iteration, ensuring proper order and de-duplication where applicable.</p>
+     *
+     * <h3>Key Methods:</h3>
+     *
+     * <ul>
+     *     <li><b>{@code makeNext()}:</b> Retrieves the next key-value pair in the merged range, ensuring
+     *     the result is within the specified range and boundary conditions.</li>
+     *     <li><b>{@code initializeIterators()}:</b> Initializes the RocksDB iterators based on the specified range and direction.</li>
+     *     <li><b>{@code isInRange()}:</b> Verifies if the current key-value pair is within the range defined by {@code from} and {@code to}.</li>
+     *     <li><b>{@code fetchNextKeyValue()}:</b> Determines the next key-value pair to return based on the state of both iterators.</li>
+     * </ul>
+     *
+     * <h3>Thread Safety:</h3>
+     *
+     * <p>The iterator is thread-safe for sequential operations but should not be accessed concurrently from multiple
+     * threads without external synchronization.</p>
+     *
+     * <h2>Examples</h2>
+     *
+     * <h3>Iterate over a range:</h3>
+     *
+     * <pre>{@code
+     * RocksIterator noTimestampIterator = accessor.newIterator(noTimestampColumnFamily);
+     * RocksIterator withTimestampIterator = accessor.newIterator(withTimestampColumnFamily);
+     *
+     * try (RocksDBDualCFRangeIterator iterator = new RocksDBDualCFRangeIterator(
+     *         new Bytes("keyStart".getBytes()),
+     *         new Bytes("keyEnd".getBytes()),
+     *         noTimestampIterator,
+     *         withTimestampIterator,
+     *         "storeName",
+     *         true,  // Forward iteration
+     *         true   // Inclusive upper boundary
+     * )) {
+     *     while (iterator.hasNext()) {
+     *         KeyValue<Bytes, byte[]> entry = iterator.next();
+     *         System.out.println("Key: " + entry.key + ", Value: " + Arrays.toString(entry.value));
+     *     }
+     * }
+     * }</pre>
+     *
+     * <h2>Exceptions</h2>
+     *
+     * <ul>
+     *     <li><b>{@link InvalidStateStoreException}:</b> Thrown if the iterator is accessed after being closed.</li>
+     *     <li><b>{@link IllegalStateException}:</b> Thrown if the close callback is not properly set before usage.</li>
+     * </ul>
+     *
+     * @see AbstractIterator
+     * @see ManagedKeyValueIterator
+     * @see RocksDBStore
+     */
     private static class RocksDBDualCFRangeIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implements ManagedKeyValueIterator<Bytes, byte[]> {
         private Runnable closeCallback;
         private byte[] noTimestampNext;
@@ -288,6 +372,20 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private final byte[] rawLastKey;
         private volatile boolean open = true;
 
+        /**
+         * Constructs a new {@code RocksDBDualCFRangeIterator}.
+         *
+         * <p>Initializes the RocksDB iterators for two column families (timestamped and non-timestamped) and sets up
+         * the range and direction for iteration.</p>
+         *
+         * @param from                  The starting key of the range. Can be {@code null} for an open range.
+         * @param to                    The ending key of the range. Can be {@code null} for an open range.
+         * @param noTimestampIterator   The iterator for the non-timestamped column family.
+         * @param withTimestampIterator The iterator for the timestamped column family.
+         * @param storeName             The name of the store associated with this iterator.
+         * @param forward               {@code true} for forward iteration; {@code false} for reverse iteration.
+         * @param toInclusive           Whether the upper boundary of the range is inclusive.
+         */
         RocksDBDualCFRangeIterator(final Bytes from,
                                    final Bytes to,
                                    final RocksIterator noTimestampIterator,
@@ -304,6 +402,15 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             this.rawLastKey = initializeIterators(from, to);
         }
 
+        /**
+         * Retrieves the next key-value pair in the range.
+         *
+         * <p>This method determines the next key-value pair to return by merging the results from the two column
+         * families. If both column families have keys, it selects the one that matches the iteration order and range
+         * conditions. Keys outside the specified range are skipped.</p>
+         *
+         * @return The next {@link KeyValue} pair in the range, or {@code null} if no more elements are available.
+         */
         @Override
         protected KeyValue<Bytes, byte[]> makeNext() {
             loadNextKeys();
@@ -312,24 +419,58 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             return isInRange(next) ? next : allDone();
         }
 
+        /**
+         * Returns the next key in the range without advancing the iterator.
+         *
+         * <p>This method retrieves the key of the next {@link KeyValue} pair that would be returned by {@link #next()},
+         * without moving the iterator forward. This is useful for inspecting the next key without affecting the
+         * iterator's state.</p>
+         *
+         * @return The next key as a {@link Bytes} object.
+         *
+         * @throws NoSuchElementException If there are no more elements in the iterator.
+         */
         @Override
         public Bytes peekNextKey() {
             if (!hasNext()) throw new NoSuchElementException();
             return super.peek().key;
         }
 
+        /**
+         * Advances the iterator and returns the next key-value pair.
+         *
+         * @return The next {@link KeyValue} pair in the range.
+         *
+         * @throws InvalidStateStoreException If the iterator has been closed.
+         */
         @Override
         public synchronized KeyValue<Bytes, byte[]> next() {
             ensureOpen();
             return super.next();
         }
 
+        /**
+         * Checks if there are more elements available in the range.
+         *
+         * @return {@code true} if the iterator has more elements; {@code false} otherwise.
+         *
+         * @throws InvalidStateStoreException If the iterator has been closed.
+         */
         @Override
         public synchronized boolean hasNext() {
             ensureOpen();
             return super.hasNext();
         }
 
+        /**
+         * Closes the iterator and releases associated resources.
+         *
+         * <p>This method ensures that the RocksDB iterators for both column families are properly closed. After this
+         * method is called, any subsequent calls to {@link #hasNext()}, {@link #next()}, or {@link #peekNextKey()} will
+         * result in an {@link InvalidStateStoreException}.</p>
+         *
+         * @throws IllegalStateException If the close callback has not been set before calling this method.
+         */
         @Override
         public synchronized void close() {
             if (closeCallback == null) {
@@ -343,6 +484,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             open = false;
         }
 
+        /**
+         * Registers a callback to be executed when the iterator is closed.
+         *
+         * @param closeCallback A {@link Runnable} to execute during the {@link #close()} operation.
+         */
         @Override
         public void onClose(final Runnable closeCallback) {
             this.closeCallback = closeCallback;
@@ -357,6 +503,15 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             }
         }
 
+        /**
+         * Determines the next key-value pair to return.
+         *
+         * <p>If one of the column family iterators is exhausted, the method returns the result from the other iterator.
+         * If both iterators have keys, the method compares the keys and returns the appropriate result based on the
+         * iteration direction.</p>
+         *
+         * @return The next {@link KeyValue} pair to return.
+         */
         private KeyValue<Bytes, byte[]> fetchNextKeyValue() {
             if (noTimestampNext == null) {
                 return handleWithTimestampOnly();
@@ -381,6 +536,16 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             return result;
         }
 
+        /**
+         * Checks if the given key-value pair is within the specified range.
+         *
+         * <p>The method compares the key against the range's upper boundary ({@code rawLastKey}) and determines if it
+         * falls within the range.</p>
+         *
+         * @param keyValue The key-value pair to check.
+         *
+         * @return {@code true} if the key is within the range; {@code false} otherwise.
+         */
         private boolean isInRange(final KeyValue<Bytes, byte[]> keyValue) {
             if (rawLastKey == null) return true; // Open-ended range
             final int comparison = comparator.compare(keyValue.key.get(), rawLastKey);
@@ -389,6 +554,17 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                     : comparison > 0 || (toInclusive && comparison == 0);
         }
 
+        /**
+         * Initializes the RocksDB iterators based on the specified range and direction.
+         *
+         * <p>This method positions the iterators at the starting point of the range and determines the raw byte
+         * representation of the upper boundary (if provided).</p>
+         *
+         * @param from The starting key of the range. Can be {@code null} for an open range.
+         * @param to   The ending key of the range. Can be {@code null} for an open range.
+         *
+         * @return The raw byte representation of the upper boundary, or {@code null} if no boundary is specified.
+         */
         private byte[] initializeIterators(final Bytes from, final Bytes to) {
             if (forward) {
                 seekIterator(from, withTimestampIterator, true);
@@ -408,11 +584,22 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             }
         }
 
+        /**
+         * Loads the next keys from the iterators if they are valid.
+         *
+         * <p>This method checks whether the next key for each column family is null. If the corresponding iterator is
+         * valid, it fetches the next key.</p>
+         */
         private void loadNextKeys() {
             if (noTimestampNext == null && noTimestampIterator.isValid()) noTimestampNext = noTimestampIterator.key();
             if (withTimestampNext == null && withTimestampIterator.isValid()) withTimestampNext = withTimestampIterator.key();
         }
 
+        /**
+         * Advances the given iterator based on the iteration direction.
+         *
+         * @param iterator The {@link RocksIterator} to advance.
+         */
         private void moveIterator(final RocksIterator iterator) {
             if (forward) {
                 iterator.next();
@@ -421,6 +608,16 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             }
         }
 
+        /**
+         * Seeks the iterator to the specified position.
+         *
+         * <p>If the target is {@code null}, the iterator is positioned at the start or end of the dataset, depending on
+         * the direction.</p>
+         *
+         * @param iterator The {@link RocksIterator} to seek.
+         * @param target   The target key to seek to. Can be {@code null}.
+         * @param forward  {@code true} for forward iteration; {@code false} for reverse.
+         */
         private void seekIterator(final Bytes target, final RocksIterator iterator, final boolean forward) {
             if (target == null) {
                 if (forward) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -193,13 +193,13 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                                                             final Bytes to,
                                                             final boolean forward) {
             return RocksDBDualCFRangeIterator.of(
-                    from,
-                    to,
-                    accessor.newIterator(oldColumnFamily),
-                    accessor.newIterator(newColumnFamily),
-                    name,
-                    forward,
-                    true);
+                from,
+                to,
+                accessor.newIterator(oldColumnFamily),
+                accessor.newIterator(newColumnFamily),
+                name,
+                forward,
+                true);
         }
 
         @Override
@@ -234,13 +234,13 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor, final Bytes prefix) {
             final Bytes to = incrementWithoutOverflow(prefix);
             return RocksDBDualCFRangeIterator.of(
-                    prefix,
-                    to,
-                    accessor.newIterator(oldColumnFamily),
-                    accessor.newIterator(newColumnFamily),
-                    name,
-                    true,
-                    false
+                prefix,
+                to,
+                accessor.newIterator(oldColumnFamily),
+                accessor.newIterator(newColumnFamily),
+                name,
+                true,
+                false
             );
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -193,13 +193,13 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                                                             final Bytes to,
                                                             final boolean forward) {
             return new RocksDBDualCFRangeIterator(
-                name,
-                accessor.newIterator(newColumnFamily),
-                accessor.newIterator(oldColumnFamily),
-                from,
-                to,
-                forward,
-                true);
+                    from,
+                    to,
+                    accessor.newIterator(oldColumnFamily),
+                    accessor.newIterator(newColumnFamily),
+                    name,
+                    forward,
+                    true);
         }
 
         @Override
@@ -221,11 +221,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> all(final DBAccessor accessor, final boolean forward) {
             return new RocksDBDualCFRangeIterator(
-                    name,
-                    accessor.newIterator(newColumnFamily),
+                    null,
+                    null,
                     accessor.newIterator(oldColumnFamily),
-                    null,
-                    null,
+                    accessor.newIterator(newColumnFamily),
+                    name,
                     forward,
                     true);
         }
@@ -234,13 +234,13 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor, final Bytes prefix) {
             final Bytes to = incrementWithoutOverflow(prefix);
             return new RocksDBDualCFRangeIterator(
-                name,
-                accessor.newIterator(newColumnFamily),
-                accessor.newIterator(oldColumnFamily),
-                prefix,
-                to,
-                true,
-                false
+                    prefix,
+                    to,
+                    accessor.newIterator(oldColumnFamily),
+                    accessor.newIterator(newColumnFamily),
+                    name,
+                    true,
+                    false
             );
         }
 
@@ -275,176 +275,166 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
     }
 
-    private class RocksDBDualCFRangeIterator extends AbstractIterator<KeyValue<Bytes, byte[]>>
-            implements ManagedKeyValueIterator<Bytes, byte[]> {
-        // RocksDB's JNI interface does not expose getters/setters that allow the
-        // comparator to be pluggable, and the default is lexicographic, so it's
-        // safe to just force lexicographic comparator here for now.
+    private static class RocksDBDualCFRangeIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implements ManagedKeyValueIterator<Bytes, byte[]> {
+        private Runnable closeCallback;
+        private byte[] noTimestampNext;
+        private byte[] withTimestampNext;
         private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
-        private final byte[] rawLastKey;
+        private final RocksIterator noTimestampIterator;
+        private final RocksIterator withTimestampIterator;
+        private final String storeName;
         private final boolean forward;
         private final boolean toInclusive;
-
-        private final String storeName;
-        private final RocksIterator iterWithTimestamp;
-        private final RocksIterator iterNoTimestamp;
-
+        private final byte[] rawLastKey;
         private volatile boolean open = true;
 
-        private byte[] nextWithTimestamp;
-        private byte[] nextNoTimestamp;
-        private KeyValue<Bytes, byte[]> next;
-        private Runnable closeCallback = null;
-
-        RocksDBDualCFRangeIterator(final String storeName,
-                                   final RocksIterator iterWithTimestamp,
-                                   final RocksIterator iterNoTimestamp,
-                                   final Bytes from,
+        RocksDBDualCFRangeIterator(final Bytes from,
                                    final Bytes to,
+                                   final RocksIterator noTimestampIterator,
+                                   final RocksIterator withTimestampIterator,
+                                   final String storeName,
                                    final boolean forward,
                                    final boolean toInclusive) {
-            this.storeName = storeName;
-            this.iterWithTimestamp = iterWithTimestamp;
-            this.iterNoTimestamp = iterNoTimestamp;
             this.forward = forward;
+            this.noTimestampIterator = noTimestampIterator;
+            this.storeName = storeName;
             this.toInclusive = toInclusive;
-            if (forward) {
-                if (from == null) {
-                    iterWithTimestamp.seekToFirst();
-                    iterNoTimestamp.seekToFirst();
-                } else {
-                    iterWithTimestamp.seek(from.get());
-                    iterNoTimestamp.seek(from.get());
-                }
-                rawLastKey = to == null ? null : to.get();
-            } else {
-                if (to == null) {
-                    iterWithTimestamp.seekToLast();
-                    iterNoTimestamp.seekToLast();
-                } else {
-                    iterWithTimestamp.seekForPrev(to.get());
-                    iterNoTimestamp.seekForPrev(to.get());
-                }
-                rawLastKey = from == null ? null : from.get();
-            }
+            this.withTimestampIterator = withTimestampIterator;
+
+            this.rawLastKey = initializeIterators(from, to);
         }
 
         @Override
         protected KeyValue<Bytes, byte[]> makeNext() {
-            if (nextNoTimestamp == null && iterNoTimestamp.isValid()) {
-                nextNoTimestamp = iterNoTimestamp.key();
-            }
-
-            if (nextWithTimestamp == null && iterWithTimestamp.isValid()) {
-                nextWithTimestamp = iterWithTimestamp.key();
-            }
-
-            if (nextNoTimestamp == null && !iterNoTimestamp.isValid()) {
-                if (nextWithTimestamp == null && !iterWithTimestamp.isValid()) {
-                    return allDone();
-                } else {
-                    next = KeyValue.pair(new Bytes(nextWithTimestamp), iterWithTimestamp.value());
-                    nextWithTimestamp = null;
-                    if (forward) {
-                        iterWithTimestamp.next();
-                    } else {
-                        iterWithTimestamp.prev();
-                    }
-                }
-            } else {
-                if (nextWithTimestamp == null) {
-                    next = KeyValue.pair(new Bytes(nextNoTimestamp), convertToTimestampedFormat(iterNoTimestamp.value()));
-                    nextNoTimestamp = null;
-                    if (forward) {
-                        iterNoTimestamp.next();
-                    } else {
-                        iterNoTimestamp.prev();
-                    }
-                } else {
-                    if (forward) {
-                        if (comparator.compare(nextNoTimestamp, nextWithTimestamp) <= 0) {
-                            next = KeyValue.pair(new Bytes(nextNoTimestamp), convertToTimestampedFormat(iterNoTimestamp.value()));
-                            nextNoTimestamp = null;
-                            iterNoTimestamp.next();
-                        } else {
-                            next = KeyValue.pair(new Bytes(nextWithTimestamp), iterWithTimestamp.value());
-                            nextWithTimestamp = null;
-                            iterWithTimestamp.next();
-                        }
-                    } else {
-                        if (comparator.compare(nextNoTimestamp, nextWithTimestamp) >= 0) {
-                            next = KeyValue.pair(new Bytes(nextNoTimestamp), convertToTimestampedFormat(iterNoTimestamp.value()));
-                            nextNoTimestamp = null;
-                            iterNoTimestamp.prev();
-                        } else {
-                            next = KeyValue.pair(new Bytes(nextWithTimestamp), iterWithTimestamp.value());
-                            nextWithTimestamp = null;
-                            iterWithTimestamp.prev();
-                        }
-                    }
-                }
-            }
-
-            if (next == null) {
-                return allDone();
-            } else if (rawLastKey == null) {
-                //null means range endpoint is open
-                return next;
-            } else {
-                if (forward) {
-                    if (comparator.compare(next.key.get(), rawLastKey) < 0) {
-                        return next;
-                    } else if (comparator.compare(next.key.get(), rawLastKey) == 0) {
-                        return toInclusive ? next : allDone();
-                    } else {
-                        return allDone();
-                    }
-                } else {
-                    if (comparator.compare(next.key.get(), rawLastKey) >= 0) {
-                        return next;
-                    } else {
-                        return allDone();
-                    }
-                }
-            }
+            loadNextKeys();
+            if (noTimestampNext == null && withTimestampNext == null) return allDone();
+            final KeyValue<Bytes, byte[]> next = fetchNextKeyValue();
+            return isInRange(next) ? next : allDone();
         }
 
         @Override
-        public synchronized boolean hasNext() {
-            if (!open) {
-                throw new InvalidStateStoreException(String.format("RocksDB iterator for store %s has closed", storeName));
-            }
-            return super.hasNext();
+        public Bytes peekNextKey() {
+            if (!hasNext()) throw new NoSuchElementException();
+            return super.peek().key;
         }
 
         @Override
         public synchronized KeyValue<Bytes, byte[]> next() {
+            ensureOpen();
             return super.next();
+        }
+
+        @Override
+        public synchronized boolean hasNext() {
+            ensureOpen();
+            return super.hasNext();
         }
 
         @Override
         public synchronized void close() {
             if (closeCallback == null) {
-                throw new IllegalStateException("RocksDBDualCFIterator expects close callback to be set immediately upon creation");
+                final String message = "RocksDBDualCFIterator expects close callback to be set immediately upon creation";
+                throw new IllegalStateException(message);
             }
             closeCallback.run();
 
-            iterNoTimestamp.close();
-            iterWithTimestamp.close();
+            noTimestampIterator.close();
+            withTimestampIterator.close();
             open = false;
-        }
-
-        @Override
-        public Bytes peekNextKey() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return next.key;
         }
 
         @Override
         public void onClose(final Runnable closeCallback) {
             this.closeCallback = closeCallback;
+        }
+
+        private KeyValue<Bytes, byte[]> compareAndHandleKeys() {
+            final int comparison = comparator.compare(noTimestampNext, withTimestampNext);
+            if (forward ? comparison <= 0 : comparison >= 0) {
+                return handleNoTimestampOnly();
+            } else {
+                return handleWithTimestampOnly();
+            }
+        }
+
+        private KeyValue<Bytes, byte[]> fetchNextKeyValue() {
+            if (noTimestampNext == null) {
+                return handleWithTimestampOnly();
+            } else if (withTimestampNext == null) {
+                return handleNoTimestampOnly();
+            } else {
+                return compareAndHandleKeys();
+            }
+        }
+
+        private KeyValue<Bytes, byte[]> handleNoTimestampOnly() {
+            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(noTimestampNext), convertToTimestampedFormat(noTimestampIterator.value()));
+            moveIterator(noTimestampIterator);
+            noTimestampNext = null;
+            return result;
+        }
+
+        private KeyValue<Bytes, byte[]> handleWithTimestampOnly() {
+            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(withTimestampNext), withTimestampIterator.value());
+            moveIterator(withTimestampIterator);
+            withTimestampNext = null;
+            return result;
+        }
+
+        private boolean isInRange(final KeyValue<Bytes, byte[]> keyValue) {
+            if (rawLastKey == null) return true; // Open-ended range
+            final int comparison = comparator.compare(keyValue.key.get(), rawLastKey);
+            return forward
+                    ? comparison < 0 || (toInclusive && comparison == 0)
+                    : comparison > 0 || (toInclusive && comparison == 0);
+        }
+
+        private byte[] initializeIterators(final Bytes from, final Bytes to) {
+            if (forward) {
+                seekIterator(from, withTimestampIterator, true);
+                seekIterator(from, noTimestampIterator, true);
+                return to == null ? null : to.get();
+            } else {
+                seekIterator(to, withTimestampIterator, false);
+                seekIterator(to, noTimestampIterator, false);
+                return from == null ? null : from.get();
+            }
+        }
+
+        private void ensureOpen() {
+            if (!open) {
+                final String message = String.format("RocksDB iterator for store %s has closed", storeName);
+                throw new InvalidStateStoreException(message);
+            }
+        }
+
+        private void loadNextKeys() {
+            if (noTimestampNext == null && noTimestampIterator.isValid()) noTimestampNext = noTimestampIterator.key();
+            if (withTimestampNext == null && withTimestampIterator.isValid()) withTimestampNext = withTimestampIterator.key();
+        }
+
+        private void moveIterator(final RocksIterator iterator) {
+            if (forward) {
+                iterator.next();
+            } else {
+                iterator.prev();
+            }
+        }
+
+        private void seekIterator(final Bytes target, final RocksIterator iterator, final boolean forward) {
+            if (target == null) {
+                if (forward) {
+                    iterator.seekToFirst();
+                } else {
+                    iterator.seekToLast();
+                }
+            } else {
+                if (forward) {
+                    iterator.seek(target.get());
+                } else {
+                    iterator.seekForPrev(target.get());
+                }
+            }
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -220,16 +220,14 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> all(final DBAccessor accessor, final boolean forward) {
-            final RocksIterator innerIterWithTimestamp = accessor.newIterator(newColumnFamily);
-            final RocksIterator innerIterNoTimestamp = accessor.newIterator(oldColumnFamily);
-            if (forward) {
-                innerIterWithTimestamp.seekToFirst();
-                innerIterNoTimestamp.seekToFirst();
-            } else {
-                innerIterWithTimestamp.seekToLast();
-                innerIterNoTimestamp.seekToLast();
-            }
-            return new RocksDBDualCFIterator(name, innerIterWithTimestamp, innerIterNoTimestamp, forward);
+            return new RocksDBDualCFRangeIterator(
+                    name,
+                    accessor.newIterator(newColumnFamily),
+                    accessor.newIterator(oldColumnFamily),
+                    null,
+                    null,
+                    forward,
+                    true);
         }
 
         @Override
@@ -277,18 +275,19 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
     }
 
-    private class RocksDBDualCFIterator extends AbstractIterator<KeyValue<Bytes, byte[]>>
-        implements ManagedKeyValueIterator<Bytes, byte[]> {
-
+    private class RocksDBDualCFRangeIterator extends AbstractIterator<KeyValue<Bytes, byte[]>>
+            implements ManagedKeyValueIterator<Bytes, byte[]> {
         // RocksDB's JNI interface does not expose getters/setters that allow the
         // comparator to be pluggable, and the default is lexicographic, so it's
         // safe to just force lexicographic comparator here for now.
         private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
+        private final byte[] rawLastKey;
+        private final boolean forward;
+        private final boolean toInclusive;
 
         private final String storeName;
         private final RocksIterator iterWithTimestamp;
         private final RocksIterator iterNoTimestamp;
-        private final boolean forward;
 
         private volatile boolean open = true;
 
@@ -297,27 +296,37 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private KeyValue<Bytes, byte[]> next;
         private Runnable closeCallback = null;
 
-        RocksDBDualCFIterator(final String storeName,
-                              final RocksIterator iterWithTimestamp,
-                              final RocksIterator iterNoTimestamp,
-                              final boolean forward) {
+        RocksDBDualCFRangeIterator(final String storeName,
+                                   final RocksIterator iterWithTimestamp,
+                                   final RocksIterator iterNoTimestamp,
+                                   final Bytes from,
+                                   final Bytes to,
+                                   final boolean forward,
+                                   final boolean toInclusive) {
+            this.storeName = storeName;
             this.iterWithTimestamp = iterWithTimestamp;
             this.iterNoTimestamp = iterNoTimestamp;
-            this.storeName = storeName;
             this.forward = forward;
-        }
-
-        @Override
-        public synchronized boolean hasNext() {
-            if (!open) {
-                throw new InvalidStateStoreException(String.format("RocksDB iterator for store %s has closed", storeName));
+            this.toInclusive = toInclusive;
+            if (forward) {
+                if (from == null) {
+                    iterWithTimestamp.seekToFirst();
+                    iterNoTimestamp.seekToFirst();
+                } else {
+                    iterWithTimestamp.seek(from.get());
+                    iterNoTimestamp.seek(from.get());
+                }
+                rawLastKey = to == null ? null : to.get();
+            } else {
+                if (to == null) {
+                    iterWithTimestamp.seekToLast();
+                    iterNoTimestamp.seekToLast();
+                } else {
+                    iterWithTimestamp.seekForPrev(to.get());
+                    iterNoTimestamp.seekForPrev(to.get());
+                }
+                rawLastKey = from == null ? null : from.get();
             }
-            return super.hasNext();
-        }
-
-        @Override
-        public synchronized KeyValue<Bytes, byte[]> next() {
-            return super.next();
         }
 
         @Override
@@ -375,7 +384,42 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                     }
                 }
             }
-            return next;
+
+            if (next == null) {
+                return allDone();
+            } else if (rawLastKey == null) {
+                //null means range endpoint is open
+                return next;
+            } else {
+                if (forward) {
+                    if (comparator.compare(next.key.get(), rawLastKey) < 0) {
+                        return next;
+                    } else if (comparator.compare(next.key.get(), rawLastKey) == 0) {
+                        return toInclusive ? next : allDone();
+                    } else {
+                        return allDone();
+                    }
+                } else {
+                    if (comparator.compare(next.key.get(), rawLastKey) >= 0) {
+                        return next;
+                    } else {
+                        return allDone();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public synchronized boolean hasNext() {
+            if (!open) {
+                throw new InvalidStateStoreException(String.format("RocksDB iterator for store %s has closed", storeName));
+            }
+            return super.hasNext();
+        }
+
+        @Override
+        public synchronized KeyValue<Bytes, byte[]> next() {
+            return super.next();
         }
 
         @Override
@@ -401,75 +445,6 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         @Override
         public void onClose(final Runnable closeCallback) {
             this.closeCallback = closeCallback;
-        }
-    }
-
-    private class RocksDBDualCFRangeIterator extends RocksDBDualCFIterator {
-        // RocksDB's JNI interface does not expose getters/setters that allow the
-        // comparator to be pluggable, and the default is lexicographic, so it's
-        // safe to just force lexicographic comparator here for now.
-        private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
-        private final byte[] rawLastKey;
-        private final boolean forward;
-        private final boolean toInclusive;
-
-        RocksDBDualCFRangeIterator(final String storeName,
-                                   final RocksIterator iterWithTimestamp,
-                                   final RocksIterator iterNoTimestamp,
-                                   final Bytes from,
-                                   final Bytes to,
-                                   final boolean forward,
-                                   final boolean toInclusive) {
-            super(storeName, iterWithTimestamp, iterNoTimestamp, forward);
-            this.forward = forward;
-            this.toInclusive = toInclusive;
-            if (forward) {
-                if (from == null) {
-                    iterWithTimestamp.seekToFirst();
-                    iterNoTimestamp.seekToFirst();
-                } else {
-                    iterWithTimestamp.seek(from.get());
-                    iterNoTimestamp.seek(from.get());
-                }
-                rawLastKey = to == null ? null : to.get();
-            } else {
-                if (to == null) {
-                    iterWithTimestamp.seekToLast();
-                    iterNoTimestamp.seekToLast();
-                } else {
-                    iterWithTimestamp.seekForPrev(to.get());
-                    iterNoTimestamp.seekForPrev(to.get());
-                }
-                rawLastKey = from == null ? null : from.get();
-            }
-        }
-
-        @Override
-        protected KeyValue<Bytes, byte[]> makeNext() {
-            final KeyValue<Bytes, byte[]> next = super.makeNext();
-
-            if (next == null) {
-                return allDone();
-            } else if (rawLastKey == null) {
-                //null means range endpoint is open
-                return next;
-            } else {
-                if (forward) {
-                    if (comparator.compare(next.key.get(), rawLastKey) < 0) {
-                        return next;
-                    } else if (comparator.compare(next.key.get(), rawLastKey) == 0) {
-                        return toInclusive ? next : allDone();
-                    } else {
-                        return allDone();
-                    }
-                } else {
-                    if (comparator.compare(next.key.get(), rawLastKey) >= 0) {
-                        return next;
-                    } else {
-                        return allDone();
-                    }
-                }
-            }
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -332,14 +332,14 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
      * <h3>Iterate over a range:</h3>
      *
      * <pre>{@code
-     * RocksIterator noTimestampIterator = accessor.newIterator(noTimestampColumnFamily);
-     * RocksIterator withTimestampIterator = accessor.newIterator(withTimestampColumnFamily);
+     * RocksIterator nonTimestampedIterator = accessor.newIterator(noTimestampColumnFamily);
+     * RocksIterator timestampedIterator = accessor.newIterator(withTimestampColumnFamily);
      *
      * try (RocksDBDualCFRangeIterator iterator = new RocksDBDualCFRangeIterator(
      *         new Bytes("keyStart".getBytes()),
      *         new Bytes("keyEnd".getBytes()),
-     *         noTimestampIterator,
-     *         withTimestampIterator,
+     *         nonTimestampedIterator,
+     *         timestampedIterator,
      *         "storeName",
      *         true,  // Forward iteration
      *         true   // Inclusive upper boundary
@@ -364,11 +364,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
      */
     private static class RocksDBDualCFRangeIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implements ManagedKeyValueIterator<Bytes, byte[]> {
         private Runnable closeCallback;
-        private byte[] noTimestampNext;
-        private byte[] withTimestampNext;
+        private byte[] nonTimestampedNext;
+        private byte[] timestampedNext;
         private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
-        private final RocksIterator noTimestampIterator;
-        private final RocksIterator withTimestampIterator;
+        private final RocksIterator nonTimestampedIterator;
+        private final RocksIterator timestampedIterator;
         private final String storeName;
         private final boolean forward;
         private final boolean toInclusive;
@@ -376,17 +376,17 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private volatile boolean open = true;
 
         private RocksDBDualCFRangeIterator(final Bytes from,
-                                   final Bytes to,
-                                   final RocksIterator noTimestampIterator,
-                                   final RocksIterator withTimestampIterator,
-                                   final String storeName,
-                                   final boolean forward,
-                                   final boolean toInclusive) {
+                                           final Bytes to,
+                                           final RocksIterator nonTimestampedIterator,
+                                           final RocksIterator timestampedIterator,
+                                           final String storeName,
+                                           final boolean forward,
+                                           final boolean toInclusive) {
             this.forward = forward;
-            this.noTimestampIterator = noTimestampIterator;
+            this.nonTimestampedIterator = nonTimestampedIterator;
             this.storeName = storeName;
             this.toInclusive = toInclusive;
-            this.withTimestampIterator = withTimestampIterator;
+            this.timestampedIterator = timestampedIterator;
 
             this.rawLastKey = initializeIterators(from, to);
         }
@@ -397,27 +397,27 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
          * <p>Initializes the RocksDB iterators for two column families (timestamped and non-timestamped) and sets up
          * the range and direction for iteration.</p>
          *
-         * @param from                  The starting key of the range. Can be {@code null} for an open range.
-         * @param to                    The ending key of the range. Can be {@code null} for an open range.
-         * @param noTimestampIterator   The iterator for the non-timestamped column family.
-         * @param withTimestampIterator The iterator for the timestamped column family.
-         * @param storeName             The name of the store associated with this iterator.
-         * @param forward               {@code true} for forward iteration; {@code false} for reverse iteration.
-         * @param toInclusive           Whether the upper boundary of the range is inclusive.
+         * @param from                   The starting key of the range. Can be {@code null} for an open range.
+         * @param to                     The ending key of the range. Can be {@code null} for an open range.
+         * @param nonTimestampedIterator The iterator for the non-timestamped column family.
+         * @param timestampedIterator    The iterator for the timestamped column family.
+         * @param storeName              The name of the store associated with this iterator.
+         * @param forward                {@code true} for forward iteration; {@code false} for reverse iteration.
+         * @param toInclusive            Whether the upper boundary of the range is inclusive.
          */
         public static RocksDBDualCFRangeIterator of(final Bytes from,
-                                             final Bytes to,
-                                             final RocksIterator noTimestampIterator,
-                                             final RocksIterator withTimestampIterator,
-                                             final String storeName,
-                                             final boolean forward,
-                                             final boolean toInclusive) {
+                                                    final Bytes to,
+                                                    final RocksIterator nonTimestampedIterator,
+                                                    final RocksIterator timestampedIterator,
+                                                    final String storeName,
+                                                    final boolean forward,
+                                                    final boolean toInclusive) {
             final RocksDBDualCFRangeIterator iterator =
                 new RocksDBDualCFRangeIterator(
                     from,
                     to,
-                    noTimestampIterator,
-                    withTimestampIterator,
+                    nonTimestampedIterator,
+                    timestampedIterator,
                     storeName,
                     forward,
                     toInclusive
@@ -438,7 +438,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         @Override
         protected KeyValue<Bytes, byte[]> makeNext() {
             loadNextKeys();
-            if (noTimestampNext == null && withTimestampNext == null) return allDone();
+            if (nonTimestampedNext == null && timestampedNext == null) return allDone();
             final KeyValue<Bytes, byte[]> next = fetchNextKeyValue();
             return isInRange(next) ? next : allDone();
         }
@@ -503,8 +503,8 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             }
             closeCallback.run();
 
-            noTimestampIterator.close();
-            withTimestampIterator.close();
+            nonTimestampedIterator.close();
+            timestampedIterator.close();
             open = false;
         }
 
@@ -519,11 +519,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         private KeyValue<Bytes, byte[]> compareAndHandleKeys() {
-            final int comparison = comparator.compare(noTimestampNext, withTimestampNext);
+            final int comparison = comparator.compare(nonTimestampedNext, timestampedNext);
             if (forward ? comparison <= 0 : comparison >= 0) {
-                return handleNoTimestampOnly();
+                return handleNonTimestampedOnly();
             } else {
-                return handleWithTimestampOnly();
+                return handleTimestampedOnly();
             }
         }
 
@@ -537,26 +537,26 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
          * @return The next {@link KeyValue} pair to return.
          */
         private KeyValue<Bytes, byte[]> fetchNextKeyValue() {
-            if (noTimestampNext == null) {
-                return handleWithTimestampOnly();
-            } else if (withTimestampNext == null) {
-                return handleNoTimestampOnly();
+            if (nonTimestampedNext == null) {
+                return handleTimestampedOnly();
+            } else if (timestampedNext == null) {
+                return handleNonTimestampedOnly();
             } else {
                 return compareAndHandleKeys();
             }
         }
 
-        private KeyValue<Bytes, byte[]> handleNoTimestampOnly() {
-            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(noTimestampNext), convertToTimestampedFormat(noTimestampIterator.value()));
-            moveIterator(noTimestampIterator);
-            noTimestampNext = null;
+        private KeyValue<Bytes, byte[]> handleNonTimestampedOnly() {
+            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(nonTimestampedNext), convertToTimestampedFormat(nonTimestampedIterator.value()));
+            moveIterator(nonTimestampedIterator);
+            nonTimestampedNext = null;
             return result;
         }
 
-        private KeyValue<Bytes, byte[]> handleWithTimestampOnly() {
-            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(withTimestampNext), withTimestampIterator.value());
-            moveIterator(withTimestampIterator);
-            withTimestampNext = null;
+        private KeyValue<Bytes, byte[]> handleTimestampedOnly() {
+            final KeyValue<Bytes, byte[]> result = KeyValue.pair(new Bytes(timestampedNext), timestampedIterator.value());
+            moveIterator(timestampedIterator);
+            timestampedNext = null;
             return result;
         }
 
@@ -589,12 +589,12 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
          */
         private byte[] initializeIterators(final Bytes from, final Bytes to) {
             if (forward) {
-                seekIterator(from, withTimestampIterator, true);
-                seekIterator(from, noTimestampIterator, true);
+                seekIterator(from, timestampedIterator, true);
+                seekIterator(from, nonTimestampedIterator, true);
                 return to == null ? null : to.get();
             } else {
-                seekIterator(to, withTimestampIterator, false);
-                seekIterator(to, noTimestampIterator, false);
+                seekIterator(to, timestampedIterator, false);
+                seekIterator(to, nonTimestampedIterator, false);
                 return from == null ? null : from.get();
             }
         }
@@ -613,8 +613,8 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
          * valid, it fetches the next key.</p>
          */
         private void loadNextKeys() {
-            if (noTimestampNext == null && noTimestampIterator.isValid()) noTimestampNext = noTimestampIterator.key();
-            if (withTimestampNext == null && withTimestampIterator.isValid()) withTimestampNext = withTimestampIterator.key();
+            if (nonTimestampedNext == null && nonTimestampedIterator.isValid()) nonTimestampedNext = nonTimestampedIterator.key();
+            if (timestampedNext == null && timestampedIterator.isValid()) timestampedNext = timestampedIterator.key();
         }
 
         /**


### PR DESCRIPTION
Key refactorings:

* Use `RocksDBDualCFRangeIterator` for `DualColumnFamilyAccessor#all`, since it iterate over all when passing `null` as `from` and `to` key ranges;
* Create helper methods to:
    * `loadNextKeys()`;
    * `fetchNextKeyValue()`;
    * `handleWithTimestampOnly()`;
    * `handleNoTimestampOnly()`;
    * `compareAndHandleKeys()`;
    * check if some key-value `isInRange()`; and
    * `ensureOpen()`.
* Rewrite methods with new helper methods:
  * `makeNext()`;
  * `next()`; and
  * `hasNext()`.
* Improve members naming with:
  * `noTimestampNext`;
  * `withTimestampNext`;
  * `noTimestampIterator`; and
  * `withTimestampIterator`.
* Sort members and method arguments alphanumerically;
* Add documentation.