### PR TITLE
KAFKA-18603: Maintain batch ordering in ShareAcknowledge requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.protocol.Errors;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -307,5 +308,22 @@ public class Acknowledgements {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(acknowledgements, acknowledgeErrorCode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Acknowledgements other = (Acknowledgements) o;
+        return this.acknowledgements.equals(other.acknowledgements) && this.acknowledgeErrorCode == other.acknowledgeErrorCode;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -176,8 +176,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 if (acknowledgementsToSend != null) {
                     metricsManager.recordAcknowledgementSent(acknowledgementsToSend.size());
                     fetchAcknowledgementsInFlight.put(tip, acknowledgementsToSend);
+                    handler.addPartitionToFetch(tip, Collections.singletonList(acknowledgementsToSend));
+                } else {
+                    handler.addPartitionToFetch(tip, null);
                 }
-                handler.addPartitionToFetch(tip, acknowledgementsToSend);
                 fetchedPartitions.add(tip);
                 topicNamesMap.putIfAbsent(new IdAndPartition(tip.topicId(), tip.partition()), tip.topic());
 
@@ -204,7 +206,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                 metricsManager.recordAcknowledgementSent(acknowledgementsToSend.size());
                                 fetchAcknowledgementsInFlight.put(tip, acknowledgementsToSend);
 
-                                sessionHandler.addPartitionToFetch(tip, acknowledgementsToSend);
+                                sessionHandler.addPartitionToFetch(tip, Collections.singletonList(acknowledgementsToSend));
                                 handlerMap.put(node, sessionHandler);
 
                                 partitionsToForgetMap.putIfAbsent(node, new ArrayList<>());
@@ -469,11 +471,11 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 acknowledgeRequestStates.putIfAbsent(nodeId, new Tuple<>(null, null, null));
 
                 // Add the incoming commitSync() request to the queue.
-                Map<TopicIdPartition, Acknowledgements> acknowledgementsMapForNode = new HashMap<>();
+                Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsMapForNode = new HashMap<>();
                 for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
                     Acknowledgements acknowledgements = acknowledgementsMap.get(tip);
                     if (acknowledgements != null) {
-                        acknowledgementsMapForNode.put(tip, acknowledgements);
+                        acknowledgementsMapForNode.computeIfAbsent(tip, p -> new ArrayList<>()).add(acknowledgements);
 
                         metricsManager.recordAcknowledgementSent(acknowledgements.size());
                         log.debug("Added sync acknowledge request for partition {} to node {}", tip.topicPartition(), node.id());
@@ -512,14 +514,14 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         sessionHandlers.forEach((nodeId, sessionHandler) -> {
             Node node = cluster.nodeById(nodeId);
             if (node != null) {
-                Map<TopicIdPartition, Acknowledgements> acknowledgementsMapForNode = new HashMap<>();
+                Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsMapForNode = new HashMap<>();
 
                 acknowledgeRequestStates.putIfAbsent(nodeId, new Tuple<>(null, null, null));
 
                 for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
                     Acknowledgements acknowledgements = acknowledgementsMap.get(tip);
                     if (acknowledgements != null) {
-                        acknowledgementsMapForNode.put(tip, acknowledgements);
+                        acknowledgementsMapForNode.computeIfAbsent(tip, p -> new ArrayList<>()).add(acknowledgements);
 
                         metricsManager.recordAcknowledgementSent(acknowledgements.size());
                         log.debug("Added async acknowledge request for partition {} to node {}", tip.topicPartition(), node.id());
@@ -537,9 +539,9 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                     AcknowledgeRequestType.COMMIT_ASYNC
                             ));
                         } else {
-                            Acknowledgements prevAcks = asyncRequestState.acknowledgementsToSend.putIfAbsent(tip, acknowledgements);
-                            if (prevAcks != null) {
-                                asyncRequestState.acknowledgementsToSend.get(tip).merge(acknowledgements);
+                            List<Acknowledgements> prevAcks = asyncRequestState.acknowledgementsToSend.putIfAbsent(tip, new ArrayList<>(Collections.singletonList(acknowledgements)));
+                            if (prevAcks != null && !prevAcks.isEmpty()) {
+                                asyncRequestState.acknowledgementsToSend.get(tip).add(acknowledgements);
                             }
                         }
                     }
@@ -571,7 +573,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         sessionHandlers.forEach((nodeId, sessionHandler) -> {
             Node node = cluster.nodeById(nodeId);
             if (node != null) {
-                Map<TopicIdPartition, Acknowledgements> acknowledgementsMapForNode = new HashMap<>();
+                Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsMapForNode = new HashMap<>();
                 for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
                     Acknowledgements acknowledgements = acknowledgementsMap.getOrDefault(tip, Acknowledgements.empty());
 
@@ -582,7 +584,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     }
 
                     if (acknowledgements != null && !acknowledgements.isEmpty()) {
-                        acknowledgementsMapForNode.put(tip, acknowledgements);
+                        acknowledgementsMapForNode.put(tip, new ArrayList<>(Collections.singletonList(acknowledgements)));
 
                         metricsManager.recordAcknowledgementSent(acknowledgements.size());
                         log.debug("Added closing acknowledge request for partition {} to node {}", tip.topicPartition(), node.id());
@@ -926,17 +928,17 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         /**
          * The map of acknowledgements to send
          */
-        private final Map<TopicIdPartition, Acknowledgements> acknowledgementsToSend;
+        private final Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsToSend;
 
         /**
          * The map of acknowledgements to be retried in the next attempt.
          */
-        private final Map<TopicIdPartition, Acknowledgements> incompleteAcknowledgements;
+        private final Map<TopicIdPartition, List<Acknowledgements>> incompleteAcknowledgements;
 
         /**
          * The in-flight acknowledgements
          */
-        private final Map<TopicIdPartition, Acknowledgements> inFlightAcknowledgements;
+        private final Map<TopicIdPartition, List<Acknowledgements>> inFlightAcknowledgements;
 
         /**
          * This handles completing a future when all results are known.
@@ -964,7 +966,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                 long retryBackoffMaxMs,
                                 ShareSessionHandler sessionHandler,
                                 int nodeId,
-                                Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
+                                Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsMap,
                                 ResultHandler resultHandler,
                                 AcknowledgeRequestType acknowledgeRequestType) {
             super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, deadlineTimer(time, deadlineMs));
@@ -984,10 +986,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 sessionHandler.notifyClose();
             }
 
-            Map<TopicIdPartition, Acknowledgements> finalAcknowledgementsToSend = new HashMap<>(
+            Map<TopicIdPartition, List<Acknowledgements>> finalAcknowledgementsToSend = new HashMap<>(
                     incompleteAcknowledgements.isEmpty() ? acknowledgementsToSend : incompleteAcknowledgements);
 
-            for (Map.Entry<TopicIdPartition, Acknowledgements> entry : finalAcknowledgementsToSend.entrySet()) {
+            for (Map.Entry<TopicIdPartition, List<Acknowledgements>> entry : finalAcknowledgementsToSend.entrySet()) {
                 sessionHandler.addPartitionToFetch(entry.getKey(), entry.getValue());
             }
 
@@ -1026,29 +1028,29 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         }
 
         int getInFlightAcknowledgementsCount(TopicIdPartition tip) {
-            Acknowledgements acks = inFlightAcknowledgements.get(tip);
-            if (acks == null) {
+            List<Acknowledgements> acksList = inFlightAcknowledgements.get(tip);
+            if (acksList == null || acksList.isEmpty()) {
                 return 0;
             } else {
-                return acks.size();
+                return acksList.stream().mapToInt(Acknowledgements::size).sum();
             }
         }
 
         int getIncompleteAcknowledgementsCount(TopicIdPartition tip) {
-            Acknowledgements acks = incompleteAcknowledgements.get(tip);
-            if (acks == null) {
+            List<Acknowledgements> acksList = incompleteAcknowledgements.get(tip);
+            if (acksList == null || acksList.isEmpty()) {
                 return 0;
             } else {
-                return acks.size();
+                return acksList.stream().mapToInt(Acknowledgements::size).sum();
             }
         }
 
         int getAcknowledgementsToSendCount(TopicIdPartition tip) {
-            Acknowledgements acks = acknowledgementsToSend.get(tip);
-            if (acks == null) {
+            List<Acknowledgements> acksList = acknowledgementsToSend.get(tip);
+            if (acksList == null || acksList.isEmpty()) {
                 return 0;
             } else {
-                return acks.size();
+                return acksList.stream().mapToInt(Acknowledgements::size).sum();
             }
         }
 
@@ -1063,11 +1065,16 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * through a background event.
          */
         void handleAcknowledgeErrorCode(TopicIdPartition tip, Errors acknowledgeErrorCode) {
-            Acknowledgements acks = inFlightAcknowledgements.get(tip);
-            if (acks != null) {
-                acks.setAcknowledgeErrorCode(acknowledgeErrorCode);
+            List<Acknowledgements> acksList = inFlightAcknowledgements.get(tip);
+            Acknowledgements mergedAcks = null;
+            if (acksList != null && !acksList.isEmpty()) {
+                mergedAcks = Acknowledgements.empty();
+                // We just need to update callback with the offsets and the error code.
+                // Hence, merging the list of acknowledgements into one object.
+                acksList.forEach(mergedAcks::merge);
+                mergedAcks.setAcknowledgeErrorCode(acknowledgeErrorCode);
             }
-            resultHandler.complete(tip, acks, onCommitAsync());
+            resultHandler.complete(tip, mergedAcks, onCommitAsync());
         }
 
         /**
@@ -1075,11 +1082,16 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * after some retries.
          */
         void handleAcknowledgeTimedOut(TopicIdPartition tip) {
-            Acknowledgements acks = incompleteAcknowledgements.get(tip);
-            if (acks != null) {
-                acks.setAcknowledgeErrorCode(Errors.REQUEST_TIMED_OUT);
+            List<Acknowledgements> acksList = incompleteAcknowledgements.get(tip);
+            Acknowledgements mergedAcks = null;
+            if (acksList != null && !acksList.isEmpty()) {
+                mergedAcks = Acknowledgements.empty();
+                // We just need to update callback with the offsets and the error code.
+                // Hence, merging the list of acknowledgements into one object.
+                acksList.forEach(mergedAcks::merge);
+                mergedAcks.setAcknowledgeErrorCode(Errors.REQUEST_TIMED_OUT);
             }
-            resultHandler.complete(tip, acks, onCommitAsync());
+            resultHandler.complete(tip, mergedAcks, onCommitAsync());
         }
 
         /**
@@ -1088,14 +1100,19 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * being sent.
          */
         void handleSessionErrorCode(Errors errorCode) {
-            Map<TopicIdPartition, Acknowledgements> acknowledgementsMapToClear =
+            Map<TopicIdPartition, List<Acknowledgements>> acknowledgementsMapToClear =
                     incompleteAcknowledgements.isEmpty() ? acknowledgementsToSend : incompleteAcknowledgements;
 
-            acknowledgementsMapToClear.forEach((tip, acks) -> {
-                if (acks != null) {
-                    acks.setAcknowledgeErrorCode(errorCode);
+            acknowledgementsMapToClear.forEach((tip, acksList) -> {
+                Acknowledgements mergedAcks = null;
+                if (acksList != null && !acksList.isEmpty()) {
+                    mergedAcks = Acknowledgements.empty();
+                    // We just need to update callback with the offsets and the error code.
+                    // Hence, merging the list of acknowledgements into one object.
+                    acksList.forEach(mergedAcks::merge);
+                    mergedAcks.setAcknowledgeErrorCode(errorCode);
                 }
-                resultHandler.complete(tip, acks, onCommitAsync());
+                resultHandler.complete(tip, mergedAcks, onCommitAsync());
             });
             acknowledgementsMapToClear.clear();
             processingComplete();
@@ -1129,8 +1146,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * in the next request.
          */
         public void moveToIncompleteAcks(TopicIdPartition tip) {
-            Acknowledgements acks = inFlightAcknowledgements.remove(tip);
-            if (acks != null) {
+            List<Acknowledgements> acks = inFlightAcknowledgements.remove(tip);
+            if (acks != null && !acks.isEmpty()) {
                 incompleteAcknowledgements.put(tip, acks);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -76,7 +76,7 @@ public class ShareSessionHandler {
     /*
      * The acknowledgements to be included in the next ShareFetch/ShareAcknowledge request.
      */
-    private LinkedHashMap<TopicIdPartition, Acknowledgements> nextAcknowledgements;
+    private LinkedHashMap<TopicIdPartition, List<Acknowledgements>> nextAcknowledgements;
 
     public ShareSessionHandler(LogContext logContext, int node, Uuid memberId) {
         this.log = logContext.logger(ShareSessionHandler.class);
@@ -96,9 +96,9 @@ public class ShareSessionHandler {
         return Collections.unmodifiableCollection(sessionPartitions.values());
     }
 
-    public void addPartitionToFetch(TopicIdPartition topicIdPartition, Acknowledgements partitionAcknowledgements) {
+    public void addPartitionToFetch(TopicIdPartition topicIdPartition, List<Acknowledgements> partitionAcknowledgements) {
         nextPartitions.put(topicIdPartition.topicPartition(), topicIdPartition);
-        if (partitionAcknowledgements != null) {
+        if (partitionAcknowledgements != null && !partitionAcknowledgements.isEmpty()) {
             nextAcknowledgements.put(topicIdPartition, partitionAcknowledgements);
         }
     }
@@ -162,9 +162,12 @@ public class ShareSessionHandler {
         removed.addAll(replaced);
 
         Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
-        nextAcknowledgements.forEach((partition, acknowledgements) -> acknowledgementBatches.put(partition, acknowledgements.getAcknowledgementBatches()
-                .stream().map(AcknowledgementBatch::toShareFetchRequest)
-                .collect(Collectors.toList())));
+        nextAcknowledgements.forEach((partition, acknowledgementsList) ->
+            acknowledgementsList.forEach(acknowledgements ->
+                acknowledgementBatches.computeIfAbsent(partition, p -> new ArrayList<>())
+                    .addAll(acknowledgements.getAcknowledgementBatches()
+                            .stream().map(AcknowledgementBatch::toShareFetchRequest)
+                            .collect(Collectors.toList()))));
 
         nextPartitions = new LinkedHashMap<>();
         nextAcknowledgements = new LinkedHashMap<>();
@@ -184,10 +187,12 @@ public class ShareSessionHandler {
         }
 
         Map<TopicIdPartition, List<ShareAcknowledgeRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
-        nextAcknowledgements.forEach((partition, acknowledgements) ->
-                acknowledgementBatches.put(partition, acknowledgements.getAcknowledgementBatches()
+        nextAcknowledgements.forEach((partition, acknowledgementsList) ->
+            acknowledgementsList.forEach(acknowledgements ->
+                acknowledgementBatches.computeIfAbsent(partition, p -> new ArrayList<>())
+                    .addAll(acknowledgements.getAcknowledgementBatches()
                         .stream().map(AcknowledgementBatch::toShareAcknowledgeRequest)
-                        .collect(Collectors.toList())));
+                        .collect(Collectors.toList()))));
 
         nextAcknowledgements = new LinkedHashMap<>();
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -336,6 +336,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.NONE);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         completedAcknowledgements.clear();
     }
@@ -369,6 +370,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.NONE);
+        assertEquals(completedAcknowledgements.get(0).get(tip0), acknowledgements);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         completedAcknowledgements.clear();
     }
@@ -407,12 +410,14 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(null, true);
         networkClientDelegate.poll(time.timer(0));
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.UNKNOWN_SERVER_ERROR);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         assertEquals(Errors.UNKNOWN_SERVER_ERROR, completedAcknowledgements.get(0).get(tip0).getAcknowledgeErrorCode());
         completedAcknowledgements.clear();
 
         assertEquals(1, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
 
+        acknowledgements2.setAcknowledgeErrorCode(Errors.SHARE_SESSION_NOT_FOUND);
         TestUtils.retryOnExceptionWithTimeout(() -> {
             assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
             // We expect the remaining acknowledgements to be cleared due to share session epoch being set to 0.
@@ -508,6 +513,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.NONE);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         completedAcknowledgements.clear();
     }
@@ -547,6 +553,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.NONE);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
         completedAcknowledgements.clear();
     }
@@ -657,9 +664,9 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.commitAsync(Collections.singletonMap(tip0, acknowledgements));
 
         Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(5L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
+        acknowledgements2.add(4L, AcknowledgeType.ACCEPT);
+        acknowledgements2.add(5L, AcknowledgeType.ACCEPT);
+        acknowledgements2.add(6L, AcknowledgeType.ACCEPT);
 
         shareConsumeRequestManager.commitAsync(Collections.singletonMap(tip0, acknowledgements2));
 
@@ -1092,6 +1099,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
+        acknowledgements.setAcknowledgeErrorCode(Errors.NONE);
         assertEquals(Collections.singletonMap(tip0, acknowledgements), completedAcknowledgements.get(0));
 
         completedAcknowledgements.clear();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
@@ -431,7 +431,7 @@ public class ShareSessionHandlerTest {
         Acknowledgements acknowledgements = Acknowledgements.empty();
         acknowledgements.add(0L, AcknowledgeType.ACCEPT);
 
-        handler.addPartitionToFetch(foo0, acknowledgements);
+        handler.addPartitionToFetch(foo0, Collections.singletonList(acknowledgements));
 
         // As we start with a ShareAcknowledge on epoch 0, we expect a null response.
         assertNull(handler.newShareAcknowledgeBuilder(groupId, fetchConfig));


### PR DESCRIPTION
*What*
Currently, when we merge/coalesce Acknowledge requests in `ShareConsumeRequestManager`, we lose track of the batches in which they came in from the `ShareFetchResponse`.
After the introduction of `FetchBatchSize` here(https://issues.apache.org/jira/browse/KAFKA-18433) which helps in maintaining batch order in clients and brokers, we expect to maintain the batch ordering in the `ShareAcknowledge` requests to exploit the ordering.
This will ensure broker does not break up the batches into offset tracking batches, helping in optimisation.


