### PR TITLE
KAFKA-18171: Unexpected Change in bootstrap.servers Behavior After Upgrade to 3.8.0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -80,7 +80,7 @@ import java.util.stream.Collectors;
  */
 public class ConfigDef {
 
-    private static final Pattern COMMA_WITH_WHITESPACE = Pattern.compile("\\s*,\\s*");
+    private static final Pattern COMMA_WITH_WHITESPACE_OR_ONLY_WHITESPACE = Pattern.compile("\\s*,\\s*|\\s+");
 
     /**
      * A unique Java object which represents the lack of a default value.
@@ -759,7 +759,7 @@ public class ConfigDef {
                         if (trimmed.isEmpty())
                             return Collections.emptyList();
                         else
-                            return Arrays.asList(COMMA_WITH_WHITESPACE.split(trimmed, -1));
+                            return Arrays.asList(COMMA_WITH_WHITESPACE_OR_ONLY_WHITESPACE.split(trimmed, -1));
                     else
                         throw new ConfigException(name, value, "Expected a comma separated list.");
                 case CLASS:


### PR DESCRIPTION
JIRA: [KAFKA-18171](https://issues.apache.org/jira/browse/KAFKA-18171)

*This PR check *

*With this change, bootstrap.servers property now will support values that is separated by space or new line or comma followed by new line.
We can specify values for bootstrap.servers like below-

1. "broker1:port1 broker2:port2 broker3:port3"
2. "broker1:port1,broker2:port2,broker3:port3"
3. "broker1:port1, broker2:port2, broker3:port3"
4. 
"broker1:port1,
broker2:port2,
broker3:port3"

*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
