### PR TITLE
KAFKA-18168: Adding checkpointing for GlobalKTable during restoration…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -96,7 +96,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
         }
         initTopology();
         processorContext.initialize();
-        this.flushState();
+        flushState();
         lastFlush = time.milliseconds();
         return stateMgr.changelogOffsets();
     }
@@ -139,7 +139,9 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void close(final boolean wipeStateStore) throws IOException {
-        this.flushState();
+        if (!wipeStateStore) {
+            flushState();
+        }
         stateMgr.close();
         if (wipeStateStore) {
             try {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -96,6 +96,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
         }
         initTopology();
         processorContext.initialize();
+        this.flushState();
         lastFlush = time.milliseconds();
         return stateMgr.changelogOffsets();
     }
@@ -138,6 +139,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void close(final boolean wipeStateStore) throws IOException {
+        this.flushState();
         stateMgr.close();
         if (wipeStateStore) {
             try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
@@ -252,6 +252,10 @@ public class GlobalStateTaskTest {
     @Test
     public void shouldNotCheckpointIfNotReceivedEnoughRecords() {
         globalStateTask.initialize();
+        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
+
         globalStateTask.update(record(topic1, 1, currentOffsetT1 + 9000L, "foo".getBytes(), "foo".getBytes()));
         time.sleep(flushInterval); // flush interval elapsed
         globalStateTask.maybeCheckpoint();
@@ -264,6 +268,9 @@ public class GlobalStateTaskTest {
     @Test
     public void shouldNotCheckpointWhenFlushIntervalHasNotLapsed() {
         globalStateTask.initialize();
+        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
 
         // offset delta exceeded
         globalStateTask.update(record(topic1, 1, currentOffsetT1 + 10000L, "foo".getBytes(), "foo".getBytes()));
@@ -283,6 +290,9 @@ public class GlobalStateTaskTest {
         expectedOffsets.put(t2, 100L);
 
         globalStateTask.initialize();
+        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
 
         time.sleep(flushInterval); // flush interval elapsed
 
@@ -332,5 +342,22 @@ public class GlobalStateTaskTest {
         assertTrue(stateMgr.baseDir().exists());
         globalStateTask.close(true);
         assertFalse(stateMgr.baseDir().exists());
+    }
+
+    @Test
+    public void shouldCheckpointDuringInitialization() {
+        globalStateTask.initialize();
+
+        assertTrue(stateMgr.checkpointWritten);
+        assertTrue(stateMgr.flushed);
+    }
+
+    @Test
+    public void shouldCheckpointDuringClose() throws Exception {
+        globalStateTask.initialize();
+        globalStateTask.close(false);
+
+        assertTrue(stateMgr.checkpointWritten);
+        assertTrue(stateMgr.flushed);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
@@ -252,12 +252,12 @@ public class GlobalStateTaskTest {
     @Test
     public void shouldNotCheckpointIfNotReceivedEnoughRecords() {
         globalStateTask.initialize();
-        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
+        globalStateTask.update(record(topic1, 1, currentOffsetT1 + 9000L, "foo".getBytes(), "foo".getBytes()));
+        time.sleep(flushInterval); // flush interval elapsed
+
         stateMgr.checkpointWritten = false;
         stateMgr.flushed = false;
 
-        globalStateTask.update(record(topic1, 1, currentOffsetT1 + 9000L, "foo".getBytes(), "foo".getBytes()));
-        time.sleep(flushInterval); // flush interval elapsed
         globalStateTask.maybeCheckpoint();
 
         assertEquals(offsets, stateMgr.changelogOffsets());
@@ -268,14 +268,15 @@ public class GlobalStateTaskTest {
     @Test
     public void shouldNotCheckpointWhenFlushIntervalHasNotLapsed() {
         globalStateTask.initialize();
-        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
-        stateMgr.checkpointWritten = false;
-        stateMgr.flushed = false;
 
         // offset delta exceeded
         globalStateTask.update(record(topic1, 1, currentOffsetT1 + 10000L, "foo".getBytes(), "foo".getBytes()));
 
         time.sleep(flushInterval / 2);
+
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
+
         globalStateTask.maybeCheckpoint();
 
         assertEquals(offsets, stateMgr.changelogOffsets());
@@ -290,14 +291,15 @@ public class GlobalStateTaskTest {
         expectedOffsets.put(t2, 100L);
 
         globalStateTask.initialize();
-        // Reset after initialization since checkpointing should happen during initialization, KAFKA-18168
-        stateMgr.checkpointWritten = false;
-        stateMgr.flushed = false;
 
         time.sleep(flushInterval); // flush interval elapsed
 
         // 10000 records received since last flush => do not flush
         globalStateTask.update(record(topic1, 1, currentOffsetT1 + 9999L, "foo".getBytes(), "foo".getBytes()));
+
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
+
         globalStateTask.maybeCheckpoint();
 
         assertEquals(offsets, stateMgr.changelogOffsets());
@@ -355,6 +357,10 @@ public class GlobalStateTaskTest {
     @Test
     public void shouldCheckpointDuringClose() throws Exception {
         globalStateTask.initialize();
+
+        stateMgr.checkpointWritten = false;
+        stateMgr.flushed = false;
+
         globalStateTask.close(false);
 
         assertTrue(stateMgr.checkpointWritten);


### PR DESCRIPTION
… and closing.

To address the issue of not creating a checkpoint file during the restoring and closing process, called the GlobalStateUpdateTask.flushState() method in GlobalStateUpdateTask.initialize() and GlobalStateUpdateTask.close() methods. This will flush the state and create a checkpoint file thereby, avoiding the need to completely restore the entire state.

As discussed with @mjsax in the Jira ticket.
