### PR TITLE
KAFKA-18598 Remove ControllerMetadataMetrics zk related Metrics

### DIFF
--- a/docs/zk2kraft.html
+++ b/docs/zk2kraft.html
@@ -164,5 +164,17 @@
                 In Kraft mode, Zookeeper is not used, so the metrics is removed.
             </p>
         </li>
+        <li>
+            <p>
+                Remove the metrics which is monitoring the number of Zookeeper migrations.
+            </p>
+            <ul>
+                <li><code>kafka.controller:type=KafkaController,name=MigratingZkBrokerCount</code></li>
+                <li><code>kafka.controller:type=KafkaController,name=ZkMigrationState</code></li>
+            </ul>
+            <p>
+                Kafka remove all zookeeper dependencies, so the metrics is removed.
+            </p>
+        </li>
     </ul>
 </div>

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -39,10 +39,6 @@ import java.util.Optional;
  * behind the latest in-memory state which has not yet been fully persisted to the log. This is
  * reasonable for metrics, which don't need up-to-the-millisecond update latency.
  *
- * NOTE: the ZK controller has some special rules for calculating preferredReplicaImbalanceCount
- * which we haven't implemented here. Specifically, the ZK controller considers reassigning
- * partitions to always have their preferred leader, even if they don't.
- * All other metrics should be the same, as far as is possible.
  */
 public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
     private final ControllerMetadataMetrics metrics;
@@ -121,15 +117,11 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
         metrics.setGlobalTopicCount(newImage.topics().topicsById().size());
         int fencedBrokers = 0;
         int activeBrokers = 0;
-        int zkBrokers = 0;
         for (BrokerRegistration broker : newImage.cluster().brokers().values()) {
             if (broker.fenced()) {
                 fencedBrokers++;
             } else {
                 activeBrokers++;
-            }
-            if (broker.isMigratingZkBroker()) {
-                zkBrokers++;
             }
         }
         metrics.setFencedBrokerCount(fencedBrokers);

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -134,7 +134,6 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
         }
         metrics.setFencedBrokerCount(fencedBrokers);
         metrics.setActiveBrokerCount(activeBrokers);
-        metrics.setMigratingZkBrokerCount(zkBrokers);
 
         int totalPartitions = 0;
         int offlinePartitions = 0;

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -157,9 +157,6 @@ class ControllerMetricsChanges {
         if (activeBrokersChange != 0) {
             metrics.addToActiveBrokerCount(activeBrokersChange);
         }
-        if (migratingZkBrokersChange != 0) {
-            metrics.addToMigratingZkBrokerCount(migratingZkBrokersChange);
-        }
         if (globalTopicsChange != 0) {
             metrics.addToGlobalTopicCount(globalTopicsChange);
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -43,7 +43,6 @@ class ControllerMetricsChanges {
 
     private int fencedBrokersChange = 0;
     private int activeBrokersChange = 0;
-    private int migratingZkBrokersChange = 0;
     private int globalTopicsChange = 0;
     private int globalPartitionsChange = 0;
     private int offlinePartitionsChange = 0;
@@ -56,10 +55,6 @@ class ControllerMetricsChanges {
 
     public int activeBrokersChange() {
         return activeBrokersChange;
-    }
-
-    public int migratingZkBrokersChange() {
-        return migratingZkBrokersChange;
     }
 
     public int globalTopicsChange() {
@@ -81,23 +76,18 @@ class ControllerMetricsChanges {
     void handleBrokerChange(BrokerRegistration prev, BrokerRegistration next) {
         boolean wasFenced = false;
         boolean wasActive = false;
-        boolean wasZk = false;
         if (prev != null) {
             wasFenced = prev.fenced();
             wasActive = !prev.fenced();
-            wasZk = prev.isMigratingZkBroker();
         }
         boolean isFenced = false;
         boolean isActive = false;
-        boolean isZk = false;
         if (next != null) {
             isFenced = next.fenced();
             isActive = !next.fenced();
-            isZk = next.isMigratingZkBroker();
         }
         fencedBrokersChange += delta(wasFenced, isFenced);
         activeBrokersChange += delta(wasActive, isActive);
-        migratingZkBrokersChange += delta(wasZk, isZk);
     }
 
     void handleDeletedTopic(TopicImage deletedTopic) {

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -43,13 +43,11 @@ public class ControllerMetadataMetricsTest {
                     new HashSet<>(Arrays.asList(
                         "kafka.controller:type=KafkaController,name=ActiveBrokerCount",
                         "kafka.controller:type=KafkaController,name=FencedBrokerCount",
-                        "kafka.controller:type=KafkaController,name=MigratingZkBrokerCount",
                         "kafka.controller:type=KafkaController,name=GlobalPartitionCount",
                         "kafka.controller:type=KafkaController,name=GlobalTopicCount",
                         "kafka.controller:type=KafkaController,name=MetadataErrorCount",
                         "kafka.controller:type=KafkaController,name=OfflinePartitionsCount",
                         "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount",
-                        "kafka.controller:type=KafkaController,name=ZkMigrationState",
                         "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec"
                     )));
             }

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -60,18 +60,6 @@ public class ControllerMetricsChangesTest {
             setInControlledShutdown(false).build();
     }
 
-    private static BrokerRegistration zkBrokerRegistration(
-        int brokerId
-    ) {
-        return new BrokerRegistration.Builder().
-            setId(brokerId).
-            setEpoch(100L).
-            setIncarnationId(Uuid.fromString("Pxi6QwS2RFuN8VSKjqJZyQ")).
-            setFenced(false).
-            setInControlledShutdown(false).
-            setIsMigratingZkBroker(true).build();
-    }
-
     @Test
     public void testInitialValues() {
         ControllerMetricsChanges changes = new ControllerMetricsChanges();
@@ -113,20 +101,6 @@ public class ControllerMetricsChangesTest {
         changes.handleBrokerChange(brokerRegistration(1, true), brokerRegistration(1, false));
         assertEquals(-1, changes.fencedBrokersChange());
         assertEquals(1, changes.activeBrokersChange());
-    }
-
-    @Test
-    public void testHandleZkBroker() {
-        ControllerMetricsChanges changes = new ControllerMetricsChanges();
-        changes.handleBrokerChange(null, zkBrokerRegistration(1));
-        assertEquals(1, changes.migratingZkBrokersChange());
-        changes.handleBrokerChange(null, zkBrokerRegistration(2));
-        changes.handleBrokerChange(null, zkBrokerRegistration(3));
-        assertEquals(3, changes.migratingZkBrokersChange());
-
-        changes.handleBrokerChange(zkBrokerRegistration(3), brokerRegistration(3, true));
-        changes.handleBrokerChange(brokerRegistration(3, true), brokerRegistration(3, false));
-        assertEquals(2, changes.migratingZkBrokersChange());
     }
 
     @Test


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18598

These metrics is unused in Kraft mode, It doesn't return the correct number, thus we should remove these metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
