### PR TITLE
KAFKA-18644: improve generic type names for internal FK-join classes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKey.java
@@ -14,26 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
 import java.util.Objects;
 
-public class CombinedKey<KF, KP> {
-    private final KF foreignKey;
-    private final KP primaryKey;
+public class CombinedKey<KRight, KLeft> {
+    private final KRight foreignKey;
+    private final KLeft primaryKey;
 
-    CombinedKey(final KF foreignKey, final KP primaryKey) {
+    CombinedKey(final KRight foreignKey, final KLeft primaryKey) {
         Objects.requireNonNull(primaryKey, "primaryKey can't be null");
         this.foreignKey = foreignKey;
         this.primaryKey = primaryKey;
     }
 
-    public KF foreignKey() {
+    public KRight foreignKey() {
         return foreignKey;
     }
 
-    public KP primaryKey() {
+    public KLeft primaryKey() {
         return primaryKey;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchema.java
@@ -28,20 +28,20 @@ import java.util.function.Supplier;
 /**
  * Factory for creating CombinedKey serializers / deserializers.
  */
-public class CombinedKeySchema<KO, K> {
+public class CombinedKeySchema<KRight, KLeft> {
     private final Supplier<String> undecoratedPrimaryKeySerdeTopicSupplier;
     private final Supplier<String> undecoratedForeignKeySerdeTopicSupplier;
     private String primaryKeySerdeTopic;
     private String foreignKeySerdeTopic;
-    private Serializer<K> primaryKeySerializer;
-    private Deserializer<K> primaryKeyDeserializer;
-    private Serializer<KO> foreignKeySerializer;
-    private Deserializer<KO> foreignKeyDeserializer;
+    private Serializer<KLeft> primaryKeySerializer;
+    private Deserializer<KLeft> primaryKeyDeserializer;
+    private Serializer<KRight> foreignKeySerializer;
+    private Deserializer<KRight> foreignKeyDeserializer;
 
     public CombinedKeySchema(final Supplier<String> foreignKeySerdeTopicSupplier,
-                             final Serde<KO> foreignKeySerde,
+                             final Serde<KRight> foreignKeySerde,
                              final Supplier<String> primaryKeySerdeTopicSupplier,
-                             final Serde<K> primaryKeySerde) {
+                             final Serde<KLeft> primaryKeySerde) {
         undecoratedPrimaryKeySerdeTopicSupplier = primaryKeySerdeTopicSupplier;
         undecoratedForeignKeySerdeTopicSupplier = foreignKeySerdeTopicSupplier;
         primaryKeySerializer = primaryKeySerde == null ? null : primaryKeySerde.serializer();
@@ -50,17 +50,17 @@ public class CombinedKeySchema<KO, K> {
         foreignKeySerializer = foreignKeySerde == null ? null : foreignKeySerde.serializer();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "resource"})
     public void init(final ProcessorContext<?, ?> context) {
         primaryKeySerdeTopic = undecoratedPrimaryKeySerdeTopicSupplier.get();
         foreignKeySerdeTopic = undecoratedForeignKeySerdeTopicSupplier.get();
-        primaryKeySerializer = primaryKeySerializer == null ? (Serializer<K>) context.keySerde().serializer() : primaryKeySerializer;
-        primaryKeyDeserializer = primaryKeyDeserializer == null ? (Deserializer<K>) context.keySerde().deserializer() : primaryKeyDeserializer;
-        foreignKeySerializer = foreignKeySerializer == null ? (Serializer<KO>) context.keySerde().serializer() : foreignKeySerializer;
-        foreignKeyDeserializer = foreignKeyDeserializer == null ? (Deserializer<KO>) context.keySerde().deserializer() : foreignKeyDeserializer;
+        primaryKeySerializer = primaryKeySerializer == null ? (Serializer<KLeft>) context.keySerde().serializer() : primaryKeySerializer;
+        primaryKeyDeserializer = primaryKeyDeserializer == null ? (Deserializer<KLeft>) context.keySerde().deserializer() : primaryKeyDeserializer;
+        foreignKeySerializer = foreignKeySerializer == null ? (Serializer<KRight>) context.keySerde().serializer() : foreignKeySerializer;
+        foreignKeyDeserializer = foreignKeyDeserializer == null ? (Deserializer<KRight>) context.keySerde().deserializer() : foreignKeyDeserializer;
     }
 
-    Bytes toBytes(final KO foreignKey, final K primaryKey) {
+    Bytes toBytes(final KRight foreignKey, final KLeft primaryKey) {
         //The serialization format - note that primaryKeySerialized may be null, such as when a prefixScan
         //key is being created.
         //{Integer.BYTES foreignKeyLength}{foreignKeySerialized}{Optional-primaryKeySerialized}
@@ -79,22 +79,22 @@ public class CombinedKeySchema<KO, K> {
     }
 
 
-    public CombinedKey<KO, K> fromBytes(final Bytes data) {
+    public CombinedKey<KRight, KLeft> fromBytes(final Bytes data) {
         //{Integer.BYTES foreignKeyLength}{foreignKeySerialized}{Optional-primaryKeySerialized}
         final byte[] dataArray = data.get();
         final ByteBuffer dataBuffer = ByteBuffer.wrap(dataArray);
         final int foreignKeyLength = dataBuffer.getInt();
         final byte[] foreignKeyRaw = new byte[foreignKeyLength];
         dataBuffer.get(foreignKeyRaw, 0, foreignKeyLength);
-        final KO foreignKey = foreignKeyDeserializer.deserialize(foreignKeySerdeTopic, foreignKeyRaw);
+        final KRight foreignKey = foreignKeyDeserializer.deserialize(foreignKeySerdeTopic, foreignKeyRaw);
 
         final byte[] primaryKeyRaw = new byte[dataArray.length - foreignKeyLength - Integer.BYTES];
         dataBuffer.get(primaryKeyRaw, 0, primaryKeyRaw.length);
-        final K primaryKey = primaryKeyDeserializer.deserialize(primaryKeySerdeTopic, primaryKeyRaw);
+        final KLeft primaryKey = primaryKeyDeserializer.deserialize(primaryKeySerdeTopic, primaryKeyRaw);
         return new CombinedKey<>(foreignKey, primaryKey);
     }
 
-    Bytes prefixBytes(final KO key) {
+    Bytes prefixBytes(final KRight key) {
         //The serialization format. Note that primaryKeySerialized is not required/used in this function.
         //{Integer.BYTES foreignKeyLength}{foreignKeySerialized}{Optional-primaryKeySerialized}
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignKeyExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignKeyExtractor.java
@@ -30,19 +30,19 @@ import java.util.function.Function;
  *   <li>{@link #fromBiFunction(BiFunction)} - when the foreign key depends on both key and value</li>
  * </ul>
  *
- * @param <K>  Type of primary table's key
- * @param <V>  Type of primary table's value
- * @param <KO> Type of the foreign key to extract
+ * @param <KLeft>  Type of primary table's key
+ * @param <VLeft>  Type of primary table's value
+ * @param <KRight> Type of the foreign key to extract
  */
 @FunctionalInterface
-public interface ForeignKeyExtractor<K, V, KO> {
-    KO extract(K key, V value);
+public interface ForeignKeyExtractor<KLeft, VLeft, KRight> {
+    KRight extract(KLeft key, VLeft value);
 
-    static <K, V, KO> ForeignKeyExtractor<? super K, ? super V, ? extends KO> fromFunction(Function<? super V, ? extends KO> function) {
+    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromFunction(Function<? super VLeft, ? extends KRight> function) {
         return (key, value) -> function.apply(value);
     }
 
-    static <K, V, KO> ForeignKeyExtractor<? super K, ? super V, ? extends KO> fromBiFunction(BiFunction<? super K, ? super V, ? extends KO> biFunction) {
+    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromBiFunction(BiFunction<? super KLeft, ? super VLeft, ? extends KRight> biFunction) {
         return biFunction::apply;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ResponseJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ResponseJoinProcessorSupplier.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
@@ -43,23 +42,25 @@ import java.util.function.Supplier;
  * of the primary key. This eliminates race-condition results for rapidly-changing foreign-keys for a given primary key.
  * Applies the join and emits nulls according to LEFT/INNER rules.
  *
- * @param <K> Type of primary keys
- * @param <V> Type of primary values
- * @param <VO> Type of foreign values
- * @param <VR> Type of joined result of primary and foreign values
+ * @param <KLeft> Type of primary keys
+ * @param <VLeft> Type of primary values
+ * @param <VRight> Type of foreign values
+ * @param <VOut> Type of joined result of primary and foreign values
  */
-public class ResponseJoinProcessorSupplier<K, V, VO, VR> implements ProcessorSupplier<K, SubscriptionResponseWrapper<VO>, K, VR> {
+public class ResponseJoinProcessorSupplier<KLeft, VLeft, VRight, VOut>
+    implements ProcessorSupplier<KLeft, SubscriptionResponseWrapper<VRight>, KLeft, VOut> {
+
     private static final Logger LOG = LoggerFactory.getLogger(ResponseJoinProcessorSupplier.class);
-    private final KTableValueGetterSupplier<K, V> valueGetterSupplier;
-    private final Serializer<V> constructionTimeValueSerializer;
+    private final KTableValueGetterSupplier<KLeft, VLeft> valueGetterSupplier;
+    private final Serializer<VLeft> constructionTimeValueSerializer;
     private final Supplier<String> valueHashSerdePseudoTopicSupplier;
-    private final ValueJoiner<? super V, ? super VO, ? extends VR> joiner;
+    private final ValueJoiner<? super VLeft, ? super VRight, ? extends VOut> joiner;
     private final boolean leftJoin;
 
-    public ResponseJoinProcessorSupplier(final KTableValueGetterSupplier<K, V> valueGetterSupplier,
-                                         final Serializer<V> valueSerializer,
+    public ResponseJoinProcessorSupplier(final KTableValueGetterSupplier<KLeft, VLeft> valueGetterSupplier,
+                                         final Serializer<VLeft> valueSerializer,
                                          final Supplier<String> valueHashSerdePseudoTopicSupplier,
-                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                         final ValueJoiner<? super VLeft, ? super VRight, ? extends VOut> joiner,
                                          final boolean leftJoin) {
         this.valueGetterSupplier = valueGetterSupplier;
         constructionTimeValueSerializer = valueSerializer;
@@ -69,24 +70,24 @@ public class ResponseJoinProcessorSupplier<K, V, VO, VR> implements ProcessorSup
     }
 
     @Override
-    public Processor<K, SubscriptionResponseWrapper<VO>, K, VR> get() {
+    public Processor<KLeft, SubscriptionResponseWrapper<VRight>, KLeft, VOut> get() {
         return new ContextualProcessor<>() {
             private String valueHashSerdePseudoTopic;
-            private Serializer<V> runtimeValueSerializer = constructionTimeValueSerializer;
+            private Serializer<VLeft> runtimeValueSerializer = constructionTimeValueSerializer;
 
-            private KTableValueGetter<K, V> valueGetter;
+            private KTableValueGetter<KLeft, VLeft> valueGetter;
             private Sensor droppedRecordsSensor;
 
 
             @SuppressWarnings({"unchecked", "resource"})
             @Override
-            public void init(final ProcessorContext<K, VR> context) {
+            public void init(final ProcessorContext<KLeft, VOut> context) {
                 super.init(context);
                 valueHashSerdePseudoTopic = valueHashSerdePseudoTopicSupplier.get();
                 valueGetter = valueGetterSupplier.get();
                 valueGetter.init(context);
                 if (runtimeValueSerializer == null) {
-                    runtimeValueSerializer = (Serializer<V>) context.valueSerde().serializer();
+                    runtimeValueSerializer = (Serializer<VLeft>) context.valueSerde().serializer();
                 }
 
                 final InternalProcessorContext<?, ?> internalProcessorContext = (InternalProcessorContext<?, ?>) context;
@@ -98,14 +99,14 @@ public class ResponseJoinProcessorSupplier<K, V, VO, VR> implements ProcessorSup
             }
 
             @Override
-            public void process(final Record<K, SubscriptionResponseWrapper<VO>> record) {
+            public void process(final Record<KLeft, SubscriptionResponseWrapper<VRight>> record) {
                 if (record.value().version() != SubscriptionResponseWrapper.CURRENT_VERSION) {
                     //Guard against modifications to SubscriptionResponseWrapper. Need to ensure that there is
                     //compatibility with previous versions to enable rolling upgrades. Must develop a strategy for
                     //upgrading from older SubscriptionWrapper versions to newer versions.
                     throw new UnsupportedVersionException("SubscriptionResponseWrapper is of an incompatible version.");
                 }
-                final ValueAndTimestamp<V> currentValueWithTimestamp = valueGetter.get(record.key());
+                final ValueAndTimestamp<VLeft> currentValueWithTimestamp = valueGetter.get(record.key());
 
                 final long[] currentHash = currentValueWithTimestamp == null ?
                     null :
@@ -115,7 +116,7 @@ public class ResponseJoinProcessorSupplier<K, V, VO, VR> implements ProcessorSup
 
                 //If this value doesn't match the current value from the original table, it is stale and should be discarded.
                 if (java.util.Arrays.equals(messageHash, currentHash)) {
-                    final VR result;
+                    final VOut result;
 
                     if (record.value().foreignValue() == null && (!leftJoin || currentValueWithTimestamp == null)) {
                         result = null; //Emit tombstone

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapper.java
@@ -21,22 +21,22 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class SubscriptionResponseWrapper<FV> {
+public class SubscriptionResponseWrapper<VRight> {
     static final byte CURRENT_VERSION = 0;
     // v0 fields:
     private final long[] originalValueHash;
-    private final FV foreignValue;
+    private final VRight foreignValue;
     private final byte version;
     // non-serializing fields
     private final Integer primaryPartition;
 
-    public SubscriptionResponseWrapper(final long[] originalValueHash, final FV foreignValue, final Integer primaryPartition) {
+    public SubscriptionResponseWrapper(final long[] originalValueHash, final VRight foreignValue, final Integer primaryPartition) {
         this(originalValueHash, foreignValue, CURRENT_VERSION, primaryPartition);
     }
 
     public SubscriptionResponseWrapper(
         final long[] originalValueHash,
-        final FV foreignValue,
+        final VRight foreignValue,
         final byte version,
         final Integer primaryPartition) {
         if (version < 0 || version > CURRENT_VERSION) {
@@ -52,7 +52,7 @@ public class SubscriptionResponseWrapper<FV> {
         return originalValueHash;
     }
 
-    public FV foreignValue() {
+    public VRight foreignValue() {
         return foreignValue;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerde.java
@@ -26,22 +26,22 @@ import org.apache.kafka.streams.processor.internals.SerdeGetter;
 
 import java.nio.ByteBuffer;
 
-public class SubscriptionResponseWrapperSerde<V> implements Serde<SubscriptionResponseWrapper<V>> {
-    private final SubscriptionResponseWrapperSerializer<V> serializer;
-    private final SubscriptionResponseWrapperDeserializer<V> deserializer;
+public class SubscriptionResponseWrapperSerde<VRight> implements Serde<SubscriptionResponseWrapper<VRight>> {
+    private final SubscriptionResponseWrapperSerializer<VRight> serializer;
+    private final SubscriptionResponseWrapperDeserializer<VRight> deserializer;
 
-    public SubscriptionResponseWrapperSerde(final Serde<V> foreignValueSerde) {
+    public SubscriptionResponseWrapperSerde(final Serde<VRight> foreignValueSerde) {
         serializer = new SubscriptionResponseWrapperSerializer<>(foreignValueSerde == null ? null : foreignValueSerde.serializer());
         deserializer = new SubscriptionResponseWrapperDeserializer<>(foreignValueSerde == null ? null : foreignValueSerde.deserializer());
     }
 
     @Override
-    public Serializer<SubscriptionResponseWrapper<V>> serializer() {
+    public Serializer<SubscriptionResponseWrapper<VRight>> serializer() {
         return serializer;
     }
 
     @Override
-    public Deserializer<SubscriptionResponseWrapper<V>> deserializer() {
+    public Deserializer<SubscriptionResponseWrapper<VRight>> deserializer() {
         return deserializer;
     }
 
@@ -54,7 +54,7 @@ public class SubscriptionResponseWrapperSerde<V> implements Serde<SubscriptionRe
             this.serializer = serializer;
         }
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "resource"})
         @Override
         public void setIfUnset(final SerdeGetter getter) {
             if (serializer == null) {
@@ -101,7 +101,7 @@ public class SubscriptionResponseWrapperSerde<V> implements Serde<SubscriptionRe
             this.deserializer = deserializer;
         }
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "resource"})
         @Override
         public void setIfUnset(final SerdeGetter getter) {
             if (deserializer == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapper.java
@@ -21,8 +21,7 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import java.util.Arrays;
 import java.util.Objects;
 
-
-public class SubscriptionWrapper<K> {
+public class SubscriptionWrapper<KLeft> {
     static final byte VERSION_0 = 0;
     static final byte VERSION_1 = 1;
 
@@ -32,7 +31,7 @@ public class SubscriptionWrapper<K> {
     private final long[] hash;
     private final Instruction instruction;
     private final byte version;
-    private final K primaryKey;
+    private final KLeft primaryKey;
     // v1 fields:
     private final Integer primaryPartition;
 
@@ -71,11 +70,11 @@ public class SubscriptionWrapper<K> {
         }
     }
 
-    public SubscriptionWrapper(final long[] hash, final Instruction instruction, final K primaryKey, final Integer primaryPartition) {
+    public SubscriptionWrapper(final long[] hash, final Instruction instruction, final KLeft primaryKey, final Integer primaryPartition) {
         this(hash, instruction, primaryKey, CURRENT_VERSION, primaryPartition);
     }
 
-    public SubscriptionWrapper(final long[] hash, final Instruction instruction, final K primaryKey, final byte version, final Integer primaryPartition) {
+    public SubscriptionWrapper(final long[] hash, final Instruction instruction, final KLeft primaryKey, final byte version, final Integer primaryPartition) {
         Objects.requireNonNull(instruction, "instruction cannot be null. Required by downstream processor.");
         Objects.requireNonNull(primaryKey, "primaryKey cannot be null. Required by downstream processor.");
         if (version < 0 || version > CURRENT_VERSION) {
@@ -97,7 +96,7 @@ public class SubscriptionWrapper<K> {
         return hash;
     }
 
-    public K primaryKey() {
+    public KLeft primaryKey() {
         return primaryKey;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionSendProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionSendProcessorSupplierTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class SubscriptionSendProcessorSupplierTest {
 
     private final Processor<String, Change<LeftValue>, String, SubscriptionWrapper<String>> leftJoinProcessor =
-        new SubscriptionSendProcessorSupplier<String, String, LeftValue>(
+        new SubscriptionSendProcessorSupplier<String, LeftValue, String>(
             ForeignKeyExtractor.fromFunction(LeftValue::getForeignKey),
             () -> "subscription-topic-fk",
             () -> "value-serde-topic",
@@ -54,7 +54,7 @@ public class SubscriptionSendProcessorSupplierTest {
         ).get();
 
     private final Processor<String, Change<LeftValue>, String, SubscriptionWrapper<String>> innerJoinProcessor =
-        new SubscriptionSendProcessorSupplier<String, String, LeftValue>(
+        new SubscriptionSendProcessorSupplier<String, LeftValue, String>(
             ForeignKeyExtractor.fromFunction(LeftValue::getForeignKey),
             () -> "subscription-topic-fk",
             () -> "value-serde-topic",
@@ -329,7 +329,7 @@ public class SubscriptionSendProcessorSupplierTest {
 
     // Bi-function tests: inner join, left join
     private final Processor<String, Change<LeftValue>, String, SubscriptionWrapper<String>> biFunctionLeftJoinProcessor =
-        new SubscriptionSendProcessorSupplier<String, String, LeftValue>(
+        new SubscriptionSendProcessorSupplier<String, LeftValue, String>(
             ForeignKeyExtractor.fromBiFunction((key, value) -> value.getForeignKey() == null ? null : key + value.getForeignKey()),
             () -> "subscription-topic-fk",
             () -> "value-serde-topic",
@@ -339,7 +339,7 @@ public class SubscriptionSendProcessorSupplierTest {
         ).get();
 
     private final Processor<String, Change<LeftValue>, String, SubscriptionWrapper<String>> biFunctionInnerJoinProcessor =
-        new SubscriptionSendProcessorSupplier<String, String, LeftValue>(
+        new SubscriptionSendProcessorSupplier<String, LeftValue, String>(
             ForeignKeyExtractor.fromBiFunction((key, value) -> value.getForeignKey() == null ? null : key + value.getForeignKey()),
             () -> "subscription-topic-fk",
             () -> "value-serde-topic",
@@ -628,6 +628,7 @@ public class SubscriptionSendProcessorSupplierTest {
     }
 
     private static class LeftValueSerializer implements Serializer<LeftValue> {
+        @SuppressWarnings("resource")
         @Override
         public byte[] serialize(final String topic, final LeftValue data) {
             if (data == null) return null;
@@ -648,6 +649,7 @@ public class SubscriptionSendProcessorSupplierTest {
         }
     }
 
+    @SuppressWarnings("resource")
     private static long[] hash(final LeftValue value) {
         return Murmur3.hash128(new LeftValueSerializer().serialize("value-serde-topic", value));
     }


### PR DESCRIPTION
Naming of generic types is not consistent, and hard to read. Standardizing to use `KLeft`/`VLeft` for the left/primary table, and `KRight`/`VRight` for right/foreign table, and using `VOut` as join result type.