### PR TITLE
KAFKA-18610 [1/N]: add flush-interval-ms metric

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -780,6 +780,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     }
 
                     long flushStartMs = time.milliseconds();
+                    runtimeMetrics.recordFlushIntervalTime(flushStartMs - currentBatch.appendTimeMs);
                     // Write the records to the log and update the last written offset.
                     long offset = partitionWriter.append(
                         tp,

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -68,9 +68,9 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordFlushTime(long durationMs);
 
     /**
-     * Record the flush time.
+     * Record the flush interval time.
      *
-     * @param durationMs The flush time in milliseconds.
+     * @param durationMs The flush interval time in milliseconds.
      */
     void recordFlushIntervalTime(long durationMs);
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -68,6 +68,13 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordFlushTime(long durationMs);
 
     /**
+     * Record the flush time.
+     *
+     * @param durationMs The flush time in milliseconds.
+     */
+    void recordFlushIntervalTime(long durationMs);
+
+    /**
      * Record the thread idle time.
      * @param idleTimeMs The idle time in milliseconds.
      */

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogram.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogram.java
@@ -67,6 +67,7 @@ public final class KafkaMetricHistogram implements CompoundStat {
      */
     private final Function<String, MetricName> metricNameFactory;
     private final HdrHistogram hdrHistogram;
+    private final long highestTrackableValue;
 
     /**
      * Creates a new histogram with the purpose of tracking latency values. As such, the histogram
@@ -105,6 +106,7 @@ public final class KafkaMetricHistogram implements CompoundStat {
     ) {
         this.metricNameFactory = metricNameFactory;
         this.hdrHistogram = new HdrHistogram(highestTrackableValue, numberOfSignificantValueDigits);
+        this.highestTrackableValue = highestTrackableValue;
     }
 
     @Override
@@ -125,6 +127,6 @@ public final class KafkaMetricHistogram implements CompoundStat {
 
     @Override
     public void record(MetricConfig config, double value, long timeMs) {
-        hdrHistogram.record((long) value);
+        hdrHistogram.record(Math.min(highestTrackableValue, (long) value));
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_FLUSH_INTERVAL_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_FLUSH_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PROCESSING_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PURGATORY_TIME_METRIC_NAME;
@@ -76,7 +77,12 @@ public class CoordinatorRuntimeMetricsImplTest {
             kafkaMetricName(metrics, "batch-flush-time-ms-p50"),
             kafkaMetricName(metrics, "batch-flush-time-ms-p95"),
             kafkaMetricName(metrics, "batch-flush-time-ms-p99"),
-            kafkaMetricName(metrics, "batch-flush-time-ms-p999")
+            kafkaMetricName(metrics, "batch-flush-time-ms-p999"),
+            kafkaMetricName(metrics, "batch-flush-interval-time-ms-max"),
+            kafkaMetricName(metrics, "batch-flush-interval-time-ms-p50"),
+            kafkaMetricName(metrics, "batch-flush-interval-time-ms-p95"),
+            kafkaMetricName(metrics, "batch-flush-interval-time-ms-p99"),
+            kafkaMetricName(metrics, "batch-flush-interval-time-ms-p999")
         ));
 
         try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
@@ -160,7 +166,8 @@ public class CoordinatorRuntimeMetricsImplTest {
         EVENT_QUEUE_TIME_METRIC_NAME,
         EVENT_PROCESSING_TIME_METRIC_NAME,
         EVENT_PURGATORY_TIME_METRIC_NAME,
-        BATCH_FLUSH_TIME_METRIC_NAME
+        BATCH_FLUSH_TIME_METRIC_NAME,
+        BATCH_FLUSH_INTERVAL_METRIC_NAME
     })
     public void testHistogramMetrics(String metricNamePrefix) {
         Time time = new MockTime();
@@ -181,6 +188,9 @@ public class CoordinatorRuntimeMetricsImplTest {
                     break;
                 case BATCH_FLUSH_TIME_METRIC_NAME:
                     runtimeMetrics.recordFlushTime(i);
+                    break;
+                case BATCH_FLUSH_INTERVAL_METRIC_NAME:
+                    runtimeMetrics.recordFlushIntervalTime(i);
             }
         });
 


### PR DESCRIPTION
Add flush-interval-ms histogram: track how long it takes from when a batch is first created, to right before writing to disk. The bulk of the time will represent the time spent in the timer, waiting to execute the task.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
