### PR TITLE
MINOR: Remove the noisy log from the consumer manager

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
@@ -108,7 +108,6 @@ public class ConsumerManager implements Closeable {
         long offset = recordMetadata.offset();
         long startTimeMs = time.milliseconds();
         long consumeCheckIntervalMs = Math.min(CONSUME_RECHECK_INTERVAL_MS, timeoutMs);
-        log.info("Wait until the consumer is caught up with the target partition {} up-to offset {}", partition, offset);
         while (true) {
             long readOffset = consumerTask.readOffsetForMetadataPartition(partition).orElse(-1L);
             if (readOffset >= offset) {


### PR DESCRIPTION
The statement gets logged in the INFO level and gets printed for every message produced to the `__remote_log_metadata` topic. Removed the log statement as it is needed only during debug session. And, we have another log at DEBUG level to capture this information.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
