### PR TITLE
MINOR: fix KStream#to incorrect javadoc

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -540,7 +540,7 @@ public interface KStream<K, V> {
     void to(final String topic);
 
     /**
-     * See {@link #to(String).}
+     * See {@link #to(String)}.
      */
     void to(final String topic,
             final Produced<K, V> produced);


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/4953b99e-2344-4ceb-bf15-3c8d6ecd792c)

after:
![image](https://github.com/user-attachments/assets/e7c65a6a-e137-457e-ad07-6cade36395b6)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
