### PR TITLE
KAFKA-18585 Fix fail test ValuesTest#shouldConvertDateValues

### DIFF
--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -901,8 +902,12 @@ public class ValuesTest {
         assertEquals(currentDate, d2);
 
         // ISO8601 strings - accept a string matching pattern "yyyy-MM-dd"
+        // Values.convertToDate convert the "yyyy-MM-dd" string will miss the time and timezone information, 
+        // so we need to adjust the date from the current timezone to UTC0
+        TimeZone tz = TimeZone.getDefault();
+        java.util.Date currentDate3 = new java.util.Date(current.getTime() - currentMillis - tz.getOffset(current.getTime()));
         java.util.Date d3 = Values.convertToDate(Date.SCHEMA, LocalDate.ofEpochDay(days).format(DateTimeFormatter.ISO_LOCAL_DATE));
-        assertEquals(currentDate, d3);
+        assertEquals(currentDate3, d3);
 
         // Days as string
         java.util.Date d4 = Values.convertToDate(Date.SCHEMA, Long.toString(days));

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -888,7 +887,9 @@ public class ValuesTest {
 
     @Test
     public void shouldConvertDateValues() {
-        java.util.Date current = new java.util.Date();
+        LocalDateTime localTime = LocalDateTime.now();
+        ZoneOffset zoneOffset = ZoneId.systemDefault().getRules().getOffset(localTime);
+        java.util.Date current = new java.util.Date(localTime.toEpochSecond(zoneOffset) * 1000);
         long currentMillis = current.getTime() % MILLIS_PER_DAY;
         long days = current.getTime() / MILLIS_PER_DAY;
 
@@ -902,12 +903,10 @@ public class ValuesTest {
         assertEquals(currentDate, d2);
 
         // ISO8601 strings - accept a string matching pattern "yyyy-MM-dd"
-        // Values.convertToDate convert the "yyyy-MM-dd" string will miss the time and timezone information, 
-        // so we need to adjust the date from the current timezone to UTC0
-        TimeZone tz = TimeZone.getDefault();
-        java.util.Date currentDate3 = new java.util.Date(current.getTime() - currentMillis - tz.getOffset(current.getTime()));
+        LocalDateTime localTimeTruncated = localTime.truncatedTo(ChronoUnit.DAYS);
         java.util.Date d3 = Values.convertToDate(Date.SCHEMA, LocalDate.ofEpochDay(days).format(DateTimeFormatter.ISO_LOCAL_DATE));
-        assertEquals(currentDate3, d3);
+        LocalDateTime date3 = LocalDateTime.ofInstant(Instant.ofEpochMilli(d3.getTime()), ZoneId.systemDefault());
+        assertEquals(localTimeTruncated, date3);
 
         // Days as string
         java.util.Date d4 = Values.convertToDate(Date.SCHEMA, Long.toString(days));


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18585

The test scenario involves inputting dates in ISO8601 format `yyyy-MM-dd`. At this point, the time information is already lost. Then in the `Values#convertToDate` method, the date conversion is performed using string manipulation, without any timezone information being provided. Therefore, it's expected and normal behavior that the time gets converted to 00:00:00.

The solution is to explicitly convert Java Date objects, which internally store UTC timestamps, to UTC+0 timezone

before:
![CleanShot 2025-01-19 at 00 13 28@2x](https://github.com/user-attachments/assets/4211574a-89cf-4334-9254-9425bb49cede)
after:
![CleanShot 2025-01-19 at 00 14 17@2x](https://github.com/user-attachments/assets/9d0af954-f810-45d6-be5e-35839a5bbf6e)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
