### PR TITLE
MINOR: Update the Outdated method name

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -260,11 +260,11 @@ class BrokerLifecycleManager(
       new OfflineDirBrokerFailureEvent(directory))
   }
 
-  def resendBrokerRegistrationUnlessZkMode(): Unit = {
-    eventQueue.append(new ResendBrokerRegistrationUnlessZkModeEvent())
+  def resendBrokerRegistration(): Unit = {
+    eventQueue.append(new ResendBrokerRegistrationEvent())
   }
 
-  private class ResendBrokerRegistrationUnlessZkModeEvent extends EventQueue.Event {
+  private class ResendBrokerRegistrationEvent extends EventQueue.Event {
     override def run(): Unit = {
       registered = false
       scheduleNextCommunicationImmediately()

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -534,7 +534,7 @@ class BrokerServer(
       })
       metadataPublishers.add(brokerMetadataPublisher)
       brokerRegistrationTracker = new BrokerRegistrationTracker(config.brokerId,
-        () => lifecycleManager.resendBrokerRegistrationUnlessZkMode())
+        () => lifecycleManager.resendBrokerRegistration())
       metadataPublishers.add(brokerRegistrationTracker)
 
 

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -288,7 +288,7 @@ class BrokerLifecycleManagerTest {
     assertEquals(1000L, manager.brokerEpoch)
 
     // Trigger JBOD MV update
-    manager.resendBrokerRegistrationUnlessZkMode()
+    manager.resendBrokerRegistration()
 
     // Accept new registration, response sets epoch to 1200
     nextRegistrationRequest(1200L)


### PR DESCRIPTION
this method name is contained "UnlessZkMode", this is Outdated when we deprecate Zookeeper

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
