### PR TITLE
KAFKA-18570: Update documentation to add remainingLogsToRecover and remainingSegmentsToRecover metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1770,6 +1770,16 @@ NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTi
         <td>kafka.log:type=Log,name=LogEndOffset,topic=([-.\w]+),partition=([0-9]+)</td>
         <td>The last offset in a partition.</td>
       </tr>
+      <tr>
+        <td>Remaining logs to recover</td>
+        <td>kafka.log:type=LogManager,name=remainingLogsToRecover</td>
+        <td>The number of remaining logs for each log.dir to be recovered.This metric provides an overview of the recovery progress for a given log directory.</td>
+      </tr>
+      <tr>
+        <td>Remaining segments to recover for the current recovery thread</td>
+        <td>kafka.log:type=LogManager,name=remainingSegmentsToRecover</td>
+        <td>The number of remaining segments assigned to the currently active recovery thread.</td>
+      </tr>
   </tbody></table>
 
 <h4 class="anchor-heading"><a id="tiered_storage_monitoring" class="anchor-link"></a><a href="#tiered_storage_monitoring">Tiered Storage Monitoring</a></h4>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1780,6 +1780,11 @@ NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTi
         <td>kafka.log:type=LogManager,name=remainingSegmentsToRecover</td>
         <td>The number of remaining segments assigned to the currently active recovery thread.</td>
       </tr>
+      <tr>
+        <td>Log directory offline status</td>
+        <td>kafka.log:type=LogManager,name=LogDirectoryOffline</td>
+        <td>Indicates if a log directory is offline (1) or online (0).</td>
+      </tr>
   </tbody></table>
 
 <h4 class="anchor-heading"><a id="tiered_storage_monitoring" class="anchor-link"></a><a href="#tiered_storage_monitoring">Tiered Storage Monitoring</a></h4>


### PR DESCRIPTION
`remainingLogsToRecover` and `remainingSegmentsToRecover` metrics were added as part of [KIP-831](https://cwiki.apache.org/confluence/display/KAFKA/KIP-831) but they are not part of the documentation here: https://kafka.apache.org/documentation/

The metrics were added as part of Kafka 3.3.0 with this PR so it should be safe to update the documentation.


*Summary of testing strategy (including rationale)
Loaded the html page and verified that documentation is showing up as expected


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
