### PR TITLE
HOTFIX: ListShareGroupOffsetResult javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
@@ -45,7 +45,7 @@ public class ListShareGroupOffsetsResult {
     /**
      * Return the future when the requests for all groups succeed.
      *
-     * @return - Future which yields all Map<String, Map<TopicPartition, Long> objects, if requests for all the groups succeed.
+     * @return - Future which yields all Map&lt;String, Map&lt;TopicPartition, Long&gt;&gt; objects, if requests for all the groups succeed.
      */
     public KafkaFuture<Map<String, Map<TopicPartition, Long>>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
@@ -65,7 +65,7 @@ public class ListShareGroupOffsetsResult {
     }
 
     /**
-     * @param groupId - The groupId for which the Map<TopicPartition, Long> is needed
+     * @param groupId - The groupId for which the Map&lt;TopicPartition, Long&gt; is needed
      * @return - Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, Long>> partitionsToOffset(String groupId) {


### PR DESCRIPTION
When trying to run `./gradlew cleanTest :clients:test`, it shows following error:

```
> Task :clients:javadoc
/Users/poanyang/Project/apache/kafka/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java:48: warning: invalid input: '<'
     * @return - Future which yields all Map<String, Map<TopicPartition, Long> objects, if requests for all the groups succeed.
                                            ^
/Users/poanyang/Project/apache/kafka/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java:48: warning: invalid input: '<'
     * @return - Future which yields all Map<String, Map<TopicPartition, Long> objects, if requests for all the groups succeed.
                                                        ^
/Users/poanyang/Project/apache/kafka/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java:68: warning: invalid input: '<'
     * @param groupId - The groupId for which the Map<TopicPartition, Long> is needed
                                                     ^
error: warnings found and -Werror specified
1 error
3 warnings
```

Escape "<" and  ">" to fix the error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
