### PR TITLE
HOTFIX: KStream java doc build error

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -540,7 +540,7 @@ public interface KStream<K, V> {
     void to(final String topic);
 
     /**
-     * See {@link #to(String).}
+     * See {@link #to(String)}
      */
     void to(final String topic,
             final Produced<K, V> produced);


### PR DESCRIPTION
I use `./gradlew :streams:javadoc`, it will have an error 
```
> Configure project :
Starting build with version 4.1.0-SNAPSHOT (commit id 7fef5b86) using Gradle 8.10.2, Java 17 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=32, maxScalacThreads=8, maxTestRetries=0

> Task :streams:javadoc FAILED
KStream.java:543: warning: invalid usage of tag {@link #to(String).
     * See {@link #to(String).}
           ^
KStream.java:543: warning: invalid usage of tag {@link #to(String).
     * See {@link #to(String).}
           ^
KStream.java:543: warning: invalid usage of tag {@link #to(String).
     * See {@link #to(String).}
           ^
error: warnings found and -Werror specified
1 error
3 warnings

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':streams:javadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 2s
11 actionable tasks: 1 executed, 10 up-to-date
```
after fix 
```
> Configure project :
Starting build with version 4.1.0-SNAPSHOT (commit id 7fef5b86) using Gradle 8.10.2, Java 17 and Scala 2.13.15
Build properties: ignoreFailures=false, maxParallelForks=32, maxScalacThreads=8, maxTestRetries=0

BUILD SUCCESSFUL in 2s
11 actionable tasks: 2 executed, 9 up-to-date
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
