### PR TITLE
Only real topics are output in exceptions

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -210,7 +210,7 @@ public abstract class TopicCommand {
         // If no topic name was mentioned, do not need to throw exception.
         if (requestedTopic.isPresent() && !requestedTopic.get().isEmpty() && requireTopicExists && foundTopics.isEmpty()) {
             // If given topic doesn't exist then throw exception
-            throw new IllegalArgumentException(String.format("Topic '%s' does not exist as expected", requestedTopic));
+            throw new IllegalArgumentException(String.format("Topic '%s' does not exist as expected", requestedTopic.get()));
         }
     }
 


### PR DESCRIPTION
Only real topics are output in exceptions.

before:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/da41ccc0-d085-4882-8d10-3b9d15194c9e" />

after:
<img width="671" alt="image" src="https://github.com/user-attachments/assets/e7d8d565-e107-477a-b4a5-971096ff046c" />


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
