### PR TITLE
KAFKA-18146; tests/kafkatest/tests/core/upgrade_test.py needs to be re-added as KRaft

### DIFF
--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -32,10 +32,10 @@ from kafkatest.version import LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LA
 # ZK mode. The upgrade process is also somewhat different for KRaft because we
 # use metadata.version instead of inter.broker.protocol.
 #
-class TestKRaftUpgrade(ProduceConsumeValidateTest):
+class TestUpgrade(ProduceConsumeValidateTest):
 
     def __init__(self, test_context):
-        super(TestKRaftUpgrade, self).__init__(test_context=test_context)
+        super(TestUpgrade, self).__init__(test_context=test_context)
         self.may_truncate_acked_records = False
 
     def setUp(self):


### PR DESCRIPTION
This patch renames kraft_upgrade_test.py to upgrade_test.py. This is enough to cover the old upgrade/downgrade tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
