### PR TITLE
Refactor heartbeat response to include standbys

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
@@ -120,7 +120,7 @@ public class StreamsAssignmentInterface {
     /**
      * List of partitions available on each host. Updated by the streams protocol client.
      */
-    public final AtomicReference<Map<HostInfo, List<TopicPartition>>> partitionsByHost = new AtomicReference<>(Collections.emptyMap());
+    public final AtomicReference<Map<HostInfo, EndpointPartitions>> partitionsByHost = new AtomicReference<>(Collections.emptyMap());
 
     public static class HostInfo {
 
@@ -142,6 +142,27 @@ public class StreamsAssignmentInterface {
         }
 
     }
+
+    public static class EndpointPartitions {
+        public final List<TopicPartition> activePartitions;
+        public final List<TopicPartition> standbyPartitions;
+
+        public EndpointPartitions(final List<TopicPartition> activePartitions,
+                                  final List<TopicPartition> standbyPartitions) {
+            this.activePartitions = activePartitions;
+            this.standbyPartitions = standbyPartitions;
+        }
+
+        @Override
+        public String toString() {
+            return "EndpointPartitions {"
+                    + "activePartitions=" + activePartitions
+                    + ", standbyPartitions=" + standbyPartitions
+                    + '}';
+        }
+    }
+
+
 
     public static class Assignment {
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsAssignmentInterface.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.internals.events.StreamsOnTasksRevokedC
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,12 +141,11 @@ public class StreamsAssignmentInterface {
                 ", port=" + port +
                 '}';
         }
-
     }
 
     public static class EndpointPartitions {
-        public final List<TopicPartition> activePartitions;
-        public final List<TopicPartition> standbyPartitions;
+        private final List<TopicPartition> activePartitions;
+        private final List<TopicPartition> standbyPartitions;
 
         public EndpointPartitions(final List<TopicPartition> activePartitions,
                                   final List<TopicPartition> standbyPartitions) {
@@ -153,6 +153,13 @@ public class StreamsAssignmentInterface {
             this.standbyPartitions = standbyPartitions;
         }
 
+        public List<TopicPartition> activePartitions() {
+            return new ArrayList<>(activePartitions);
+        }
+
+        public List<TopicPartition> standbyPartitions() {
+            return new ArrayList<>(standbyPartitions);
+        }
         @Override
         public String toString() {
             return "EndpointPartitions {"
@@ -161,9 +168,7 @@ public class StreamsAssignmentInterface {
                     + '}';
         }
     }
-
-
-
+    
     public static class Assignment {
 
         public static final Assignment EMPTY = new Assignment();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -253,18 +253,24 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
         membershipManager.onHeartbeatSuccess(response);
     }
 
-    private static Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> convertHostInfoMap(
+    private static Map<StreamsAssignmentInterface.HostInfo, StreamsAssignmentInterface.EndpointPartitions> convertHostInfoMap(
         final StreamsGroupHeartbeatResponseData data) {
-        Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> partitionsByHost = new HashMap<>();
+        Map<StreamsAssignmentInterface.HostInfo, StreamsAssignmentInterface.EndpointPartitions> partitionsByHost = new HashMap<>();
         data.partitionsByUserEndpoint().forEach(endpoint -> {
-            List<TopicPartition> topicPartitions = endpoint.partitions().stream()
-                .flatMap(partition ->
-                    partition.partitions().stream().map(partitionId -> new TopicPartition(partition.topic(), partitionId)))
-                .collect(Collectors.toList());
+            List<TopicPartition> activeTopicPartitions = getTopicPartitionList(endpoint.activePartitions());
+            List<TopicPartition> standbyTopicPartitions = getTopicPartitionList(endpoint.standbyPartitions());
             Endpoint userEndpoint = endpoint.userEndpoint();
-            partitionsByHost.put(new StreamsAssignmentInterface.HostInfo(userEndpoint.host(), userEndpoint.port()), topicPartitions);
+            StreamsAssignmentInterface.EndpointPartitions endpointPartitions = new StreamsAssignmentInterface.EndpointPartitions(activeTopicPartitions, standbyTopicPartitions);
+            partitionsByHost.put(new StreamsAssignmentInterface.HostInfo(userEndpoint.host(), userEndpoint.port()), endpointPartitions);
         });
         return partitionsByHost;
+    }
+
+    private static List<TopicPartition> getTopicPartitionList(List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions) {
+        return topicPartitions.stream()
+            .flatMap(partition ->
+                partition.partitions().stream().map(partitionId -> new TopicPartition(partition.topic(), partitionId)))
+            .collect(Collectors.toList());
     }
 
     private void updateTaskIdCollection(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -266,7 +266,7 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
         return partitionsByHost;
     }
 
-    private static List<TopicPartition> getTopicPartitionList(List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions) {
+    static List<TopicPartition> getTopicPartitionList(List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions) {
         return topicPartitions.stream()
             .flatMap(partition ->
                 partition.partitions().stream().map(partitionId -> new TopicPartition(partition.topic(), partitionId)))

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -71,9 +71,9 @@
         { "name": "UserEndpoint", "type": "Endpoint", "versions": "0+",
           "about": "User-defined endpoint to connect to the node" },
         { "name": "ActivePartitions", "type": "[]TopicPartition", "versions": "0+",
-          "about": "All active partitions available on the node" },
+          "about": "All topic partitions materialized by active tasks on the node" },
         { "name": "StandbyPartitions", "type": "[]TopicPartition", "versions": "0+",
-          "about": "All standby partitions available on the node" }
+          "about": "All topic partitions materialized by standby tasks on the node" }
       ]
     }
   ],

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -70,8 +70,10 @@
       "fields": [
         { "name": "UserEndpoint", "type": "Endpoint", "versions": "0+",
           "about": "User-defined endpoint to connect to the node" },
-        { "name": "Partitions", "type": "[]TopicPartition", "versions": "0+",
-          "about": "All partitions available on the node" }
+        { "name": "ActivePartitions", "type": "[]TopicPartition", "versions": "0+",
+          "about": "All active partitions available on the node" },
+        { "name": "StandbyPartitions", "type": "[]TopicPartition", "versions": "0+",
+          "about": "All standby partitions available on the node" }
       ]
     }
   ],

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -292,6 +292,22 @@ class StreamsGroupHeartbeatRequestManagerTest {
         final Uuid uuid0 = Uuid.randomUuid();
         final Uuid uuid1 = Uuid.randomUuid();
 
+        final StreamsGroupHeartbeatResponseData.Endpoint endpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+        endpoint.setHost("localhost");
+        endpoint.setPort(8080);
+        StreamsGroupHeartbeatResponseData.TopicPartition active = new StreamsGroupHeartbeatResponseData.TopicPartition();
+        active.setTopic("activeTopic");
+        active.setPartitions(Arrays.asList(0, 1, 2));
+        StreamsGroupHeartbeatResponseData.TopicPartition standby = new StreamsGroupHeartbeatResponseData.TopicPartition();
+        standby.setTopic("standbyTopic");
+        standby.setPartitions(Arrays.asList(3, 4, 5));
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
+        endpointToPartitions.setActivePartitions(List.of(active));
+        endpointToPartitions.setStandbyPartitions(List.of(standby));
+        endpointToPartitions.setUserEndpoint(endpoint);
+
+
+
         final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Optional.empty(), Collections.emptyMap());
 
         when(metadata.topicIds()).thenReturn(
@@ -299,6 +315,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
                 mkEntry("source0", uuid0),
                 mkEntry("repartition0", uuid1)
             ));
+
 
         streamsAssignmentInterface.subtopologyMap().put("0",
             new Subtopology(
@@ -332,6 +349,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
             .setMemberEpoch(TEST_MEMBER_EPOCH)
             .setThrottleTimeMs(TEST_THROTTLE_TIME_MS)
             .setHeartbeatIntervalMs(1000)
+            .setPartitionsByUserEndpoint(List.of(endpointToPartitions))
             .setActiveTasks(Collections.singletonList(
                 new StreamsGroupHeartbeatResponseData.TaskIds().setSubtopologyId("0").setPartitions(Collections.singletonList(0))))
             .setStandbyTasks(Collections.singletonList(
@@ -352,6 +370,14 @@ class StreamsGroupHeartbeatRequestManagerTest {
         assertEquals(data.activeTasks(), response.activeTasks());
         assertEquals(data.standbyTasks(), response.standbyTasks());
         assertEquals(data.warmupTasks(), response.warmupTasks());
+        
+        assertEquals(data.partitionsByUserEndpoint(), response.partitionsByUserEndpoint());
+        Map<StreamsAssignmentInterface.HostInfo, StreamsAssignmentInterface.EndpointPartitions> endpointPartitionsMap = streamsAssignmentInterface.partitionsByHost.get();
+        assertEquals(endpointPartitionsMap.size(), response.partitionsByUserEndpoint().size());
+        StreamsAssignmentInterface.HostInfo hostInfo = endpointPartitionsMap.keySet().iterator().next();
+        assertEquals(hostInfo.host, endpoint.host());
+        assertEquals(hostInfo.port, endpoint.port());
+        StreamsAssignmentInterface.EndpointPartitions endpointPartitions = endpointPartitionsMap.get(hostInfo);
     }
 
     private void mockResponse(final StreamsGroupHeartbeatResponseData data) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.consumer.internals.StreamsAssignmentInterface.Su
 import org.apache.kafka.clients.consumer.internals.StreamsAssignmentInterface.TopicInfo;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
@@ -55,9 +56,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.apache.kafka.clients.consumer.internals.StreamsGroupHeartbeatRequestManager.getTopicPartitionList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -306,8 +309,6 @@ class StreamsGroupHeartbeatRequestManagerTest {
         endpointToPartitions.setStandbyPartitions(List.of(standby));
         endpointToPartitions.setUserEndpoint(endpoint);
 
-
-
         final TopicInfo emptyTopicInfo = new TopicInfo(Optional.empty(), Optional.empty(), Collections.emptyMap());
 
         when(metadata.topicIds()).thenReturn(
@@ -315,8 +316,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
                 mkEntry("source0", uuid0),
                 mkEntry("repartition0", uuid1)
             ));
-
-
+        
         streamsAssignmentInterface.subtopologyMap().put("0",
             new Subtopology(
                 Collections.singleton("source0"),
@@ -375,9 +375,13 @@ class StreamsGroupHeartbeatRequestManagerTest {
         Map<StreamsAssignmentInterface.HostInfo, StreamsAssignmentInterface.EndpointPartitions> endpointPartitionsMap = streamsAssignmentInterface.partitionsByHost.get();
         assertEquals(endpointPartitionsMap.size(), response.partitionsByUserEndpoint().size());
         StreamsAssignmentInterface.HostInfo hostInfo = endpointPartitionsMap.keySet().iterator().next();
-        assertEquals(hostInfo.host, endpoint.host());
-        assertEquals(hostInfo.port, endpoint.port());
+        assertEquals(endpoint.host(), hostInfo.host);
+        assertEquals(endpoint.port(), hostInfo.port);
         StreamsAssignmentInterface.EndpointPartitions endpointPartitions = endpointPartitionsMap.get(hostInfo);
+        List<TopicPartition> activeTopicPartitions = getTopicPartitionList(endpointToPartitions.activePartitions());
+        List<TopicPartition> standbyTopicPartitions = getTopicPartitionList(endpointToPartitions.standbyPartitions());
+        assertIterableEquals(endpointPartitions.activePartitions(), activeTopicPartitions);
+        assertIterableEquals(endpointPartitions.standbyPartitions(), standbyTopicPartitions);
     }
 
     private void mockResponse(final StreamsGroupHeartbeatResponseData data) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -147,6 +147,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+import org.apache.kafka.coordinator.group.streams.topics.EndpointToPartitionsManager;
 import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
 import org.apache.kafka.coordinator.group.streams.topics.TopicConfigurationException;
 import org.apache.kafka.coordinator.group.taskassignor.TaskAssignor;
@@ -2340,12 +2341,13 @@ public class GroupMetadataManager {
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
-
+        List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitions = maybeBuildEndpointToPartitions(group);
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
             .setMemberId(updatedMember.memberId())
             .setMemberEpoch(updatedMember.memberEpoch())
-            .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs);
+            .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs)
+            .setPartitionsByUserEndpoint(endpointToPartitions);
 
         // The assignment is only provided in the following cases:
         // 1. The member sent a full request.
@@ -2377,6 +2379,27 @@ public class GroupMetadataManager {
         }
         return new CoordinatorResult<>(records, new StreamsGroupHeartbeatResult(response, internalTopicsToBeCreated));
     }
+
+    private List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> maybeBuildEndpointToPartitions(StreamsGroup group) {
+        List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList = new ArrayList<>();
+        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
+        // Build the endpoint to topic partition information
+        final Map<String, StreamsGroupMember> members = group.members();
+        for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
+            final String memberIdForAssignment = entry.getKey();
+            final StreamsGroupMemberMetadataValue.Endpoint endpoint = members.get(memberIdForAssignment).userEndpoint();
+            StreamsGroupMember groupMember = entry.getValue();
+            if (endpoint != null) {
+                final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+                responseEndpoint.setHost(endpoint.host());
+                responseEndpoint.setPort(endpoint.port());
+                StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = endpointToPartitionsManager.endpointToPartitions(groupMember, responseEndpoint, group);
+                endpointToPartitionsList.add(endpointToPartitions);
+            }
+        }
+        return endpointToPartitionsList;
+    }
+
 
     private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIds(final Map<String, Set<Integer>> taskIds) {
         return taskIds.entrySet().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2382,8 +2382,6 @@ public class GroupMetadataManager {
 
     private List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> maybeBuildEndpointToPartitions(StreamsGroup group) {
         List<StreamsGroupHeartbeatResponseData.EndpointToPartitions> endpointToPartitionsList = new ArrayList<>();
-        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
-        // Build the endpoint to topic partition information
         final Map<String, StreamsGroupMember> members = group.members();
         for (Map.Entry<String, StreamsGroupMember> entry : members.entrySet()) {
             final String memberIdForAssignment = entry.getKey();
@@ -2393,13 +2391,12 @@ public class GroupMetadataManager {
                 final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
                 responseEndpoint.setHost(endpoint.host());
                 responseEndpoint.setPort(endpoint.port());
-                StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = endpointToPartitionsManager.endpointToPartitions(groupMember, responseEndpoint, group);
+                StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = EndpointToPartitionsManager.endpointToPartitions(groupMember, responseEndpoint, group);
                 endpointToPartitionsList.add(endpointToPartitions);
             }
         }
         return endpointToPartitionsList;
     }
-
 
     private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIds(final Map<String, Set<Integer>> taskIds) {
         return taskIds.entrySet().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+
+public class EndpointToPartitionsManager {
+
+
+    public EndpointToPartitionsManager() {}
+
+    public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions(final StreamsGroupMember streamsGroupMember,
+                                                                                       final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
+                                                                                       final StreamsGroup streamsGroup) {
+
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> activeTopicPartitions = new ArrayList<>();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyTopicPartitions = new ArrayList<>();
+        for (Map.Entry<String, ConfiguredSubtopology> entry : streamsGroup.configuredTopology().subtopologies().entrySet()) {
+            ConfiguredSubtopology configuredSubtopology = entry.getValue();
+            endpointToPartitions.setUserEndpoint(responseEndpoint);
+            final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
+            Set<Map.Entry<String, Set<Integer>>> taskEntrySet = streamsGroupMember.assignedActiveTasks().entrySet();
+            Supplier<Stream<String>> topicNameStreamSupplier = () -> Stream.concat(configuredSubtopology.sourceTopics().stream(),
+                    configuredSubtopology.repartitionSourceTopics().keySet().stream());
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = getTopicPartitions(taskEntrySet, topicNameStreamSupplier, groupTopicMetadata);
+            activeTopicPartitions.addAll(topicPartitionList);
+
+            Set<Map.Entry<String, Set<Integer>>> standbyTaskEntrySet = streamsGroupMember.assignedStandbyTasks().entrySet();
+            Supplier<Stream<String>> changelogTopicNameStreamSupplier = () -> configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name);
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyList = getTopicPartitions(standbyTaskEntrySet, changelogTopicNameStreamSupplier, groupTopicMetadata);
+            standbyTopicPartitions.addAll(standbyList);
+        }
+        endpointToPartitions.setActivePartitions(activeTopicPartitions);
+        endpointToPartitions.setStandbyPartitions(standbyTopicPartitions);
+        return endpointToPartitions;
+    }
+
+    private List<StreamsGroupHeartbeatResponseData.TopicPartition> getTopicPartitions(final Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
+                                                                                      final Supplier<Stream<String>> topicNameStreamSupplier,
+                                                                                      final Map<String, TopicMetadata> groupTopicMetadata) {
+        final List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionsForTasks = new ArrayList<>();
+        for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList =
+                    topicNameStreamSupplier.get().map(topic -> {
+                        int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
+                        StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
+                        tp.setTopic(topic);
+                        List<Integer> tpPartitions = new ArrayList<>(taskEntry.getValue());
+                        if (numPartitionsForTopic < taskEntry.getValue().size()) {
+                            Collections.sort(tpPartitions);
+                            tp.setPartitions(tpPartitions.subList(0, numPartitionsForTopic));
+                        } else {
+                            tp.setPartitions(tpPartitions);
+                        }
+                        return tp;
+                    }).toList();
+            topicPartitionsForTasks.addAll(topicPartitionList);
+        }
+        return topicPartitionsForTasks;
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -27,35 +27,31 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
-
 
 public class EndpointToPartitionsManager {
 
+    private EndpointToPartitionsManager() {}
 
-    public EndpointToPartitionsManager() {}
-
-    public StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions(final StreamsGroupMember streamsGroupMember,
+    public static StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions(final StreamsGroupMember streamsGroupMember,
                                                                                        final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint,
                                                                                        final StreamsGroup streamsGroup) {
-
         StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
         List<StreamsGroupHeartbeatResponseData.TopicPartition> activeTopicPartitions = new ArrayList<>();
         List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyTopicPartitions = new ArrayList<>();
         for (Map.Entry<String, ConfiguredSubtopology> entry : streamsGroup.configuredTopology().subtopologies().entrySet()) {
             ConfiguredSubtopology configuredSubtopology = entry.getValue();
             endpointToPartitions.setUserEndpoint(responseEndpoint);
+            Set<String> sourceTopics = configuredSubtopology.sourceTopics();
+            Set<String> repartitionSourceTopics = configuredSubtopology.repartitionSourceTopics().keySet();
+
             final Map<String, TopicMetadata> groupTopicMetadata = streamsGroup.partitionMetadata();
             Set<Map.Entry<String, Set<Integer>>> taskEntrySet = streamsGroupMember.assignedActiveTasks().entrySet();
-            Supplier<Stream<String>> topicNameStreamSupplier = () -> Stream.concat(configuredSubtopology.sourceTopics().stream(),
-                    configuredSubtopology.repartitionSourceTopics().keySet().stream());
-            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = getTopicPartitions(taskEntrySet, topicNameStreamSupplier, groupTopicMetadata);
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList = getTopicPartitions(taskEntrySet, sourceTopics, repartitionSourceTopics, groupTopicMetadata);
             activeTopicPartitions.addAll(topicPartitionList);
 
             Set<Map.Entry<String, Set<Integer>>> standbyTaskEntrySet = streamsGroupMember.assignedStandbyTasks().entrySet();
-            Supplier<Stream<String>> changelogTopicNameStreamSupplier = () -> configuredSubtopology.nonSourceChangelogTopics().stream().map(ConfiguredInternalTopic::name);
-            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyList = getTopicPartitions(standbyTaskEntrySet, changelogTopicNameStreamSupplier, groupTopicMetadata);
+            List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyList = getTopicPartitions(standbyTaskEntrySet, sourceTopics, repartitionSourceTopics, groupTopicMetadata);
             standbyTopicPartitions.addAll(standbyList);
         }
         endpointToPartitions.setActivePartitions(activeTopicPartitions);
@@ -63,13 +59,14 @@ public class EndpointToPartitionsManager {
         return endpointToPartitions;
     }
 
-    private List<StreamsGroupHeartbeatResponseData.TopicPartition> getTopicPartitions(final Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
-                                                                                      final Supplier<Stream<String>> topicNameStreamSupplier,
+    private static List<StreamsGroupHeartbeatResponseData.TopicPartition> getTopicPartitions(final Set<Map.Entry<String, Set<Integer>>> taskEntrySet,
+                                                                                      final Set<String> topicNames,
+                                                                                      final Set<String> repartitionTopicNames,
                                                                                       final Map<String, TopicMetadata> groupTopicMetadata) {
         final List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionsForTasks = new ArrayList<>();
         for (Map.Entry<String, Set<Integer>> taskEntry : taskEntrySet) {
             List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitionList =
-                    topicNameStreamSupplier.get().map(topic -> {
+                    Stream.concat(topicNames.stream(), repartitionTopicNames.stream()).map(topic -> {
                         int numPartitionsForTopic = groupTopicMetadata.get(topic).numPartitions();
                         StreamsGroupHeartbeatResponseData.TopicPartition tp = new StreamsGroupHeartbeatResponseData.TopicPartition();
                         tp.setTopic(topic);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -110,6 +110,7 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
 import org.apache.kafka.server.common.MetadataVersion;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -48,8 +48,6 @@ class EndpointToPartitionsManagerTest {
     private StreamsGroupMember streamsGroupMember;
     private ConfiguredTopology configuredTopology;
     private ConfiguredSubtopology configuredSubtopology;
-
-    private EndpointToPartitionsManager endpointToPartitionsManager;
     private final Map<String, Set<Integer>> activeTasks = new HashMap<>();
     private final Map<String, Set<Integer>> standbyTasks = new HashMap<>();
     private final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
@@ -59,27 +57,18 @@ class EndpointToPartitionsManagerTest {
         streamsGroup = mock(StreamsGroup.class);
         streamsGroupMember = mock(StreamsGroupMember.class);
         configuredTopology = mock(ConfiguredTopology.class);
-        endpointToPartitionsManager = new EndpointToPartitionsManager();
-
         configuredSubtopology = new ConfiguredSubtopology();
         configuredSubtopology.setSourceTopics(Set.of("Topic-A", "Topic-B"));
-        ConfiguredInternalTopic stateChangelogTopic = new ConfiguredInternalTopic("StateChangeLog-A");
-        ConfiguredInternalTopic stateChangelogTopic2 = new ConfiguredInternalTopic("StateChangeLog-B");
-        configuredSubtopology.setStateChangelogTopics(Map.of("StateChangeLog-A", stateChangelogTopic, "StateChangeLog-B", stateChangelogTopic2));
         configuredTopology.subtopologies().put("0", configuredSubtopology);
-
         responseEndpoint.setHost("localhost");
         responseEndpoint.setPort(9092);
     }
 
     @Test
     void testEndpointToPartitionsWithStandbyTaskAssignments() {
-
         Map<String, TopicMetadata> topicMetadata = new HashMap<>();
         topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", 3, Collections.emptyMap()));
         topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", 3, Collections.emptyMap()));
-        topicMetadata.put("StateChangeLog-A", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-A", 3, Collections.emptyMap()));
-        topicMetadata.put("StateChangeLog-B", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-B", 3, Collections.emptyMap()));
 
         activeTasks.put("0", Set.of(0, 1, 2));
         standbyTasks.put("0", Set.of(0, 1, 2));
@@ -89,33 +78,26 @@ class EndpointToPartitionsManagerTest {
         when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
         when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
 
-        // Invoke the method under test
         StreamsGroupHeartbeatResponseData.EndpointToPartitions result =
-                endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
+                EndpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
 
-        // Validate the results
         assertEquals(responseEndpoint, result.userEndpoint());
         assertEquals(2, result.activePartitions().size());
         assertEquals(2, result.standbyPartitions().size());
-
         List<StreamsGroupHeartbeatResponseData.TopicPartition> activePartitions = result.activePartitions();
         List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyPartitions = result.standbyPartitions();
-
         activePartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
-        
-        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionA = standbyPartitions.stream().filter(tp -> tp.topic().equals("StateChangeLog-A")).findFirst().get();
-        assertEquals("StateChangeLog-A", standbyPartitionA.topic());
-        assertEquals(List.of(0, 1, 2), standbyPartitionA.partitions().stream().sorted().toList());
+        standbyPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
+        assertTopicPartitionsAssigned(activePartitions);
+        assertTopicPartitionsAssigned(standbyPartitions);
+    }
 
-        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionB = result.standbyPartitions().stream().filter(tp -> tp.topic().equals("StateChangeLog-B")).findFirst().get();
-        assertEquals("StateChangeLog-B", standbyPartitionB.topic());
-        assertEquals(List.of(0, 1, 2), standbyPartitionB.partitions().stream().sorted().toList());
-
-        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-A")).findFirst().get();
+    private static void assertTopicPartitionsAssigned(List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions) {
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = topicPartitions.stream().filter(tp -> tp.topic().equals("Topic-A")).findFirst().get();
         assertEquals("Topic-A", topicAPartition.topic());
         assertEquals(List.of(0, 1, 2), topicAPartition.partitions().stream().sorted().toList());
 
-        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-B")).findFirst().get();
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = topicPartitions.stream().filter(tp -> tp.topic().equals("Topic-B")).findFirst().get();
         assertEquals("Topic-B", topicBPartition.topic());
         assertEquals(List.of(0, 1, 2), topicBPartition.partitions().stream().sorted().toList());
     }
@@ -128,9 +110,7 @@ class EndpointToPartitionsManagerTest {
                                                                      List<Integer> topicBExpectedPartitions,
                                                                      String testName
                                                                      ) {
-
         Map<Integer, Set<String>> emptyRackMap = Collections.emptyMap();
-
         Map<String, TopicMetadata> topicMetadata = new HashMap<>();
         topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", topicAPartitions, emptyRackMap));
         topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", topicBPartitions, emptyRackMap));
@@ -142,9 +122,7 @@ class EndpointToPartitionsManagerTest {
         when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
         when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
 
-        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
-
-        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = EndpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
 
         assertEquals(responseEndpoint, result.userEndpoint());
         assertEquals(2, result.activePartitions().size());
@@ -161,13 +139,10 @@ class EndpointToPartitionsManagerTest {
         assertEquals(topicBExpectedPartitions, topicBPartition.partitions().stream().sorted().toList());
     }
 
-
-
     static Stream<Arguments> argsProvider() {
         return Stream.of(
                 arguments(2, 5, List.of(0, 1), List.of(0, 1, 2, 3, 4), "Should assign correct partitions when partitions differ between topics"),
                 arguments(3, 3, List.of(0, 1, 2), List.of(0, 1, 2), "Should assign correct partitions when partitions same between topics")
         );
     }
-
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group.streams.topics;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.coordinator.group.streams.StreamsGroup;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
+import org.apache.kafka.coordinator.group.streams.TopicMetadata;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EndpointToPartitionsManagerTest {
+
+    private StreamsGroup streamsGroup;
+    private StreamsGroupMember streamsGroupMember;
+    private ConfiguredTopology configuredTopology;
+    private ConfiguredSubtopology configuredSubtopology;
+
+    private EndpointToPartitionsManager endpointToPartitionsManager;
+    private final Map<String, Set<Integer>> activeTasks = new HashMap<>();
+    private final Map<String, Set<Integer>> standbyTasks = new HashMap<>();
+    private final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
+
+    @BeforeEach
+    public void setUp() {
+        streamsGroup = mock(StreamsGroup.class);
+        streamsGroupMember = mock(StreamsGroupMember.class);
+        configuredTopology = mock(ConfiguredTopology.class);
+        endpointToPartitionsManager = new EndpointToPartitionsManager();
+
+        configuredSubtopology = new ConfiguredSubtopology();
+        configuredSubtopology.setSourceTopics(Set.of("Topic-A", "Topic-B"));
+        ConfiguredInternalTopic stateChangelogTopic = new ConfiguredInternalTopic("StateChangeLog-A");
+        ConfiguredInternalTopic stateChangelogTopic2 = new ConfiguredInternalTopic("StateChangeLog-B");
+        configuredSubtopology.setStateChangelogTopics(Map.of("StateChangeLog-A", stateChangelogTopic, "StateChangeLog-B", stateChangelogTopic2));
+        configuredTopology.subtopologies().put("0", configuredSubtopology);
+
+        responseEndpoint.setHost("localhost");
+        responseEndpoint.setPort(9092);
+    }
+
+    @Test
+    void testEndpointToPartitionsWithStandbyTaskAssignments() {
+
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", 3, Collections.emptyMap()));
+        topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", 3, Collections.emptyMap()));
+        topicMetadata.put("StateChangeLog-A", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-A", 3, Collections.emptyMap()));
+        topicMetadata.put("StateChangeLog-B", new TopicMetadata(Uuid.randomUuid(), "StateChangeLog-B", 3, Collections.emptyMap()));
+
+        activeTasks.put("0", Set.of(0, 1, 2));
+        standbyTasks.put("0", Set.of(0, 1, 2));
+        when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
+        when(streamsGroupMember.assignedStandbyTasks()).thenReturn(standbyTasks);
+        when((streamsGroup.partitionMetadata())).thenReturn(topicMetadata);
+        when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
+        when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
+
+        // Invoke the method under test
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result =
+                endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
+
+        // Validate the results
+        assertEquals(responseEndpoint, result.userEndpoint());
+        assertEquals(2, result.activePartitions().size());
+        assertEquals(2, result.standbyPartitions().size());
+
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> activePartitions = result.activePartitions();
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> standbyPartitions = result.standbyPartitions();
+
+        activePartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
+        
+        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionA = standbyPartitions.stream().filter(tp -> tp.topic().equals("StateChangeLog-A")).findFirst().get();
+        assertEquals("StateChangeLog-A", standbyPartitionA.topic());
+        assertEquals(List.of(0, 1, 2), standbyPartitionA.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition standbyPartitionB = result.standbyPartitions().stream().filter(tp -> tp.topic().equals("StateChangeLog-B")).findFirst().get();
+        assertEquals("StateChangeLog-B", standbyPartitionB.topic());
+        assertEquals(List.of(0, 1, 2), standbyPartitionB.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-A")).findFirst().get();
+        assertEquals("Topic-A", topicAPartition.topic());
+        assertEquals(List.of(0, 1, 2), topicAPartition.partitions().stream().sorted().toList());
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.activePartitions().stream().filter(tp -> tp.topic().equals("Topic-B")).findFirst().get();
+        assertEquals("Topic-B", topicBPartition.topic());
+        assertEquals(List.of(0, 1, 2), topicBPartition.partitions().stream().sorted().toList());
+    }
+
+    @ParameterizedTest(name = "{4}")
+    @MethodSource("argsProvider")
+    void testEndpointToPartitionsWithTwoTopicsAndDifferentPartitions(int topicAPartitions,
+                                                                     int topicBPartitions,
+                                                                     List<Integer> topicAExpectedPartitions,
+                                                                     List<Integer> topicBExpectedPartitions,
+                                                                     String testName
+                                                                     ) {
+
+        Map<Integer, Set<String>> emptyRackMap = Collections.emptyMap();
+
+        Map<String, TopicMetadata> topicMetadata = new HashMap<>();
+        topicMetadata.put("Topic-A", new TopicMetadata(Uuid.randomUuid(), "Topic-A", topicAPartitions, emptyRackMap));
+        topicMetadata.put("Topic-B", new TopicMetadata(Uuid.randomUuid(), "Topic-B", topicBPartitions, emptyRackMap));
+
+        activeTasks.put("0", Set.of(0, 1, 2, 3, 4));
+        when(streamsGroupMember.assignedStandbyTasks()).thenReturn(Collections.emptyMap());
+        when(streamsGroupMember.assignedActiveTasks()).thenReturn(activeTasks);
+        when(streamsGroup.partitionMetadata()).thenReturn(topicMetadata);
+        when(streamsGroup.configuredTopology()).thenReturn(configuredTopology);
+        when(configuredTopology.subtopologies()).thenReturn(Map.of("0", configuredSubtopology));
+
+        EndpointToPartitionsManager endpointToPartitionsManager = new EndpointToPartitionsManager();
+
+        StreamsGroupHeartbeatResponseData.EndpointToPartitions result = endpointToPartitionsManager.endpointToPartitions(streamsGroupMember, responseEndpoint, streamsGroup);
+
+        assertEquals(responseEndpoint, result.userEndpoint());
+        assertEquals(2, result.activePartitions().size());
+
+        List<StreamsGroupHeartbeatResponseData.TopicPartition> topicPartitions = result.activePartitions();
+        topicPartitions.sort(Comparator.comparing(StreamsGroupHeartbeatResponseData.TopicPartition::topic));
+
+        StreamsGroupHeartbeatResponseData.TopicPartition topicAPartition = result.activePartitions().get(0);
+        assertEquals("Topic-A", topicAPartition.topic());
+        assertEquals(topicAExpectedPartitions, topicAPartition.partitions().stream().sorted().toList());
+        
+        StreamsGroupHeartbeatResponseData.TopicPartition topicBPartition = result.activePartitions().get(1);
+        assertEquals("Topic-B", topicBPartition.topic());
+        assertEquals(topicBExpectedPartitions, topicBPartition.partitions().stream().sorted().toList());
+    }
+
+
+
+    static Stream<Arguments> argsProvider() {
+        return Stream.of(
+                arguments(2, 5, List.of(0, 1), List.of(0, 1, 2, 3, 4), "Should assign correct partitions when partitions differ between topics"),
+                arguments(3, 3, List.of(0, 1, 2), List.of(0, 1, 2), "Should assign correct partitions when partitions same between topics")
+        );
+    }
+
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/taskassignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/taskassignor/StickyTaskAssignorTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.coordinator.group.taskassignor;
 
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1408,8 +1408,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             final Map<HostInfo, Set<TopicPartition>> standbyHostInfoMap = new HashMap<>();
 
             partitionsByEndpoint.forEach((hostInfo, endpointPartitions) -> {
-                activeHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.activePartitions));
-                standbyHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.standbyPartitions));
+                activeHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.activePartitions()));
+                standbyHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.standbyPartitions()));
             });
             streamsMetadataState.onChange(
                 activeHostInfoMap,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -76,7 +76,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -1403,15 +1402,19 @@ public class StreamThread extends Thread implements ProcessingThread {
             }
 
             // Process metadata from Streams Rebalance Protocol
-            final Map<StreamsAssignmentInterface.HostInfo, List<TopicPartition>> partitionsByEndpoint =
+            final Map<StreamsAssignmentInterface.HostInfo, StreamsAssignmentInterface.EndpointPartitions> partitionsByEndpoint =
                 streamsAssignmentInterface.get().partitionsByHost.get();
-            final Map<HostInfo, Set<TopicPartition>> convertedHostInfoMap = new HashMap<>();
-            partitionsByEndpoint.forEach((hostInfo, topicPartitions) ->
-                convertedHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(topicPartitions)));
+            final Map<HostInfo, Set<TopicPartition>> activeHostInfoMap = new HashMap<>();
+            final Map<HostInfo, Set<TopicPartition>> standbyHostInfoMap = new HashMap<>();
+
+            partitionsByEndpoint.forEach((hostInfo, endpointPartitions) -> {
+                activeHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.activePartitions));
+                standbyHostInfoMap.put(new HostInfo(hostInfo.host, hostInfo.port), new HashSet<>(endpointPartitions.standbyPartitions));
+            });
             streamsMetadataState.onChange(
-                convertedHostInfoMap,
-                Collections.emptyMap(), // TODO: We cannot differentiate between standby and active tasks here?!
-                getTopicPartitionInfo(convertedHostInfoMap)
+                activeHostInfoMap,
+                standbyHostInfoMap,
+                getTopicPartitionInfo(activeHostInfoMap)
             );
 
             // Process assignment from Streams Rebalance Protocol

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -223,7 +223,7 @@ public class StreamsGroupCommand {
         }
 
         private void printTaskType(List<StreamsGroupMemberAssignment.TaskIds> tasks, String taskType) {
-            System.out.printf("%s\n", taskType + ": " + tasks.stream().map(taskId -> taskId.subtopologyId() + ": [" + taskId.partitions()).collect(Collectors.joining(",")) + "] ");
+            System.out.printf("%s%n", taskType + ": " + tasks.stream().map(taskId -> taskId.subtopologyId() + ": [" + taskId.partitions()).collect(Collectors.joining(",")) + "] ");
         }
 
         private void printTasks(StreamsGroupMemberAssignment assignment, boolean isTarget) {
@@ -241,11 +241,11 @@ public class StreamsGroupCommand {
             int coordinatorLen = Math.max(25, coordinator.length());
 
             if (!verbose) {
-                String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %s\n";
+                String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %s%n";
                 System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "#MEMBERS");
                 System.out.printf(fmt, description.groupId(), coordinator, description.groupState().toString(), description.members().size());
             } else {
-                String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %-15s %-15s %s\n";
+                String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %-15s %-15s %s%n";
                 System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS");
                 System.out.printf(fmt, description.groupId(), coordinator, description.groupState().toString(), description.groupEpoch(), description.targetAssignmentEpoch(), description.members().size());
             }
@@ -261,13 +261,13 @@ public class StreamsGroupCommand {
                 }
 
                 if (!verbose) {
-                    String fmt =  "%" + (-groupLen) + "s %" + (-maxTopicLen) + "s %-10s %s\n";
+                    String fmt =  "%" + (-groupLen) + "s %" + (-maxTopicLen) + "s %-10s %s%n";
                     System.out.printf(fmt, "GROUP", "TOPIC", "PARTITION", "OFFSET-LAG");
                     for (Map.Entry<TopicPartition, Long> offset : offsets.entrySet()) {
                         System.out.printf(fmt, description.groupId(), offset.getKey().topic(), offset.getKey().partition(), offset.getValue());
                     }
                 } else {
-                    String fmt =  "%" + (-groupLen) + "s %" + (-maxTopicLen) + "s %-10s %-15s %s\n";
+                    String fmt =  "%" + (-groupLen) + "s %" + (-maxTopicLen) + "s %-10s %-15s %s%n";
                     System.out.printf(fmt, "GROUP", "TOPIC", "PARTITION", "LEADER-EPOCH", "OFFSET-LAG");
                     for (Map.Entry<TopicPartition, Long> offset : offsets.entrySet()) {
                         System.out.printf(fmt, description.groupId(), offset.getKey().topic(), offset.getKey().partition(), "", offset.getValue());


### PR DESCRIPTION
Refactor the `StreamsGroupHeartbeatResponse` to include standby tasks.

Updated the `StreamsGroupHeartbeatRequestManagerTest` to account for endpoint to partitions metadata in a successful response.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
