### PR TITLE
KAFKA-18675: Add unit test to verify space separated brokers won't cause exception for 3.8 and 3.9

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -130,7 +130,8 @@ public class ClientUtilsTest {
 
     @Test
     public void testInvalidConfig() {
-        assertThrows(ConfigException.class, () -> checkWithoutLookup("localhost:10000", "localhost:10001"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ClientUtils.parseAndValidateAddresses(Collections.singletonList("localhost:10000"), "random.value"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -103,6 +103,7 @@ public class ClientUtilsTest {
     static Stream<List<String>> provideValidBrokerAddressTestCases() {
         return Stream.of(
             Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
+            Arrays.asList("localhost:9997", "localhost:9998", " localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
             Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
         );
@@ -116,16 +117,20 @@ public class ClientUtilsTest {
 
     static Stream<List<String>> provideInvalidBrokerAddressTestCases() {
         return Stream.of(
-            Collections.singletonList("localhost:9997\nlocalhost:9998\nlocalhost:9999"),
-            Collections.singletonList("localhost:10000")
+            Collections.singletonList("localhost:9997\nlocalhost:9998\nlocalhost:9999")
         );
     }
 
     @ParameterizedTest
     @MethodSource("provideInvalidBrokerAddressTestCases")
     public void testInvalidBrokerAddress(List<String> addresses) {
-        assertThrows(IllegalArgumentException.class,
-            () -> ClientUtils.parseAndValidateAddresses(addresses, "random.value"));
+        assertThrows(ConfigException.class,
+            () -> ClientUtils.parseAndValidateAddresses(addresses, ClientDnsLookup.USE_ALL_DNS_IPS));
+    }
+
+    @Test
+    public void testInvalidConfig() {
+        assertThrows(ConfigException.class, () -> checkWithoutLookup("localhost:10000", "localhost:10001"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -104,7 +104,8 @@ public class ClientUtilsTest {
         return Stream.of(
             Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
-            Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
+            Arrays.asList("localhost:9997 localhost:9998 localhost:9999"),
+            Arrays.asList("localhost:9997\nlocalhost:9998\nlocalhost:9999")
         );
     }
 
@@ -114,10 +115,18 @@ public class ClientUtilsTest {
         assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(addresses, ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
-    @Test
-    public void testInvalidConfig() {
+    static Stream<List<String>> provideInvalidBrokerAddressTestCases() {
+        return Stream.of(
+            Collections.singletonList("localhost:9997\nlocalhost:9998\nlocalhost:9999"),
+            Collections.singletonList("localhost:10000")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidBrokerAddressTestCases")
+    public void testInvalidConfig(List<String> addresses) {
         assertThrows(IllegalArgumentException.class,
-            () -> ClientUtils.parseAndValidateAddresses(Collections.singletonList("localhost:10000"), "random.value"));
+            () -> ClientUtils.parseAndValidateAddresses(addresses, "random.value"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.clients;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -28,8 +30,10 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -94,6 +98,20 @@ public class ClientUtilsTest {
                 );
             }
         }
+    }
+
+    static Stream<List<String>> provideBrokerListTestCases() {
+        return Stream.of(
+            Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
+            // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
+            Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBrokerListTestCases")
+    public void testValidBrokerList(List<String> brokerList) {
+        assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(brokerList, ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -102,9 +102,9 @@ public class ClientUtilsTest {
 
     static Stream<List<String>> provideBrokerListTestCases() {
         return Stream.of(
-            Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
+            List.of("localhost:9997", "localhost:9998", "localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
-            Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
+            List.of("localhost:9997 localhost:9998 localhost:9999")
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -131,7 +131,7 @@ public class ClientUtilsTest {
     @Test
     public void testInvalidConfig() {
         assertThrows(IllegalArgumentException.class,
-                () -> ClientUtils.parseAndValidateAddresses(Collections.singletonList("localhost:10000"), "random.value"));
+            () -> ClientUtils.parseAndValidateAddresses(Collections.singletonList("localhost:10000"), "random.value"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -100,7 +100,7 @@ public class ClientUtilsTest {
         }
     }
 
-    static Stream<List<String>> provideBrokerListTestCases() {
+    static Stream<List<String>> provideValidBrokerAddressTestCases() {
         return Stream.of(
             List.of("localhost:9997", "localhost:9998", "localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
@@ -109,7 +109,7 @@ public class ClientUtilsTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideBrokerListTestCases")
+    @MethodSource("provideValidBrokerAddressTestCases")
     public void testValidBrokerList(List<String> brokerList) {
         assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(brokerList, ClientDnsLookup.USE_ALL_DNS_IPS));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -110,8 +110,8 @@ public class ClientUtilsTest {
 
     @ParameterizedTest
     @MethodSource("provideValidBrokerAddressTestCases")
-    public void testValidBrokerList(List<String> brokerList) {
-        assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(brokerList, ClientDnsLookup.USE_ALL_DNS_IPS));
+    public void testValidBrokerAddress(List<String> addresses) {
+        assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(addresses, ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -102,9 +102,9 @@ public class ClientUtilsTest {
 
     static Stream<List<String>> provideValidBrokerAddressTestCases() {
         return Stream.of(
-            List.of("localhost:9997", "localhost:9998", "localhost:9999"),
+            Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
-            List.of("localhost:9997 localhost:9998 localhost:9999")
+            Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -104,8 +104,7 @@ public class ClientUtilsTest {
         return Stream.of(
             Arrays.asList("localhost:9997", "localhost:9998", "localhost:9999"),
             // Intentionally provide a single string, as users may provide space-separated brokers, which will be parsed as a single string.
-            Arrays.asList("localhost:9997 localhost:9998 localhost:9999"),
-            Arrays.asList("localhost:9997\nlocalhost:9998\nlocalhost:9999")
+            Arrays.asList("localhost:9997 localhost:9998 localhost:9999")
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -123,7 +123,7 @@ public class ClientUtilsTest {
 
     @ParameterizedTest
     @MethodSource("provideInvalidBrokerAddressTestCases")
-    public void testInvalidConfig(List<String> addresses) {
+    public void testInvalidBrokerAddress(List<String> addresses) {
         assertThrows(IllegalArgumentException.class,
             () -> ClientUtils.parseAndValidateAddresses(addresses, "random.value"));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -115,17 +115,11 @@ public class ClientUtilsTest {
         assertDoesNotThrow(() -> ClientUtils.parseAndValidateAddresses(addresses, ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
-    static Stream<List<String>> provideInvalidBrokerAddressTestCases() {
-        return Stream.of(
-            Collections.singletonList("localhost:9997\nlocalhost:9998\nlocalhost:9999")
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideInvalidBrokerAddressTestCases")
-    public void testInvalidBrokerAddress(List<String> addresses) {
+    @Test
+    public void testInvalidBrokerAddress() {
+        List<String> invalidBrokerAddress = Collections.singletonList("localhost:9997\nlocalhost:9998\nlocalhost:9999");
         assertThrows(ConfigException.class,
-            () -> ClientUtils.parseAndValidateAddresses(addresses, ClientDnsLookup.USE_ALL_DNS_IPS));
+            () -> ClientUtils.parseAndValidateAddresses(invalidBrokerAddress, ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
     @Test


### PR DESCRIPTION
Based on the discussion https://github.com/apache/kafka/pull/18741#issuecomment-2623740585
Add unit test to ensure user can provide space-separated broker list

This change need to be backported to 3.8 as well

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
