### PR TITLE
DRAFT KAFKA-18692: Consider to unify KStreamImpl "repartitionRequired" with GraphNode "keyChangingOperation"

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/BranchedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/BranchedKStreamImpl.java
@@ -33,7 +33,6 @@ public class BranchedKStreamImpl<K, V> implements BranchedKStream<K, V> {
     private static final String BRANCH_NAME = "KSTREAM-BRANCH-";
 
     private final KStreamImpl<K, V> source;
-    private final boolean repartitionRequired;
     private final String splitterName;
     private final Map<String, KStream<K, V>> outputBranches = new HashMap<>();
 
@@ -41,9 +40,8 @@ public class BranchedKStreamImpl<K, V> implements BranchedKStream<K, V> {
     private final List<String> childNames = new ArrayList<>();
     private final ProcessorGraphNode<K, V> splitterNode;
 
-    BranchedKStreamImpl(final KStreamImpl<K, V> source, final boolean repartitionRequired, final NamedInternal named) {
+    BranchedKStreamImpl(final KStreamImpl<K, V> source, final NamedInternal named) {
         this.source = source;
-        this.repartitionRequired = repartitionRequired;
         this.splitterName = named.orElseGenerateWithPrefix(source.builder, BRANCH_NAME);
 
         // predicates and childNames are passed by reference so when the user adds a branch they get added to
@@ -86,7 +84,7 @@ public class BranchedKStreamImpl<K, V> implements BranchedKStream<K, V> {
         source.builder.addGraphNode(splitterNode, branchChildNode);
         final KStreamImpl<K, V> branch = new KStreamImpl<>(branchChildName, source.keySerde,
                 source.valueSerde, source.subTopologySourceNodes,
-                repartitionRequired, branchChildNode, source.builder);
+                branchChildNode, source.builder);
         process(branch, branchChildName, branchedInternal);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -210,7 +210,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                      final String queryableName) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
-            if (repartitionReqs.isRepartitionRequired()) {
+            if (repartitionReqs.repartitioningRequired()) {
 
                 final OptimizableRepartitionNodeBuilder<K, ?> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -210,7 +210,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                      final String queryableName) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
-            if (repartitionReqs.repartitionRequired) {
+            if (repartitionReqs.isRepartitionRequired()) {
 
                 final OptimizableRepartitionNodeBuilder<K, ?> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -36,7 +36,6 @@ class GroupedStreamAggregateBuilder<K, V> {
     private final InternalStreamsBuilder builder;
     private final Serde<K> keySerde;
     private final Serde<V> valueSerde;
-    private final boolean repartitionRequired;
     private final String userProvidedRepartitionTopicName;
     private final Set<String> subTopologySourceNodes;
     private final String name;
@@ -51,7 +50,6 @@ class GroupedStreamAggregateBuilder<K, V> {
 
     GroupedStreamAggregateBuilder(final InternalStreamsBuilder builder,
                                   final GroupedInternal<K, V> groupedInternal,
-                                  final boolean repartitionRequired,
                                   final Set<String> subTopologySourceNodes,
                                   final String name,
                                   final GraphNode graphNode) {
@@ -59,7 +57,6 @@ class GroupedStreamAggregateBuilder<K, V> {
         this.builder = builder;
         this.keySerde = groupedInternal.keySerde();
         this.valueSerde = groupedInternal.valueSerde();
-        this.repartitionRequired = repartitionRequired;
         this.subTopologySourceNodes = subTopologySourceNodes;
         this.name = name;
         this.graphNode = graphNode;
@@ -124,7 +121,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         String sourceName = this.name;
         GraphNode parentNode = graphNode;
 
-        if (repartitionRequired) {
+        if (graphNode.isRepartitionRequired()) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 
             final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeName;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -121,7 +121,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         String sourceName = this.name;
         GraphNode parentNode = graphNode;
 
-        if (graphNode.isRepartitionRequired()) {
+        if (graphNode.repartitioningRequired()) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 
             final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeName;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -102,7 +102,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
         final String name = new NamedInternal(consumed.name()).orElseGenerateWithPrefix(this, KStreamImpl.SOURCE_NAME);
         final StreamSourceNode<K, V> streamSourceNode = new StreamSourceNode<>(name, topics, consumed);
-        streamSourceNode.forbidRepartition();
+        streamSourceNode.disableRepartition();
 
         addGraphNode(root, streamSourceNode);
 
@@ -118,7 +118,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                        final ConsumedInternal<K, V> consumed) {
         final String name = new NamedInternal(consumed.name()).orElseGenerateWithPrefix(this, KStreamImpl.SOURCE_NAME);
         final StreamSourceNode<K, V> streamPatternSourceNode = new StreamSourceNode<>(name, topicPattern, consumed);
-        streamPatternSourceNode.forbidRepartition();
+        streamPatternSourceNode.disableRepartition();
 
         addGraphNode(root, streamPatternSourceNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -64,7 +64,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class InternalStreamsBuilder implements InternalNameProvider {
@@ -103,6 +102,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
         final String name = new NamedInternal(consumed.name()).orElseGenerateWithPrefix(this, KStreamImpl.SOURCE_NAME);
         final StreamSourceNode<K, V> streamSourceNode = new StreamSourceNode<>(name, topics, consumed);
+        streamSourceNode.forbidRepartition();
 
         addGraphNode(root, streamSourceNode);
 
@@ -110,7 +110,6 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                  consumed.keySerde(),
                                  consumed.valueSerde(),
                                  Collections.singleton(name),
-                                 false,
                                  streamSourceNode,
                                  this);
     }
@@ -119,6 +118,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                        final ConsumedInternal<K, V> consumed) {
         final String name = new NamedInternal(consumed.name()).orElseGenerateWithPrefix(this, KStreamImpl.SOURCE_NAME);
         final StreamSourceNode<K, V> streamPatternSourceNode = new StreamSourceNode<>(name, topicPattern, consumed);
+        streamPatternSourceNode.forbidRepartition();
 
         addGraphNode(root, streamPatternSourceNode);
 
@@ -126,7 +126,6 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                  consumed.keySerde(),
                                  consumed.valueSerde(),
                                  Collections.singleton(name),
-                                 false,
                                  streamPatternSourceNode,
                                  this);
     }
@@ -501,7 +500,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
             for (final OptimizableRepartitionNode<?, ?> repartitionNodeToBeReplaced : entry.getValue()) {
 
-                final GraphNode keyChangingNodeChild = findParentNodeMatching(repartitionNodeToBeReplaced, gn -> gn.parentNodes().contains(keyChangingNode));
+                final GraphNode keyChangingNodeChild = repartitionNodeToBeReplaced.findParentNodeMatching(gn -> gn.parentNodes().contains(keyChangingNode));
 
                 if (keyChangingNodeChild == null) {
                     throw new StreamsException(String.format("Found a null keyChangingChild node for %s", repartitionNodeToBeReplaced));
@@ -553,7 +552,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             final Set<Map.Entry<GraphNode, LinkedHashSet<OptimizableRepartitionNode<?, ?>>>> entrySet = keyChangingOperationsToOptimizableRepartitionNodes.entrySet();
             for (final Map.Entry<GraphNode, LinkedHashSet<OptimizableRepartitionNode<?, ?>>> entry : entrySet) {
                 if (mergeNodeHasRepartitionChildren(mergeNode, entry.getValue())) {
-                    final GraphNode maybeParentKey = findParentNodeMatching(mergeNode, node -> node.parentNodes().contains(entry.getKey()));
+                    final GraphNode maybeParentKey = mergeNode.findParentNodeMatching(node -> node.parentNodes().contains(entry.getKey()));
                     if (maybeParentKey != null) {
                         mergeNodesToKeyChangers.get(mergeNode).add(entry.getKey());
                     }
@@ -579,7 +578,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     private boolean mergeNodeHasRepartitionChildren(final GraphNode mergeNode,
                                                     final LinkedHashSet<OptimizableRepartitionNode<?, ?>> repartitionNodes) {
-        return repartitionNodes.stream().allMatch(n -> findParentNodeMatching(n, gn -> gn.parentNodes().contains(mergeNode)) != null);
+        return repartitionNodes.stream().allMatch(n -> n.findParentNodeMatching(gn -> gn.parentNodes().contains(mergeNode)) != null);
     }
 
     private <K, V> OptimizableRepartitionNode<K, V> createRepartitionNode(final String repartitionTopicName,
@@ -608,9 +607,9 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     }
 
     private GraphNode getKeyChangingParentNode(final GraphNode repartitionNode) {
-        final GraphNode shouldBeKeyChangingNode = findParentNodeMatching(repartitionNode, n -> n.isKeyChangingOperation() || n.isValueChangingOperation());
+        final GraphNode shouldBeKeyChangingNode = repartitionNode.findParentNodeMatching(n -> n.isKeyChangingOperation() || n.isValueChangingOperation());
 
-        final GraphNode keyChangingNode = findParentNodeMatching(repartitionNode, GraphNode::isKeyChangingOperation);
+        final GraphNode keyChangingNode = repartitionNode.findParentNodeMatching(GraphNode::isKeyChangingOperation);
         if (shouldBeKeyChangingNode != null && shouldBeKeyChangingNode.equals(keyChangingNode)) {
             return keyChangingNode;
         }
@@ -686,22 +685,6 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         }
 
         return isVersionedUpstream(startSeekingNode);
-    }
-
-    private GraphNode findParentNodeMatching(final GraphNode startSeekingNode,
-                                             final Predicate<GraphNode> parentNodePredicate) {
-        if (parentNodePredicate.test(startSeekingNode)) {
-            return startSeekingNode;
-        }
-        GraphNode foundParentNode = null;
-
-        for (final GraphNode parentNode : startSeekingNode.parentNodes()) {
-            if (parentNodePredicate.test(parentNode)) {
-                return parentNode;
-            }
-            foundParentNode = findParentNodeMatching(parentNode, parentNodePredicate);
-        }
-        return foundParentNode;
     }
 
     public GraphNode root() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -45,26 +45,26 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
     static final String AGGREGATE_NAME = "KSTREAM-AGGREGATE-";
 
     private final GroupedStreamAggregateBuilder<K, V> aggregateBuilder;
-    final boolean repartitionRequired;
     final String userProvidedRepartitionTopicName;
 
     KGroupedStreamImpl(final String name,
                        final Set<String> subTopologySourceNodes,
                        final GroupedInternal<K, V> groupedInternal,
-                       final boolean repartitionRequired,
                        final GraphNode graphNode,
                        final InternalStreamsBuilder builder) {
         super(name, groupedInternal.keySerde(), groupedInternal.valueSerde(), subTopologySourceNodes, graphNode, builder);
-        this.repartitionRequired = repartitionRequired;
         this.userProvidedRepartitionTopicName = groupedInternal.name();
         this.aggregateBuilder = new GroupedStreamAggregateBuilder<>(
             builder,
             groupedInternal,
-            repartitionRequired,
             subTopologySourceNodes,
             name,
             graphNode
         );
+    }
+
+    public boolean isRepartitionRequired() {
+        return graphNode.isRepartitionRequired();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -63,8 +63,8 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
         );
     }
 
-    public boolean isRepartitionRequired() {
-        return graphNode.isRepartitionRequired();
+    public boolean repartitioningRequired() {
+        return graphNode.repartitioningRequired();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -138,8 +138,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
     }
 
-    private boolean isRepartitionRequired() {
-        return graphNode.isRepartitionRequired();
+    private boolean repartitioningRequired() {
+        return graphNode.repartitioningRequired();
     }
 
     @Override
@@ -522,7 +522,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         );
 
         final UnoptimizableRepartitionNode<K, V> unoptimizableRepartitionNode = unoptimizableRepartitionNodeBuilder.build();
-        unoptimizableRepartitionNode.forbidRepartition();
+        unoptimizableRepartitionNode.disableRepartition();
 
         builder.addGraphNode(graphNode, unoptimizableRepartitionNode);
 
@@ -618,7 +618,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final Set<String> subTopologySourceNodes;
         final GraphNode tableParentNode;
 
-        if (isRepartitionRequired()) {
+        if (repartitioningRequired()) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
             final String sourceName = createRepartitionedSource(
                 builder,
@@ -884,7 +884,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final StreamJoinedInternal<K, V, VRight> streamJoinedInternal = new StreamJoinedInternal<>(streamJoined, builder);
         final NamedInternal name = new NamedInternal(streamJoinedInternal.name());
-        if (joinThis.isRepartitionRequired()) {
+        if (joinThis.repartitioningRequired()) {
             final String joinThisName = joinThis.name;
             final String leftJoinRepartitionTopicName = name.suffixWithOrElseGet("-left", joinThisName);
 
@@ -895,7 +895,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 name.name() != null);
         }
 
-        if (joinOther.isRepartitionRequired()) {
+        if (joinOther.repartitioningRequired()) {
             final String joinOtherName = joinOther.name;
             final String rightJoinRepartitionTopicName = name.suffixWithOrElseGet("-right", joinOtherName);
 
@@ -942,7 +942,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         if (repartitionNode == null || !name.equals(repartitionName)) {
             repartitionNode = optimizableRepartitionNodeBuilder.build();
-            repartitionNode.forbidRepartition();
+            repartitionNode.disableRepartition();
             builder.addGraphNode(graphNode, repartitionNode);
         }
 
@@ -1047,7 +1047,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final JoinedInternal<K, V, TableValue> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
 
-        if (isRepartitionRequired()) {
+        if (repartitioningRequired()) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                     name != null ? name : this.name,
                     joinedInternal.keySerde(),
@@ -1088,7 +1088,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final JoinedInternal<K, V, VTable> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
 
-        if (isRepartitionRequired()) {
+        if (repartitioningRequired()) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                     name != null ? name : this.name,
                     joinedInternal.keySerde(),
@@ -1149,7 +1149,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             this.name,
             joinedInternal.gracePeriod()
         );
-        streamTableJoinNode.forbidRepartition();
+        streamTableJoinNode.disableRepartition();
 
         builder.addGraphNode(graphNode, streamTableJoinNode);
         if (leftJoin) {
@@ -1301,7 +1301,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             processNode.setValueChangingOperation(true);
         }
 
-        processNode.mustRepartition();
         builder.addGraphNode(graphNode, processNode);
 
         // cannot inherit key and value serde

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1301,6 +1301,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             processNode.setValueChangingOperation(true);
         }
 
+        processNode.mustRepartition();
         builder.addGraphNode(graphNode, processNode);
 
         // cannot inherit key and value serde

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -127,19 +127,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     private static final String REPARTITION_NAME = "KSTREAM-REPARTITION-";
 
-    private final boolean repartitionRequired;
-
     private OptimizableRepartitionNode<K, V> repartitionNode;
 
     KStreamImpl(final String name,
                 final Serde<K> keySerde,
                 final Serde<V> valueSerde,
                 final Set<String> subTopologySourceNodes,
-                final boolean repartitionRequired,
                 final GraphNode graphNode,
                 final InternalStreamsBuilder builder) {
         super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
-        this.repartitionRequired = repartitionRequired;
+    }
+
+    private boolean isRepartitionRequired() {
+        return graphNode.isRepartitionRequired();
     }
 
     @Override
@@ -166,7 +166,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             valueSerde,
             subTopologySourceNodes,
-            repartitionRequired,
             filterProcessorNode,
             builder);
     }
@@ -195,7 +194,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             valueSerde,
             subTopologySourceNodes,
-            repartitionRequired,
             filterNotProcessorNode,
             builder);
     }
@@ -222,7 +220,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             null,
             valueSerde,
             subTopologySourceNodes,
-            true,
             selectKeyProcessorNode,
             builder);
     }
@@ -274,7 +271,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             null,
             subTopologySourceNodes,
-            repartitionRequired,
             mapValuesProcessorNode,
             builder);
     }
@@ -305,7 +301,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             null,
             null,
             subTopologySourceNodes,
-            true,
             mapProcessorNode,
             builder);
     }
@@ -331,7 +326,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         builder.addGraphNode(graphNode, flatMapNode);
 
         // key and value serde cannot be preserved
-        return new KStreamImpl<>(name, null, null, subTopologySourceNodes, true, flatMapNode, builder);
+        return new KStreamImpl<>(name, null, null, subTopologySourceNodes, flatMapNode, builder);
     }
 
     @Override
@@ -371,7 +366,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             null,
             subTopologySourceNodes,
-            repartitionRequired,
             flatMapValuesNode,
             builder);
     }
@@ -434,20 +428,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             valueSerde,
             subTopologySourceNodes,
-            repartitionRequired,
             peekNode,
             builder);
     }
 
     @Override
     public BranchedKStream<K, V> split() {
-        return new BranchedKStreamImpl<>(this, repartitionRequired, NamedInternal.empty());
+        return new BranchedKStreamImpl<>(this, NamedInternal.empty());
     }
 
     @Override
     public BranchedKStream<K, V> split(final Named named) {
         Objects.requireNonNull(named, "named cannot be null");
-        return new BranchedKStreamImpl<>(this, repartitionRequired, new NamedInternal(named));
+        return new BranchedKStreamImpl<>(this, new NamedInternal(named));
     }
 
     @Override
@@ -468,7 +461,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(named, "named cannot be null");
 
         final KStreamImpl<K, V> streamImpl = (KStreamImpl<K, V>) otherStream;
-        final boolean requireRepartitioning = streamImpl.repartitionRequired || repartitionRequired;
         final String name = named.orElseGenerateWithPrefix(builder, MERGE_NAME);
         final Set<String> allSubTopologySourceNodes = new HashSet<>();
         allSubTopologySourceNodes.addAll(subTopologySourceNodes);
@@ -488,7 +480,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             null,
             null,
             allSubTopologySourceNodes,
-            requireRepartitioning,
             mergeNode,
             builder);
     }
@@ -531,6 +522,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         );
 
         final UnoptimizableRepartitionNode<K, V> unoptimizableRepartitionNode = unoptimizableRepartitionNodeBuilder.build();
+        unoptimizableRepartitionNode.forbidRepartition();
 
         builder.addGraphNode(graphNode, unoptimizableRepartitionNode);
 
@@ -542,7 +534,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             valueSerde,
             Collections.unmodifiableSet(sourceNodes),
-            false,
             unoptimizableRepartitionNode,
             builder
         );
@@ -627,7 +618,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final Set<String> subTopologySourceNodes;
         final GraphNode tableParentNode;
 
-        if (repartitionRequired) {
+        if (isRepartitionRequired()) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
             final String sourceName = createRepartitionedSource(
                 builder,
@@ -684,7 +675,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             name,
             subTopologySourceNodes,
             groupedInternal,
-            repartitionRequired,
             graphNode,
             builder);
     }
@@ -710,7 +700,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             selectKeyMapNode.nodeName(),
             subTopologySourceNodes,
             groupedInternal,
-            true,
             selectKeyMapNode,
             builder);
     }
@@ -895,7 +884,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final StreamJoinedInternal<K, V, VRight> streamJoinedInternal = new StreamJoinedInternal<>(streamJoined, builder);
         final NamedInternal name = new NamedInternal(streamJoinedInternal.name());
-        if (joinThis.repartitionRequired) {
+        if (joinThis.isRepartitionRequired()) {
             final String joinThisName = joinThis.name;
             final String leftJoinRepartitionTopicName = name.suffixWithOrElseGet("-left", joinThisName);
 
@@ -906,7 +895,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 name.name() != null);
         }
 
-        if (joinOther.repartitionRequired) {
+        if (joinOther.isRepartitionRequired()) {
             final String joinOtherName = joinOther.name;
             final String rightJoinRepartitionTopicName = name.suffixWithOrElseGet("-right", joinOtherName);
 
@@ -953,6 +942,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         if (repartitionNode == null || !name.equals(repartitionName)) {
             repartitionNode = optimizableRepartitionNodeBuilder.build();
+            repartitionNode.forbidRepartition();
             builder.addGraphNode(graphNode, repartitionNode);
         }
 
@@ -961,7 +951,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             repartitionKeySerde,
             repartitionValueSerde,
             Collections.singleton(repartitionedSourceName),
-            false,
             repartitionNode,
             builder);
     }
@@ -1058,7 +1047,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final JoinedInternal<K, V, TableValue> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
 
-        if (repartitionRequired) {
+        if (isRepartitionRequired()) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                     name != null ? name : this.name,
                     joinedInternal.keySerde(),
@@ -1099,7 +1088,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final JoinedInternal<K, V, VTable> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
 
-        if (repartitionRequired) {
+        if (isRepartitionRequired()) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                     name != null ? name : this.name,
                     joinedInternal.keySerde(),
@@ -1160,6 +1149,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             this.name,
             joinedInternal.gracePeriod()
         );
+        streamTableJoinNode.forbidRepartition();
 
         builder.addGraphNode(graphNode, streamTableJoinNode);
         if (leftJoin) {
@@ -1172,7 +1162,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             joinedInternal.keySerde() != null ? joinedInternal.keySerde() : keySerde,
             null,
             allSourceNodes,
-            false,
             streamTableJoinNode,
             builder);
     }
@@ -1272,7 +1261,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             null,
             subTopologySourceNodes,
-            repartitionRequired,
             streamTableJoinNode,
             builder);
     }
@@ -1321,7 +1309,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             null,
             null,
             subTopologySourceNodes,
-            true,
             processNode,
             builder);
     }
@@ -1368,7 +1355,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             keySerde,
             null,
             subTopologySourceNodes,
-            repartitionRequired,
             processNode,
             builder);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -225,6 +225,7 @@ class KStreamImplJoin {
                    .withNodeName(joinMergeName);
 
         final GraphNode joinGraphNode = joinBuilder.build();
+        joinGraphNode.forbidRepartition();
 
         if (leftOuter || rightOuter) {
             joinGraphNode.addLabel(GraphNode.Label.NULL_KEY_RELAXED_JOIN);
@@ -236,7 +237,7 @@ class KStreamImplJoin {
 
         // do not have serde for joined result;
         // also for key serde we do not inherit from either since we cannot tell if these two serdes are different
-        return new KStreamImpl<>(joinMergeName, streamJoinedInternal.keySerde(), null, allSourceNodes, false, joinGraphNode, builder);
+        return new KStreamImpl<>(joinMergeName, streamJoinedInternal.keySerde(), null, allSourceNodes, joinGraphNode, builder);
     }
 
     private void assertWindowSettings(final WindowBytesStoreSupplier supplier, final JoinWindows joinWindows) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -225,7 +225,7 @@ class KStreamImplJoin {
                    .withNodeName(joinMergeName);
 
         final GraphNode joinGraphNode = joinBuilder.build();
-        joinGraphNode.forbidRepartition();
+        joinGraphNode.disableRepartition();
 
         if (leftOuter || rightOuter) {
             joinGraphNode.addLabel(GraphNode.Label.NULL_KEY_RELAXED_JOIN);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -516,11 +516,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             name,
             processorParameters
         );
+        toStreamNode.forbidRepartition();
 
         builder.addGraphNode(this.graphNode, toStreamNode);
 
         // we can inherit parent key and value serde
-        return new KStreamImpl<>(name, keySerde, valueSerde, subTopologySourceNodes, false, toStreamNode, builder);
+        return new KStreamImpl<>(name, keySerde, valueSerde, subTopologySourceNodes, toStreamNode, builder);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -516,7 +516,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             name,
             processorParameters
         );
-        toStreamNode.forbidRepartition();
+        toStreamNode.disableRepartition();
 
         builder.addGraphNode(this.graphNode, toStreamNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -25,14 +25,15 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public abstract class GraphNode {
-
     private final Collection<GraphNode> childNodes = new LinkedHashSet<>();
     private final Collection<GraphNode> parentNodes = new LinkedHashSet<>();
 
     private final Collection<Label> labels = new LinkedList<>();
     private final String nodeName;
+    private boolean repartitionForbidden = false;
     private boolean keyChangingOperation;
     private boolean valueChangingOperation;
     private boolean mergeNode;
@@ -93,6 +94,23 @@ public abstract class GraphNode {
         return nodeName;
     }
 
+    public boolean canDetermineRepartition() {
+        return keyChangingOperation || repartitionForbidden;
+    }
+
+    public boolean isRepartitionRequired() {
+        final GraphNode find = findParentNodeMatching(GraphNode::canDetermineRepartition);
+        if (find == null) {
+            return false;
+        }
+
+        if (find.repartitionForbidden) {
+            return false;
+        }
+
+        return find.keyChangingOperation;
+    }
+
     public boolean isKeyChangingOperation() {
         return keyChangingOperation;
     }
@@ -103,6 +121,10 @@ public abstract class GraphNode {
 
     public boolean isMergeNode() {
         return mergeNode;
+    }
+
+    public void forbidRepartition() {
+        repartitionForbidden = true;
     }
 
     public void setMergeNode(final boolean mergeNode) {
@@ -141,6 +163,21 @@ public abstract class GraphNode {
 
     public void setOutputVersioned(final boolean outputVersioned) {
         this.outputVersioned = Optional.of(outputVersioned);
+    }
+
+    public GraphNode findParentNodeMatching(final Predicate<GraphNode> parentNodePredicate) {
+        if (parentNodePredicate.test(this)) {
+            return this;
+        }
+        GraphNode foundParentNode = null;
+
+        for (final GraphNode parentNode : this.parentNodes()) {
+            if (parentNodePredicate.test(parentNode)) {
+                return parentNode;
+            }
+            foundParentNode = parentNode.findParentNodeMatching(parentNodePredicate);
+        }
+        return foundParentNode;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -20,11 +20,15 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 public abstract class GraphNode {
@@ -99,7 +103,7 @@ public abstract class GraphNode {
     }
 
     public boolean isRepartitionRequired() {
-        final GraphNode find = findParentNodeMatching(GraphNode::canDetermineRepartition);
+        final GraphNode find = findNearestParentNodeMatching(GraphNode::canDetermineRepartition);
         if (find == null) {
             return false;
         }
@@ -178,6 +182,29 @@ public abstract class GraphNode {
             foundParentNode = parentNode.findParentNodeMatching(parentNodePredicate);
         }
         return foundParentNode;
+    }
+
+    private GraphNode findNearestParentNodeMatching(final Predicate<GraphNode> parentNodePredicate) {
+        if (parentNodePredicate.test(this)) {
+            return this;
+        }
+
+        final Set<GraphNode> visited = new HashSet<>();
+        final Queue<GraphNode> queue = new ArrayDeque<>(this.parentNodes());
+        visited.add(this);
+
+        while (!queue.isEmpty()) {
+            final GraphNode current = queue.poll();
+            if (!visited.add(current)) {
+                continue;
+            }
+            if (parentNodePredicate.test(current)) {
+                return current;
+            }
+            queue.addAll(current.parentNodes());
+        }
+
+        return null;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -24,10 +24,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
@@ -37,8 +33,7 @@ public abstract class GraphNode {
 
     private final Collection<Label> labels = new LinkedList<>();
     private final String nodeName;
-    private boolean repartitionForbidden = false;
-    private boolean repartitionRequired = false;
+    private boolean repartitionDisabled = false;
     private boolean keyChangingOperation;
     private boolean valueChangingOperation;
     private boolean mergeNode;
@@ -99,21 +94,21 @@ public abstract class GraphNode {
         return nodeName;
     }
 
-    public boolean canDetermineRepartition() {
-        return keyChangingOperation || repartitionForbidden || repartitionRequired;
-    }
-
-    public boolean isRepartitionRequired() {
-        final GraphNode find = findNearestParentNodeMatching(GraphNode::canDetermineRepartition);
+    public boolean repartitioningRequired() {
+        final GraphNode find = findParentNodeMatching(GraphNode::isRepartitionDetermining);
         if (find == null) {
             return false;
         }
 
-        if (find.repartitionForbidden) {
+        if (find.repartitionDisabled) {
             return false;
         }
 
-        return find.keyChangingOperation || repartitionRequired;
+        return find.keyChangingOperation;
+    }
+
+    private boolean isRepartitionDetermining() {
+        return keyChangingOperation || repartitionDisabled;
     }
 
     public boolean isKeyChangingOperation() {
@@ -128,14 +123,8 @@ public abstract class GraphNode {
         return mergeNode;
     }
 
-    public void forbidRepartition() {
-        repartitionForbidden = true;
-        repartitionRequired = false;
-    }
-
-    public void mustRepartition() {
-        repartitionRequired = true;
-        repartitionForbidden = false;
+    public void disableRepartition() {
+        repartitionDisabled = true;
     }
 
     public void setMergeNode(final boolean mergeNode) {
@@ -180,38 +169,15 @@ public abstract class GraphNode {
         if (parentNodePredicate.test(this)) {
             return this;
         }
-        GraphNode foundParentNode = null;
 
-        for (final GraphNode parentNode : this.parentNodes()) {
+        GraphNode foundParentNode = null;
+        for (final GraphNode parentNode : parentNodes()) {
             if (parentNodePredicate.test(parentNode)) {
                 return parentNode;
             }
             foundParentNode = parentNode.findParentNodeMatching(parentNodePredicate);
         }
         return foundParentNode;
-    }
-
-    private GraphNode findNearestParentNodeMatching(final Predicate<GraphNode> parentNodePredicate) {
-        if (parentNodePredicate.test(this)) {
-            return this;
-        }
-
-        final Set<GraphNode> visited = new HashSet<>();
-        final Queue<GraphNode> queue = new ArrayDeque<>(this.parentNodes());
-        visited.add(this);
-
-        while (!queue.isEmpty()) {
-            final GraphNode current = queue.poll();
-            if (!visited.add(current)) {
-                continue;
-            }
-            if (parentNodePredicate.test(current)) {
-                return current;
-            }
-            queue.addAll(current.parentNodes());
-        }
-
-        return null;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -38,6 +38,7 @@ public abstract class GraphNode {
     private final Collection<Label> labels = new LinkedList<>();
     private final String nodeName;
     private boolean repartitionForbidden = false;
+    private boolean repartitionRequired = false;
     private boolean keyChangingOperation;
     private boolean valueChangingOperation;
     private boolean mergeNode;
@@ -99,7 +100,7 @@ public abstract class GraphNode {
     }
 
     public boolean canDetermineRepartition() {
-        return keyChangingOperation || repartitionForbidden;
+        return keyChangingOperation || repartitionForbidden || repartitionRequired;
     }
 
     public boolean isRepartitionRequired() {
@@ -112,7 +113,7 @@ public abstract class GraphNode {
             return false;
         }
 
-        return find.keyChangingOperation;
+        return find.keyChangingOperation || repartitionRequired;
     }
 
     public boolean isKeyChangingOperation() {
@@ -129,6 +130,12 @@ public abstract class GraphNode {
 
     public void forbidRepartition() {
         repartitionForbidden = true;
+        repartitionRequired = false;
+    }
+
+    public void mustRepartition() {
+        repartitionRequired = true;
+        repartitionForbidden = false;
     }
 
     public void setMergeNode(final boolean mergeNode) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -95,7 +95,11 @@ public abstract class GraphNode {
     }
 
     public boolean repartitioningRequired() {
-        final GraphNode find = findParentNodeMatching(GraphNode::isRepartitionDetermining);
+        if (isMergeNode()) {
+            return parentNodes().stream().anyMatch(GraphNode::repartitioningRequired);
+        }
+
+        GraphNode find = findParentNodeMatching(GraphNode::isRepartitionDetermining);
         if (find == null) {
             return false;
         }
@@ -170,14 +174,13 @@ public abstract class GraphNode {
             return this;
         }
 
-        GraphNode foundParentNode = null;
         for (final GraphNode parentNode : parentNodes()) {
-            if (parentNodePredicate.test(parentNode)) {
-                return parentNode;
+            final GraphNode foundParentNode = parentNode.findParentNodeMatching(parentNodePredicate);
+            if (foundParentNode != null) {
+                return foundParentNode;
             }
-            foundParentNode = parentNode.findParentNodeMatching(parentNodePredicate);
         }
-        return foundParentNode;
+        return null;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.NoopValueTransformerWithKey;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -93,8 +92,9 @@ public class AbstractStreamTest {
             final ProcessorGraphNode<K, V> processorNode = new ProcessorGraphNode<>(
                 name,
                 new ProcessorParameters<>(new ExtendedKStreamDummy<>(), name));
+            processorNode.forbidRepartition();
             builder.addGraphNode(this.graphNode, processorNode);
-            return new KStreamImpl<>(name, null, null, subTopologySourceNodes, false, processorNode, builder);
+            return new KStreamImpl<>(name, null, null, subTopologySourceNodes, processorNode, builder);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
@@ -92,7 +92,7 @@ public class AbstractStreamTest {
             final ProcessorGraphNode<K, V> processorNode = new ProcessorGraphNode<>(
                 name,
                 new ProcessorParameters<>(new ExtendedKStreamDummy<>(), name));
-            processorNode.forbidRepartition();
+            processorNode.disableRepartition();
             builder.addGraphNode(this.graphNode, processorNode);
             return new KStreamImpl<>(name, null, null, subTopologySourceNodes, processorNode, builder);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
@@ -125,8 +125,9 @@ public class StreamsGraphTest {
         properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "test-application");
         properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         properties.setProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        properties.setProperty(TopologyConfig.InternalConfig.ENABLE_PROCESS_PROCESSVALUE_FIX, "true");
 
-        final StreamsBuilder builder = new StreamsBuilder();
+        final StreamsBuilder builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(properties)));
         initializer = () -> "";
         aggregator = (aggKey, value, aggregate) -> aggregate + value.length();
         final ProcessorSupplier<String, String, String, String> processorSupplier =
@@ -546,20 +547,20 @@ public class StreamsGraphTest {
             "    Source: KSTREAM-SOURCE-0000000000 (topics: [retryTopic])\n" +
             "      --> KSTREAM-PROCESSOR-0000000001\n" +
             "    Processor: KSTREAM-PROCESSOR-0000000001 (stores: [])\n" +
-            "      --> KSTREAM-FILTER-0000000005\n" +
+            "      --> KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-filter\n" +
             "      <-- KSTREAM-SOURCE-0000000000\n" +
-            "    Processor: KSTREAM-FILTER-0000000005 (stores: [])\n" +
-            "      --> KSTREAM-SINK-0000000004\n" +
+            "    Processor: KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-filter (stores: [])\n" +
+            "      --> KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-sink\n" +
             "      <-- KSTREAM-PROCESSOR-0000000001\n" +
-            "    Sink: KSTREAM-SINK-0000000004 (topic: KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition)\n" +
-            "      <-- KSTREAM-FILTER-0000000005\n" +
+            "    Sink: KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-sink (topic: KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition)\n" +
+            "      <-- KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-filter\n" +
             "\n" +
             "  Sub-topology: 1\n" +
-            "    Source: KSTREAM-SOURCE-0000000006 (topics: [KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition])\n" +
+            "    Source: KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-source (topics: [KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition])\n" +
             "      --> KSTREAM-AGGREGATE-0000000003\n" +
             "    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [KSTREAM-AGGREGATE-STATE-STORE-0000000002])\n" +
             "      --> KTABLE-SUPPRESS-0000000007\n" +
-            "      <-- KSTREAM-SOURCE-0000000006\n" +
+            "      <-- KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition-source\n" +
             "    Source: KSTREAM-SOURCE-0000000019 (topics: [internal-topic-command])\n" +
             "      --> KSTREAM-PEEK-0000000020\n" +
             "    Processor: KTABLE-SUPPRESS-0000000007 (stores: [KTABLE-SUPPRESS-STATE-STORE-0000000008])\n" +


### PR DESCRIPTION
That PR is a POC.

For now, I only focused on modifying `KStreamImpl.repartitionRequired` to replace it with `GraphNode.keyChangingOperation`.

So I'll be working on it further to make sure it's the right fix and need to write some test code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
