### PR TITLE
KAFKA-18568 Flaky test ClientIdQuota

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -61,6 +61,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   this.producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "-1")
   this.producerConfig.setProperty(ProducerConfig.BUFFER_MEMORY_CONFIG, "300000")
   this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
+  this.producerConfig.setProperty(ProducerConfig.LINGER_MS_CONFIG, 0.toString)
   this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "QuotasTest")
   this.consumerConfig.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 4096.toString)
   this.consumerConfig.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18568

The main reason is https://github.com/apache/kafka/pull/18080 this commit modify the `linger.ms` config from 0 to 5, and these test are testing about "Low enough quota that a producer sending a small payload in a tight loop should get throttled", thus this config will Influence these test scenario.

testing in my local with command `I=0;  while ./gradlew :core:test --tests "kafka.api.ClientIdQuotaTest" --tests "kafka.api.UserClientIdQuotaTest" --tests "kafka.api.UserQuotaTest"--rerun --fail-fast; do  (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done`
![image](https://github.com/user-attachments/assets/538b11f3-40a5-4de0-9fe4-46eb47cd09a7)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
