### PR TITLE
KAFKA-18674: Document the incompatible changes in parsing --bootstrap-server

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -85,7 +85,8 @@
                         <li>The default properties files for KRaft mode are no longer stored in the separate <code>config/kraft</code> directory since Zookeeper has been removed. These files have been consolidated with other configuration files.
                             Now all configuration files are in <code>config</code> directory.
                         </li>
-                        <li>The valid format for <code>--bootstrap-server</code> only supports comma-separated values, <code>host1:port1,host2:port2,...</code>. Providing other formats, like space-separated bootstrap servers (e.g., <code>host1:port1 host2:port2 host3:port3</code>), will result in an exception.
+                        <li>The valid format for <code>--bootstrap-server</code> only supports comma-separated value, such as <code>host1:port1,host2:port2,...</code>.
+                            Providing other formats, like space-separated bootstrap servers (e.g., <code>host1:port1 host2:port2 host3:port3</code>), will result in an exception, even though this was allowed in Apache Kafka versions prior to 4.0.
                         </li>
                     </ul>
                 </li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -85,7 +85,7 @@
                         <li>The default properties files for KRaft mode are no longer stored in the separate <code>config/kraft</code> directory since Zookeeper has been removed. These files have been consolidated with other configuration files.
                             Now all configuration files are in <code>config</code> directory.
                         </li>
-                        <li>The validation of <code>--bootstrap-server</code> has become stricter. Providing space-separated bootstrap servers (e.g., "broker1:9092 broker2:9092 broker3:9092") instead of comma-separated (e.g., "broker1:9092,broker2:9092,broker3:9092") will result in an exception.
+                        <li>The valid format for <code>--bootstrap-server</code> only supports comma-separated values, <code>host1:port1,host2:port2,...</code>. Providing other formats, like space-separated bootstrap servers (e.g., <code>host1:port1 host2:port2 host3:port3</code>), will result in an exception.
                         </li>
                     </ul>
                 </li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -85,6 +85,8 @@
                         <li>The default properties files for KRaft mode are no longer stored in the separate <code>config/kraft</code> directory since Zookeeper has been removed. These files have been consolidated with other configuration files.
                             Now all configuration files are in <code>config</code> directory.
                         </li>
+                        <li>The validation of <code>--bootstrap-server</code> has become stricter. Providing space-separated bootstrap servers (e.g., "broker1:9092 broker2:9092 broker3:9092") instead of comma-separated (e.g., "broker1:9092,broker2:9092,broker3:9092") will result in an exception.
+                        </li>
                     </ul>
                 </li>
                 <li><b>Broker</b>


### PR DESCRIPTION
Based on the discussion of https://github.com/apache/kafka/pull/18741#issuecomment-2623018045, add the description to `docs/upgrade.html`

> The change in behavior requiring strict validation seems reasonable for 4.0 so we probably ought to mention it in the documentation in docs/upgrade.html.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
