### PR TITLE
KAFKA-18629: Add persister impl and tests for DeleteShareGroupState RPC. [2/N]

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -347,6 +347,8 @@
               files="(ShareCoordinatorServiceTest|DefaultStatePersisterTest|PersisterStateManagerTest).java"/>
     <suppress checks="CyclomaticComplexity"
               files="ShareCoordinatorShard.java"/>
+    <suppress checks="ClassFanOutComplexity"
+              files="PersisterStateManagerTest.java"/>
 
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -348,7 +348,7 @@
     <suppress checks="CyclomaticComplexity"
               files="ShareCoordinatorShard.java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="PersisterStateManagerTest.java"/>
+              files="(PersisterStateManagerTest|DefaultStatePersisterTest).java"/>
 
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateRequest.java
@@ -34,7 +34,7 @@ public class DeleteShareGroupStateRequest extends AbstractRequest {
         private final DeleteShareGroupStateRequestData data;
 
         public Builder(DeleteShareGroupStateRequestData data) {
-            this(data, false);
+            this(data, true);
         }
 
         public Builder(DeleteShareGroupStateRequestData data, boolean enableUnstableLastVersion) {


### PR DESCRIPTION
* This PR adds the impl for `DeleteShareGroupState` RPC in `DefaultStatePersister`
* Adds client side handlers in `PersisterStateManager`
* Tests wherever applicable.