### PR TITLE
KAFKA-18441: Remove flaky tag on KafkaAdminClientTest#testAdminClientApisAuthenticationFailure

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -242,7 +242,6 @@ import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetrySender;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -1793,7 +1792,6 @@ public class KafkaAdminClientTest {
         }
     }
 
-    @Flaky("KAFKA-18441")
     @Test
     public void testAdminClientApisAuthenticationFailure() {
         Cluster cluster = mockBootstrapCluster();


### PR DESCRIPTION
The PR https://github.com/apache/kafka/pull/18735 was merged on Jan 30. After that, we don't see any flaky for ten days. I think we can remove `@Flaky` for `KafkaAdminClientTest#testAdminClientApisAuthenticationFailure`.

<img width="1291" alt="Screenshot 2025-02-10 at 1 07 59 PM" src="https://github.com/user-attachments/assets/9f60e4fe-ef65-444c-8c41-35b16d7ed0f9" />


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
