### PR TITLE
Cherry-pick KAFKA-18583 fix (#18635) to 3.9

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -431,7 +431,7 @@ class KRaftMetadataCache(
     val image = _currentImage
     val result = new mutable.HashMap[Int, Node]()
     Option(image.topics().getTopic(tp.topic())).foreach { topic =>
-      topic.partitions().values().forEach { partition =>
+      Option(topic.partitions().get(tp.partition())).foreach { partition =>
         partition.replicas.foreach { replicaId =>
           val broker = image.cluster().broker(replicaId)
           if (broker != null && !broker.fenced()) {


### PR DESCRIPTION
The cherry-pick required reimplementing the accompanying test to work with `UpdateMetadataRequest` (removed in 4.0 and trunk) in order to also apply to `ZkMetadataCache`. If the removal of `UpdateMetadataRequest` is backported here as well, the test can be changed to match the trunk version.
- The test now passes locally against both the ZK and the KRaft metadata caches.

_Conflicts: core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala_

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
