### PR TITLE
MINOR: Remove the test for ZooKeeper metrics used by ZooKeeperClient

### DIFF
--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -234,23 +234,6 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     })
   }
 
-  /**
-   * Test that the metrics are created with the right name, testZooKeeperStateChangeRateMetrics
-   * and testZooKeeperSessionStateMetric in ZooKeeperClientTest test the metrics behaviour.
-   */
-  @ParameterizedTest
-  @ValueSource(strings = Array("kraft"))
-  def testSessionExpireListenerMetrics(quorum: String): Unit = {
-    val metrics = KafkaYammerMetrics.defaultRegistry.allMetrics
-    val expectedNumMetrics = 0
-    assertEquals(expectedNumMetrics, metrics.keySet.asScala.
-      count(_.getMBeanName == "kafka.server:type=SessionExpireListener,name=SessionState"))
-    assertEquals(expectedNumMetrics, metrics.keySet.asScala.
-      count(_.getMBeanName == "kafka.server:type=SessionExpireListener,name=ZooKeeperExpiresPerSec"))
-    assertEquals(expectedNumMetrics, metrics.keySet.asScala.
-      count(_.getMBeanName == "kafka.server:type=SessionExpireListener,name=ZooKeeperDisconnectsPerSec"))
-  }
-
   private def topicMetrics(topic: Option[String]): Set[String] = {
     val metricNames = KafkaYammerMetrics.defaultRegistry.allMetrics().keySet.asScala.map(_.getMBeanName)
     filterByTopicMetricRegex(metricNames, topic)

--- a/docs/zk2kraft.html
+++ b/docs/zk2kraft.html
@@ -199,8 +199,12 @@
                 <li><code>kafka.server:type=DelayedOperationPurgatory,name=NumDelayedOperations,delayedOperation=ElectLeader</code></li>
                 <li><code>kafka.server:type=DelayedOperationPurgatory,name=NumDelayedOperations,delayedOperation=topic</code></li>
                 <li><code>kafka.server:type=SessionExpireListener,name=SessionState</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperAuthFailuresPerSec</code></li>
                 <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperDisconnectsPerSec</code></li>
                 <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperExpiresPerSec</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperReadOnlyConnectsPerSec</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperSaslAuthenticationsPerSec</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperSyncConnectsPerSec</code></li>
                 <li><code>kafka.server:type=ZooKeeperClientMetrics,name=ZooKeeperRequestLatencyMs</code></li>
             </ul>
         </li>

--- a/docs/zk2kraft.html
+++ b/docs/zk2kraft.html
@@ -198,6 +198,9 @@
                 <li><code>kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=topic</code></li>
                 <li><code>kafka.server:type=DelayedOperationPurgatory,name=NumDelayedOperations,delayedOperation=ElectLeader</code></li>
                 <li><code>kafka.server:type=DelayedOperationPurgatory,name=NumDelayedOperations,delayedOperation=topic</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=SessionState</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperDisconnectsPerSec</code></li>
+                <li><code>kafka.server:type=SessionExpireListener,name=ZooKeeperExpiresPerSec</code></li>
                 <li><code>kafka.server:type=ZooKeeperClientMetrics,name=ZooKeeperRequestLatencyMs</code></li>
             </ul>
         </li>


### PR DESCRIPTION
## Description
Remove the test for three metrics already removed in #18450, used only by ZooKeeper, and document them.
- kafka.server:type=SessionExpireListener,name=SessionState
- SessionExpireListener,name=ZooKeeperExpiresPerSec
- SessionExpireListener,name=ZooKeeperDisconnectsPerSec



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
