### PR TITLE
KAFKA-18633: Remove errorUnavailableEndpoints from handleTopicMetadataRequest

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -805,11 +805,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     allowAutoTopicCreation: Boolean,
     topics: Set[String],
     listenerName: ListenerName,
-    errorUnavailableEndpoints: Boolean,
     errorUnavailableListeners: Boolean
   ): Seq[MetadataResponseTopic] = {
-    val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
-      errorUnavailableEndpoints, errorUnavailableListeners)
+    val topicResponses = metadataCache.getTopicMetadata(topics, listenerName, errorUnavailableListeners)
 
     if (topics.isEmpty || topicResponses.size == topics.size || fetchAllTopics) {
       topicResponses
@@ -899,7 +897,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // do not disclose the existence of topics unauthorized for Describe, so we've not even checked if they exist or not
     val unauthorizedForDescribeTopicMetadata =
       // In case of all topics, don't include topics unauthorized for Describe
-      if ((requestVersion == 0 && (metadataRequest.topics == null || metadataRequest.topics.isEmpty)) || metadataRequest.isAllTopics)
+      if (metadataRequest.isAllTopics)
         Set.empty[MetadataResponseTopic]
       else if (useTopicId) {
         // Topic IDs are not considered sensitive information, so returning TOPIC_AUTHORIZATION_FAILED is OK
@@ -911,16 +909,13 @@ class KafkaApis(val requestChannel: RequestChannel,
           metadataResponseTopic(Errors.TOPIC_AUTHORIZATION_FAILED, topic, Uuid.ZERO_UUID, isInternal = false, util.Collections.emptyList()))
       }
 
-    // In version 0, we returned an error when brokers with replicas were unavailable,
-    // while in higher versions we simply don't include the broker in the returned broker list
-    val errorUnavailableEndpoints = requestVersion == 0
     // In versions 5 and below, we returned LEADER_NOT_AVAILABLE if a matching listener was not found on the leader.
     // From version 6 onwards, we return LISTENER_NOT_FOUND to enable diagnosis of configuration errors.
     val errorUnavailableListeners = requestVersion >= 6
 
     val allowAutoCreation = config.autoCreateTopicsEnable && metadataRequest.allowAutoTopicCreation && !metadataRequest.isAllTopics
     val topicMetadata = getTopicMetadata(request, metadataRequest.isAllTopics, allowAutoCreation, authorizedTopics,
-      request.context.listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
+      request.context.listenerName, errorUnavailableListeners)
 
     var clusterAuthorizedOperations = Int.MinValue // Default value in the schema
     if (requestVersion >= 8) {

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -36,8 +36,6 @@ trait MetadataCache extends ConfigRepository {
    *
    * @param topics                      The set of topics.
    * @param listenerName                The listener name.
-   * @param errorUnavailableEndpoints   If true, we return an error on unavailable brokers. This is used to support
-   *                                    MetadataResponse version 0.
    * @param errorUnavailableListeners   If true, return LEADER_NOT_AVAILABLE if the listener is not found on the leader.
    *                                    This is used for MetadataResponse versions 0-5.
    * @return                            A collection of topic metadata.
@@ -45,7 +43,6 @@ trait MetadataCache extends ConfigRepository {
   def getTopicMetadata(
     topics: collection.Set[String],
     listenerName: ListenerName,
-    errorUnavailableEndpoints: Boolean = false,
     errorUnavailableListeners: Boolean = false): collection.Seq[MetadataResponseData.MetadataResponseTopic]
 
   def getAllTopics(): collection.Set[String]

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -60,42 +60,25 @@ class KRaftMetadataCache(
 
   // This method is the main hotspot when it comes to the performance of metadata requests,
   // we should be careful about adding additional logic here.
-  // filterUnavailableEndpoints exists to support v0 MetadataResponses
   private def maybeFilterAliveReplicas(image: MetadataImage,
                                        brokers: Array[Int],
-                                       listenerName: ListenerName,
-                                       filterUnavailableEndpoints: Boolean): java.util.List[Integer] = {
-    if (!filterUnavailableEndpoints) {
+                                       listenerName: ListenerName): java.util.List[Integer] = {
       Replicas.toList(brokers)
-    } else {
-      val res = new util.ArrayList[Integer](brokers.length)
-      for (brokerId <- brokers) {
-        Option(image.cluster().broker(brokerId)).foreach { b =>
-          if (!b.fenced() && b.listeners().containsKey(listenerName.value())) {
-            res.add(brokerId)
-          }
-        }
-      }
-      res
-    }
   }
 
   def currentImage(): MetadataImage = _currentImage
 
-  // errorUnavailableEndpoints exists to support v0 MetadataResponses
   // If errorUnavailableListeners=true, return LISTENER_NOT_FOUND if listener is missing on the broker.
   // Otherwise, return LEADER_NOT_AVAILABLE for broker unavailable and missing listener (Metadata response v5 and below).
-  private def getPartitionMetadata(image: MetadataImage, topicName: String, listenerName: ListenerName, errorUnavailableEndpoints: Boolean,
+  private def getPartitionMetadata(image: MetadataImage, topicName: String, listenerName: ListenerName,
                                    errorUnavailableListeners: Boolean): Option[Iterator[MetadataResponsePartition]] = {
     Option(image.topics().getTopic(topicName)) match {
       case None => None
       case Some(topic) => Some(topic.partitions().entrySet().asScala.map { entry =>
         val partitionId = entry.getKey
         val partition = entry.getValue
-        val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas,
-          listenerName, errorUnavailableEndpoints)
-        val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName,
-          errorUnavailableEndpoints)
+        val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas, listenerName)
+        val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName)
         val offlineReplicas = getOfflineReplicas(image, partition, listenerName)
         val maybeLeader = getAliveEndpoint(image, partition.leader, listenerName)
         maybeLeader match {
@@ -171,9 +154,8 @@ class KRaftMetadataCache(
         for (partitionId <- startIndex until upperIndex) {
           topic.partitions().get(partitionId) match {
             case partition : PartitionRegistration => {
-              val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas,
-                listenerName, filterUnavailableEndpoints = false)
-              val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName, filterUnavailableEndpoints = false)
+              val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas, listenerName)
+              val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName)
               val offlineReplicas = getOfflineReplicas(image, partition, listenerName)
               val maybeLeader = getAliveEndpoint(image, partition.leader, listenerName)
               maybeLeader match {
@@ -238,14 +220,12 @@ class KRaftMetadataCache(
     Option(image.cluster().broker(id)).flatMap(_.node(listenerName.value()).toScala)
   }
 
-  // errorUnavailableEndpoints exists to support v0 MetadataResponses
   override def getTopicMetadata(topics: Set[String],
                                 listenerName: ListenerName,
-                                errorUnavailableEndpoints: Boolean = false,
                                 errorUnavailableListeners: Boolean = false): Seq[MetadataResponseTopic] = {
     val image = _currentImage
     topics.toSeq.flatMap { topic =>
-      getPartitionMetadata(image, topic, listenerName, errorUnavailableEndpoints, errorUnavailableListeners).map { partitionMetadata =>
+      getPartitionMetadata(image, topic, listenerName, errorUnavailableListeners).map { partitionMetadata =>
         new MetadataResponseTopic()
           .setErrorCode(Errors.NONE.code)
           .setName(topic)

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -58,14 +58,6 @@ class KRaftMetadataCache(
   // image values.
   @volatile private var _currentImage: MetadataImage = MetadataImage.EMPTY
 
-  // This method is the main hotspot when it comes to the performance of metadata requests,
-  // we should be careful about adding additional logic here.
-  private def maybeFilterAliveReplicas(image: MetadataImage,
-                                       brokers: Array[Int],
-                                       listenerName: ListenerName): java.util.List[Integer] = {
-      Replicas.toList(brokers)
-  }
-
   def currentImage(): MetadataImage = _currentImage
 
   // If errorUnavailableListeners=true, return LISTENER_NOT_FOUND if listener is missing on the broker.
@@ -77,8 +69,8 @@ class KRaftMetadataCache(
       case Some(topic) => Some(topic.partitions().entrySet().asScala.map { entry =>
         val partitionId = entry.getKey
         val partition = entry.getValue
-        val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas, listenerName)
-        val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName)
+        val replicas = Replicas.toList(partition.replicas)
+        val isr = Replicas.toList(partition.isr)
         val offlineReplicas = getOfflineReplicas(image, partition, listenerName)
         val maybeLeader = getAliveEndpoint(image, partition.leader, listenerName)
         maybeLeader match {
@@ -96,17 +88,17 @@ class KRaftMetadataCache(
               .setPartitionIndex(partitionId)
               .setLeaderId(MetadataResponse.NO_LEADER_ID)
               .setLeaderEpoch(partition.leaderEpoch)
-              .setReplicaNodes(filteredReplicas)
-              .setIsrNodes(filteredIsr)
+              .setReplicaNodes(replicas)
+              .setIsrNodes(isr)
               .setOfflineReplicas(offlineReplicas)
           case Some(leader) =>
-            val error = if (filteredReplicas.size < partition.replicas.length) {
+            val error = if (replicas.size < partition.replicas.length) {
               debug(s"Error while fetching metadata for $topicName-$partitionId: replica information not available for " +
-                s"following brokers ${partition.replicas.filterNot(filteredReplicas.contains).mkString(",")}")
+                s"following brokers ${partition.replicas.filterNot(replicas.contains).mkString(",")}")
               Errors.REPLICA_NOT_AVAILABLE
-            } else if (filteredIsr.size < partition.isr.length) {
+            } else if (isr.size < partition.isr.length) {
               debug(s"Error while fetching metadata for $topicName-$partitionId: in sync replica information not available for " +
-                s"following brokers ${partition.isr.filterNot(filteredIsr.contains).mkString(",")}")
+                s"following brokers ${partition.isr.filterNot(isr.contains).mkString(",")}")
               Errors.REPLICA_NOT_AVAILABLE
             } else {
               Errors.NONE
@@ -117,8 +109,8 @@ class KRaftMetadataCache(
               .setPartitionIndex(partitionId)
               .setLeaderId(leader.id())
               .setLeaderEpoch(partition.leaderEpoch)
-              .setReplicaNodes(filteredReplicas)
-              .setIsrNodes(filteredIsr)
+              .setReplicaNodes(replicas)
+              .setIsrNodes(isr)
               .setOfflineReplicas(offlineReplicas)
         }
       }.iterator)
@@ -154,8 +146,8 @@ class KRaftMetadataCache(
         for (partitionId <- startIndex until upperIndex) {
           topic.partitions().get(partitionId) match {
             case partition : PartitionRegistration => {
-              val filteredReplicas = maybeFilterAliveReplicas(image, partition.replicas, listenerName)
-              val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName)
+              val replicas = Replicas.toList(partition.replicas)
+              val isr = Replicas.toList(partition.isr)
               val offlineReplicas = getOfflineReplicas(image, partition, listenerName)
               val maybeLeader = getAliveEndpoint(image, partition.leader, listenerName)
               maybeLeader match {
@@ -164,8 +156,8 @@ class KRaftMetadataCache(
                     .setPartitionIndex(partitionId)
                     .setLeaderId(MetadataResponse.NO_LEADER_ID)
                     .setLeaderEpoch(partition.leaderEpoch)
-                    .setReplicaNodes(filteredReplicas)
-                    .setIsrNodes(filteredIsr)
+                    .setReplicaNodes(replicas)
+                    .setIsrNodes(isr)
                     .setOfflineReplicas(offlineReplicas)
                     .setEligibleLeaderReplicas(Replicas.toList(partition.elr))
                     .setLastKnownElr(Replicas.toList(partition.lastKnownElr)))
@@ -174,8 +166,8 @@ class KRaftMetadataCache(
                     .setPartitionIndex(partitionId)
                     .setLeaderId(leader.id())
                     .setLeaderEpoch(partition.leaderEpoch)
-                    .setReplicaNodes(filteredReplicas)
-                    .setIsrNodes(filteredIsr)
+                    .setReplicaNodes(replicas)
+                    .setIsrNodes(isr)
                     .setOfflineReplicas(offlineReplicas)
                     .setEligibleLeaderReplicas(Replicas.toList(partition.elr))
                     .setLastKnownElr(Replicas.toList(partition.lastKnownElr)))

--- a/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.java
+++ b/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.java
@@ -71,7 +71,6 @@ public class ShareCoordinatorMetadataCacheHelperImpl implements ShareCoordinator
                 metadataCache.getTopicMetadata(
                     CollectionConverters.asScala(topicSet),
                     interBrokerListenerName,
-                    false,
                     false
                 )
             );

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -3585,7 +3585,6 @@ class KafkaApisTest extends Logging {
     when(metadataCache.getTopicMetadata(
       ArgumentMatchers.eq(topicsReturnedFromMetadataCacheForAuthorization),
       any[ListenerName],
-      anyBoolean,
       anyBoolean
     )).thenReturn(Seq(
       new MetadataResponseTopic()

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -322,8 +322,7 @@ class MetadataCacheTest {
         .setReplicas(replicas))
     MetadataCacheTest.updateCache(cache, brokers ++ topicRecords ++ partitionStates)
 
-    // Validate errorUnavailableEndpoints = false
-    val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
+    val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName)
     assertEquals(1, topicMetadatas.size)
 
     val topicMetadata = topicMetadatas.head
@@ -337,22 +336,6 @@ class MetadataCacheTest {
     assertEquals(Errors.NONE.code, partitionMetadata.errorCode)
     assertEquals(Set(0, 1), partitionMetadata.replicaNodes.asScala.toSet)
     assertEquals(Set(0), partitionMetadata.isrNodes.asScala.toSet)
-
-    // Validate errorUnavailableEndpoints = true
-    val topicMetadatasWithError = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = true)
-    assertEquals(1, topicMetadatasWithError.size)
-
-    val topicMetadataWithError = topicMetadatasWithError.head
-    assertEquals(Errors.NONE.code, topicMetadataWithError.errorCode)
-
-    val partitionMetadatasWithError = topicMetadataWithError.partitions()
-    assertEquals(1, partitionMetadatasWithError.size)
-
-    val partitionMetadataWithError = partitionMetadatasWithError.get(0)
-    assertEquals(0, partitionMetadataWithError.partitionIndex)
-    assertEquals(Errors.REPLICA_NOT_AVAILABLE.code, partitionMetadataWithError.errorCode)
-    assertEquals(Set(0), partitionMetadataWithError.replicaNodes.asScala.toSet)
-    assertEquals(Set(0), partitionMetadataWithError.isrNodes.asScala.toSet)
   }
 
   @ParameterizedTest
@@ -396,8 +379,7 @@ class MetadataCacheTest {
       .setReplicas(replicas))
     MetadataCacheTest.updateCache(cache, brokers ++ topicRecords ++ partitionStates)
 
-    // Validate errorUnavailableEndpoints = false
-    val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
+    val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName)
     assertEquals(1, topicMetadatas.size)
 
     val topicMetadata = topicMetadatas.head
@@ -411,22 +393,6 @@ class MetadataCacheTest {
     assertEquals(Errors.NONE.code, partitionMetadata.errorCode)
     assertEquals(Set(0), partitionMetadata.replicaNodes.asScala.toSet)
     assertEquals(Set(0, 1), partitionMetadata.isrNodes.asScala.toSet)
-
-    // Validate errorUnavailableEndpoints = true
-    val topicMetadatasWithError = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = true)
-    assertEquals(1, topicMetadatasWithError.size)
-
-    val topicMetadataWithError = topicMetadatasWithError.head
-    assertEquals(Errors.NONE.code, topicMetadataWithError.errorCode)
-
-    val partitionMetadatasWithError = topicMetadataWithError.partitions
-    assertEquals(1, partitionMetadatasWithError.size)
-
-    val partitionMetadataWithError = partitionMetadatasWithError.get(0)
-    assertEquals(0, partitionMetadataWithError.partitionIndex)
-    assertEquals(Errors.REPLICA_NOT_AVAILABLE.code, partitionMetadataWithError.errorCode)
-    assertEquals(Set(0), partitionMetadataWithError.replicaNodes.asScala.toSet)
-    assertEquals(Set(0), partitionMetadataWithError.isrNodes.asScala.toSet)
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description
Remove `errorUnavailableEndpoints`, this is no longer required as the min version of MetadataRequest is v4 so the flag is always false now.

Jira: https://issues.apache.org/jira/browse/KAFKA-18633
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
