### PR TITLE
KAFKA-18754: Allow `PlainSaslServer` to pass client info through the negotiated properties.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
@@ -27,6 +27,7 @@ import javax.security.auth.callback.Callback;
 public class PlainAuthenticateCallback implements Callback {
     private final char[] password;
     private boolean authenticated;
+    private Object clientInfo;
 
     /**
      * Creates a callback with the password provided by the client
@@ -59,5 +60,24 @@ public class PlainAuthenticateCallback implements Callback {
      */
     public void authenticated(boolean authenticated) {
         this.authenticated = authenticated;
+    }
+
+    /**
+     * Sets the client info. Custom implementations of server-side callback handler can use
+     * this method to pass along client info which can then be used by, for example, a custom 
+     * authorizer to make authorization decisions.
+     *
+     * @param clientInfo Object representing client info
+     */
+    public void clientInfo(Object clientInfo) {
+        this.clientInfo = clientInfo;
+    }
+
+    /**
+     * Returns null if client password doesn't match expected password, otherwise return
+     * value can be (but is not necessarily) non-null.
+     */
+    public Object clientInfo() {
+        return this.clientInfo;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
@@ -78,6 +78,6 @@ public class PlainAuthenticateCallback implements Callback {
      * value can be (but is not necessarily) non-null.
      */
     public Object clientInfo() {
-        return this.clientInfo;
+        return clientInfo;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -48,6 +48,7 @@ import javax.security.sasl.SaslServerFactory;
 public class PlainSaslServer implements SaslServer {
 
     public static final String PLAIN_MECHANISM = "PLAIN";
+    public static final String NEGOTIATED_PROPERTY_KEY_TOKEN = PLAIN_MECHANISM + ".clientInfo";
 
     private final CallbackHandler callbackHandler;
     private boolean complete;

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -48,11 +48,12 @@ import javax.security.sasl.SaslServerFactory;
 public class PlainSaslServer implements SaslServer {
 
     public static final String PLAIN_MECHANISM = "PLAIN";
-    public static final String NEGOTIATED_PROPERTY_KEY_TOKEN = PLAIN_MECHANISM + ".clientInfo";
+    public static final String NEGOTIATED_PROPERTY_KEY_CLIENT_INFO = PLAIN_MECHANISM + ".clientInfo";
 
     private final CallbackHandler callbackHandler;
     private boolean complete;
     private String authorizationId;
+    private Object clientInfo;
 
     public PlainSaslServer(CallbackHandler callbackHandler) {
         this.callbackHandler = callbackHandler;
@@ -109,6 +110,7 @@ public class PlainSaslServer implements SaslServer {
             throw new SaslAuthenticationException("Authentication failed: Client requested an authorization id that is different from username");
 
         this.authorizationId = username;
+        this.clientInfo = authenticateCallback.clientInfo();
 
         complete = true;
         return new byte[0];
@@ -150,6 +152,8 @@ public class PlainSaslServer implements SaslServer {
     public Object getNegotiatedProperty(String propName) {
         if (!complete)
             throw new IllegalStateException("Authentication exchange has not completed");
+        if (NEGOTIATED_PROPERTY_KEY_CLIENT_INFO.equals(propName))
+            return clientInfo;
         return null;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -19,17 +19,27 @@ package org.apache.kafka.common.security.plain.internals;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
+import org.apache.kafka.common.security.plain.PlainAuthenticateCallback;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import static org.apache.kafka.common.security.plain.internals.PlainSaslServer.NEGOTIATED_PROPERTY_KEY_CLIENT_INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 public class PlainSaslServerTest {
 
@@ -113,5 +123,37 @@ public class PlainSaslServerTest {
         String nul = "\u0000";
         String message = String.format("%s%s%s%s%s", authorizationId, nul, userName, nul, password);
         return message.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testClientInfo() throws IOException, UnsupportedCallbackException {
+        DummyClientInfo expectedClientInfo = new DummyClientInfo("my-org", Set.of("view", "edit"));
+        PlainServerCallbackHandler callbackHandler = mock(PlainServerCallbackHandler.class);
+        doAnswer(invocation -> {
+            Callback[] callbacks = invocation.getArgument(0);
+            for (Callback callback : callbacks) {
+                if (callback instanceof PlainAuthenticateCallback) {
+                    ((PlainAuthenticateCallback) callback).authenticated(true);
+                    ((PlainAuthenticateCallback) callback).clientInfo(expectedClientInfo);
+                }
+            }
+            return null;
+        }).when(callbackHandler).handle(any());
+
+        PlainSaslServer server = new PlainSaslServer(callbackHandler);
+        server.evaluateResponse(saslMessage("username", "username", "password"));
+        DummyClientInfo actualClientInfo = (DummyClientInfo) server.getNegotiatedProperty(NEGOTIATED_PROPERTY_KEY_CLIENT_INFO);
+        assertEquals(expectedClientInfo.scope, actualClientInfo.scope);
+        assertEquals(expectedClientInfo.roles, actualClientInfo.roles);
+    }
+
+    private static class DummyClientInfo {
+        private final String scope;
+        private final Set<String> roles;
+
+        DummyClientInfo(String scope, Set<String> roles) {
+            this.scope = scope;
+            this.roles = roles;
+        }
     }
 }


### PR DESCRIPTION
In our organization, we use a custom Kafka authorizer that makes decisions based on client roles assigned by our IAM server. We've also implemented a custom `PlainServerCallbackHandler` that authenticates clients using their username and password through the IAM server. The IAM server also returns client info, such as assigned roles, but we're facing an issue—`PlainSaslServer` can only pass the authorizationID to the authorizer, meaning the client info is lost. To solve this, we want to extend `PlainSaslServer` so it can pass client info through the negotiated properties.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
