### PR TITLE
feat(clients): MemberToRemove accepting memberId field on constructor…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberToRemove.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberToRemove.java
@@ -26,9 +26,16 @@ import java.util.Objects;
  */
 public class MemberToRemove {
     private final String groupInstanceId;
+    private final String memberId;
 
     public MemberToRemove(String groupInstanceId) {
         this.groupInstanceId = groupInstanceId;
+        this.memberId = null;
+    }
+
+    public MemberToRemove(String groupInstanceId, String memberId) {
+        this.groupInstanceId = groupInstanceId;
+        this.memberId = memberId;
     }
 
     @Override
@@ -49,7 +56,7 @@ public class MemberToRemove {
     MemberIdentity toMemberIdentity() {
         return new MemberIdentity()
             .setGroupInstanceId(groupInstanceId)
-            .setMemberId(JoinGroupRequest.UNKNOWN_MEMBER_ID);
+            .setMemberId(memberId != null ? memberId : JoinGroupRequest.UNKNOWN_MEMBER_ID);
     }
 
     public String groupInstanceId() {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RemoveMembersFromConsumerGroupResultTest {
 
     private final MemberToRemove instanceOne = new MemberToRemove("instance-1");
-    private final MemberToRemove instanceTwo = new MemberToRemove("instance-2");
+    private final MemberToRemove instanceTwo = new MemberToRemove("instance-2", "member-id");
     private Set<MemberToRemove> membersToRemove;
     private Map<MemberIdentity, Errors> errorsMap;
 
@@ -103,6 +105,12 @@ public class RemoveMembersFromConsumerGroupResultTest {
         assertNull(noErrorResult.all().get());
         assertNull(noErrorResult.memberResult(instanceOne).get());
         assertNull(noErrorResult.memberResult(instanceTwo).get());
+    }
+
+    @Test
+    public void testMemberIdentityMemberId() {
+        assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, instanceOne.toMemberIdentity().memberId());
+        assertEquals("member-id", instanceTwo.toMemberIdentity().memberId());
     }
 
     private RemoveMembersFromConsumerGroupResult createAndVerifyMemberLevelError() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
… so it is used to build up the MemberIdentity, making it possible to use removeMembersFromConsumerGroup method from admin client to disconnect a member (denoted by memberId) from the given consumer group (denoted by groupInstanceId)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*
This change allows to use admin client's `removeMembersFromConsumerGroup` pointing to an actual consumer group member

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Unit test checking both options for MemberIdentity generated from MemberToRemove if holding memberId or not

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
