### PR TITLE
MINOR: Java version and TLS documentation improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1527,7 +1527,7 @@ project(':group-coordinator') {
 
 
 project(':test-common:test-common-internal-api') {
-  // Interfaces, config classes, and other test APIs. Java 17 only
+  // Interfaces, config classes, and other test APIs. Java 17 is the minimum Java version.
   base {
     archivesName = "kafka-test-common-internal-api"
   }
@@ -1554,7 +1554,7 @@ project(':test-common:test-common-internal-api') {
 }
 
 project(':test-common:test-common-util') {
-  // Runtime-only JUnit extensions for entire project. Java 11 only
+  // Runtime-only JUnit extensions for entire project. Java 11 is the minimum Java version required.
   base {
     archivesName = "kafka-test-common-util"
   }
@@ -1577,7 +1577,7 @@ project(':test-common:test-common-util') {
 }
 
 project(':test-common:test-common-runtime') {
-  // Runtime-only JUnit extensions for integration tests. Java 17 only
+  // Runtime-only JUnit extensions for integration tests. Java 17 is the minimum Java version.
   base {
     archivesName = "kafka-test-common-runtime"
   }

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -29,14 +29,12 @@ public class SslConfigs {
      */
 
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
-    public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "
-        + "The default is 'TLSv1.3' when running with Java 11 or newer, 'TLSv1.2' otherwise. "
-        + "This value should be fine for most use cases. "
-        + "Allowed values in recent JVMs are 'TLSv1.2' and 'TLSv1.3'. 'TLS', 'TLSv1.1', 'SSL', 'SSLv2' and 'SSLv3' "
-        + "may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities. "
-        + "With the default value for this config and 'ssl.enabled.protocols', clients will downgrade to 'TLSv1.2' if "
-        + "the server does not support 'TLSv1.3'. If this config is set to 'TLSv1.2', clients will not use 'TLSv1.3' even "
-        + "if it is one of the values in ssl.enabled.protocols and the server only supports 'TLSv1.3'.";
+    public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. The default is 'TLSv1.3', "
+        + "which should be fine for most use cases. A typical alternative to the default is 'TLSv1.2'. Allowed values for "
+        + "this config are dependent on the JVM. "
+        + "Clients using the defaults for this config and 'ssl.enabled.protocols' will downgrade to 'TLSv1.2' if "
+        + "the server does not support 'TLSv1.3'. If this config is set to 'TLSv1.2', however, clients will not use 'TLSv1.3' even "
+        + "if it is one of the values in `ssl.enabled.protocols` and the server only supports 'TLSv1.3'.";
 
     public static final String DEFAULT_SSL_PROTOCOL = "TLSv1.3";
 
@@ -49,10 +47,9 @@ public class SslConfigs {
 
     public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
     public static final String SSL_ENABLED_PROTOCOLS_DOC = "The list of protocols enabled for SSL connections. "
-        + "The default is 'TLSv1.2,TLSv1.3' when running with Java 11 or newer, 'TLSv1.2' otherwise. With the "
-        + "default value for Java 11, clients and servers will prefer TLSv1.3 if both support it and fallback "
-        + "to TLSv1.2 otherwise (assuming both support at least TLSv1.2). This default should be fine for most "
-        + "cases. Also see the config documentation for `ssl.protocol`.";
+        + "The default is 'TLSv1.2,TLSv1.3'. This means that clients and servers will prefer TLSv1.3 if both support it "
+        + "and fallback to TLSv1.2 otherwise (assuming both support at least TLSv1.2). This default should be fine for most use "
+        + "cases. Also see the config documentation for `ssl.protocol` to understand how it can impact the TLS version negotiation behavior.";
     public static final String DEFAULT_SSL_ENABLED_PROTOCOLS = "TLSv1.2,TLSv1.3";
 
     public static final String SSL_KEYSTORE_TYPE_CONFIG = "ssl.keystore.type";

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1218,11 +1218,13 @@ $ bin/kafka-acls.sh \
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.5 Java Version</a></h3>
 
   Java 17 and Java 21 are fully supported while Java 11 is supported for a subset of modules (clients, streams and related).
-  We generally recommend running Apache Kafka with the most recent LTS release (Java 21 at the time of writing) for performance
-  and efficiency reasons.
+  Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
+  most recent non LTS version.
 
   <p>
-  From a security perspective, we recommend the latest released patch version as older versions typically have disclosed security vulnerabilities.
+  We generally recommend running Apache Kafka with the most recent LTS release (Java 21 at the time of writing) for performance,
+  efficiency and support reasons. From a security perspective, we recommend the latest released patch version as older versions
+  typically have disclosed security vulnerabilities.
   <p>
   Typical arguments for running Kafka with OpenJDK-based Java implementations (including Oracle JDK) are:
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1218,11 +1218,7 @@ $ bin/kafka-acls.sh \
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.5 Java Version</a></h3>
 
   Java 11, Java 17, Java 21 and Java 23 are supported.
-  <p>
-  Note that Java 11 support for the broker and tools has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.
-  <p>
-  Java 11 and later versions perform significantly better if TLS is enabled, so they are highly recommended (they also include a number of other
-  performance improvements: G1GC, CRC32C, Compact Strings, Thread-Local Handshakes and more).
+
   <p>
   From a security perspective, we recommend the latest released patch version as older freely available versions have disclosed security vulnerabilities.
   <p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1217,10 +1217,12 @@ $ bin/kafka-acls.sh \
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.5 Java Version</a></h3>
 
-  Java 11, Java 17, Java 21 and Java 23 are supported.
+  Java 17 and Java 21 are fully supported while Java 11 is supported for a subset of modules (clients, streams and related).
+  We generally recommend running Apache Kafka with the most recent LTS release (Java 21 at the time of writing) for performance
+  and efficiency reasons.
 
   <p>
-  From a security perspective, we recommend the latest released patch version as older freely available versions have disclosed security vulnerabilities.
+  From a security perspective, we recommend the latest released patch version as older versions typically have disclosed security vulnerabilities.
   <p>
   Typical arguments for running Kafka with OpenJDK-based Java implementations (including Oracle JDK) are:
 

--- a/docs/streams/developer-guide/interactive-queries.html
+++ b/docs/streams/developer-guide/interactive-queries.html
@@ -269,7 +269,7 @@ public class MyCustomStoreBuilder implements StoreBuilder {
                     interface to get access to the underlying instances of your store.
                     <code class="docutils literal"><span class="pre">StateStoreProvider#stores(String</span> <span class="pre">storeName,</span> <span class="pre">QueryableStoreType&lt;T&gt;</span> <span class="pre">queryableStoreType)</span></code> returns a <code class="docutils literal"><span class="pre">List</span></code> of state
                     stores with the given storeName and of the type as defined by <code class="docutils literal"><span class="pre">queryableStoreType</span></code>.</p>
-                <p>Here is an example implementation of the wrapper follows (Java 8+):</p>
+                <p>Here is an example implementation of the wrapper follows (Java 11+):</p>
                 <pre class="line-numbers"><code class="language-java">// We strongly recommended implementing a read-only interface
 // to restrict usage of the store to safe read operations!
 public class MyCustomStoreTypeWrapper&lt;K,V&gt; implements MyReadableCustomStore&lt;K,V&gt; {

--- a/docs/streams/developer-guide/interactive-queries.html
+++ b/docs/streams/developer-guide/interactive-queries.html
@@ -269,7 +269,7 @@ public class MyCustomStoreBuilder implements StoreBuilder {
                     interface to get access to the underlying instances of your store.
                     <code class="docutils literal"><span class="pre">StateStoreProvider#stores(String</span> <span class="pre">storeName,</span> <span class="pre">QueryableStoreType&lt;T&gt;</span> <span class="pre">queryableStoreType)</span></code> returns a <code class="docutils literal"><span class="pre">List</span></code> of state
                     stores with the given storeName and of the type as defined by <code class="docutils literal"><span class="pre">queryableStoreType</span></code>.</p>
-                <p>Here is an example implementation of the wrapper follows (Java 11+):</p>
+                <p>Here is an example implementation of the wrapper:</p>
                 <pre class="line-numbers"><code class="language-java">// We strongly recommended implementing a read-only interface
 // to restrict usage of the store to safe read operations!
 public class MyCustomStoreTypeWrapper&lt;K,V&gt; implements MyReadableCustomStore&lt;K,V&gt; {

--- a/docs/streams/developer-guide/write-streams.html
+++ b/docs/streams/developer-guide/write-streams.html
@@ -151,7 +151,7 @@ streams.start();</code></pre>
         For more information, see <a class="reference internal" href="../architecture.html#streams_architecture_tasks"><span class="std std-ref">Stream Partitions and Tasks</span></a> and <a class="reference internal" href="../architecture.html#streams_architecture_threads"><span class="std std-ref">Threading Model</span></a>.</p>
       <p>To catch any unexpected exceptions, you can set an <code class="docutils literal"><span class="pre">java.lang.Thread.UncaughtExceptionHandler</span></code> before you start the
         application.  This handler is called whenever a stream thread is terminated by an unexpected exception:</p>
-        <pre class="line-numbers"><code class="language-java">// Java 8+, using lambda expressions
+        <pre class="line-numbers"><code class="language-java">// Java 11+, using lambda expressions
 streams.setUncaughtExceptionHandler((Thread thread, Throwable throwable) -&gt; {
   // here you should examine the throwable/exception and perform an appropriate action!
 });
@@ -161,7 +161,7 @@ streams.setUncaughtExceptionHandler((Thread thread, Throwable throwable) -&gt; {
 streams.close();</code></pre>
       <p>To allow your application to gracefully shutdown in response to SIGTERM, it is recommended that you add a shutdown hook
         and call <code class="docutils literal"><span class="pre">KafkaStreams#close</span></code>.</p>
-      <p class="first">Here is a shutdown hook example in Java 8+:</p>
+      <p class="first">Here is a shutdown hook example in Java 11+:</p>
             <pre class="line-numbers"><code class="language-java">// Add shutdown hook to stop the Kafka Streams threads.
 // You can optionally provide a timeout to `close`.
 Runtime.getRuntime().addShutdownHook(new Thread(streams::close));</code></pre>

--- a/docs/streams/developer-guide/write-streams.html
+++ b/docs/streams/developer-guide/write-streams.html
@@ -151,8 +151,7 @@ streams.start();</code></pre>
         For more information, see <a class="reference internal" href="../architecture.html#streams_architecture_tasks"><span class="std std-ref">Stream Partitions and Tasks</span></a> and <a class="reference internal" href="../architecture.html#streams_architecture_threads"><span class="std std-ref">Threading Model</span></a>.</p>
       <p>To catch any unexpected exceptions, you can set an <code class="docutils literal"><span class="pre">java.lang.Thread.UncaughtExceptionHandler</span></code> before you start the
         application.  This handler is called whenever a stream thread is terminated by an unexpected exception:</p>
-        <pre class="line-numbers"><code class="language-java">// Java 11+, using lambda expressions
-streams.setUncaughtExceptionHandler((Thread thread, Throwable throwable) -&gt; {
+        <pre class="line-numbers"><code class="language-java">streams.setUncaughtExceptionHandler((Thread thread, Throwable throwable) -&gt; {
   // here you should examine the throwable/exception and perform an appropriate action!
 });
 </code></pre>

--- a/docs/streams/developer-guide/write-streams.html
+++ b/docs/streams/developer-guide/write-streams.html
@@ -161,7 +161,7 @@ streams.setUncaughtExceptionHandler((Thread thread, Throwable throwable) -&gt; {
 streams.close();</code></pre>
       <p>To allow your application to gracefully shutdown in response to SIGTERM, it is recommended that you add a shutdown hook
         and call <code class="docutils literal"><span class="pre">KafkaStreams#close</span></code>.</p>
-      <p class="first">Here is a shutdown hook example in Java 11+:</p>
+      <p class="first">Here is a shutdown hook example in Java:</p>
             <pre class="line-numbers"><code class="language-java">// Add shutdown hook to stop the Kafka Streams threads.
 // You can optionally provide a timeout to `close`.
 Runtime.getRuntime().addShutdownHook(new Thread(streams::close));</code></pre>

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -193,7 +193,7 @@
 
        <div class="code-example">
            <div class="btn-group">
-               <a class="selected b-java-8" data-section="java-8">Java 8+</a>
+               <a class="selected b-java-8" data-section="java-8">Java 11+</a>
                <a class="b-scala" data-section="scala">Scala</a>
            </div>
 

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -193,7 +193,7 @@
 
        <div class="code-example">
            <div class="btn-group">
-               <a class="selected b-java-8" data-section="java-8">Java 11+</a>
+               <a class="selected b-java-8" data-section="java-8">Java</a>
                <a class="b-scala" data-section="scala">Scala</a>
            </div>
 

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -45,7 +45,7 @@
   </p>
   <p>
 This quickstart example will demonstrate how to run a streaming application coded in this library. Here is the gist
-of the <code><a href="https://github.com/apache/kafka/blob/{{dotVersion}}/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountDemo.java">WordCountDemo</a></code> example code (converted to use Java 8 lambda expressions for easy reading).
+of the <code><a href="https://github.com/apache/kafka/blob/{{dotVersion}}/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountDemo.java">WordCountDemo</a></code> example code.
 </p>
 <pre class="line-numbers"><code class="language-java">// Serializers/deserializers (serde) for String and Long types
 final Serde&lt;String&gt; stringSerde = Serdes.String();

--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -70,7 +70,7 @@ streams-quickstart
 
     <p>
         The <code>pom.xml</code> file included in the project already has the Streams dependency defined.
-        Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java versions.
+        Note, that the generated <code>pom.xml</code> targets Java 11.
     </p>
 
     <p>


### PR DESCRIPTION
Most of the changes are obvious clean-ups/fixes. A couple of noteworthy items:
1. Support for non LTS versions is clarified (we were incorrectly stating full support
for Java 23).
2. TLS version negotiation details are clarified.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
