### PR TITLE
KAFKA-18325: Add TargetAssignmentBuilder

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
+import org.apache.kafka.coordinator.group.streams.assignor.AssignmentMemberSpec;
+import org.apache.kafka.coordinator.group.streams.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.streams.assignor.GroupSpecImpl;
+import org.apache.kafka.coordinator.group.streams.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Build a new Target TasksTuple based on the provided parameters. As a result, it yields the records that must be persisted to the log and
+ * the new member assignments as a map.
+ * <p>
+ * Records are only created for members which have a new target assignment. If their assignment did not change, no new record is needed.
+ * <p>
+ * When a member is deleted, it is assumed that its target assignment record is deleted as part of the member deletion process. In other
+ * words, this class does not yield a tombstone for removed members.
+ */
+public class TargetAssignmentBuilder {
+
+    /**
+     * The group id.
+     */
+    private final String groupId;
+    /**
+     * The group epoch.
+     */
+    private final int groupEpoch;
+    /**
+     * The partition assignor used to compute the assignment.
+     */
+    private final TaskAssignor assignor;
+    /**
+     * The assignment configs.
+     */
+    private final Map<String, String> assignmentConfigs;
+    /**
+     * The members which have been updated or deleted. Deleted members are signaled by a null value.
+     */
+    private final Map<String, StreamsGroupMember> updatedMembers = new HashMap<>();
+    /**
+     * The members in the group.
+     */
+    private Map<String, StreamsGroupMember> members = Map.of();
+
+    /**
+     * The subscription metadata.
+     */
+    private Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> subscriptionMetadata = Map.of();
+
+    /**
+     * The existing target assignment.
+     */
+    private Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment = Map.of();
+
+    /**
+     * The topology.
+     */
+    private ConfiguredTopology topology;
+    /**
+     * The static members in the group.
+     */
+    private Map<String, String> staticMembers = Map.of();
+
+    /**
+     * Constructs the object.
+     *
+     * @param groupId    The group id.
+     * @param groupEpoch The group epoch to compute a target assignment for.
+     * @param assignor   The assignor to use to compute the target assignment.
+     */
+    public TargetAssignmentBuilder(
+        String groupId,
+        int groupEpoch,
+        TaskAssignor assignor,
+        Map<String, String> assignmentConfigs
+    ) {
+        this.groupId = Objects.requireNonNull(groupId);
+        this.groupEpoch = groupEpoch;
+        this.assignor = Objects.requireNonNull(assignor);
+        this.assignmentConfigs = Objects.requireNonNull(assignmentConfigs);
+    }
+
+    static AssignmentMemberSpec createAssignmentMemberSpec(
+        StreamsGroupMember member,
+        TasksTuple targetAssignment
+    ) {
+        return new AssignmentMemberSpec(
+            member.instanceId(),
+            member.rackId(),
+            targetAssignment.activeTasks(),
+            targetAssignment.standbyTasks(),
+            targetAssignment.warmupTasks(),
+            member.processId(),
+            member.clientTags(),
+            Map.of(),
+            Map.of()
+        );
+    }
+
+    /**
+     * Adds all the existing members.
+     *
+     * @param members The existing members in the streams group.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withMembers(
+        Map<String, StreamsGroupMember> members
+    ) {
+        this.members = members;
+        return this;
+    }
+
+    /**
+     * Adds all the existing static members.
+     *
+     * @param staticMembers The existing static members in the streams group.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withStaticMembers(
+        Map<String, String> staticMembers
+    ) {
+        this.staticMembers = staticMembers;
+        return this;
+    }
+
+    /**
+     * Adds the subscription metadata to use.
+     *
+     * @param partitionMetadata The subscription metadata.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withPartitionMetadata(
+        Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> partitionMetadata
+    ) {
+        this.subscriptionMetadata = partitionMetadata;
+        return this;
+    }
+
+    /**
+     * Adds the existing target assignment.
+     *
+     * @param targetAssignment The existing target assignment.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withTargetAssignment(
+        Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment
+    ) {
+        this.targetAssignment = targetAssignment;
+        return this;
+    }
+
+    /**
+     * Adds the topology image.
+     *
+     * @param topology The topology.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withTopology(
+        ConfiguredTopology topology
+    ) {
+        this.topology = topology;
+        return this;
+    }
+
+
+    /**
+     * Adds or updates a member. This is useful when the updated member is not yet materialized in memory.
+     *
+     * @param memberId The member id.
+     * @param member   The member to add or update.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder addOrUpdateMember(
+        String memberId,
+        StreamsGroupMember member
+    ) {
+        this.updatedMembers.put(memberId, member);
+        return this;
+    }
+
+    /**
+     * Removes a member. This is useful when the removed member is not yet materialized in memory.
+     *
+     * @param memberId The member id.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder removeMember(
+        String memberId
+    ) {
+        return addOrUpdateMember(memberId, null);
+    }
+
+    /**
+     * Builds the new target assignment.
+     *
+     * @return A TargetAssignmentResult which contains the records to update the existing target assignment.
+     * @throws TaskAssignorException if the target assignment cannot be computed.
+     */
+    public TargetAssignmentResult build() throws TaskAssignorException {
+        Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
+
+        // Prepare the member spec for all members.
+        members.forEach((memberId, member) -> memberSpecs.put(memberId, createAssignmentMemberSpec(
+            member,
+            targetAssignment.getOrDefault(memberId, org.apache.kafka.coordinator.group.streams.TasksTuple.EMPTY)
+        )));
+
+        // Update the member spec if updated or deleted members.
+        updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+            if (updatedMemberOrNull == null) {
+                memberSpecs.remove(memberId);
+            } else {
+                org.apache.kafka.coordinator.group.streams.TasksTuple assignment = targetAssignment.getOrDefault(memberId,
+                    org.apache.kafka.coordinator.group.streams.TasksTuple.EMPTY);
+
+                // A new static member joins and needs to replace an existing departed one.
+                if (updatedMemberOrNull.instanceId().isPresent()) {
+                    String previousMemberId = staticMembers.get(updatedMemberOrNull.instanceId().get());
+                    if (previousMemberId != null && !previousMemberId.equals(memberId)) {
+                        assignment = targetAssignment.getOrDefault(previousMemberId,
+                            org.apache.kafka.coordinator.group.streams.TasksTuple.EMPTY);
+                    }
+                }
+
+                memberSpecs.put(memberId, createAssignmentMemberSpec(
+                    updatedMemberOrNull,
+                    assignment
+                ));
+            }
+        });
+
+        // Compute the assignment.
+        GroupAssignment newGroupAssignment;
+        if (topology.isReady()) {
+            newGroupAssignment = assignor.assign(
+                new GroupSpecImpl(
+                    Collections.unmodifiableMap(memberSpecs),
+                    assignmentConfigs
+                ),
+                new TopologyMetadata(subscriptionMetadata, topology)
+            );
+        } else {
+            newGroupAssignment = new GroupAssignment(
+                memberSpecs.keySet().stream().collect(Collectors.toMap(x -> x, x -> MemberAssignment.empty())));
+        }
+
+        // Compute delta from previous to new target assignment and create the
+        // relevant records.
+        List<CoordinatorRecord> records = new ArrayList<>();
+        Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> newTargetAssignment = new HashMap<>();
+
+        memberSpecs.keySet().forEach(memberId -> {
+            org.apache.kafka.coordinator.group.streams.TasksTuple oldMemberAssignment = targetAssignment.get(memberId);
+            org.apache.kafka.coordinator.group.streams.TasksTuple newMemberAssignment = newMemberAssignment(newGroupAssignment, memberId);
+
+            newTargetAssignment.put(memberId, newMemberAssignment);
+
+            if (oldMemberAssignment == null) {
+                // If the member had no assignment, we always create a record for it.
+                records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(
+                    groupId,
+                    memberId,
+                    newMemberAssignment
+                ));
+            } else {
+                // If the member had an assignment, we only create a record if the
+                // new assignment is different.
+                if (!newMemberAssignment.equals(oldMemberAssignment)) {
+                    records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(
+                        groupId,
+                        memberId,
+                        newMemberAssignment
+                    ));
+                }
+            }
+        });
+
+        // Bump the target assignment epoch.
+        records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, groupEpoch));
+
+        return new TargetAssignmentResult(records, newTargetAssignment);
+    }
+
+    private org.apache.kafka.coordinator.group.streams.TasksTuple newMemberAssignment(
+        GroupAssignment newGroupAssignment,
+        String memberId
+    ) {
+        MemberAssignment newMemberAssignment = newGroupAssignment.members().get(memberId);
+        if (newMemberAssignment != null) {
+            return new org.apache.kafka.coordinator.group.streams.TasksTuple(
+                newMemberAssignment.activeTasks(),
+                newMemberAssignment.standbyTasks(),
+                newMemberAssignment.warmupTasks()
+            );
+        } else {
+            return org.apache.kafka.coordinator.group.streams.TasksTuple.EMPTY;
+        }
+    }
+
+    /**
+     * The assignment result returned by {{@link TargetAssignmentBuilder#build()}}.
+     */
+    public static class TargetAssignmentResult {
+
+        /**
+         * The records that must be applied to the __streams_offsets topics to persist the new target assignment.
+         */
+        private final List<CoordinatorRecord> records;
+
+        /**
+         * The new target assignment for the group.
+         */
+        private final Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment;
+
+        TargetAssignmentResult(
+            List<CoordinatorRecord> records,
+            Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment
+        ) {
+            Objects.requireNonNull(records);
+            Objects.requireNonNull(targetAssignment);
+            this.records = records;
+            this.targetAssignment = targetAssignment;
+        }
+
+        /**
+         * @return The records.
+         */
+        public List<CoordinatorRecord> records() {
+            return records;
+        }
+
+        /**
+         * @return The target assignment.
+         */
+        public Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment() {
+            return targetAssignment;
+        }
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -34,8 +34,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Build a new Target TasksTuple based on the provided parameters. As a result, it yields the records that must be persisted to the log and
- * the new member assignments as a map.
+ * Build the new target member assignments based on the provided parameters by calling the task assignor.
+ * As a result,
+ * it yields the records that must be persisted to the log and the new member assignments as a map from member ID to tasks tuple.
  * <p>
  * Records are only created for members which have a new target assignment. If their assignment did not change, no new record is needed.
  * <p>
@@ -45,34 +46,38 @@ import java.util.stream.Collectors;
 public class TargetAssignmentBuilder {
 
     /**
-     * The group id.
+     * The group ID.
      */
     private final String groupId;
     /**
      * The group epoch.
      */
     private final int groupEpoch;
+
     /**
      * The partition assignor used to compute the assignment.
      */
     private final TaskAssignor assignor;
+
     /**
      * The assignment configs.
      */
     private final Map<String, String> assignmentConfigs;
+
     /**
-     * The members which have been updated or deleted. Deleted members are signaled by a null value.
+     * The members which have been updated or deleted. A null value signals deleted members.
      */
     private final Map<String, StreamsGroupMember> updatedMembers = new HashMap<>();
+
     /**
      * The members in the group.
      */
     private Map<String, StreamsGroupMember> members = Map.of();
 
     /**
-     * The subscription metadata.
+     * The partition metadata.
      */
-    private Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> subscriptionMetadata = Map.of();
+    private Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> partitionMetadata = Map.of();
 
     /**
      * The existing target assignment.
@@ -83,6 +88,7 @@ public class TargetAssignmentBuilder {
      * The topology.
      */
     private ConfiguredTopology topology;
+
     /**
      * The static members in the group.
      */
@@ -91,7 +97,7 @@ public class TargetAssignmentBuilder {
     /**
      * Constructs the object.
      *
-     * @param groupId    The group id.
+     * @param groupId    The group ID.
      * @param groupEpoch The group epoch to compute a target assignment for.
      * @param assignor   The assignor to use to compute the target assignment.
      */
@@ -151,15 +157,15 @@ public class TargetAssignmentBuilder {
     }
 
     /**
-     * Adds the subscription metadata to use.
+     * Adds the partition metadata to use.
      *
-     * @param partitionMetadata The subscription metadata.
+     * @param partitionMetadata The partition metadata.
      * @return This object.
      */
     public TargetAssignmentBuilder withPartitionMetadata(
         Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> partitionMetadata
     ) {
-        this.subscriptionMetadata = partitionMetadata;
+        this.partitionMetadata = partitionMetadata;
         return this;
     }
 
@@ -193,7 +199,7 @@ public class TargetAssignmentBuilder {
     /**
      * Adds or updates a member. This is useful when the updated member is not yet materialized in memory.
      *
-     * @param memberId The member id.
+     * @param memberId The member ID.
      * @param member   The member to add or update.
      * @return This object.
      */
@@ -208,7 +214,7 @@ public class TargetAssignmentBuilder {
     /**
      * Removes a member. This is useful when the removed member is not yet materialized in memory.
      *
-     * @param memberId The member id.
+     * @param memberId The member ID.
      * @return This object.
      */
     public TargetAssignmentBuilder removeMember(
@@ -264,7 +270,7 @@ public class TargetAssignmentBuilder {
                     Collections.unmodifiableMap(memberSpecs),
                     assignmentConfigs
                 ),
-                new TopologyMetadata(subscriptionMetadata, topology)
+                new TopologyMetadata(partitionMetadata, topology)
             );
         } else {
             newGroupAssignment = new GroupAssignment(
@@ -308,59 +314,35 @@ public class TargetAssignmentBuilder {
         return new TargetAssignmentResult(records, newTargetAssignment);
     }
 
-    private org.apache.kafka.coordinator.group.streams.TasksTuple newMemberAssignment(
+    private TasksTuple newMemberAssignment(
         GroupAssignment newGroupAssignment,
         String memberId
     ) {
         MemberAssignment newMemberAssignment = newGroupAssignment.members().get(memberId);
         if (newMemberAssignment != null) {
-            return new org.apache.kafka.coordinator.group.streams.TasksTuple(
+            return new TasksTuple(
                 newMemberAssignment.activeTasks(),
                 newMemberAssignment.standbyTasks(),
                 newMemberAssignment.warmupTasks()
             );
         } else {
-            return org.apache.kafka.coordinator.group.streams.TasksTuple.EMPTY;
+            return TasksTuple.EMPTY;
         }
     }
 
     /**
      * The assignment result returned by {{@link TargetAssignmentBuilder#build()}}.
+     *
+     * @param records          The records that must be applied to the __consumer_offsets topics to persist the new target assignment.
+     * @param targetAssignment The new target assignment for the group.
      */
-    public static class TargetAssignmentResult {
-
-        /**
-         * The records that must be applied to the __streams_offsets topics to persist the new target assignment.
-         */
-        private final List<CoordinatorRecord> records;
-
-        /**
-         * The new target assignment for the group.
-         */
-        private final Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment;
-
-        TargetAssignmentResult(
-            List<CoordinatorRecord> records,
-            Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment
-        ) {
+    public record TargetAssignmentResult(
+        List<CoordinatorRecord> records,
+        Map<String, TasksTuple> targetAssignment
+    ) {
+        public TargetAssignmentResult {
             Objects.requireNonNull(records);
             Objects.requireNonNull(targetAssignment);
-            this.records = records;
-            this.targetAssignment = targetAssignment;
-        }
-
-        /**
-         * @return The records.
-         */
-        public List<CoordinatorRecord> records() {
-            return records;
-        }
-
-        /**
-         * @return The target assignment.
-         */
-        public Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> targetAssignment() {
-            return targetAssignment;
         }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -265,12 +265,15 @@ public class TargetAssignmentBuilder {
         // Compute the assignment.
         GroupAssignment newGroupAssignment;
         if (topology.isReady()) {
+            if (topology.subtopologies().isEmpty()) {
+                throw new IllegalStateException("Subtopologies must be present if topology is ready.");
+            }
             newGroupAssignment = assignor.assign(
                 new GroupSpecImpl(
                     Collections.unmodifiableMap(memberSpecs),
                     assignmentConfigs
                 ),
-                new TopologyMetadata(partitionMetadata, topology)
+                new TopologyMetadata(partitionMetadata, topology.subtopologies().get())
             );
         } else {
             newGroupAssignment = new GroupAssignment(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
@@ -20,23 +20,26 @@ import org.apache.kafka.coordinator.group.streams.assignor.TopologyDescriber;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.stream.Stream;
 
 /**
- * The topology metadata class is used by the {@link org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor} to obtain topic and
+ * The topology metadata class is used by the {@link org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor} to get topic and
  * partition metadata for the topology that the streams group using.
  *
  * @param topicMetadata The topic Ids mapped to their corresponding {@link TopicMetadata} object, which contains topic and partition
  *                      metadata.
+ * @param topology      The configured topology, containing subtopologies and internal topics.
  */
 public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, ConfiguredTopology topology) implements TopologyDescriber {
 
     public TopologyMetadata {
-        Objects.requireNonNull(topicMetadata);
+        topicMetadata = Objects.requireNonNull(Collections.unmodifiableMap(topicMetadata));
         Objects.requireNonNull(topology);
     }
 
@@ -50,30 +53,48 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
         return this.topicMetadata;
     }
 
+    /**
+     * Checks whether the given subtopology is associated with a changelog topic.
+     *
+     * @param subtopologyId String identifying the subtopology.
+     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured.
+     * @return true if the subtopology is associated with a changelog topic, false otherwise.
+     */
     @Override
     public boolean isStateful(String subtopologyId) {
         final ConfiguredSubtopology subtopology = getSubtopologyOrFail(subtopologyId);
         return !subtopology.stateChangelogTopics().isEmpty();
     }
 
+    /**
+     * The list of subtopologies in the topology.
+     *
+     * @throws IllegalStateException if the topology is not configured.
+     * @return a list of subtopology IDs.
+     */
     @Override
     public List<String> subtopologies() {
         return getSubtopologiesOrFail().keySet().stream().toList();
     }
 
     /**
-     * The number of partitions for the given subtopology ID.
+     * The maximal number of input partitions among all source topics for the given subtopology.
      *
-     * @param subtopologyId ID of the corresponding subtopology
-     * @return The number of partitions corresponding to the given subtopology ID, or -1 if the subtopology ID does not exist.
+     * @param subtopologyId String identifying the subtopology.
+     *
+     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured, or the subtopology
+     *                               contains no source topics.
+     * @return The maximal number of input partitions among all source topics for the given subtopology.
      */
     @Override
-    public int numTasks(String subtopologyId) {
+    public int maxNumInputPartitions(String subtopologyId) {
         final ConfiguredSubtopology subtopology = getSubtopologyOrFail(subtopologyId);
         return Stream.concat(
             subtopology.sourceTopics().stream(),
             subtopology.repartitionSourceTopics().keySet().stream()
-        ).map(topic -> this.topicMetadata.get(topic).numPartitions()).max(Integer::compareTo).orElse(-1);
+        ).map(topic -> this.topicMetadata.get(topic).numPartitions()).max(Integer::compareTo).orElseThrow(
+            () -> new IllegalStateException("Subtopology does not contain any source topics")
+        );
     }
 
     private ConfiguredSubtopology getSubtopologyOrFail(String subtopologyId) {
@@ -85,7 +106,7 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
     }
 
     private Map<String, ConfiguredSubtopology> getSubtopologiesOrFail() {
-        final Optional<Map<String, ConfiguredSubtopology>> subtopologies = topology.subtopologies();
+        final Optional<SortedMap<String, ConfiguredSubtopology>> subtopologies = topology.subtopologies();
         if (subtopologies.isEmpty()) {
             throw new IllegalStateException("Topology is not configured");
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.assignor.TopologyDescriber;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The topology metadata class is used by the {@link org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor} to obtain topic and
+ * partition metadata for the topology that the streams group using.
+ *
+ * @param topicMetadata The topic Ids mapped to their corresponding {@link TopicMetadata} object, which contains topic and partition
+ *                      metadata.
+ */
+public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, ConfiguredTopology topology) implements TopologyDescriber {
+
+    public TopologyMetadata {
+        Objects.requireNonNull(topicMetadata);
+        Objects.requireNonNull(topology);
+    }
+
+    /**
+     * Map of topic names to topic metadata.
+     *
+     * @return The map of topic Ids to topic metadata.
+     */
+    @Override
+    public Map<String, TopicMetadata> topicMetadata() {
+        return this.topicMetadata;
+    }
+
+    @Override
+    public boolean isStateful(String subtopologyId) {
+        final ConfiguredSubtopology subtopology = getSubtopologyOrFail(subtopologyId);
+        return !subtopology.stateChangelogTopics().isEmpty();
+    }
+
+    @Override
+    public List<String> subtopologies() {
+        return getSubtopologiesOrFail().keySet().stream().toList();
+    }
+
+    /**
+     * The number of partitions for the given subtopology ID.
+     *
+     * @param subtopologyId ID of the corresponding subtopology
+     * @return The number of partitions corresponding to the given subtopology ID, or -1 if the subtopology ID does not exist.
+     */
+    @Override
+    public int numTasks(String subtopologyId) {
+        final ConfiguredSubtopology subtopology = getSubtopologyOrFail(subtopologyId);
+        return Stream.concat(
+            subtopology.sourceTopics().stream(),
+            subtopology.repartitionSourceTopics().keySet().stream()
+        ).map(topic -> this.topicMetadata.get(topic).numPartitions()).max(Integer::compareTo).orElse(-1);
+    }
+
+    private ConfiguredSubtopology getSubtopologyOrFail(String subtopologyId) {
+        final Map<String, ConfiguredSubtopology> subtopologies = getSubtopologiesOrFail();
+        if (!subtopologies.containsKey(subtopologyId)) {
+            throw new IllegalStateException(String.format("Topology does not contain subtopology %s", subtopologyId));
+        }
+        return subtopologies.get(subtopologyId);
+    }
+
+    private Map<String, ConfiguredSubtopology> getSubtopologiesOrFail() {
+        final Optional<Map<String, ConfiguredSubtopology>> subtopologies = topology.subtopologies();
+        if (subtopologies.isEmpty()) {
+            throw new IllegalStateException("Topology is not configured");
+        }
+        return subtopologies.get();
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TopologyMetadata.java
@@ -18,13 +18,12 @@ package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.streams.assignor.TopologyDescriber;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.stream.Stream;
 
@@ -32,15 +31,15 @@ import java.util.stream.Stream;
  * The topology metadata class is used by the {@link org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor} to get topic and
  * partition metadata for the topology that the streams group using.
  *
- * @param topicMetadata The topic Ids mapped to their corresponding {@link TopicMetadata} object, which contains topic and partition
- *                      metadata.
- * @param topology      The configured topology, containing subtopologies and internal topics.
+ * @param topicMetadata  The topic Ids mapped to their corresponding {@link TopicMetadata} object, which contains topic and partition
+ *                       metadata.
+ * @param subtopologyMap The configured subtopologies
  */
-public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, ConfiguredTopology topology) implements TopologyDescriber {
+public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, SortedMap<String, ConfiguredSubtopology> subtopologyMap) implements TopologyDescriber {
 
     public TopologyMetadata {
         topicMetadata = Objects.requireNonNull(Collections.unmodifiableMap(topicMetadata));
-        Objects.requireNonNull(topology);
+        subtopologyMap = Objects.requireNonNull(Collections.unmodifiableSortedMap(subtopologyMap));
     }
 
     /**
@@ -57,7 +56,7 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
      * Checks whether the given subtopology is associated with a changelog topic.
      *
      * @param subtopologyId String identifying the subtopology.
-     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured.
+     * @throws NoSuchElementException if the subtopology ID does not exist.
      * @return true if the subtopology is associated with a changelog topic, false otherwise.
      */
     @Override
@@ -69,12 +68,11 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
     /**
      * The list of subtopologies in the topology.
      *
-     * @throws IllegalStateException if the topology is not configured.
      * @return a list of subtopology IDs.
      */
     @Override
     public List<String> subtopologies() {
-        return getSubtopologiesOrFail().keySet().stream().toList();
+        return subtopologyMap.keySet().stream().toList();
     }
 
     /**
@@ -82,8 +80,8 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
      *
      * @param subtopologyId String identifying the subtopology.
      *
-     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured, or the subtopology
-     *                               contains no source topics.
+     * @throws NoSuchElementException if the subtopology ID does not exist.
+     * @throws IllegalStateException if the subtopology contains no source topics.
      * @return The maximal number of input partitions among all source topics for the given subtopology.
      */
     @Override
@@ -98,18 +96,10 @@ public record TopologyMetadata(Map<String, TopicMetadata> topicMetadata, Configu
     }
 
     private ConfiguredSubtopology getSubtopologyOrFail(String subtopologyId) {
-        final Map<String, ConfiguredSubtopology> subtopologies = getSubtopologiesOrFail();
-        if (!subtopologies.containsKey(subtopologyId)) {
-            throw new IllegalStateException(String.format("Topology does not contain subtopology %s", subtopologyId));
+        if (!subtopologyMap.containsKey(subtopologyId)) {
+            throw new NoSuchElementException(String.format("Topology does not contain subtopology %s", subtopologyId));
         }
-        return subtopologies.get(subtopologyId);
+        return subtopologyMap.get(subtopologyId);
     }
 
-    private Map<String, ConfiguredSubtopology> getSubtopologiesOrFail() {
-        final Optional<SortedMap<String, ConfiguredSubtopology>> subtopologies = topology.subtopologies();
-        if (subtopologies.isEmpty()) {
-            throw new IllegalStateException("Topology is not configured");
-        }
-        return subtopologies.get();
-    }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignor.java
@@ -46,7 +46,7 @@ public class MockAssignor implements TaskAssignor {
         Map<String, String[]> subtopologyToActiveMember = new HashMap<>();
 
         for (String subtopology : topologyDescriber.subtopologies()) {
-            int numberOfPartitions = topologyDescriber.numTasks(subtopology);
+            int numberOfPartitions = topologyDescriber.maxNumInputPartitions(subtopology);
             subtopologyToActiveMember.put(subtopology, new String[numberOfPartitions]);
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -72,7 +72,7 @@ public class StickyTaskAssignor implements TaskAssignor {
         Set<TaskId> ret = new HashSet<>();
         for (String subtopology : topologyDescriber.subtopologies()) {
             if (isActive || topologyDescriber.isStateful(subtopology)) {
-                int numberOfPartitions = topologyDescriber.numTasks(subtopology);
+                int numberOfPartitions = topologyDescriber.maxNumInputPartitions(subtopology);
                 for (int i = 0; i < numberOfPartitions; i++) {
                     ret.add(new TaskId(subtopology, i));
                 }
@@ -85,7 +85,7 @@ public class StickyTaskAssignor implements TaskAssignor {
         localState = new LocalState();
         localState.allTasks = 0;
         for (String subtopology : topologyDescriber.subtopologies()) {
-            int numberOfPartitions = topologyDescriber.numTasks(subtopology);
+            int numberOfPartitions = topologyDescriber.maxNumInputPartitions(subtopology);
             localState.allTasks += numberOfPartitions;
         }
         localState.totalCapacity = groupSpec.members().size();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/TopologyDescriber.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/TopologyDescriber.java
@@ -20,30 +20,35 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * The subscribed topic describer is used by the {@link TaskAssignor} to obtain topic and task metadata of the groups topology.
+ * The topology describer is used by the {@link TaskAssignor} to get topic and task metadata of the group's topology.
  */
 public interface TopologyDescriber {
 
     /**
+     * Map of topic names to topic metadata.
+     *
+     * @throws IllegalStateException if the topology is not configured.
      * @return The list of subtopologies IDs.
      */
     List<String> subtopologies();
 
     /**
-     * The number of tasks for the given subtopology.
+     * The maximal number of input partitions among all source topics for the given subtopology.
      *
      * @param subtopologyId String identifying the subtopology.
      *
-     * @return The number of tasks corresponding to the given subtopology ID.
-     * @throws NoSuchElementException if subtopology does not exist in the topology.
+     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured, or the subtopology
+     *                               contains no source topics.
+     * @return The maximal number of input partitions among all source topics for the given subtopology.
      */
-    int numTasks(String subtopologyId) throws NoSuchElementException;
+    int maxNumInputPartitions(String subtopologyId) throws NoSuchElementException;
 
     /**
-     * Whether the given subtopology is stateful.
+     * Checks whether the given subtopology is associated with a changelog topic.
      *
      * @param subtopologyId String identifying the subtopology.
-     * @return true if the subtopology is stateful, false otherwise.
+     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured.
+     * @return true if the subtopology is associated with a changelog topic, false otherwise.
      */
     boolean isStateful(String subtopologyId);
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/TopologyDescriber.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/TopologyDescriber.java
@@ -27,7 +27,6 @@ public interface TopologyDescriber {
     /**
      * Map of topic names to topic metadata.
      *
-     * @throws IllegalStateException if the topology is not configured.
      * @return The list of subtopologies IDs.
      */
     List<String> subtopologies();
@@ -37,8 +36,8 @@ public interface TopologyDescriber {
      *
      * @param subtopologyId String identifying the subtopology.
      *
-     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured, or the subtopology
-     *                               contains no source topics.
+     * @throws NoSuchElementException if the subtopology ID does not exist.
+     * @throws IllegalStateException if the subtopology contains no source topics.
      * @return The maximal number of input partitions among all source topics for the given subtopology.
      */
     int maxNumInputPartitions(String subtopologyId) throws NoSuchElementException;
@@ -47,7 +46,7 @@ public interface TopologyDescriber {
      * Checks whether the given subtopology is associated with a changelog topic.
      *
      * @param subtopologyId String identifying the subtopology.
-     * @throws IllegalStateException if the subtopology ID does not exist, or the topology is not configured.
+     * @throws NoSuchElementException if the subtopology ID does not exist.
      * @return true if the subtopology is associated with a changelog topic, false otherwise.
      */
     boolean isStateful(String subtopologyId);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopology.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopology.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
 
 /**
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
  *                                    reported back to the client.
  */
 public record ConfiguredTopology(int topologyEpoch,
-                                 Optional<Map<String, ConfiguredSubtopology>> subtopologies,
+                                 Optional<SortedMap<String, ConfiguredSubtopology>> subtopologies,
                                  Map<String, CreatableTopic> internalTopicsToBeCreated,
                                  Optional<TopicConfigurationException> topicConfigurationException) {
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
@@ -32,11 +33,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -55,6 +59,29 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TargetAssignmentBuilderTest {
+
+    @Test
+    public void testBuildEmptyAssignmentWhenTopologyNotReady() {
+        String groupId = "test-group";
+        int groupEpoch = 1;
+        TaskAssignor assignor = mock(TaskAssignor.class);
+        ConfiguredTopology topology = mock(ConfiguredTopology.class);
+        Map<String, String> assignmentConfigs = new HashMap<>();
+
+        when(topology.isReady()).thenReturn(false);
+
+        TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor, assignmentConfigs)
+            .withTopology(topology);
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+
+        List<CoordinatorRecord> expectedRecords = Collections.singletonList(
+            StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, groupEpoch)
+        );
+
+        assertEquals(expectedRecords, result.records());
+        assertEquals(Collections.emptyMap(), result.targetAssignment());
+    }
 
     @ParameterizedTest
     @EnumSource(TaskRole.class)
@@ -247,7 +274,7 @@ public class TargetAssignmentBuilderTest {
             mkTasks(barSubtopologyId, 4, 5, 6)
         ));
 
-        context.updateMemberSubscription("member-3");
+        context.updateMemberMetadata("member-3");
 
         context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
             mkTasks(fooSubtopologyId, 1, 2),
@@ -331,7 +358,7 @@ public class TargetAssignmentBuilderTest {
             mkTasks(barSubtopologyId, 5, 6)
         ));
 
-        context.updateMemberSubscription(
+        context.updateMemberMetadata(
             "member-3",
             Optional.of("instance-id-3"),
             Optional.of("rack-0")
@@ -500,7 +527,7 @@ public class TargetAssignmentBuilderTest {
             mkTasks(barSubtopologyId, 5, 6)
         ));
 
-        context.removeMemberSubscription("member-3");
+        context.removeMember("member-3");
 
         context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
             mkTasks(fooSubtopologyId, 1, 2, 3),
@@ -573,10 +600,10 @@ public class TargetAssignmentBuilderTest {
         ));
 
         // Static member 3 leaves
-        context.removeMemberSubscription("member-3");
+        context.removeMember("member-3");
 
         // Another static member joins with the same instance id as the departed one
-        context.updateMemberSubscription("member-3-a", Optional.of("instance-member-3"),
+        context.updateMemberMetadata("member-3-a", Optional.of("instance-member-3"),
             Optional.empty());
 
         context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
@@ -633,7 +660,7 @@ public class TargetAssignmentBuilderTest {
         private final String groupId;
         private final int groupEpoch;
         private final TaskAssignor assignor = mock(TaskAssignor.class);
-        private final Map<String, ConfiguredSubtopology> subtopologies = new HashMap<>();
+        private final SortedMap<String, ConfiguredSubtopology> subtopologies = new TreeMap<>();
         private final ConfiguredTopology topology = new ConfiguredTopology(0, Optional.of(subtopologies), new HashMap<>(),
             Optional.empty());
         private final Map<String, StreamsGroupMember> members = new HashMap<>();
@@ -699,17 +726,17 @@ public class TargetAssignmentBuilderTest {
             return subtopologyId;
         }
 
-        public void updateMemberSubscription(
+        public void updateMemberMetadata(
             String memberId
         ) {
-            updateMemberSubscription(
+            updateMemberMetadata(
                 memberId,
                 Optional.empty(),
                 Optional.empty()
             );
         }
 
-        public void updateMemberSubscription(
+        public void updateMemberMetadata(
             String memberId,
             Optional<String> instanceId,
             Optional<String> rackId
@@ -732,7 +759,7 @@ public class TargetAssignmentBuilderTest {
                 .build());
         }
 
-        public void removeMemberSubscription(
+        public void removeMember(
             String memberId
         ) {
             this.updatedMembers.put(memberId, null);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -809,8 +809,8 @@ public class TargetAssignmentBuilderTest {
                 }
             });
 
-            // Prepare the expected subscription topic metadata.
-            TopologyMetadata topologyMetadata = new TopologyMetadata(subscriptionMetadata, topology);
+            // Prepare the expected topology metadata.
+            TopologyMetadata topologyMetadata = new TopologyMetadata(subscriptionMetadata, subtopologies);
 
             // Prepare the expected assignment spec.
             GroupSpecImpl groupSpec = new GroupSpecImpl(memberSpecs, new HashMap<>());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -1,0 +1,825 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.MetadataImageBuilder;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
+import org.apache.kafka.coordinator.group.streams.assignor.AssignmentMemberSpec;
+import org.apache.kafka.coordinator.group.streams.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.streams.assignor.GroupSpecImpl;
+import org.apache.kafka.coordinator.group.streams.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedRecordsEquals;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorRecordHelpersTest.mkMapOfPartitionRacks;
+import static org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord;
+import static org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord;
+import static org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.createAssignmentMemberSpec;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TargetAssignmentBuilderTest {
+
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testCreateAssignmentMemberSpec(TaskRole taskRole) {
+        String fooSubtopologyId = Uuid.randomUuid().toString();
+        String barSubtopologyId = Uuid.randomUuid().toString();
+
+        final Map<String, String> clientTags = mkMap(mkEntry("tag1", "value1"), mkEntry("tag2", "value2"));
+        StreamsGroupMember member = new StreamsGroupMember.Builder("member-id")
+            .setRackId("rackId")
+            .setInstanceId("instanceId")
+            .setProcessId("processId")
+            .setClientTags(clientTags)
+            .build();
+
+        TasksTuple assignment = mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        );
+
+        AssignmentMemberSpec assignmentMemberSpec = createAssignmentMemberSpec(
+            member,
+            assignment
+        );
+
+        assertEquals(new AssignmentMemberSpec(
+            Optional.of("instanceId"),
+            Optional.of("rackId"),
+            assignment.activeTasks(),
+            assignment.standbyTasks(),
+            assignment.warmupTasks(),
+            "processId",
+            clientTags,
+            Map.of(),
+            Map.of()
+        ), assignmentMemberSpec);
+    }
+
+    @Test
+    public void testEmpty() {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+        assertEquals(List.of(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        )), result.records());
+        assertEquals(Map.of(), result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testAssignmentHasNotChanged(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(List.of(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        )), result.records());
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testAssignmentSwapped(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(3, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 4, 5, 6),
+                mkTasks(barSubtopologyId, 4, 5, 6)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 1, 2, 3),
+                mkTasks(barSubtopologyId, 1, 2, 3)
+            ))
+        )), result.records().subList(0, 2));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(2));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testNewMember(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        context.updateMemberSubscription("member-3");
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(4, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 1, 2),
+                mkTasks(barSubtopologyId, 1, 2)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 3, 4),
+                mkTasks(barSubtopologyId, 3, 4)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-3", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 5, 6),
+                mkTasks(barSubtopologyId, 5, 6)
+            ))
+        )), result.records().subList(0, 3));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(3));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+        expectedAssignment.put("member-3", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testUpdateMember(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", mkTasksTuple(taskRole,
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.updateMemberSubscription(
+            "member-3",
+            Optional.of("instance-id-3"),
+            Optional.of("rack-0")
+        );
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(4, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 1, 2),
+                mkTasks(barSubtopologyId, 1, 2)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 3, 4),
+                mkTasks(barSubtopologyId, 3, 4)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-3", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 5, 6),
+                mkTasks(barSubtopologyId, 5, 6)
+            ))
+        )), result.records().subList(0, 3));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(3));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+        expectedAssignment.put("member-3", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testPartialAssignmentUpdate(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, mkMapOfPartitionRacks(6));
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, mkMapOfPartitionRacks(6));
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4, 5),
+            mkTasks(barSubtopologyId, 3, 4, 5)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 6),
+            mkTasks(barSubtopologyId, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(3, result.records().size());
+
+        // Member 1 has no record because its assignment did not change.
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 3, 4, 5),
+                mkTasks(barSubtopologyId, 3, 4, 5)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-3", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 6),
+                mkTasks(barSubtopologyId, 6)
+            ))
+        )), result.records().subList(0, 2));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(2));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 3, 4, 5),
+            mkTasks(barSubtopologyId, 3, 4, 5)
+        ));
+        expectedAssignment.put("member-3", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 6),
+            mkTasks(barSubtopologyId, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testDeleteMember(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.removeMemberSubscription("member-3");
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(3, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 1, 2, 3),
+                mkTasks(barSubtopologyId, 1, 2, 3)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 4, 5, 6),
+                mkTasks(barSubtopologyId, 4, 5, 6)
+            ))
+        )), result.records().subList(0, 2));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(2));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2, 3),
+            mkTasks(barSubtopologyId, 1, 2, 3)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 4, 5, 6),
+            mkTasks(barSubtopologyId, 4, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testReplaceStaticMember(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6, Map.of());
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6, Map.of());
+
+        context.addGroupMember("member-1", "instance-member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", "instance-member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", "instance-member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        // Static member 3 leaves
+        context.removeMemberSubscription("member-3");
+
+        // Another static member joins with the same instance id as the departed one
+        context.updateMemberSubscription("member-3-a", Optional.of("instance-member-3"),
+            Optional.empty());
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3-a", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(2, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-3-a", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 5, 6),
+                mkTasks(barSubtopologyId, 5, 6)
+            ))
+        )), result.records().subList(0, 1));
+
+        assertEquals(newStreamsGroupTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(1));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        expectedAssignment.put("member-3-a", mkTasksTuple(taskRole, 
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    public static class TargetAssignmentBuilderTestContext {
+
+        private final String groupId;
+        private final int groupEpoch;
+        private final TaskAssignor assignor = mock(TaskAssignor.class);
+        private final Map<String, ConfiguredSubtopology> subtopologies = new HashMap<>();
+        private final ConfiguredTopology topology = new ConfiguredTopology(0, Optional.of(subtopologies), new HashMap<>(),
+            Optional.empty());
+        private final Map<String, StreamsGroupMember> members = new HashMap<>();
+        private final Map<String, org.apache.kafka.coordinator.group.streams.TopicMetadata> subscriptionMetadata = new HashMap<>();
+        private final Map<String, StreamsGroupMember> updatedMembers = new HashMap<>();
+        private final Map<String, TasksTuple> targetAssignment = new HashMap<>();
+        private final Map<String, MemberAssignment> memberAssignments = new HashMap<>();
+        private final Map<String, String> staticMembers = new HashMap<>();
+        private MetadataImageBuilder topicsImageBuilder = new MetadataImageBuilder();
+
+        public TargetAssignmentBuilderTestContext(
+            String groupId,
+            int groupEpoch
+        ) {
+            this.groupId = groupId;
+            this.groupEpoch = groupEpoch;
+        }
+
+        public void addGroupMember(
+            String memberId,
+            TasksTuple targetTasks
+        ) {
+            addGroupMember(memberId, null, targetTasks);
+        }
+
+        private void addGroupMember(
+            String memberId,
+            String instanceId,
+            TasksTuple targetTasks
+        ) {
+            StreamsGroupMember.Builder memberBuilder = new StreamsGroupMember.Builder(memberId);
+            memberBuilder.setProcessId("processId");
+            memberBuilder.setClientTags(Map.of());
+            memberBuilder.setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090));
+
+            if (instanceId != null) {
+                memberBuilder.setInstanceId(instanceId);
+                staticMembers.put(instanceId, memberId);
+            } else {
+                memberBuilder.setInstanceId(null);
+            }
+            memberBuilder.setRackId(null);
+            members.put(memberId, memberBuilder.build());
+            targetAssignment.put(memberId, targetTasks);
+        }
+
+        public String addSubtopologyWithSingleSourceTopic(
+            String topicName,
+            int numTasks,
+            Map<Integer, Set<String>> partitionRacks
+        ) {
+            String subtopologyId = Uuid.randomUuid().toString();
+            Uuid topicId = Uuid.randomUuid();
+            subscriptionMetadata.put(topicName, new org.apache.kafka.coordinator.group.streams.TopicMetadata(
+                topicId,
+                topicName,
+                numTasks,
+                partitionRacks
+            ));
+            topicsImageBuilder = topicsImageBuilder.addTopic(topicId, topicName, numTasks);
+            subtopologies.put(subtopologyId, new ConfiguredSubtopology(Set.of(topicId.toString()), Map.of(), Set.of(), Map.of()));
+
+            return subtopologyId;
+        }
+
+        public void updateMemberSubscription(
+            String memberId
+        ) {
+            updateMemberSubscription(
+                memberId,
+                Optional.empty(),
+                Optional.empty()
+            );
+        }
+
+        public void updateMemberSubscription(
+            String memberId,
+            Optional<String> instanceId,
+            Optional<String> rackId
+        ) {
+            StreamsGroupMember existingMember = members.get(memberId);
+            StreamsGroupMember.Builder builder;
+            if (existingMember != null) {
+                builder = new StreamsGroupMember.Builder(existingMember);
+            } else {
+                builder = new StreamsGroupMember.Builder(memberId);
+                builder.setProcessId("processId");
+                builder.setRackId(null);
+                builder.setInstanceId(null);
+                builder.setClientTags(Map.of());
+                builder.setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host").setPort(9090));
+            }
+            updatedMembers.put(memberId, builder
+                .maybeUpdateInstanceId(instanceId)
+                .maybeUpdateRackId(rackId)
+                .build());
+        }
+
+        public void removeMemberSubscription(
+            String memberId
+        ) {
+            this.updatedMembers.put(memberId, null);
+        }
+
+        public void prepareMemberAssignment(
+            String memberId,
+            TasksTuple assignment
+        ) {
+            memberAssignments.put(memberId, new MemberAssignment(assignment.activeTasks(), assignment.standbyTasks(), assignment.warmupTasks()));
+        }
+
+        public org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult build() {
+            // Prepare expected member specs.
+            Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
+
+            // All the existing members are prepared.
+            members.forEach((memberId, member) ->
+                memberSpecs.put(memberId, createAssignmentMemberSpec(
+                        member,
+                        targetAssignment.getOrDefault(memberId, TasksTuple.EMPTY)
+                    )
+                ));
+
+            // All the updated are added and all the deleted
+            // members are removed.
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull == null) {
+                    memberSpecs.remove(memberId);
+                } else {
+                    TasksTuple assignment = targetAssignment.getOrDefault(memberId,
+                        TasksTuple.EMPTY);
+
+                    // A new static member joins and needs to replace an existing departed one.
+                    if (updatedMemberOrNull.instanceId().isPresent()) {
+                        String previousMemberId = staticMembers.get(updatedMemberOrNull.instanceId().get());
+                        if (previousMemberId != null && !previousMemberId.equals(memberId)) {
+                            assignment = targetAssignment.getOrDefault(previousMemberId,
+                                TasksTuple.EMPTY);
+                        }
+                    }
+
+                    memberSpecs.put(memberId, createAssignmentMemberSpec(
+                        updatedMemberOrNull,
+                        assignment
+                    ));
+                }
+            });
+
+            // Prepare the expected subscription topic metadata.
+            TopologyMetadata topologyMetadata = new TopologyMetadata(subscriptionMetadata, topology);
+
+            // Prepare the expected assignment spec.
+            GroupSpecImpl groupSpec = new GroupSpecImpl(memberSpecs, new HashMap<>());
+
+            // We use `any` here to always return an assignment but use `verify` later on
+            // to ensure that the input was correct.
+            when(assignor.assign(any(), any()))
+                .thenReturn(new GroupAssignment(memberAssignments));
+
+            // Create and populate the assignment builder.
+            org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder builder = new org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder(
+                groupId, groupEpoch, assignor, Map.of())
+                .withMembers(members)
+                .withTopology(topology)
+                .withStaticMembers(staticMembers)
+                .withPartitionMetadata(subscriptionMetadata)
+                .withTargetAssignment(targetAssignment);
+
+            // Add the updated members or delete the deleted members.
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull != null) {
+                    builder.addOrUpdateMember(memberId, updatedMemberOrNull);
+                } else {
+                    builder.removeMember(memberId);
+                }
+            });
+
+            // Execute the builder.
+            org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+
+            // Verify that the assignor was called once with the expected
+            // assignment spec.
+            verify(assignor, times(1))
+                .assign(groupSpec, topologyMetadata);
+
+            return result;
+        }
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredInternalTopic;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+class TopologyMetadataTest {
+
+    private Map<String, TopicMetadata> topicMetadata;
+    private ConfiguredTopology configuredTopology;
+    private TopologyMetadata topologyMetadata;
+
+    @BeforeEach
+    void setUp() {
+        topicMetadata = new HashMap<>();
+        configuredTopology = mock(ConfiguredTopology.class);
+        topologyMetadata = new TopologyMetadata(topicMetadata, configuredTopology);
+    }
+
+    @Test
+    void testTopicMetadata() {
+        assertEquals(topicMetadata, topologyMetadata.topicMetadata());
+    }
+
+    @Test
+    void testTopology() {
+        assertEquals(configuredTopology, topologyMetadata.topology());
+    }
+
+    @Test
+    void testIsStateful() {
+        ConfiguredInternalTopic internalTopic = mock(ConfiguredInternalTopic.class);
+        ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
+        ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
+        when(configuredTopology.subtopologies()).thenReturn(
+            Optional.of(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2)));
+        when(subtopology1.stateChangelogTopics()).thenReturn(Map.of("state_changelog_topic", internalTopic));
+        when(subtopology2.stateChangelogTopics()).thenReturn(Map.of());
+
+        assertTrue(topologyMetadata.isStateful("subtopology1"));
+        assertFalse(topologyMetadata.isStateful("subtopology2"));
+    }
+
+    @Test
+    void testNumTasks() {
+        ConfiguredInternalTopic internalTopic = mock(ConfiguredInternalTopic.class);
+        ConfiguredSubtopology subtopology = mock(ConfiguredSubtopology.class);
+        when(configuredTopology.subtopologies()).thenReturn(Optional.of(Map.of("subtopology1", subtopology)));
+        when(subtopology.sourceTopics()).thenReturn(Set.of("source_topic"));
+        when(subtopology.repartitionSourceTopics()).thenReturn(Map.of("repartition_source_topic", internalTopic));
+
+        TopicMetadata topicMeta1 = mock(TopicMetadata.class);
+        TopicMetadata topicMeta2 = mock(TopicMetadata.class);
+        topicMetadata.put("source_topic", topicMeta1);
+        topicMetadata.put("repartition_source_topic", topicMeta2);
+        when(topicMeta1.numPartitions()).thenReturn(3);
+        when(topicMeta2.numPartitions()).thenReturn(4);
+
+        assertEquals(4, topologyMetadata.numTasks("subtopology1"));
+    }
+
+    @Test
+    void testSubtopologies() {
+        ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
+        ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
+        when(configuredTopology.subtopologies()).thenReturn(
+            Optional.of(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2)));
+
+        List<String> expectedSubtopologies = List.of("subtopology1", "subtopology2");
+        assertEquals(expectedSubtopologies, topologyMetadata.subtopologies());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredInternalTopic;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,9 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,14 +41,14 @@ import static org.mockito.Mockito.when;
 class TopologyMetadataTest {
 
     private Map<String, TopicMetadata> topicMetadata;
-    private ConfiguredTopology configuredTopology;
+    private SortedMap<String, ConfiguredSubtopology> subtopologyMap;
     private TopologyMetadata topologyMetadata;
 
     @BeforeEach
     void setUp() {
         topicMetadata = new HashMap<>();
-        configuredTopology = mock(ConfiguredTopology.class);
-        topologyMetadata = new TopologyMetadata(topicMetadata, configuredTopology);
+        subtopologyMap = new TreeMap<>();
+        topologyMetadata = new TopologyMetadata(topicMetadata, subtopologyMap);
     }
 
     @Test
@@ -58,7 +58,7 @@ class TopologyMetadataTest {
 
     @Test
     void testTopology() {
-        assertEquals(configuredTopology, topologyMetadata.topology());
+        assertEquals(subtopologyMap, topologyMetadata.subtopologyMap());
     }
 
     @Test
@@ -66,8 +66,8 @@ class TopologyMetadataTest {
         ConfiguredInternalTopic internalTopic = mock(ConfiguredInternalTopic.class);
         ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
         ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
-        when(configuredTopology.subtopologies()).thenReturn(
-            Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2))));
+        subtopologyMap.put("subtopology1", subtopology1);
+        subtopologyMap.put("subtopology2", subtopology2);
         when(subtopology1.stateChangelogTopics()).thenReturn(Map.of("state_changelog_topic", internalTopic));
         when(subtopology2.stateChangelogTopics()).thenReturn(Map.of());
 
@@ -79,7 +79,7 @@ class TopologyMetadataTest {
     void testMaxNumInputPartitions() {
         ConfiguredInternalTopic internalTopic = mock(ConfiguredInternalTopic.class);
         ConfiguredSubtopology subtopology = mock(ConfiguredSubtopology.class);
-        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology))));
+        subtopologyMap.put("subtopology1", subtopology);
         when(subtopology.sourceTopics()).thenReturn(Set.of("source_topic"));
         when(subtopology.repartitionSourceTopics()).thenReturn(Map.of("repartition_source_topic", internalTopic));
 
@@ -97,8 +97,8 @@ class TopologyMetadataTest {
     void testSubtopologies() {
         ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
         ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
-        when(configuredTopology.subtopologies()).thenReturn(
-            Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2))));
+        subtopologyMap.put("subtopology1", subtopology1);
+        subtopologyMap.put("subtopology2", subtopology2);
 
         List<String> expectedSubtopologies = List.of("subtopology1", "subtopology2");
         assertEquals(expectedSubtopologies, topologyMetadata.subtopologies());
@@ -106,34 +106,20 @@ class TopologyMetadataTest {
 
     @Test
     void testIsStatefulThrowsExceptionWhenSubtopologyIdDoesNotExist() {
-        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>()));
-        assertThrows(IllegalStateException.class, () -> topologyMetadata.isStateful("non_existent_subtopology"));
-    }
-
-    @Test
-    void testIsStatefulThrowsExceptionWhenTopologyNotConfigured() {
-        when(configuredTopology.subtopologies()).thenReturn(Optional.empty());
-        assertThrows(IllegalStateException.class, () -> topologyMetadata.isStateful("any_subtopology"));
+        assertThrows(NoSuchElementException.class, () -> topologyMetadata.isStateful("non_existent_subtopology"));
     }
 
     @Test
     void testMaxNumInputPartitionsThrowsExceptionWhenSubtopologyIdDoesNotExist() {
-        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>()));
-        assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("non_existent_subtopology"));
-    }
-
-    @Test
-    void testNumTasksThrowsExceptionWhenTopologyNotConfigured() {
-        when(configuredTopology.subtopologies()).thenReturn(Optional.empty());
-        assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("any_subtopology"));
+        assertThrows(NoSuchElementException.class, () -> topologyMetadata.maxNumInputPartitions("non_existent_subtopology"));
     }
 
     @Test
     void testMaxNumInputPartitionsThrowsExceptionWhenSubtopologyContainsNoSourceTopics() {
         ConfiguredSubtopology subtopology = mock(ConfiguredSubtopology.class);
-        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology))));
         when(subtopology.sourceTopics()).thenReturn(Set.of());
         when(subtopology.repartitionSourceTopics()).thenReturn(Map.of());
+        subtopologyMap.put("subtopology1", subtopology);
 
         assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("subtopology1"));
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TopologyMetadataTest.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,7 +67,7 @@ class TopologyMetadataTest {
         ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
         ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
         when(configuredTopology.subtopologies()).thenReturn(
-            Optional.of(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2)));
+            Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2))));
         when(subtopology1.stateChangelogTopics()).thenReturn(Map.of("state_changelog_topic", internalTopic));
         when(subtopology2.stateChangelogTopics()).thenReturn(Map.of());
 
@@ -74,10 +76,10 @@ class TopologyMetadataTest {
     }
 
     @Test
-    void testNumTasks() {
+    void testMaxNumInputPartitions() {
         ConfiguredInternalTopic internalTopic = mock(ConfiguredInternalTopic.class);
         ConfiguredSubtopology subtopology = mock(ConfiguredSubtopology.class);
-        when(configuredTopology.subtopologies()).thenReturn(Optional.of(Map.of("subtopology1", subtopology)));
+        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology))));
         when(subtopology.sourceTopics()).thenReturn(Set.of("source_topic"));
         when(subtopology.repartitionSourceTopics()).thenReturn(Map.of("repartition_source_topic", internalTopic));
 
@@ -88,7 +90,7 @@ class TopologyMetadataTest {
         when(topicMeta1.numPartitions()).thenReturn(3);
         when(topicMeta2.numPartitions()).thenReturn(4);
 
-        assertEquals(4, topologyMetadata.numTasks("subtopology1"));
+        assertEquals(4, topologyMetadata.maxNumInputPartitions("subtopology1"));
     }
 
     @Test
@@ -96,9 +98,43 @@ class TopologyMetadataTest {
         ConfiguredSubtopology subtopology1 = mock(ConfiguredSubtopology.class);
         ConfiguredSubtopology subtopology2 = mock(ConfiguredSubtopology.class);
         when(configuredTopology.subtopologies()).thenReturn(
-            Optional.of(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2)));
+            Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology1, "subtopology2", subtopology2))));
 
         List<String> expectedSubtopologies = List.of("subtopology1", "subtopology2");
         assertEquals(expectedSubtopologies, topologyMetadata.subtopologies());
+    }
+
+    @Test
+    void testIsStatefulThrowsExceptionWhenSubtopologyIdDoesNotExist() {
+        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>()));
+        assertThrows(IllegalStateException.class, () -> topologyMetadata.isStateful("non_existent_subtopology"));
+    }
+
+    @Test
+    void testIsStatefulThrowsExceptionWhenTopologyNotConfigured() {
+        when(configuredTopology.subtopologies()).thenReturn(Optional.empty());
+        assertThrows(IllegalStateException.class, () -> topologyMetadata.isStateful("any_subtopology"));
+    }
+
+    @Test
+    void testMaxNumInputPartitionsThrowsExceptionWhenSubtopologyIdDoesNotExist() {
+        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>()));
+        assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("non_existent_subtopology"));
+    }
+
+    @Test
+    void testNumTasksThrowsExceptionWhenTopologyNotConfigured() {
+        when(configuredTopology.subtopologies()).thenReturn(Optional.empty());
+        assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("any_subtopology"));
+    }
+
+    @Test
+    void testMaxNumInputPartitionsThrowsExceptionWhenSubtopologyContainsNoSourceTopics() {
+        ConfiguredSubtopology subtopology = mock(ConfiguredSubtopology.class);
+        when(configuredTopology.subtopologies()).thenReturn(Optional.of(new TreeMap<>(Map.of("subtopology1", subtopology))));
+        when(subtopology.sourceTopics()).thenReturn(Set.of());
+        when(subtopology.repartitionSourceTopics()).thenReturn(Map.of());
+
+        assertThrows(IllegalStateException.class, () -> topologyMetadata.maxNumInputPartitions("subtopology1"));
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignorTest.java
@@ -253,7 +253,7 @@ public class MockAssignorTest {
         }
 
         @Override
-        public int numTasks(String subtopologyId) {
+        public int maxNumInputPartitions(String subtopologyId) {
             return numPartitions;
         }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1094,7 +1094,7 @@ public class StickyTaskAssignorTest {
         }
 
         @Override
-        public int numTasks(String subtopologyId) throws NoSuchElementException {
+        public int maxNumInputPartitions(String subtopologyId) throws NoSuchElementException {
             return numTasks;
         }
 
@@ -1112,7 +1112,7 @@ public class StickyTaskAssignorTest {
         }
 
         @Override
-        public int numTasks(String subtopologyId) throws NoSuchElementException {
+        public int maxNumInputPartitions(String subtopologyId) throws NoSuchElementException {
             if (subtopologyId.equals("test-subtopology1"))
                 return 6;
             return 1;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopologyTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ConfiguredTopologyTest.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,7 +55,7 @@ public class ConfiguredTopologyTest {
         assertThrows(NullPointerException.class,
             () -> new ConfiguredTopology(
                 0,
-                Optional.of(Map.of()),
+                Optional.of(new TreeMap<>()),
                 null,
                 Optional.empty()
             )
@@ -77,7 +79,7 @@ public class ConfiguredTopologyTest {
         assertThrows(IllegalArgumentException.class,
             () -> new ConfiguredTopology(
                 -1,
-                Optional.of(Map.of()),
+                Optional.of(new TreeMap<>()),
                 Collections.emptyMap(),
                 Optional.empty()
             )
@@ -100,7 +102,7 @@ public class ConfiguredTopologyTest {
     @Test
     public void testIsReady() {
         ConfiguredTopology readyTopology = new ConfiguredTopology(
-            1, Optional.of(Map.of()), new HashMap<>(), Optional.empty());
+            1, Optional.of(new TreeMap<>()), new HashMap<>(), Optional.empty());
         assertTrue(readyTopology.isReady());
 
         ConfiguredTopology notReadyTopology = new ConfiguredTopology(
@@ -114,7 +116,7 @@ public class ConfiguredTopologyTest {
         ConfiguredSubtopology subtopologyMock = mock(ConfiguredSubtopology.class);
         StreamsGroupDescribeResponseData.Subtopology subtopologyResponse = new StreamsGroupDescribeResponseData.Subtopology();
         when(subtopologyMock.asStreamsGroupDescribeSubtopology(Mockito.anyString())).thenReturn(subtopologyResponse);
-        Map<String, ConfiguredSubtopology> subtopologies = new HashMap<>();
+        SortedMap<String, ConfiguredSubtopology> subtopologies = new TreeMap<>();
         subtopologies.put("subtopology1", subtopologyMock);
         Map<String, CreatableTopic> internalTopicsToBeCreated = new HashMap<>();
         Optional<TopicConfigurationException> topicConfigurationException = Optional.empty();


### PR DESCRIPTION
A class to build a new target assignment based on the provided parameters. As a result, it yields the records that must be persisted to the log and the new member assignments as a map.

Compared to the feature branch, I extended the unit tests (testing also standby and warm-up task logic) and adopted simplifications due to the TasksTuple class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
