### PR TITLE
KAFKA-17379: Fix inexpected state transition from ERROR to PENDING_SHUTDOWN

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -109,6 +109,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
 import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
@@ -293,13 +294,14 @@ public class KafkaStreams implements AutoCloseable {
     private final Object stateLock = new Object();
     protected volatile State state = State.CREATED;
 
-    private boolean waitOnState(final State targetState, final long waitMs) {
+    private boolean waitOnStates(final long waitMs, final State... targetStates) {
+        final Set<State> targetStateSet = Set.of(targetStates);
         final long begin = time.milliseconds();
         synchronized (stateLock) {
             boolean interrupted = false;
             long elapsedMs = 0L;
             try {
-                while (state != targetState) {
+                while (!targetStateSet.contains(state)) {
                     if (waitMs > elapsedMs) {
                         final long remainingMs = waitMs - elapsedMs;
                         try {
@@ -308,7 +310,8 @@ public class KafkaStreams implements AutoCloseable {
                             interrupted = true;
                         }
                     } else {
-                        log.debug("Cannot transit to {} within {}ms", targetState, waitMs);
+                        log.debug("Cannot transit to {} within {}ms",
+                            Arrays.stream(targetStates).map(State::toString).collect(Collectors.joining(" or ")), waitMs);
                         return false;
                     }
                     elapsedMs = time.milliseconds() - begin;
@@ -1545,39 +1548,29 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         if (!setState(State.PENDING_SHUTDOWN)) {
-
-            if (state.isShuttingDown()) {
-                log.info("Streams client is in {}, all resources are being closed and the client will be stopped.", state);
-                if (state == State.PENDING_ERROR && waitOnState(State.ERROR, timeoutMs)) {
-                    log.info("Streams client stopped to ERROR completely");
-                    return true;
-                } else if (state == State.PENDING_SHUTDOWN && waitOnState(State.NOT_RUNNING, timeoutMs)) {
-                    log.info("Streams client stopped to NOT_RUNNING completely");
-                    return true;
-                } else {
-                    log.warn("Streams client cannot transition to {} completely within the timeout",
-                        state == State.PENDING_SHUTDOWN ? State.NOT_RUNNING : State.ERROR);
+            final State stateCopy = state;
+            if (stateCopy.isShuttingDown()) {
+                log.info("Skipping shutdown since Streams client is already in {}, waiting for a terminal state", stateCopy);
+                if (!waitOnStates(timeoutMs, State.ERROR, State.NOT_RUNNING)) {
+                    log.warn("Streams client did transition to a terminal state (ERROR or NOT_RUNNING) within the {}ms timeout", timeoutMs);
                     return false;
                 }
+                log.info("Streams client stopped completely and transitioned to the terminal {} state", state);
+            } else if (stateCopy.hasCompletedShutdown()) {
+                log.info("Skipping shutdown since Streams client is already in the terminal {} state", stateCopy);
+            } else {
+                throw new IllegalStateException("If transitioning to PENDING_SHUTDOWN fails, the state should be either in "
+                    + "PENDING_SHUTDOWN, PENDING_ERROR, ERROR, or NOT_RUNNING");
             }
-
-            if (state.hasCompletedShutdown()) {
-                log.info("Streams client is already in the terminal {} state, all resources are closed and the client has stopped.", state);
-                return true;
-            }
-
-            // if we can't transition to PENDING_SHUTDOWN but not because we're already shutting down, then it must be fatal
-            log.error("Failed to transition to PENDING_SHUTDOWN, current state is {}", state);
-            throw new StreamsException("Failed to shut down while in state " + state);
-        } else {
-
-            final Thread shutdownThread = shutdownHelper(false, timeoutMs, leaveGroup);
-
-            shutdownThread.setDaemon(true);
-            shutdownThread.start();
+            return true;
         }
 
-        if (waitOnState(State.NOT_RUNNING, timeoutMs)) {
+        final Thread shutdownThread = shutdownHelper(false, timeoutMs, leaveGroup);
+
+        shutdownThread.setDaemon(true);
+        shutdownThread.start();
+
+        if (waitOnStates(timeoutMs, State.NOT_RUNNING)) {
             log.info("Streams client stopped completely");
             return true;
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -310,8 +310,11 @@ public class KafkaStreams implements AutoCloseable {
                             interrupted = true;
                         }
                     } else {
-                        log.debug("Cannot transit to {} within {}ms",
-                            Arrays.stream(targetStates).map(State::toString).collect(Collectors.joining(" or ")), waitMs);
+                        log.debug(
+                            "Cannot transit to {} within {}ms",
+                            Arrays.stream(targetStates).map(State::toString).collect(Collectors.joining(" or ")),
+                            waitMs
+                        );
                         return false;
                     }
                     elapsedMs = time.milliseconds() - begin;
@@ -1548,21 +1551,25 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         if (!setState(State.PENDING_SHUTDOWN)) {
-            final State stateCopy = state;
-            if (stateCopy.isShuttingDown()) {
-                log.info("Skipping shutdown since Streams client is already in {}, waiting for a terminal state", stateCopy);
+            // Copy the state so that we can atomically check if we are shut down and act on it (log it)
+            final State immutableStateCopy = state;
+            if (immutableStateCopy.isShuttingDown()) {
+                log.info("Skipping shutdown since Streams client is already in {}, waiting for a terminal state", immutableStateCopy);
                 if (!waitOnStates(timeoutMs, State.ERROR, State.NOT_RUNNING)) {
                     log.warn("Streams client did transition to a terminal state (ERROR or NOT_RUNNING) within the {}ms timeout", timeoutMs);
                     return false;
                 }
                 log.info("Streams client stopped completely and transitioned to the terminal {} state", state);
-            } else if (stateCopy.hasCompletedShutdown()) {
-                log.info("Skipping shutdown since Streams client is already in the terminal {} state", stateCopy);
-            } else {
-                throw new IllegalStateException("If transitioning to PENDING_SHUTDOWN fails, the state should be either in "
-                    + "PENDING_SHUTDOWN, PENDING_ERROR, ERROR, or NOT_RUNNING");
+                return true;
             }
-            return true;
+
+            if (state.hasCompletedShutdown()) {
+                log.info("Skipping shutdown since Streams client is already in the terminal {} state", state);
+                return true;
+            }
+
+            throw new IllegalStateException("If transitioning to PENDING_SHUTDOWN fails, the state should be either in "
+                + "PENDING_SHUTDOWN, PENDING_ERROR, ERROR, or NOT_RUNNING");
         }
 
         final Thread shutdownThread = shutdownHelper(false, timeoutMs, leaveGroup);

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -347,8 +347,9 @@ public class KafkaStreams implements AutoCloseable {
             } else if (state == State.REBALANCING && newState == State.REBALANCING) {
                 // when the state is already in REBALANCING, it should not transit to REBALANCING again
                 return false;
-            } else if (state == State.ERROR && (newState == State.PENDING_ERROR || newState == State.ERROR)) {
-                // when the state is already in ERROR, its transition to PENDING_ERROR or ERROR (due to consecutive close calls)
+            } else if (state == State.ERROR && (newState == State.PENDING_ERROR || newState == State.ERROR || newState == State.PENDING_SHUTDOWN)) {
+                // when the state is already in ERROR, its transition attempts to PENDING_SHUTDOWN, PENDING_ERROR or ERROR will
+                // not throw an exception.
                 return false;
             } else if (state == State.PENDING_ERROR && newState != State.ERROR) {
                 // when the state is already in PENDING_ERROR, all other transitions than ERROR (due to thread dying) will be
@@ -1543,26 +1544,28 @@ public class KafkaStreams implements AutoCloseable {
             timeoutMs = Long.MAX_VALUE;
         }
 
-        if (state.hasCompletedShutdown()) {
-            log.info("Streams client is already in the terminal {} state, all resources are closed and the client has stopped.", state);
-            return true;
-        }
-        if (state.isShuttingDown()) {
-            log.info("Streams client is in {}, all resources are being closed and the client will be stopped.", state);
-            if (state == State.PENDING_ERROR && waitOnState(State.ERROR, timeoutMs)) {
-                log.info("Streams client stopped to ERROR completely");
-                return true;
-            } else if (state == State.PENDING_SHUTDOWN && waitOnState(State.NOT_RUNNING, timeoutMs)) {
-                log.info("Streams client stopped to NOT_RUNNING completely");
-                return true;
-            } else {
-                log.warn("Streams client cannot transition to {} completely within the timeout",
-                         state == State.PENDING_SHUTDOWN ? State.NOT_RUNNING : State.ERROR);
-                return false;
-            }
-        }
-
         if (!setState(State.PENDING_SHUTDOWN)) {
+
+            if (state.isShuttingDown()) {
+                log.info("Streams client is in {}, all resources are being closed and the client will be stopped.", state);
+                if (state == State.PENDING_ERROR && waitOnState(State.ERROR, timeoutMs)) {
+                    log.info("Streams client stopped to ERROR completely");
+                    return true;
+                } else if (state == State.PENDING_SHUTDOWN && waitOnState(State.NOT_RUNNING, timeoutMs)) {
+                    log.info("Streams client stopped to NOT_RUNNING completely");
+                    return true;
+                } else {
+                    log.warn("Streams client cannot transition to {} completely within the timeout",
+                        state == State.PENDING_SHUTDOWN ? State.NOT_RUNNING : State.ERROR);
+                    return false;
+                }
+            }
+
+            if (state.hasCompletedShutdown()) {
+                log.info("Streams client is already in the terminal {} state, all resources are closed and the client has stopped.", state);
+                return true;
+            }
+
             // if we can't transition to PENDING_SHUTDOWN but not because we're already shutting down, then it must be fatal
             log.error("Failed to transition to PENDING_SHUTDOWN, current state is {}", state);
             throw new StreamsException("Failed to shut down while in state " + state);


### PR DESCRIPTION
The exception stack trace shown in the ticket can happen when we are concurrently closing the producer because of an error and doing a regular close. This is not a bug in the test, but a real race condition that can happen in the production code.

The sequence is this:

Thread1: Enter PENDING_ERROR
Thread2: Check if state is already ERROR
Thread1: Transition to ERROR
Thread2: Check if state is already PENDING_ERROR
Thread2: Transition to PENDING_SHUTDOWN

One idea to fix this would be to synchronize the sequence performed by Thread1 using the state lock (this seems to be suggested in the ticket). However, this would require larger changes, since we cannot use the normal state transition method `setState` while owning the lock, as it calls user-defined callbacks. Calling the user-defined callback while owning the lock may create deadlocks. Also, the code would become more complex, since we cannot wait for state transitions while owning the lock - it's not as simple as putting a `synchronized(stateLock)` around everything.

To avoid adding more synchronization, this change proposes to fix it by _first_ attempting to transition to PENDING_SHUTDOWN, and _then_ checking whether another thread is already attempting to shut down (states PENDING_SHUTDOWN, PENDING_ERROR, ERROR, NOT_RUNNING), if the state transition fails. This way, we can react correctly to an already shutting down an application. `setState` acts as a test-and-set operation that prevents multiple threads from entering the critical section which starts the shutdown helper.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
