### PR TITLE
KAFKA-18663: Metadata v0-v3 should be undeprecated (3.9)

### DIFF
--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -19,7 +19,6 @@
   "listeners": ["zkBroker", "broker"],
   "name": "MetadataRequest",
   "validVersions": "0-12",
-  "deprecatedVersions": "0-3",
   "flexibleVersions": "9+",
   "fields": [
     // In version 0, an empty array indicates "request metadata for all topics."  In version 1 and


### PR DESCRIPTION
See KAFKA-18648 for details.