### PR TITLE
KAFKA-18616; Refactor DumpLogSegments's MessageParsers

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -655,7 +655,7 @@ class DumpLogSegmentsTest {
 
     // The key is mandatory.
     assertEquals(
-      "Failed to decode message at offset 0 using offset topic decoder (message had a missing key)",
+      "Failed to decode message at offset 0 using the specified decoder (message had a missing key)",
       assertThrows(
         classOf[RuntimeException],
         () => parser.parse(TestUtils.singletonRecords(key = null, value = null).records.iterator.next)
@@ -813,7 +813,7 @@ class DumpLogSegmentsTest {
 
     // The key is mandatory.
     assertEquals(
-      "Failed to decode message at offset 0 using offset transaction-log decoder (message had a missing key)",
+      "Failed to decode message at offset 0 using the specified decoder (message had a missing key)",
       assertThrows(
         classOf[RuntimeException],
         () => parser.parse(TestUtils.singletonRecords(key = null, value = null).records.iterator.next)
@@ -1044,7 +1044,7 @@ class DumpLogSegmentsTest {
 
     // The key is mandatory.
     assertEquals(
-      "Failed to decode message at offset 0 using share group state topic decoder (message had a missing key)",
+      "Failed to decode message at offset 0 using the specified decoder (message had a missing key)",
       assertThrows(
         classOf[RuntimeException],
         () => parser.parse(TestUtils.singletonRecords(key = null, value = null).records.iterator.next)


### PR DESCRIPTION
All the work that we have done to automate and to simplify the coordinator records allows us to simplify the related MessageParsers in DumpLogSegments. They can all share the same based implementation. This is nice because it ensures that we handle all those records similarly. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
