### PR TITLE
MINOR: Make `forceUnmap` protected since the only test class that references it is in the same package now.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -399,7 +399,7 @@ public abstract class AbstractIndex implements Closeable {
     /**
      * Forcefully free the buffer's mmap.
      */
-    // Visible for testing, we can make this protected once OffsetIndexTest is in the same package as this class
+    // Made protected for the sake of visibility for testing.
     protected void forceUnmap() throws IOException {
         try {
             ByteBufferUnmapper.unmap(file.getAbsolutePath(), mmap);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -399,7 +399,7 @@ public abstract class AbstractIndex implements Closeable {
     /**
      * Forcefully free the buffer's mmap.
      */
-    // Made protected for the sake of visibility for testing.
+    // Visible for testing
     protected void forceUnmap() throws IOException {
         try {
             ByteBufferUnmapper.unmap(file.getAbsolutePath(), mmap);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -400,7 +400,7 @@ public abstract class AbstractIndex implements Closeable {
      * Forcefully free the buffer's mmap.
      */
     // Visible for testing, we can make this protected once OffsetIndexTest is in the same package as this class
-    public void forceUnmap() throws IOException {
+    protected void forceUnmap() throws IOException {
         try {
             ByteBufferUnmapper.unmap(file.getAbsolutePath(), mmap);
         } finally {


### PR DESCRIPTION
The `forceUnmap` method was made public for the sake of visibility for testing since the test class  `OffsetIndexTest`  was in a different package before. Now, the test class is in the same package, so that method can been made `protected`.

The sole usage of this method is inside the class that it is defined in: `AbstractIndex` and the test class: `OffsetIndexTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
