### PR TITLE
MINOR: Replace lambda expressions with method references in ProducerStateManager

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -567,15 +567,15 @@ public class ProducerStateManager {
     }
 
     public Optional<File> fetchSnapshot(long offset) {
-        return Optional.ofNullable(snapshots.get(offset)).map(x -> x.file());
+        return Optional.ofNullable(snapshots.get(offset)).map(SnapshotFile::file);
     }
 
     private Optional<SnapshotFile> oldestSnapshotFile() {
-        return Optional.ofNullable(snapshots.firstEntry()).map(x -> x.getValue());
+        return Optional.ofNullable(snapshots.firstEntry()).map(Map.Entry::getValue);
     }
 
     private Optional<SnapshotFile> latestSnapshotFile() {
-        return Optional.ofNullable(snapshots.lastEntry()).map(e -> e.getValue());
+        return Optional.ofNullable(snapshots.lastEntry()).map(Map.Entry::getValue);
     }
 
     /**


### PR DESCRIPTION
Updated `fetchSnapshot`, `oldestSnapshotFile`, and `latestSnapshotFile` to use method references for improved readability.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
