### PR TITLE
KAFKA-18171: Revert the strict config validation for 3.8 and 3.9

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -287,6 +287,16 @@ public class CommonClientConfigs {
         }
     }
 
+    public static void warnIfBootstrapServersIsSpaceDelimited(AbstractConfig config) {
+        String bootstrapServers = config.getString(BOOTSTRAP_SERVERS_CONFIG);
+        int bootstrapServerCount = bootstrapServers.trim().split("\\s+").length;
+        if (bootstrapServerCount > 1) {
+            log.warn("The configuration '{}' should be a comma-separated list of URLs. Please replace spaces with comma from the value '{}'. " +
+                    "Otherwise, the client will only connect to the first broker in the list.",
+                BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        }
+    }
+
     public static void postValidateSaslMechanismConfig(AbstractConfig config) {
         SecurityProtocol securityProtocol = SecurityProtocol.forName(config.getString(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
         String clientSaslMechanism = config.getString(SaslConfigs.SASL_MECHANISM);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -686,6 +686,7 @@ public class ConsumerConfig extends AbstractConfig {
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         CommonClientConfigs.postValidateSaslMechanismConfig(this);
         CommonClientConfigs.warnDisablingExponentialBackoff(this);
+        CommonClientConfigs.warnIfBootstrapServersIsSpaceDelimited(this);
         Map<String, Object> refinedConfigs = CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
         maybeOverrideClientId(refinedConfigs);
         maybeOverrideEnableAutoCommit(refinedConfigs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -545,6 +545,7 @@ public class ProducerConfig extends AbstractConfig {
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         CommonClientConfigs.postValidateSaslMechanismConfig(this);
         CommonClientConfigs.warnDisablingExponentialBackoff(this);
+        CommonClientConfigs.warnIfBootstrapServersIsSpaceDelimited(this);
         Map<String, Object> refinedConfigs = CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
         postProcessAndValidateIdempotenceConfigs(refinedConfigs);
         maybeOverrideClientId(refinedConfigs);

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -96,7 +96,7 @@ public final class Utils {
 
     // This matches URIs of formats: host:port and protocol://host:port
     // IPv6 is supported with [ip] pattern
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[0-9a-zA-Z\\-%._]*://)?\\[?([0-9a-zA-Z\\-%._:]*)]?:([0-9]+)");
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z][a-zA-Z\\d+-.]*://)?\\[?([0-9a-zA-Z\\-._%:]+)\\]?:([0-9]+)$");
 
     private static final Pattern VALID_HOST_CHARACTERS = Pattern.compile("([0-9a-zA-Z\\-%._:]*)");
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -94,9 +94,9 @@ public final class Utils {
 
     private Utils() {}
 
-    // This matches URIs of formats: host:port and protocol://host:port
+    // This matches URIs of formats: host:port and protocol:\\host:port
     // IPv6 is supported with [ip] pattern
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^(?:[a-zA-Z][a-zA-Z\\d+-.]*://)?\\[?([0-9a-zA-Z\\-._%:]+)\\]?:([0-9]+)$");
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile(".*?\\[?([0-9a-zA-Z\\-%._:]*)\\]?:([0-9]+)");
 
     private static final Pattern VALID_HOST_CHARACTERS = Pattern.compile("([0-9a-zA-Z\\-%._:]*)");
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -22,8 +22,6 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.Closeable;
@@ -117,35 +115,31 @@ public class UtilsTest {
         }
     }
 
-    @ParameterizedTest
-    @CsvSource(value = {"PLAINTEXT", "SASL_PLAINTEXT", "SSL", "SASL_SSL"})
-    public void testGetHostValid(String protocol) {
-        assertEquals("mydomain.com", getHost(protocol + "://mydomain.com:8080"));
-        assertEquals("MyDomain.com", getHost(protocol + "://MyDomain.com:8080"));
-        assertEquals("My_Domain.com", getHost(protocol + "://My_Domain.com:8080"));
-        assertEquals("::1", getHost(protocol + "://[::1]:1234"));
-        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost(protocol + "://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost(protocol + "://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
-        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost(protocol + "://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
+    @Test
+    public void testGetHost() {
+        // valid
         assertEquals("127.0.0.1", getHost("127.0.0.1:8000"));
+        assertEquals("mydomain.com", getHost("PLAINTEXT://mydomain.com:8080"));
+        assertEquals("MyDomain.com", getHost("PLAINTEXT://MyDomain.com:8080"));
+        assertEquals("My_Domain.com", getHost("PLAINTEXT://My_Domain.com:8080"));
         assertEquals("::1", getHost("[::1]:1234"));
-    }
+        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
+        assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
 
-    @ParameterizedTest
-    @CsvSource(value = {"PLAINTEXT", "SASL_PLAINTEXT", "SSL", "SASL_SSL"})
-    public void testGetHostInvalid(String protocol) {
-        assertNull(getHost(protocol + "://mydo)main.com:8080"));
-        assertNull(getHost(protocol + "://mydo(main.com:8080"));
-        assertNull(getHost(protocol + "://mydo()main.com:8080"));
-        assertNull(getHost(protocol + "://mydo(main).com:8080"));
-        assertNull(getHost(protocol + "://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost(protocol + "://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost(protocol + "://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost(protocol + "://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
+        // invalid
+        assertNull(getHost("PLAINTEXT://mydo)main.com:8080"));
+        assertNull(getHost("PLAINTEXT://mydo(main.com:8080"));
+        assertNull(getHost("PLAINTEXT://mydo()main.com:8080"));
+        assertNull(getHost("PLAINTEXT://mydo(main).com:8080"));
         assertNull(getHost("ho)st:9092"));
         assertNull(getHost("ho(st:9092"));
         assertNull(getHost("ho()st:9092"));
         assertNull(getHost("ho(st):9092"));
+        assertNull(getHost("PLAINTEXT://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
+        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -117,7 +117,6 @@ public class UtilsTest {
 
     @Test
     public void testGetHost() {
-        // valid
         assertEquals("127.0.0.1", getHost("127.0.0.1:8000"));
         assertEquals("mydomain.com", getHost("PLAINTEXT://mydomain.com:8080"));
         assertEquals("MyDomain.com", getHost("PLAINTEXT://MyDomain.com:8080"));
@@ -126,20 +125,6 @@ public class UtilsTest {
         assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", getHost("PLAINTEXT://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678"));
         assertEquals("2001:DB8:85A3:8D3:1319:8A2E:370:7348", getHost("PLAINTEXT://[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678"));
         assertEquals("fe80::b1da:69ca:57f7:63d8%3", getHost("PLAINTEXT://[fe80::b1da:69ca:57f7:63d8%3]:5678"));
-
-        // invalid
-        assertNull(getHost("PLAINTEXT://mydo)main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo(main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo()main.com:8080"));
-        assertNull(getHost("PLAINTEXT://mydo(main).com:8080"));
-        assertNull(getHost("ho)st:9092"));
-        assertNull(getHost("ho(st:9092"));
-        assertNull(getHost("ho()st:9092"));
-        assertNull(getHost("ho(st):9092"));
-        assertNull(getHost("PLAINTEXT://[2001:db)8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db()8:85a3:8d3:1319:8a2e:370:7348]:5678"));
-        assertNull(getHost("PLAINTEXT://[2001:db(8:85a3:)8d3:1319:8a2e:370:7348]:5678"));
     }
 
     @Test
@@ -154,7 +139,6 @@ public class UtilsTest {
 
     @Test
     public void testGetPort() {
-        // valid
         assertEquals(8000, getPort("127.0.0.1:8000").intValue());
         assertEquals(8080, getPort("mydomain.com:8080").intValue());
         assertEquals(8080, getPort("MyDomain.com:8080").intValue());
@@ -162,12 +146,6 @@ public class UtilsTest {
         assertEquals(5678, getPort("[2001:db8:85a3:8d3:1319:8a2e:370:7348]:5678").intValue());
         assertEquals(5678, getPort("[2001:DB8:85A3:8D3:1319:8A2E:370:7348]:5678").intValue());
         assertEquals(5678, getPort("[fe80::b1da:69ca:57f7:63d8%3]:5678").intValue());
-
-        // invalid
-        assertNull(getPort("host:-92"));
-        assertNull(getPort("host:-9-2"));
-        assertNull(getPort("host:92-"));
-        assertNull(getPort("host:9-2"));
     }
 
     @Test


### PR DESCRIPTION
Revert the stricter configuration validation changes(#16048, #16319) that broke compatibility when pass space-separated broker list with version >= 3.8

In addition, the previous parse method would only return the first broker when encountering a broker list separated by spaces. To address this scenario, a warning message has been added.

### Why when the space separated broker list is provided, only the first broker is used
Because we define the type of bootstrap server config as List, and List config will be parsed using comma separated pattern
* https://github.com/apache/kafka/blob/0534e42c39749cccaf35bce6006faeeea0fbfc64/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java#L367

* https://github.com/apache/kafka/blob/d5e270482cf6601e1b635d69d311957e84d6bb59/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java#L762

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
