### PR TITLE
KAFKA-18489 - Fix Connector tasks metrics task-startup-attempts, task…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -571,7 +571,7 @@ public final class Worker {
     ) {
         final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
         return startTask(id, connProps, taskProps, configState, taskStatusListener,
-                new SinkTaskBuilder(id, configState, statusListener, initialState));
+                new SinkTaskBuilder(id, configState, taskStatusListener, initialState));
     }
 
     /**
@@ -595,7 +595,7 @@ public final class Worker {
     ) {
         final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
         return startTask(id, connProps, taskProps, configState, taskStatusListener,
-                new SourceTaskBuilder(id, configState, statusListener, initialState));
+                new SourceTaskBuilder(id, configState, taskStatusListener, initialState));
     }
 
     /**
@@ -624,7 +624,7 @@ public final class Worker {
     ) {
         final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
         return startTask(id, connProps, taskProps, configState, taskStatusListener,
-                new ExactlyOnceSourceTaskBuilder(id, configState, statusListener, initialState, preProducerCheck, postProducerCheck));
+                new ExactlyOnceSourceTaskBuilder(id, configState, taskStatusListener, initialState, preProducerCheck, postProducerCheck));
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -569,7 +569,8 @@ public final class Worker {
             TaskStatus.Listener statusListener,
             TargetState initialState
     ) {
-        return startTask(id, connProps, taskProps, configState, statusListener,
+        final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
+        return startTask(id, connProps, taskProps, configState, taskStatusListener,
                 new SinkTaskBuilder(id, configState, statusListener, initialState));
     }
 
@@ -592,7 +593,8 @@ public final class Worker {
             TaskStatus.Listener statusListener,
             TargetState initialState
     ) {
-        return startTask(id, connProps, taskProps, configState, statusListener,
+        final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
+        return startTask(id, connProps, taskProps, configState, taskStatusListener,
                 new SourceTaskBuilder(id, configState, statusListener, initialState));
     }
 
@@ -620,7 +622,8 @@ public final class Worker {
             Runnable preProducerCheck,
             Runnable postProducerCheck
     ) {
-        return startTask(id, connProps, taskProps, configState, statusListener,
+        final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
+        return startTask(id, connProps, taskProps, configState, taskStatusListener,
                 new ExactlyOnceSourceTaskBuilder(id, configState, statusListener, initialState, preProducerCheck, postProducerCheck));
     }
 
@@ -644,7 +647,6 @@ public final class Worker {
             TaskBuilder<?, ?> taskBuilder
     ) {
         final WorkerTask<?, ?> workerTask;
-        final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
         try (LoggingContext loggingContext = LoggingContext.forTask(id)) {
             log.info("Creating task {}", id);
 
@@ -709,7 +711,7 @@ public final class Worker {
             } catch (Throwable t) {
                 log.error("Failed to start task {}", id, t);
                 connectorStatusMetricsGroup.recordTaskRemoved(id);
-                taskStatusListener.onFailure(id, t);
+                statusListener.onFailure(id, t);
                 return false;
             }
 


### PR DESCRIPTION
…-startup-success

A minor bug was introduced as part of [EOS in Apache Kafka 3 years ago](https://github.com/apache/kafka/commit/9e8ef8bb317599c184ce8201d494edf109d9c528#diff-90b4072cc070e1d6417b3bb59a4a35668c4d97ce1dd6a2587db9f2c9a9ebf93e) The line
```
final TaskStatus.Listener taskStatusListener = workerMetricsGroup.wrapStatusListener(statusListener);
 ```

wraps herder's listener in workerMetricsGroup's listener. WorkerMetricsGroup is the entity which records task success and failure in the metric .
In the PR, the wrapped listener was missed and instead the herder listener is passed to the task builder (as part of constructor).


workerMetricsGroup's UT already validates that the metrics get updated when tasks fail or succeed.
I did not see a way to test connector's metrics using JMX

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
