### PR TITLE
MINOR: Fix bug in json naming in ShareConsumeBenchSpec

### DIFF
--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareConsumeBenchSpec.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ShareConsumeBenchSpec.java
@@ -98,7 +98,7 @@ public final class ShareConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("bootstrapServers") String bootstrapServers,
                             @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
                             @JsonProperty("maxMessages") long maxMessages,
-                            @JsonProperty("consumerGroup") String shareGroup,
+                            @JsonProperty("shareGroup") String shareGroup,
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/workload/ShareConsumeBenchSpecTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/workload/ShareConsumeBenchSpecTest.java
@@ -50,6 +50,14 @@ class ShareConsumeBenchSpecTest {
         }
     }
 
+    @Test
+    public void testDefaultShareGroupName() {
+        ShareConsumeBenchSpec shareConsumeBenchSpec = new ShareConsumeBenchSpec(0, 0, "node", "localhost",
+                123, 1234, null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), 1,
+                Optional.empty(), List.of("abc"));
+        assertEquals("share", shareConsumeBenchSpec.shareGroup());
+    }
+
     private ShareConsumeBenchSpec shareConsumeBenchSpec(List<String> activeTopics) {
         return new ShareConsumeBenchSpec(0, 0, "node", "localhost",
                 123, 1234, "sg-1",


### PR DESCRIPTION
There was a minor bug in `ShareConsumeBenchSpec` where we change the key in json workloads to "shareGroup" instead of "consumerGroup" and that was not reflected in the class. The PR fixes the bug.