### PR TITLE
KAFKA-18320; Ensure that assignors are at the right place

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -45,6 +45,19 @@ public class GroupCoordinatorConfigTest {
             GroupCoordinatorConfig.SHARE_GROUP_CONFIG_DEF);
 
     @Test
+    public void testConsumerGroupAssignorsDefault() {
+        // The full class name of the assignors if part of our public api. Hence,
+        // we should ensure that they are not changed by mistake.
+        assertEquals(
+            List.of(
+                "org.apache.kafka.coordinator.group.assignor.UniformAssignor",
+                "org.apache.kafka.coordinator.group.assignor.RangeAssignor"
+            ),
+            GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_DEFAULT
+        );
+    }
+
+    @Test
     public void testConfigs() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG, 10);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -46,7 +46,7 @@ public class GroupCoordinatorConfigTest {
 
     @Test
     public void testConsumerGroupAssignorsDefault() {
-        // The full class name of the assignors if part of our public api. Hence,
+        // The full class name of the assignors is part of our public api. Hence,
         // we should ensure that they are not changed by mistake.
         assertEquals(
             List.of(


### PR DESCRIPTION
The full class name of the assignors if part of our public api. Hence, we should ensure that they are not changed by mistake. This patch adds a unit test verifying them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
