### PR TITLE
MINOR: fix typo in HTML docs

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -181,7 +181,7 @@ settings.put(... , ...);</code></pre>
             <td><code class="docutils literal"><span class="pre">acks="all"</span></code></td>
           </tr>
           <tr class="row-even">
-            <td>replication.factor (for broker version 2.3 or older)/td>
+            <td>replication.factor (for broker version 2.3 or older)</td>
             <td>Streams</td>
             <td><code class="docutils literal"><span class="pre">-1</span></code></td>
             <td><code class="docutils literal"><span class="pre">3</span></code> (broker 2.4+: ensure broker config <code>default.replication.factor=3</code>)</td>


### PR DESCRIPTION
This is how the current HTML is rendered:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/47e273af-7c27-4406-a53a-19ace8568472" />