### PR TITLE
MINOR increase max flaky tests allowed

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -58,7 +58,7 @@ runs:
         timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
         -PtestLoggingEvents=started,passed,skipped,failed \
         -PmaxParallelForks=2 \
-        -PmaxTestRetries=1 -PmaxTestRetryFailures=3 \
+        -PmaxTestRetries=1 -PmaxTestRetryFailures=10 \
         -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 \
         -Pkafka.test.catalog.file=$TEST_CATALOG \
         -PcommitId=xxxxxxxxxxxxxxxx \


### PR DESCRIPTION
Increase the maximum number of flaky tests we tolerate for the main test suite from 3 to 10. This will result in fewer failed trunk builds.