### PR TITLE
MINOR: Fix PerformanceService sys test

### DIFF
--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -20,7 +20,6 @@ from ducktape.tests.test import Test
 from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.performance import ProducerPerformanceService, ConsumerPerformanceService, EndToEndLatencyService
 from kafkatest.services.performance import latency, compute_aggregate_throughput
-from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.version import DEV_BRANCH, LATEST_2_1, KafkaVersion
 
 

--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -31,12 +31,6 @@ class PerformanceServiceTest(Test):
         self.num_records = 10000
         self.topic = "topic"
 
-        self.zk = ZookeeperService(test_context, 1) if quorum.for_test(test_context) == quorum.zk else None
-
-    def setUp(self):
-        if self.zk:
-            self.zk.start()
-
     @cluster(num_nodes=5)
     @matrix(version=[str(LATEST_2_1), str(DEV_BRANCH)], metadata_quorum=quorum.all_kraft)
     def test_version(self, version=str(LATEST_2_1), metadata_quorum=quorum.zk):
@@ -47,7 +41,7 @@ class PerformanceServiceTest(Test):
         version = KafkaVersion(version)
         self.kafka = KafkaService(
             self.test_context, 1,
-            self.zk, topics={self.topic: {'partitions': 1, 'replication-factor': 1}}, version=DEV_BRANCH)
+            None, topics={self.topic: {'partitions': 1, 'replication-factor': 1}}, version=DEV_BRANCH)
         self.kafka.start()
 
         # check basic run of producer performance

--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -38,7 +38,7 @@ class PerformanceServiceTest(Test):
             self.zk.start()
 
     @cluster(num_nodes=5)
-    @matrix(version=[str(LATEST_2_1), str(DEV_BRANCH)], metadata_quorum=quorum.all)
+    @matrix(version=[str(LATEST_2_1), str(DEV_BRANCH)], metadata_quorum=quorum.all_kraft)
     def test_version(self, version=str(LATEST_2_1), metadata_quorum=quorum.zk):
         """
         Sanity check out producer performance service - verify that we can run the service with a small


### PR DESCRIPTION
This patch fixes the PerformanceService system test which was still using ZK.

```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-02-04--003
run time:         1 minute 42.629 seconds
tests run:        4
passed:           4                                                                                                                                                                         flaky:            0
failed:           0                                                                                                                                                                         ignored:          0
================================================================================
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
