### PR TITLE
MINOR: Fix streams smoke test flush records

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -35,12 +35,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.generate;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.verify;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,10 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(600)
 @Tag("integration")
 public class SmokeTestDriverIntegrationTest {
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
-            3,
-            mkProperties(
-                    Collections.singletonMap("log.message.timestamp.after.max.ms", String.valueOf(Long.MAX_VALUE))));
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
 
     @BeforeAll
     public static void startCluster() throws IOException {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -306,10 +306,10 @@ public class RelationalSmokeTest extends SmokeTestUtil {
         }
 
         public static DataSet generate(final int numArticles, final int numComments) {
-            // generate four days' worth of data, starting right now (to avoid broker retention/compaction)
+            // generate four days' worth of data, starting 4 days in the past (avoiding future records)
             final int timeSpan = 1000 * 60 * 60 * 24 * 4;
-            final long dataStartTime = System.currentTimeMillis();
-            final long dataEndTime = dataStartTime + timeSpan;
+            final long dataStartTime = System.currentTimeMillis() - timeSpan;
+            final long dataEndTime = System.currentTimeMillis();
 
             // Explicitly create a seed so we can we can log.
             // If we are debugging a failed run, we can deterministically produce the same dataset
@@ -648,6 +648,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                     )
                 );
             properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
+            properties.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, Duration.ofDays(5).toMillis());
             return properties;
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -133,6 +133,7 @@ public class SmokeTestClient extends SmokeTestUtil {
         fullProps.put(StreamsConfig.CLIENT_ID_CONFIG, "SmokeTest-" + name);
         fullProps.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         fullProps.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        fullProps.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, Duration.ofDays(3).toMillis());
         fullProps.putAll(props);
         return fullProps;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -61,6 +61,12 @@ import static java.util.Collections.emptyMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 
 public class SmokeTestDriver extends SmokeTestUtil {
+    /**
+     * We are creating all records two days in the past, so that we can flush all windows by sending a final record
+     * using the current timestamp, without using timestamps in the future.
+     */
+    private static final long CREATE_TIME_SHIFT_MS = Duration.ofDays(2).toMillis();
+
     private static final String[] NUMERIC_VALUE_TOPICS = {
         "data",
         "echo",
@@ -137,6 +143,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
                 final ProducerRecord<byte[], byte[]> record =
                     new ProducerRecord<>(
                         "data",
+                        null,
+                        System.currentTimeMillis() - CREATE_TIME_SHIFT_MS,
                         stringSerde.serializer().serialize("", key),
                         intSerde.serializer().serialize("", value)
                     );
@@ -146,6 +154,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
                 final ProducerRecord<byte[], byte[]> fkRecord =
                     new ProducerRecord<>(
                         "fk",
+                        null,
+                        System.currentTimeMillis() - CREATE_TIME_SHIFT_MS,
                         intSerde.serializer().serialize("", value),
                         stringSerde.serializer().serialize("", key)
                     );
@@ -184,6 +194,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
         final List<ProducerRecord<byte[], byte[]>> dataNeedRetry = new ArrayList<>();
         final List<ProducerRecord<byte[], byte[]>> fkNeedRetry = new ArrayList<>();
 
+
         try (final KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps)) {
             while (remaining > 0) {
                 final int index = rand.nextInt(remaining);
@@ -198,6 +209,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
                     final ProducerRecord<byte[], byte[]> record =
                         new ProducerRecord<>(
                             "data",
+                            null,
+                            System.currentTimeMillis()  - CREATE_TIME_SHIFT_MS,
                             stringSerde.serializer().serialize("", key),
                             intSerde.serializer().serialize("", value)
                         );
@@ -207,6 +220,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
                     final ProducerRecord<byte[], byte[]> fkRecord =
                         new ProducerRecord<>(
                             "fk",
+                            null,
+                            System.currentTimeMillis()  - CREATE_TIME_SHIFT_MS,
                             intSerde.serializer().serialize("", value),
                             stringSerde.serializer().serialize("", key)
                         );
@@ -272,7 +287,6 @@ public class SmokeTestDriver extends SmokeTestUtil {
             producer.send(new ProducerRecord<>(
                 partition.topic(),
                 partition.partition(),
-                System.currentTimeMillis() + Duration.ofDays(2).toMillis(),
                 keyBytes,
                 valBytes
             ));

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -194,7 +194,6 @@ public class SmokeTestDriver extends SmokeTestUtil {
         final List<ProducerRecord<byte[], byte[]>> dataNeedRetry = new ArrayList<>();
         final List<ProducerRecord<byte[], byte[]>> fkNeedRetry = new ArrayList<>();
 
-
         try (final KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps)) {
             while (remaining > 0) {
                 final int index = rand.nextInt(remaining);
@@ -210,7 +209,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
                         new ProducerRecord<>(
                             "data",
                             null,
-                            System.currentTimeMillis()  - CREATE_TIME_SHIFT_MS,
+                            System.currentTimeMillis() - CREATE_TIME_SHIFT_MS,
                             stringSerde.serializer().serialize("", key),
                             intSerde.serializer().serialize("", value)
                         );
@@ -221,7 +220,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
                         new ProducerRecord<>(
                             "fk",
                             null,
-                            System.currentTimeMillis()  - CREATE_TIME_SHIFT_MS,
+                            System.currentTimeMillis() - CREATE_TIME_SHIFT_MS,
                             intSerde.serializer().serialize("", value),
                             stringSerde.serializer().serialize("", key)
                         );

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -286,6 +286,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             producer.send(new ProducerRecord<>(
                 partition.topic(),
                 partition.partition(),
+                System.currentTimeMillis(),
                 keyBytes,
                 valBytes
             ));


### PR DESCRIPTION
In the streams smoke test, flush records that are appended to the input topics, to advance the stream time so that all suppressed windows are flushed at the end of the test. The records are created with record time equal to current time + 2 days. caf0b67fbb changed the broker defaults so that records more than one hour in the future are rejected by the broker. This breaks the flush messages. By moving all record time stamps 2 days into the past, the existing logic should work correctly with the new default broker configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
