### PR TITLE
MINOR: Fix log compaction system test

### DIFF
--- a/tests/kafkatest/tests/tools/log_compaction_test.py
+++ b/tests/kafkatest/tests/tools/log_compaction_test.py
@@ -20,7 +20,6 @@ from ducktape.tests.test import Test
 from ducktape.mark.resource import cluster
 
 from kafkatest.services.kafka import config_property
-from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.log_compaction_tester import LogCompactionTester
 

--- a/tests/kafkatest/tests/tools/log_compaction_test.py
+++ b/tests/kafkatest/tests/tools/log_compaction_test.py
@@ -27,26 +27,21 @@ from kafkatest.services.log_compaction_tester import LogCompactionTester
 class LogCompactionTest(Test):
 
     # Configure smaller segment size to create more segments for compaction
-    LOG_SEGMENT_BYTES = "1024000"
+    LOG_SEGMENT_BYTES = "1048576"
 
     def __init__(self, test_context):
         super(LogCompactionTest, self).__init__(test_context)
         self.num_zk = 1
         self.num_brokers = 1
 
-        self.zk = ZookeeperService(test_context, self.num_zk) if quorum.for_test(test_context) == quorum.zk else None
         self.kafka = None
         self.compaction_verifier = None
-
-    def setUp(self):
-        if self.zk:
-            self.zk.start()
 
     def start_kafka(self, security_protocol, interbroker_security_protocol):
         self.kafka = KafkaService(
             self.test_context,
             num_nodes = self.num_brokers,
-            zk = self.zk,
+            zk = None,
             security_protocol=security_protocol,
             interbroker_security_protocol=interbroker_security_protocol,
             server_prop_overrides=[


### PR DESCRIPTION
`log.segment.bytes` must be greater or equals to 1MB (KIP-1030).

```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-02-10--003
run time:         55.903 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
================================================================================
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
