### PR TITLE
KAFKA-18583 Fix getPartitionReplicaEndpoints for KRaft

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -433,7 +433,7 @@ class KRaftMetadataCache(
     val image = _currentImage
     val result = new mutable.HashMap[Int, Node]()
     Option(image.topics().getTopic(tp.topic())).foreach { topic =>
-      topic.partitions().values().forEach { partition =>
+      Option(topic.partitions().get(tp.partition())).foreach { partition =>
         partition.replicas.foreach { replicaId =>
           val broker = image.cluster().broker(replicaId)
           if (broker != null && !broker.fenced()) {

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util
 import java.util.Arrays.asList
 import java.util.Collections
+import java.util.stream.Collectors
 import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
 
@@ -519,10 +520,11 @@ class MetadataCacheTest {
 
     // Set up broker data for the metadata cache
     val numBrokers = 10
+    val fencedBrokerId = numBrokers / 3
     val brokerRecords = (0 until numBrokers).map { brokerId =>
       new RegisterBrokerRecord()
         .setBrokerId(brokerId)
-        .setFenced(false)
+        .setFenced(brokerId == fencedBrokerId)
         .setRack("rack" + (brokerId % 3))
         .setEndPoints(new BrokerEndpointCollection(
           Seq(new BrokerEndpoint()
@@ -545,31 +547,51 @@ class MetadataCacheTest {
     val numPartitions = replicaSets.length
     val partitionRecords = (0 until numPartitions).map { partitionId =>
       val replicas = replicaSets(partitionId)
+      val nonFencedReplicas = replicas.stream().filter(id => id != fencedBrokerId).collect(Collectors.toList())
       new PartitionRecord()
         .setTopicId(topicId)
         .setPartitionId(partitionId)
         .setReplicas(replicas)
         .setLeader(replicas.get(0))
-        .setIsr(replicas)
-        .setEligibleLeaderReplicas(replicas)
+        .setIsr(nonFencedReplicas)
+        .setEligibleLeaderReplicas(nonFencedReplicas)
     }
 
     // Load the prepared data in the metadata cache
     MetadataCacheTest.updateCache(cache, brokerRecords ++ topicRecords ++ partitionRecords)
 
-    var seenReplicaSets: Set[scala.collection.Set[Int]] = Set.empty
     (0 until numPartitions).foreach { partitionId =>
       val tp = new TopicPartition(topic, partitionId)
       val brokerIdToNodeMap = cache.getPartitionReplicaEndpoints(tp, listenerName)
       val replicaSet = brokerIdToNodeMap.keySet
-      // Verify that we haven't seen before the replica set for this partition
-      assertFalse(seenReplicaSets.contains(replicaSet),
-                  s"Already seen replica set $replicaSet before partition $partitionId")
-      seenReplicaSets += replicaSet
-      // Verify that for each partition we have exactly $replicationFactor endpoints
-      assertEquals(replicationFactor,
-                   replicaSet.size,
-                   s"Unexpected replica set $replicaSet for partition $partitionId")
+      val expectedReplicaSet = partitionRecords(partitionId).replicas().asScala.toSet
+      // Verify that we have endpoints for exactly the non-fenced brokers of the replica set
+      if (expectedReplicaSet.contains(fencedBrokerId)) {
+        assertEquals(expectedReplicaSet,
+                     replicaSet + fencedBrokerId,
+                     s"Unexpected partial replica set for partition $partitionId")
+      } else {
+        assertEquals(expectedReplicaSet,
+                     replicaSet,
+                     s"Unexpected replica set for partition $partitionId")
+      }
+      // Verify that the endpoint data for each non-fenced replica is as expected
+      replicaSet.foreach { brokerId =>
+        val brokerNode =
+          brokerIdToNodeMap.getOrElse(
+            brokerId, fail(s"No brokerNode for broker $brokerId and partition $partitionId"))
+        val expectedBroker = brokerRecords(brokerId)
+        val expectedEndpoint = expectedBroker.endPoints().find(listenerName.value())
+        assertEquals(expectedEndpoint.host(),
+                     brokerNode.host(),
+                     s"Unexpected host for broker $brokerId and partition $partitionId")
+        assertEquals(expectedEndpoint.port(),
+                     brokerNode.port(),
+                     s"Unexpected port for broker $brokerId and partition $partitionId")
+        assertEquals(expectedBroker.rack(),
+                     brokerNode.rack(),
+                     s"Unexpected rack for broker $brokerId and partition $partitionId")
+      }
     }
 
     val tp = new TopicPartition(topic, numPartitions)

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiMessage, Errors}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.{DirectoryId, Uuid}
+import org.apache.kafka.common.{DirectoryId, TopicPartition, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.server.common.KRaftVersion
@@ -509,6 +509,80 @@ class MetadataCacheTest {
     // This should not change `aliveBrokersFromCache`
     updateCache((0 to 3))
     assertEquals(initialBrokerIds.toSet, aliveBrokersFromCache.map(_.id).toSet)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("cacheProvider"))
+  def testGetPartitionReplicaEndpoints(cache: MetadataCache): Unit = {
+    val securityProtocol = SecurityProtocol.PLAINTEXT
+    val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
+
+    // Set up broker data for the metadata cache
+    val numBrokers = 10
+    val brokerRecords = (0 until numBrokers).map { brokerId =>
+      new RegisterBrokerRecord()
+        .setBrokerId(brokerId)
+        .setFenced(false)
+        .setRack("rack" + (brokerId % 3))
+        .setEndPoints(new BrokerEndpointCollection(
+          Seq(new BrokerEndpoint()
+            .setHost("foo" + brokerId)
+            .setPort(9092)
+            .setSecurityProtocol(securityProtocol.id)
+            .setName(listenerName.value)
+          ).iterator.asJava))
+    }
+
+    // Set up a single topic (with many partitions) for the metadata cache
+    val topic = "many-partitions-topic"
+    val topicId = Uuid.randomUuid()
+    val topicRecords = Seq[ApiMessage](new TopicRecord().setName(topic).setTopicId(topicId))
+
+    // Set up a number of partitions such that each different combination of
+    // $replicationFactor brokers is made a replica set for exactly one partition
+    val replicationFactor = 3
+    val replicaSets = getAllReplicaSets(numBrokers, replicationFactor)
+    val numPartitions = replicaSets.length
+    val partitionRecords = (0 until numPartitions).map { partitionId =>
+      val replicas = replicaSets(partitionId)
+      new PartitionRecord()
+        .setTopicId(topicId)
+        .setPartitionId(partitionId)
+        .setReplicas(replicas)
+        .setLeader(replicas.get(0))
+        .setIsr(replicas)
+        .setEligibleLeaderReplicas(replicas)
+    }
+
+    // Load the prepared data in the metadata cache
+    MetadataCacheTest.updateCache(cache, brokerRecords ++ topicRecords ++ partitionRecords)
+
+    var seenReplicaSets: Set[scala.collection.Set[Int]] = Set.empty
+    (0 until numPartitions).foreach { partitionId =>
+      val tp = new TopicPartition(topic, partitionId)
+      val brokerIdToNodeMap = cache.getPartitionReplicaEndpoints(tp, listenerName)
+      val replicaSet = brokerIdToNodeMap.keySet
+      // Verify that we haven't seen before the replica set for this partition
+      assertFalse(seenReplicaSets.contains(replicaSet),
+                  s"Already seen replica set $replicaSet before partition $partitionId")
+      seenReplicaSets += replicaSet
+      // Verify that for each partition we have exactly $replicationFactor endpoints
+      assertEquals(replicationFactor,
+                   replicaSet.size,
+                   s"Unexpected replica set $replicaSet for partition $partitionId")
+    }
+
+    val tp = new TopicPartition(topic, numPartitions)
+    val brokerIdToNodeMap = cache.getPartitionReplicaEndpoints(tp, listenerName)
+    assertTrue(brokerIdToNodeMap.isEmpty)
+  }
+
+  private def getAllReplicaSets(numBrokers: Int,
+                                replicationFactor: Int): Array[util.List[Integer]] = {
+    (0 until numBrokers)
+      .combinations(replicationFactor)
+      .map(replicaSet => replicaSet.map(Integer.valueOf).toList.asJava)
+      .toArray
   }
 
   @Test


### PR DESCRIPTION
Although `MetadataCache`'s `getPartitionReplicaEndpoints` takes a single topic-partition, the `KRaftMetadataCache` implementation iterates over all partitions of the matching topic. This is not necessary and can cause significant performance degradation when the topic has a relatively high number of partitions.

Note that this is not a recent regression - it has been a part of `KRaftMetadataCache` since its creation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
