### PR TITLE
Return friendly prompt when no quota configs found

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -424,6 +424,8 @@ object ConfigCommand extends Logging {
 
   private def describeQuotaConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]): Unit = {
     val quotaConfigs = getAllClientQuotasConfigs(adminClient, entityTypes, entityNames)
+    if (quotaConfigs.isEmpty)
+      System.out.println("No quota configs found.")
     quotaConfigs.foreachEntry { (entity, entries) =>
       val entityEntries = entity.entries.asScala
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -424,7 +424,7 @@ object ConfigCommand extends Logging {
 
   private def describeQuotaConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]): Unit = {
     val quotaConfigs = getAllClientQuotasConfigs(adminClient, entityTypes, entityNames)
-    if (quotaConfigs.isEmpty)
+    if (quotaConfigs.isEmpty && entityTypes.contains(ConfigType.CLIENT))
       System.out.println("No quota configs found.")
     quotaConfigs.foreachEntry { (entity, entries) =>
       val entityEntries = entity.entries.asScala


### PR DESCRIPTION

Currently, when querying the quota configuration of a specified client-id, if there is no configuration, no information will be returned, which is not very friendly. When there is no configuration, we should also return a friendly prompt message.