### PR TITLE
KAFKA-18745: Handle network related errors in persister.

### DIFF
--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -3633,7 +3633,7 @@ class PersisterStateManagerTest {
             new TestHolder(true, false, true, Optional.empty()),
             new TestHolder(true, true, false, Optional.empty()),
 
-            // Handled my checkNetworkError.
+            // Handled by checkNetworkError.
             new TestHolder(false, true, false, Optional.of(Errors.NETWORK_EXCEPTION)),
             new TestHolder(false, false, true, Optional.of(Errors.REQUEST_TIMED_OUT)),
             new TestHolder(false, true, true, Optional.of(Errors.NETWORK_EXCEPTION)),   // takes precedence

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -52,15 +52,19 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -69,6 +73,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PersisterStateManagerTest {
     private static final KafkaClient CLIENT = mock(KafkaClient.class);
@@ -163,6 +168,20 @@ class PersisterStateManagerTest {
 
         @Override
         protected void findCoordinatorErrorResponse(Errors error, Exception exception) {
+            this.result.complete(new TestHandlerResponse(new TestHandlerResponseData()
+                .setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+                    .setTopicId(partitionKey().topicId())
+                    .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+                        .setPartition(partitionKey().partition())
+                        .setErrorMessage(exception == null ? error.message() : exception.getMessage())
+                        .setErrorCode(error.code()))
+                    )
+                ))
+            ));
+        }
+
+        @Override
+        protected void requestErrorResponse(Errors error, Exception exception) {
             this.result.complete(new TestHandlerResponse(new TestHandlerResponseData()
                 .setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
                     .setTopicId(partitionKey().topicId())
@@ -3590,5 +3609,74 @@ class PersisterStateManagerTest {
         } catch (Exception e) {
             fail("unexpected exception", e);
         }
+    }
+
+    static class TestHolder {
+        boolean hasResponse;
+        boolean wasDisconnected;
+        boolean wasTimedOut;
+        Optional<Errors> exp;
+
+        TestHolder(boolean hasResponse, boolean wasDisconnected, boolean wasTimedOut, Optional<Errors> exp) {
+            this.hasResponse = hasResponse;
+            this.wasDisconnected = wasDisconnected;
+            this.wasTimedOut = wasTimedOut;
+            this.exp = exp;
+        }
+    }
+
+    private static Stream<TestHolder> generatorDifferentStates() {
+        return Stream.of(
+            // Let the actual handler handle since response present.
+            new TestHolder(true, false, false, Optional.empty()),
+            new TestHolder(true, true, true, Optional.empty()),
+            new TestHolder(true, false, true, Optional.empty()),
+            new TestHolder(true, true, false, Optional.empty()),
+
+            // Handled my checkNetworkError.
+            new TestHolder(false, true, false, Optional.of(Errors.NETWORK_EXCEPTION)),
+            new TestHolder(false, false, true, Optional.of(Errors.REQUEST_TIMED_OUT)),
+            new TestHolder(false, true, true, Optional.of(Errors.NETWORK_EXCEPTION)),   // takes precedence
+            new TestHolder(false, false, false, Optional.of(Errors.UNKNOWN_SERVER_ERROR))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("generatorDifferentStates")
+    public void testNetworkErrorHandling(TestHolder holder) {
+        KafkaClient client = mock(KafkaClient.class);
+        Timer timer = mock(Timer.class);
+        PersisterStateManager psm = PersisterStateManagerBuilder
+            .builder()
+            .withTimer(timer)
+            .withKafkaClient(client)
+            .build();
+
+        SharePartitionKey key = SharePartitionKey.getInstance("group", Uuid.randomUuid(), 1);
+
+        CompletableFuture<TestStateHandler.TestHandlerResponse> future = new CompletableFuture<>();
+
+        TestStateHandler handler = spy(new TestStateHandler(
+            psm,
+            key.groupId(),
+            key.topicId(),
+            key.partition(),
+            future,
+            REQUEST_BACKOFF_MS,
+            REQUEST_BACKOFF_MAX_MS,
+            MAX_RPC_RETRY_ATTEMPTS
+        ) {
+            @Override
+            protected AbstractRequest.Builder<? extends AbstractRequest> requestBuilder() {
+                return null;
+            }
+        });
+
+        ClientResponse response = mock(ClientResponse.class);
+        when(response.hasResponse()).thenReturn(holder.hasResponse);
+        when(response.wasDisconnected()).thenReturn(holder.wasDisconnected);
+        when(response.wasTimedOut()).thenReturn(holder.wasTimedOut);
+        assertEquals(holder.exp, handler.checkNetworkError(response, (err, exp) -> {
+        }));
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -422,25 +422,6 @@ class PersisterStateManagerTest {
 
         Node suppliedNode = new Node(0, HOST, PORT);
 
-        String coordinatorKey = SharePartitionKey.asCoordinatorKey(groupId, topicId, partition);
-
-        client.prepareResponseFrom(body -> body instanceof FindCoordinatorRequest
-                && ((FindCoordinatorRequest) body).data().keyType() == FindCoordinatorRequest.CoordinatorType.SHARE.id()
-                && ((FindCoordinatorRequest) body).data().coordinatorKeys().get(0).equals(coordinatorKey),
-            new FindCoordinatorResponse(
-                new FindCoordinatorResponseData()
-                    .setCoordinators(Collections.singletonList(
-                        new FindCoordinatorResponseData.Coordinator()
-                            .setKey(coordinatorKey)
-                            .setErrorCode(Errors.NONE.code())
-                            .setHost(coordinatorKey)
-                            .setNodeId(Node.noNode().id())
-                            .setPort(Node.noNode().port())
-                    ))
-            ),
-            suppliedNode
-        );
-
         client.setUnreachable(suppliedNode, CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS + 1);
 
         ShareCoordinatorMetadataCacheHelper cacheHelper = getDefaultCacheHelper(suppliedNode);

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.server.share.persister;
 
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.common.Node;
@@ -77,8 +78,8 @@ import static org.mockito.Mockito.when;
 
 class PersisterStateManagerTest {
     private static final KafkaClient CLIENT = mock(KafkaClient.class);
-    private static final Time MOCK_TIME = new MockTime();
-    private static final Timer MOCK_TIMER = new MockTimer((MockTime) MOCK_TIME);
+    private static final MockTime MOCK_TIME = new MockTime();
+    private static final Timer MOCK_TIMER = new MockTimer(MOCK_TIME);
     private static final ShareCoordinatorMetadataCacheHelper CACHE_HELPER = mock(ShareCoordinatorMetadataCacheHelper.class);
     private static final int MAX_RPC_RETRY_ATTEMPTS = 5;
     public static final long REQUEST_BACKOFF_MS = 100L;
@@ -93,6 +94,7 @@ class PersisterStateManagerTest {
         private Time time = MOCK_TIME;
         private Timer timer = MOCK_TIMER;
         private ShareCoordinatorMetadataCacheHelper cacheHelper = CACHE_HELPER;
+        private int requestTimeoutMs =  Math.toIntExact(CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS);
 
         private PersisterStateManagerBuilder withKafkaClient(KafkaClient client) {
             this.client = client;
@@ -333,6 +335,152 @@ class PersisterStateManagerTest {
         }
 
         assertEquals(Errors.UNKNOWN_SERVER_ERROR.code(), result.data().results().get(0).partitions().get(0).errorCode());
+        verify(handler, times(1)).findShareCoordinatorBuilder();
+
+        try {
+            // Stopping the state manager
+            stateManager.stop();
+        } catch (Exception e) {
+            fail("Failed to stop state manager", e);
+        }
+    }
+
+    @Test
+    public void testFindCoordinatorNullResponse() {
+        MockClient client = new MockClient(MOCK_TIME);
+
+        String groupId = "group1";
+        Uuid topicId = Uuid.randomUuid();
+        int partition = 10;
+
+        Node suppliedNode = new Node(0, HOST, PORT);
+
+        String coordinatorKey = SharePartitionKey.asCoordinatorKey(groupId, topicId, partition);
+
+        client.prepareResponseFrom(body -> body instanceof FindCoordinatorRequest
+                && ((FindCoordinatorRequest) body).data().keyType() == FindCoordinatorRequest.CoordinatorType.SHARE.id()
+                && ((FindCoordinatorRequest) body).data().coordinatorKeys().get(0).equals(coordinatorKey),
+            null,
+            suppliedNode
+        );
+
+        ShareCoordinatorMetadataCacheHelper cacheHelper = getDefaultCacheHelper(suppliedNode);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(client)
+            .withTimer(mockTimer)
+            .withCacheHelper(cacheHelper)
+            .build();
+
+        stateManager.start();
+
+        CompletableFuture<TestStateHandler.TestHandlerResponse> future = new CompletableFuture<>();
+
+        TestStateHandler handler = spy(new TestStateHandler(
+            stateManager,
+            groupId,
+            topicId,
+            partition,
+            future,
+            REQUEST_BACKOFF_MS,
+            REQUEST_BACKOFF_MAX_MS,
+            MAX_RPC_RETRY_ATTEMPTS
+        ) {
+            @Override
+            protected AbstractRequest.Builder<? extends AbstractRequest> requestBuilder() {
+                return null;
+            }
+        });
+
+        stateManager.enqueue(handler);
+
+        TestStateHandler.TestHandlerResponse result = null;
+        try {
+            result = handler.result().get();
+        } catch (Exception e) {
+            fail("Failed to get result from future", e);
+        }
+
+        assertEquals(Errors.UNKNOWN_SERVER_ERROR.code(), result.data().results().get(0).partitions().get(0).errorCode());
+        verify(handler, times(1)).findShareCoordinatorBuilder();
+
+        try {
+            // Stopping the state manager
+            stateManager.stop();
+        } catch (Exception e) {
+            fail("Failed to stop state manager", e);
+        }
+    }
+
+    @Test
+    public void testFindCoordinatorDisconnect() {
+        MockClient client = new MockClient(MOCK_TIME);
+
+        String groupId = "group1";
+        Uuid topicId = Uuid.randomUuid();
+        int partition = 10;
+
+        Node suppliedNode = new Node(0, HOST, PORT);
+
+        String coordinatorKey = SharePartitionKey.asCoordinatorKey(groupId, topicId, partition);
+
+        client.prepareResponseFrom(body -> body instanceof FindCoordinatorRequest
+                && ((FindCoordinatorRequest) body).data().keyType() == FindCoordinatorRequest.CoordinatorType.SHARE.id()
+                && ((FindCoordinatorRequest) body).data().coordinatorKeys().get(0).equals(coordinatorKey),
+            new FindCoordinatorResponse(
+                new FindCoordinatorResponseData()
+                    .setCoordinators(Collections.singletonList(
+                        new FindCoordinatorResponseData.Coordinator()
+                            .setKey(coordinatorKey)
+                            .setErrorCode(Errors.NONE.code())
+                            .setHost(coordinatorKey)
+                            .setNodeId(Node.noNode().id())
+                            .setPort(Node.noNode().port())
+                    ))
+            ),
+            suppliedNode
+        );
+
+        client.setUnreachable(suppliedNode, CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS + 1);
+
+        ShareCoordinatorMetadataCacheHelper cacheHelper = getDefaultCacheHelper(suppliedNode);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(client)
+            .withTimer(mockTimer)
+            .withCacheHelper(cacheHelper)
+            .build();
+
+        stateManager.start();
+
+        CompletableFuture<TestStateHandler.TestHandlerResponse> future = new CompletableFuture<>();
+
+        TestStateHandler handler = spy(new TestStateHandler(
+            stateManager,
+            groupId,
+            topicId,
+            partition,
+            future,
+            REQUEST_BACKOFF_MS,
+            REQUEST_BACKOFF_MAX_MS,
+            MAX_RPC_RETRY_ATTEMPTS
+        ) {
+            @Override
+            protected AbstractRequest.Builder<? extends AbstractRequest> requestBuilder() {
+                return null;
+            }
+        });
+
+        stateManager.enqueue(handler);
+
+        TestStateHandler.TestHandlerResponse result = null;
+        try {
+            result = handler.result().get();
+        } catch (Exception e) {
+            fail("Failed to get result from future", e);
+        }
+
+        assertEquals(Errors.NETWORK_EXCEPTION.code(), result.data().results().get(0).partitions().get(0).errorCode());
         verify(handler, times(1)).findShareCoordinatorBuilder();
 
         try {


### PR DESCRIPTION
* Currently, if the RPCs managed by the `PersisterStateManager` receive network errors like null response or disconnected/timeout status in response - it is not handled.
* In this PR, we remedy the situation by handling all RPC responses containing network issue related status codes.
* Tests have been added for handler method.