### PR TITLE
KAFKA-18757: Create full-function SimpleAssignor to match KIP-932 description

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.test.ClusterInstance
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertNotNull, assertNull, assertTrue}
 import org.junit.jupiter.api.{Tag, Timeout}
 
+import java.util
 import scala.jdk.CollectionConverters._
 
 @Timeout(120)
@@ -262,15 +263,15 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
 
-      var partitionsAssigned: Set[Integer] = Set()
-      for (topicPartition <- topicPartitionsAssignedToMember1.asScala) {
-        partitionsAssigned = partitionsAssigned ++ topicPartition.partitions().asScala
-      }
-      for (topicPartition <- topicPartitionsAssignedToMember2.asScala) {
-        partitionsAssigned = partitionsAssigned ++ topicPartition.partitions().asScala
-      }
+      val partitionsAssigned: util.Set[Integer] = new util.HashSet[Integer]()
+      topicPartitionsAssignedToMember1.forEach(topicPartition => {
+        partitionsAssigned.addAll(topicPartition.partitions())
+      })
+      topicPartitionsAssignedToMember2.forEach(topicPartition => {
+        partitionsAssigned.addAll(topicPartition.partitions())
+      })
       // Verify all the 3 topic partitions for "foo" have been assigned to at least 1 member.
-      assertEquals(Set(0, 1, 2), partitionsAssigned)
+      assertEquals(util.Set.of(0, 1, 2), partitionsAssigned)
 
       // Verify the assignments are not changed for member 1.
       // Prepare another heartbeat for member 1 with latest received epoch 3 for member 1.

--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -216,17 +216,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       assertNotEquals(memberId1, memberId2)
 
       // Create the topic.
-      val topicId = TestUtils.createTopicWithAdminRaw(
+      TestUtils.createTopicWithAdminRaw(
         admin = admin,
         topic = "foo",
         numPartitions = 3
       )
-
-      // This is the expected assignment.
-      val expectedAssignment = new ShareGroupHeartbeatResponseData.Assignment()
-        .setTopicPartitions(List(new ShareGroupHeartbeatResponseData.TopicPartitions()
-          .setTopicId(topicId)
-          .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
       // Prepare the next heartbeat for member 1.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
@@ -241,10 +235,10 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       shareGroupHeartbeatResponse = null
       TestUtils.waitUntilTrue(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
-        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
-          shareGroupHeartbeatResponse.data.assignment == expectedAssignment
+        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code && shareGroupHeartbeatResponse.data.assignment != null
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
+      val topicPartitionsAssignedToMember1 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
 
@@ -261,12 +255,22 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       shareGroupHeartbeatResponse = null
       TestUtils.waitUntilTrue(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
-        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
-          shareGroupHeartbeatResponse.data.assignment == expectedAssignment
+        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code && shareGroupHeartbeatResponse.data.assignment !=  null
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
+      val topicPartitionsAssignedToMember2 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
       // Verify the response.
       assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+
+      var partitionsAssigned: Set[Integer] = Set()
+      for (topicPartition <- topicPartitionsAssignedToMember1.asScala) {
+        partitionsAssigned = partitionsAssigned ++ topicPartition.partitions().asScala
+      }
+      for (topicPartition <- topicPartitionsAssignedToMember2.asScala) {
+        partitionsAssigned = partitionsAssigned ++ topicPartition.partitions().asScala
+      }
+      // Verify all the 3 topic partitions for "foo" have been assigned to at least 1 member.
+      assertEquals(Set(0, 1, 2), partitionsAssigned)
 
       // Verify the assignments are not changed for member 1.
       // Prepare another heartbeat for member 1 with latest received epoch 3 for member 1.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -138,15 +138,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         roundRobinAssignment(groupSpec.memberIds(), unassignedPartitions, newAssignment);
 
-        // Step 3: We combine current assignment and new assignment.
-        // However, if any partitions are assigned members by step 1 in new assignment, and also have members in the current assignment assigned by 2,
-        // the members assigned in the current assignment by step 2 are ignored.
-        Map<TargetPartition, List<String>> currentAssignmentFiltered = filterCurrentAssignment(currentAssignment, assignedPartitions);
         Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
 
         // When combining current assignment, we need to only consider the topics in current assignment that are also being
         // subscribed in the new assignment as well.
-        currentAssignmentFiltered.forEach((targetPartition, members) -> {
+        currentAssignment.forEach((targetPartition, members) -> {
             if (subscribeTopicIds.contains(targetPartition.topicId))
                 members.forEach(member -> {
                     if (groupSpec.memberIds().contains(member))
@@ -190,14 +186,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             roundRobinAssignment(topicToMemberSubscription.get(unassignedTopic), unassignedPartitions.get(unassignedTopic), newAssignment));
 
         // Step 3: We combine current assignment and new assignment.
-        // However, if any partitions are assigned members by step 1 in new assignment, and also have members in the current assignment assigned by 2,
-        // the members assigned in the current assignment by step 2 are ignored.
-        Map<TargetPartition, List<String>> currentAssignmentFiltered = filterCurrentAssignment(currentAssignment, assignedPartitions);
         Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
 
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.
-        currentAssignmentFiltered.forEach((targetPartition, members) -> members.forEach(member -> {
+        currentAssignment.forEach((targetPartition, members) -> members.forEach(member -> {
             if (topicToMemberSubscription.getOrDefault(targetPartition.topicId(), Collections.emptySet()).contains(member))
                 finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
         }));
@@ -222,33 +215,6 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         });
 
         return new GroupAssignment(members);
-    }
-
-    private Map<TargetPartition, List<String>> filterCurrentAssignment(
-        Map<TargetPartition, List<String>> currentAssignment,
-        Set<TargetPartition> assignedPartitions) {
-        // topic partitions which were a part of current assignment.
-        List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
-        // members which were a part of current assignment.
-        Set<String> members = new LinkedHashSet<>();
-        currentAssignment.values().forEach(members::addAll);
-        // Computing hash based assignment that would have occurred for the current assignment.
-        Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();
-        memberHashAssignment(targetPartitions, members, hashAssignment);
-
-        Map<TargetPartition, List<String>> filteredCurrentAssignment = new HashMap<>();
-        currentAssignment.forEach((targetPartition, assignedMembers) -> {
-            if (!assignedPartitions.contains(targetPartition)) {
-                filteredCurrentAssignment.put(targetPartition, assignedMembers);
-            } else {
-                assignedMembers.forEach(assignedMember -> {
-                    // only adding members which were added by step 1 for the current assignment for the assigned partitions.
-                    if (hashAssignment.getOrDefault(targetPartition, Collections.emptyList()).contains(assignedMember))
-                        filteredCurrentAssignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(assignedMember);
-                });
-            }
-        });
-        return filteredCurrentAssignment;
     }
 
     // Visible for testing.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -109,8 +110,9 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     // Get the current assignment for subscribed topic partitions to share group members.
     private Map<TargetPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
         Map<TargetPartition, List<String>> assignment = new HashMap<>();
+        Collection<String> members = groupSpec.memberIds();
 
-        for (String member : groupSpec.memberIds()) {
+        for (String member : members) {
             Map<Uuid, Set<Integer>> assignedTopicPartitions = groupSpec.memberAssignment(member).partitions();
             assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
                 partition -> assignment.computeIfAbsent(new TargetPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
@@ -129,7 +131,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         memberHashAssignment(targetPartitions, groupSpec.memberIds(), newAssignment);
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
+        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
         List<TargetPartition> unassignedPartitions = targetPartitions.stream()
             .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
             .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
@@ -149,11 +151,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             if (subscribeTopicIds.contains(targetPartition.topicId))
                 members.forEach(member -> {
                     if (groupSpec.memberIds().contains(member))
-                        finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition);
+                        finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
                 });
         });
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition)));
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
@@ -178,7 +180,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             memberHashAssignment(partitions, Collections.singletonList(member), newAssignment));
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
+        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
         Map<Uuid, List<TargetPartition>> unassignedPartitions = new HashMap<>();
         targetPartitions.forEach(targetPartition -> {
             if (!assignedPartitions.contains(targetPartition) && !currentAssignment.containsKey(targetPartition))
@@ -198,10 +200,10 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // which is being subscribed in the new assignment as well.
         currentAssignmentFiltered.forEach((targetPartition, members) -> members.forEach(member -> {
             if (topicToMemberSubscription.getOrDefault(targetPartition.topicId(), Collections.emptySet()).contains(member))
-                finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition);
+                finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
         }));
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition)));
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
@@ -212,7 +214,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         Map<String, MemberAssignment> members = new HashMap<>();
         for (Map.Entry<String, Set<TargetPartition>> entry : assignmentByMember.entrySet()) {
             Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
-            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new LinkedHashSet<>()).add(targetPartition.partition()));
+            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partition()));
             members.put(entry.getKey(), new MemberAssignmentImpl(targetPartitions));
         }
         allGroupMembers.forEach(member -> {
@@ -229,7 +231,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // topic partitions which were a part of current assignment.
         List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
         // members which were a part of current assignment.
-        Set<String> members = new LinkedHashSet<>();
+        Set<String> members = new HashSet<>();
         currentAssignment.values().forEach(members::addAll);
         // Computing hash based assignment that would have occurred for the current assignment.
         Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -110,9 +110,8 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     // Get the current assignment for subscribed topic partitions to share group members.
     private Map<TargetPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
         Map<TargetPartition, List<String>> assignment = new HashMap<>();
-        Collection<String> members = groupSpec.memberIds();
 
-        for (String member : members) {
+        for (String member : groupSpec.memberIds()) {
             Map<Uuid, Set<Integer>> assignedTopicPartitions = groupSpec.memberAssignment(member).partitions();
             assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
                 partition -> assignment.computeIfAbsent(new TargetPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
@@ -180,7 +179,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             memberHashAssignment(partitions, Collections.singletonList(member), newAssignment));
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
+        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
         Map<Uuid, List<TargetPartition>> unassignedPartitions = new HashMap<>();
         targetPartitions.forEach(targetPartition -> {
             if (!assignedPartitions.contains(targetPartition) && !currentAssignment.containsKey(targetPartition))
@@ -231,7 +230,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // topic partitions which were a part of current assignment.
         List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
         // members which were a part of current assignment.
-        Set<String> members = new HashSet<>();
+        Set<String> members = new LinkedHashSet<>();
         currentAssignment.values().forEach(members::addAll);
         // Computing hash based assignment that would have occurred for the current assignment.
         Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -247,11 +247,12 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         List<TargetPartition> targetPartitions,
         Collection<String> memberIds,
         Map<TargetPartition, List<String>> assignment) {
-        for (String memberId : memberIds) {
-            int topicPartitionIndex = Math.abs(memberId.hashCode() % targetPartitions.size());
-            TargetPartition topicPartition = targetPartitions.get(topicPartitionIndex);
-            assignment.computeIfAbsent(topicPartition, k -> new ArrayList<>()).add(memberId);
-        }
+        if (!targetPartitions.isEmpty())
+            for (String memberId : memberIds) {
+                int topicPartitionIndex = Math.abs(memberId.hashCode() % targetPartitions.size());
+                TargetPartition topicPartition = targetPartitions.get(topicPartitionIndex);
+                assignment.computeIfAbsent(topicPartition, k -> new ArrayList<>()).add(memberId);
+            }
     }
 
     // Visible for testing.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -159,17 +159,17 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // no. of partitions assignment for every member(KAFKA-18788). Hence, the potential problem of burdening
         // the share consumers will be addressed in a future PR.
 
+        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
         // When combining current assignment, we need to only consider the topics in current assignment that are also being
         // subscribed in the new assignment as well.
         currentAssignment.forEach((targetPartition, members) -> {
             if (subscribedTopicIds.contains(targetPartition.topicId()))
                 members.forEach(member -> {
-                    if (groupSpec.memberIds().contains(member))
+                    if (groupSpec.memberIds().contains(member) && !newAssignment.containsKey(targetPartition))
                         finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
                 });
         });
-        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
@@ -222,14 +222,15 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // no. of partitions assignment for every member(KAFKA-18788). Hence, the potential problem of burdening
         // the share consumers will be addressed in a future PR.
 
+        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.
         currentAssignment.forEach((topicIdPartition, members) -> members.forEach(member -> {
-            if (topicToMemberSubscription.getOrDefault(topicIdPartition.topicId(), Collections.emptySet()).contains(member))
+            if (topicToMemberSubscription.getOrDefault(topicIdPartition.topicId(), Collections.emptySet()).contains(member)
+                && !newAssignment.containsKey(topicIdPartition))
                 finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(topicIdPartition);
         }));
-        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -110,9 +109,8 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     // Get the current assignment for subscribed topic partitions to share group members.
     private Map<TargetPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
         Map<TargetPartition, List<String>> assignment = new HashMap<>();
-        Collection<String> members = groupSpec.memberIds();
 
-        for (String member : members) {
+        for (String member : groupSpec.memberIds()) {
             Map<Uuid, Set<Integer>> assignedTopicPartitions = groupSpec.memberAssignment(member).partitions();
             assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
                 partition -> assignment.computeIfAbsent(new TargetPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
@@ -131,7 +129,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         memberHashAssignment(targetPartitions, groupSpec.memberIds(), newAssignment);
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
+        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
         List<TargetPartition> unassignedPartitions = targetPartitions.stream()
             .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
             .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
@@ -151,11 +149,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             if (subscribeTopicIds.contains(targetPartition.topicId))
                 members.forEach(member -> {
                     if (groupSpec.memberIds().contains(member))
-                        finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
+                        finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition);
                 });
         });
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+            finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
@@ -180,7 +178,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             memberHashAssignment(partitions, Collections.singletonList(member), newAssignment));
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
+        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
         Map<Uuid, List<TargetPartition>> unassignedPartitions = new HashMap<>();
         targetPartitions.forEach(targetPartition -> {
             if (!assignedPartitions.contains(targetPartition) && !currentAssignment.containsKey(targetPartition))
@@ -200,10 +198,10 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // which is being subscribed in the new assignment as well.
         currentAssignmentFiltered.forEach((targetPartition, members) -> members.forEach(member -> {
             if (topicToMemberSubscription.getOrDefault(targetPartition.topicId(), Collections.emptySet()).contains(member))
-                finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
+                finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition);
         }));
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+            finalAssignment.computeIfAbsent(member, k -> new LinkedHashSet<>()).add(targetPartition)));
 
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
@@ -214,7 +212,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         Map<String, MemberAssignment> members = new HashMap<>();
         for (Map.Entry<String, Set<TargetPartition>> entry : assignmentByMember.entrySet()) {
             Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
-            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partition()));
+            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new LinkedHashSet<>()).add(targetPartition.partition()));
             members.put(entry.getKey(), new MemberAssignmentImpl(targetPartitions));
         }
         allGroupMembers.forEach(member -> {
@@ -231,7 +229,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // topic partitions which were a part of current assignment.
         List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
         // members which were a part of current assignment.
-        Set<String> members = new HashSet<>();
+        Set<String> members = new LinkedHashSet<>();
         currentAssignment.values().forEach(members::addAll);
         // Computing hash based assignment that would have occurred for the current assignment.
         Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -128,16 +128,14 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         List<TopicIdPartition> targetPartitions,
         Map<TopicIdPartition, List<String>> currentAssignment
     ) {
-
         Map<TopicIdPartition, List<String>> newAssignment = new HashMap<>();
 
-        // Step 1: Hash member IDs to partitions.
+        // Step 1: Hash member IDs to topic partitions.
         memberHashAssignment(targetPartitions, groupSpec.memberIds(), newAssignment);
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TopicIdPartition> assignedPartitions = newAssignment.keySet();
         List<TopicIdPartition> unassignedPartitions = targetPartitions.stream()
-            .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
+            .filter(targetPartition -> !newAssignment.containsKey(targetPartition))
             .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
             .toList();
 
@@ -198,9 +196,9 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.
-        currentAssignment.forEach((targetPartition, members) -> members.forEach(member -> {
-            if (topicToMemberSubscription.getOrDefault(targetPartition.topicId(), Collections.emptySet()).contains(member))
-                finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
+        currentAssignment.forEach((topicIdPartition, members) -> members.forEach(member -> {
+            if (topicToMemberSubscription.getOrDefault(topicIdPartition.topicId(), Collections.emptySet()).contains(member))
+                finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(topicIdPartition);
         }));
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
@@ -227,45 +225,48 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     }
 
     /**
-     * This function updates assignment by hashing the member IDs of the members and maps the partitions assigned to the members based on the hash. This gives approximately even balance.
-     * @param targetPartitions - the subscribed topic partitions.
+     * This function updates assignment by hashing the member IDs of the members and maps the partitions assigned to the
+     * members based on the hash. This gives approximately even balance.
+     * @param unassignedPartitions - the subscribed topic partitions.
      * @param memberIds - the member ids to which the topic partitions need to be assigned.
      * @param assignment - the existing assignment by topic partition. We need to pass it as a parameter because this
      *                   function would be called multiple times for heterogeneous assignment.
      */
+    // Visible for testing
     void memberHashAssignment(
-        List<TopicIdPartition> targetPartitions,
+        List<TopicIdPartition> unassignedPartitions,
         Collection<String> memberIds,
         Map<TopicIdPartition, List<String>> assignment
     ) {
-        if (!targetPartitions.isEmpty())
+        if (!unassignedPartitions.isEmpty())
             for (String memberId : memberIds) {
-                int topicPartitionIndex = Math.abs(memberId.hashCode() % targetPartitions.size());
-                TopicIdPartition topicPartition = targetPartitions.get(topicPartitionIndex);
+                int topicPartitionIndex = Math.abs(memberId.hashCode() % unassignedPartitions.size());
+                TopicIdPartition topicPartition = unassignedPartitions.get(topicPartitionIndex);
                 assignment.computeIfAbsent(topicPartition, k -> new ArrayList<>()).add(memberId);
             }
     }
 
     /**
      * This functions assigns topic partitions to members by round-robin approach and updates the existing assignment.
-     * @param memberIds - the member ids to which the topic partitions need to be assigned.
-     * @param targetPartitions - the subscribed topic partitions.
+     * @param memberIds - the member ids to which the topic partitions need to be assigned, should be non-empty.
+     * @param unassignedPartitions - the subscribed topic partitions which needs assignment.
      * @param assignment - the existing assignment by topic partition.
      */
+    // Visible for testing
     void roundRobinAssignment(
         Collection<String> memberIds,
-        List<TopicIdPartition> targetPartitions,
+        List<TopicIdPartition> unassignedPartitions,
         Map<TopicIdPartition, List<String>> assignment
     ) {
         // We iterate through the target partitions and assign a memberId to them. In case we run out of members (members < targetPartitions),
         // we again start from the starting index of memberIds.
         Iterator<String> memberIdIterator = memberIds.iterator();
-        for (TopicIdPartition targetPartition : targetPartitions) {
+        for (TopicIdPartition targetPartition : unassignedPartitions) {
             if (!memberIdIterator.hasNext()) {
                 memberIdIterator = memberIds.iterator();
             }
-            String member = memberIdIterator.next();
-            assignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(member);
+            String memberId = memberIdIterator.next();
+            assignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(memberId);
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -144,6 +144,13 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // Step 3: We combine current assignment and new assignment.
         Map<String, Set<TopicIdPartition>> finalAssignment = new HashMap<>();
 
+        // As per the KIP, we should revoke the assignments from current assignment for partitions that were assigned by step 1
+        // in the new assignment and have members in current assignment by step 2. But we haven't implemented it to avoid the
+        // complexity in both the implementation and the run time complexity. This step was mentioned in the KIP to reduce
+        // the burden of certain members of the share groups. This can be achieved with the help of limiting the max
+        // no. of partitions assignment for every member(KAFKA-18788). Hence, the potential problem of burdening
+        // the share consumers will be addressed in a future PR.
+
         // When combining current assignment, we need to only consider the topics in current assignment that are also being
         // subscribed in the new assignment as well.
         currentAssignment.forEach((targetPartition, members) -> {
@@ -193,6 +200,12 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         // Step 3: We combine current assignment and new assignment.
         Map<String, Set<TopicIdPartition>> finalAssignment = new HashMap<>();
+        // As per the KIP, we should revoke the assignments from current assignment for partitions that were assigned by step 1
+        // in the new assignment and have members in current assignment by step 2. But we haven't implemented it to avoid the
+        // complexity in both the implementation and the run time complexity. This step was mentioned in the KIP to reduce
+        // the burden of certain members of the share groups. This can be achieved with the help of limiting the max
+        // no. of partitions assignment for every member(KAFKA-18788). Hence, the potential problem of burdening
+        // the share consumers will be addressed in a future PR.
 
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -25,6 +25,7 @@ import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorExceptio
 import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
 import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
+import org.apache.kafka.server.common.TopicIdPartition;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,14 +36,12 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
 
 /**
- * A simple partition assignor that assigns each member all partitions of the subscribed topics.
+ * A simple partition assignor that assigns partitions of the subscribed topics based on the rules defined in KIP-932 to different members.
  */
 public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
@@ -59,7 +58,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         SubscribedTopicDescriber subscribedTopicDescriber
     ) throws PartitionAssignorException {
         if (groupSpec.memberIds().isEmpty())
-            return new GroupAssignment(Collections.emptyMap());
+            return new GroupAssignment(Map.of());
 
         if (groupSpec.subscriptionType().equals(HOMOGENEOUS)) {
             return assignHomogenous(groupSpec, subscribedTopicDescriber);
@@ -72,78 +71,84 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         GroupSpec groupSpec,
         SubscribedTopicDescriber subscribedTopicDescriber
     ) {
-        Set<Uuid> subscribeTopicIds = groupSpec.memberSubscription(groupSpec.memberIds().iterator().next())
+        Set<Uuid> subscribedTopicIds = groupSpec.memberSubscription(groupSpec.memberIds().iterator().next())
             .subscribedTopicIds();
-        if (subscribeTopicIds.isEmpty())
-            return new GroupAssignment(Collections.emptyMap());
+        if (subscribedTopicIds.isEmpty())
+            return new GroupAssignment(Map.of());
 
         // Subscribed topic partitions for the share group.
-        List<TargetPartition> targetPartitions = computeTargetPartitions(
-            subscribeTopicIds, subscribedTopicDescriber);
+        List<TopicIdPartition> targetPartitions = computeTargetPartitions(
+            subscribedTopicIds, subscribedTopicDescriber);
 
         // The current assignment from topic partition to members.
-        Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
-        return newAssignmentHomogeneous(groupSpec, subscribeTopicIds, targetPartitions, currentAssignment);
+        Map<TopicIdPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
+        return newAssignmentHomogeneous(groupSpec, subscribedTopicIds, targetPartitions, currentAssignment);
     }
 
     private GroupAssignment assignHeterogeneous(
         GroupSpec groupSpec,
         SubscribedTopicDescriber subscribedTopicDescriber
     ) {
-        Map<String, List<TargetPartition>> memberToPartitionsSubscription = new HashMap<>();
+        Map<String, List<TopicIdPartition>> memberToPartitionsSubscription = new HashMap<>();
         for (String memberId : groupSpec.memberIds()) {
             MemberSubscription spec = groupSpec.memberSubscription(memberId);
             if (spec.subscribedTopicIds().isEmpty())
                 continue;
 
             // Subscribed topic partitions for the share group member.
-            List<TargetPartition> targetPartitions = computeTargetPartitions(
+            List<TopicIdPartition> targetPartitions = computeTargetPartitions(
                 spec.subscribedTopicIds(), subscribedTopicDescriber);
             memberToPartitionsSubscription.put(memberId, targetPartitions);
         }
 
         // The current assignment from topic partition to members.
-        Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
+        Map<TopicIdPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
         return newAssignmentHeterogeneous(groupSpec, memberToPartitionsSubscription, currentAssignment);
     }
 
-    // Get the current assignment for subscribed topic partitions to share group members.
-    private Map<TargetPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
-        Map<TargetPartition, List<String>> assignment = new HashMap<>();
+    /**
+     * Get the current assignment by topic partitions.
+     * @param groupSpec - The group metadata specifications.
+     * @return the current assignment for subscribed topic partitions to memberIds.
+     */
+    private Map<TopicIdPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
+        Map<TopicIdPartition, List<String>> assignment = new HashMap<>();
 
         for (String member : groupSpec.memberIds()) {
             Map<Uuid, Set<Integer>> assignedTopicPartitions = groupSpec.memberAssignment(member).partitions();
             assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
-                partition -> assignment.computeIfAbsent(new TargetPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
+                partition -> assignment.computeIfAbsent(new TopicIdPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
         }
         return assignment;
     }
 
     private GroupAssignment newAssignmentHomogeneous(
         GroupSpec groupSpec,
-        Set<Uuid> subscribeTopicIds,
-        List<TargetPartition> targetPartitions,
-        Map<TargetPartition, List<String>> currentAssignment) {
+        Set<Uuid> subscribedTopicIds,
+        List<TopicIdPartition> targetPartitions,
+        Map<TopicIdPartition, List<String>> currentAssignment
+    ) {
 
-        Map<TargetPartition, List<String>> newAssignment = new HashMap<>();
+        Map<TopicIdPartition, List<String>> newAssignment = new HashMap<>();
+
         // Step 1: Hash member IDs to partitions.
         memberHashAssignment(targetPartitions, groupSpec.memberIds(), newAssignment);
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
-        List<TargetPartition> unassignedPartitions = targetPartitions.stream()
+        Set<TopicIdPartition> assignedPartitions = newAssignment.keySet();
+        List<TopicIdPartition> unassignedPartitions = targetPartitions.stream()
             .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
             .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
-            .collect(Collectors.toList());
+            .toList();
 
         roundRobinAssignment(groupSpec.memberIds(), unassignedPartitions, newAssignment);
 
-        Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
+        Map<String, Set<TopicIdPartition>> finalAssignment = new HashMap<>();
 
         // When combining current assignment, we need to only consider the topics in current assignment that are also being
         // subscribed in the new assignment as well.
         currentAssignment.forEach((targetPartition, members) -> {
-            if (subscribeTopicIds.contains(targetPartition.topicId))
+            if (subscribedTopicIds.contains(targetPartition.topicId()))
                 members.forEach(member -> {
                     if (groupSpec.memberIds().contains(member))
                         finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
@@ -157,11 +162,12 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
     private GroupAssignment newAssignmentHeterogeneous(
         GroupSpec groupSpec,
-        Map<String, List<TargetPartition>> memberToPartitionsSubscription,
-        Map<TargetPartition, List<String>> currentAssignment) {
+        Map<String, List<TopicIdPartition>> memberToPartitionsSubscription,
+        Map<TopicIdPartition, List<String>> currentAssignment
+    ) {
 
         // Exhaustive set of all subscribed topic partitions.
-        Set<TargetPartition> targetPartitions = new LinkedHashSet<>();
+        Set<TopicIdPartition> targetPartitions = new LinkedHashSet<>();
         memberToPartitionsSubscription.values().forEach(targetPartitions::addAll);
 
         // Create a map for topic to members subscription.
@@ -169,14 +175,15 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         memberToPartitionsSubscription.forEach((member, partitions) ->
             partitions.forEach(partition -> topicToMemberSubscription.computeIfAbsent(partition.topicId(), k -> new LinkedHashSet<>()).add(member)));
 
-        Map<TargetPartition, List<String>> newAssignment = new HashMap<>();
+        Map<TopicIdPartition, List<String>> newAssignment = new HashMap<>();
+
         // Step 1: Hash member IDs to partitions.
         memberToPartitionsSubscription.forEach((member, partitions) ->
-            memberHashAssignment(partitions, Collections.singletonList(member), newAssignment));
+            memberHashAssignment(partitions, List.of(member), newAssignment));
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
-        Set<TargetPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
-        Map<Uuid, List<TargetPartition>> unassignedPartitions = new HashMap<>();
+        Set<TopicIdPartition> assignedPartitions = new LinkedHashSet<>(newAssignment.keySet());
+        Map<Uuid, List<TopicIdPartition>> unassignedPartitions = new HashMap<>();
         targetPartitions.forEach(targetPartition -> {
             if (!assignedPartitions.contains(targetPartition) && !currentAssignment.containsKey(targetPartition))
                 unassignedPartitions.computeIfAbsent(targetPartition.topicId(), k -> new ArrayList<>()).add(targetPartition);
@@ -186,7 +193,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             roundRobinAssignment(topicToMemberSubscription.get(unassignedTopic), unassignedPartitions.get(unassignedTopic), newAssignment));
 
         // Step 3: We combine current assignment and new assignment.
-        Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
+        Map<String, Set<TopicIdPartition>> finalAssignment = new HashMap<>();
 
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.
@@ -201,12 +208,13 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     }
 
     private GroupAssignment groupAssignment(
-        Map<String, Set<TargetPartition>> assignmentByMember,
-        Collection<String> allGroupMembers) {
+        Map<String, Set<TopicIdPartition>> assignmentByMember,
+        Collection<String> allGroupMembers
+    ) {
         Map<String, MemberAssignment> members = new HashMap<>();
-        for (Map.Entry<String, Set<TargetPartition>> entry : assignmentByMember.entrySet()) {
+        for (Map.Entry<String, Set<TopicIdPartition>> entry : assignmentByMember.entrySet()) {
             Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
-            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partition()));
+            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partitionId()));
             members.put(entry.getKey(), new MemberAssignmentImpl(targetPartitions));
         }
         allGroupMembers.forEach(member -> {
@@ -217,39 +225,48 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return new GroupAssignment(members);
     }
 
-    // Visible for testing.
+    /**
+     * This function updates assignment by hashing the member IDs of the members and maps the partitions assigned to the members based on the hash. This gives approximately even balance.
+     * @param targetPartitions - the subscribed topic partitions.
+     * @param memberIds - the member ids to which the topic partitions need to be assigned.
+     * @param assignment - the existing assignment by topic partition. We need to pass it as a parameter because this
+     *                   function would be called multiple times for heterogeneous assignment.
+     */
     void memberHashAssignment(
-        List<TargetPartition> targetPartitions,
+        List<TopicIdPartition> targetPartitions,
         Collection<String> memberIds,
-        Map<TargetPartition, List<String>> assignment) {
+        Map<TopicIdPartition, List<String>> assignment
+    ) {
         if (!targetPartitions.isEmpty())
             for (String memberId : memberIds) {
                 int topicPartitionIndex = Math.abs(memberId.hashCode() % targetPartitions.size());
-                TargetPartition topicPartition = targetPartitions.get(topicPartitionIndex);
+                TopicIdPartition topicPartition = targetPartitions.get(topicPartitionIndex);
                 assignment.computeIfAbsent(topicPartition, k -> new ArrayList<>()).add(memberId);
             }
     }
 
     // Visible for testing.
     void roundRobinAssignment(
-        Collection<String> members,
-        List<TargetPartition> partitions,
-        Map<TargetPartition, List<String>> assignment) {
-        Iterator<String> memberIterator = members.iterator();
-        for (TargetPartition targetPartition : partitions) {
-            if (!memberIterator.hasNext()) {
-                memberIterator = members.iterator();
+        Collection<String> memberIds,
+        List<TopicIdPartition> partitions,
+        Map<TopicIdPartition, List<String>> assignment
+    ) {
+        Iterator<String> memberIdIterator = memberIds.iterator();
+        for (TopicIdPartition targetPartition : partitions) {
+            if (!memberIdIterator.hasNext()) {
+                memberIdIterator = memberIds.iterator();
             }
-            String member = memberIterator.next();
+            String member = memberIdIterator.next();
             assignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(member);
         }
     }
 
-    private List<TargetPartition> computeTargetPartitions(
-        Set<Uuid> subscribeTopicIds,
-        SubscribedTopicDescriber subscribedTopicDescriber) {
-        List<TargetPartition> targetPartitions = new ArrayList<>();
-        subscribeTopicIds.forEach(topicId -> {
+    private List<TopicIdPartition> computeTargetPartitions(
+        Set<Uuid> subscribedTopicIds,
+        SubscribedTopicDescriber subscribedTopicDescriber
+    ) {
+        List<TopicIdPartition> targetPartitions = new ArrayList<>();
+        subscribedTopicIds.forEach(topicId -> {
             int numPartitions = subscribedTopicDescriber.numPartitions(topicId);
             if (numPartitions == -1) {
                 throw new PartitionAssignorException(
@@ -259,25 +276,9 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             }
 
             for (int i = 0; i < numPartitions; i++) {
-                targetPartitions.add(new TargetPartition(topicId, i));
+                targetPartitions.add(new TopicIdPartition(topicId, i));
             }
         });
         return targetPartitions;
-    }
-
-    record TargetPartition(Uuid topicId, int partition) {
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TargetPartition that = (TargetPartition) o;
-            return topicId.equals(that.topicId) && partition == that.partition;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(topicId, partition);
-        }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -26,12 +26,16 @@ import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssign
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
 import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
@@ -72,36 +76,173 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         if (subscribeTopicIds.isEmpty())
             return new GroupAssignment(Collections.emptyMap());
 
-        Map<Uuid, Set<Integer>> targetPartitions = computeTargetPartitions(
+        // Subscribed topic partitions for the share group.
+        List<TargetPartition> targetPartitions = computeTargetPartitions(
             subscribeTopicIds, subscribedTopicDescriber);
 
-        return new GroupAssignment(groupSpec.memberIds().stream().collect(Collectors.toMap(
-            Function.identity(), memberId -> new MemberAssignmentImpl(targetPartitions))));
+        // The current assignment from topic partition to members.
+        Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
+        return newAssignmentHomogeneous(groupSpec, targetPartitions, currentAssignment);
     }
 
     private GroupAssignment assignHeterogeneous(
         GroupSpec groupSpec,
         SubscribedTopicDescriber subscribedTopicDescriber
     ) {
-        Map<String, MemberAssignment> members = new HashMap<>();
+        Map<String, List<TargetPartition>> memberToPartitionsSubscription = new HashMap<>();
         for (String memberId : groupSpec.memberIds()) {
             MemberSubscription spec = groupSpec.memberSubscription(memberId);
             if (spec.subscribedTopicIds().isEmpty())
                 continue;
 
-            Map<Uuid, Set<Integer>> targetPartitions = computeTargetPartitions(
+            // Subscribed topic partitions for the share group member.
+            List<TargetPartition> targetPartitions = computeTargetPartitions(
                 spec.subscribedTopicIds(), subscribedTopicDescriber);
+            memberToPartitionsSubscription.put(memberId, targetPartitions);
+        }
 
-            members.put(memberId, new MemberAssignmentImpl(targetPartitions));
+        // The current assignment from topic partition to members.
+        Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
+        return newAssignmentHeterogeneous(memberToPartitionsSubscription, currentAssignment);
+    }
+
+    // Get the current assignment for subscribed topic partitions to share group members.
+    private Map<TargetPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
+        Map<TargetPartition, List<String>> assignment = new HashMap<>();
+        Collection<String> members = groupSpec.memberIds();
+
+        for (String member : members) {
+            Map<Uuid, Set<Integer>> assignedTopicPartitions = groupSpec.memberAssignment(member).partitions();
+            assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
+                partition -> assignment.computeIfAbsent(new TargetPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
+        }
+        return assignment;
+    }
+
+    private GroupAssignment newAssignmentHomogeneous(
+        GroupSpec groupSpec,
+        List<TargetPartition> targetPartitions,
+        Map<TargetPartition, List<String>> currentAssignment) {
+
+        Map<TargetPartition, List<String>> newAssignment = new HashMap<>();
+        // Step 1: Hash member IDs to partitions.
+        memberHashAssignment(targetPartitions, groupSpec.memberIds(), newAssignment);
+
+        // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
+        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
+        List<TargetPartition> unassignedPartitions = targetPartitions.stream()
+            .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
+            .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
+            .collect(Collectors.toList());
+
+        roundRobinAssignment(groupSpec.memberIds(), unassignedPartitions, newAssignment);
+
+        // Step 3: Combine current and new assignment and only consider the hash based assignment for the current assignment.
+        Map<TargetPartition, List<String>> currentAssignmentByHash = computePartitionsAssignmentByHash(currentAssignment);
+        Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
+
+        currentAssignmentByHash.forEach((targetPartition, members) -> members.forEach(member ->
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+
+        return groupAssignment(finalAssignment);
+    }
+
+    private GroupAssignment newAssignmentHeterogeneous(
+        Map<String, List<TargetPartition>> memberToPartitionsSubscription,
+        Map<TargetPartition, List<String>> currentAssignment) {
+
+        // exhaustive set of all subscribed topic partitions
+        Set<TargetPartition> targetPartitions = new HashSet<>();
+        memberToPartitionsSubscription.values().forEach(targetPartitions::addAll);
+
+        // Create an inverted map for partition to members subscription.
+        Map<TargetPartition, List<String>> partitionToMemberSubscription = new HashMap<>();
+        memberToPartitionsSubscription.forEach((member, partitions) ->
+            partitions.forEach(partition -> partitionToMemberSubscription.computeIfAbsent(partition, k -> new ArrayList<>()).add(member)));
+
+        Map<TargetPartition, List<String>> newAssignment = new HashMap<>();
+        // Step 1: Hash member IDs to partitions.
+        memberToPartitionsSubscription.forEach((member, partitions) ->
+            memberHashAssignment(partitions, Collections.singletonList(member), newAssignment));
+
+        // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
+        Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
+        List<TargetPartition> unassignedPartitions = targetPartitions.stream()
+            .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
+            .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
+            .toList();
+
+        unassignedPartitions.forEach(unassignedPartition ->
+            roundRobinAssignment(partitionToMemberSubscription.get(unassignedPartition), Collections.singletonList(unassignedPartition), newAssignment));
+
+        // Step 3: Combine current and new assignment and only consider the hash based assignment for the current assignment.
+        Map<TargetPartition, List<String>> currentAssignmentByHash = computePartitionsAssignmentByHash(currentAssignment);
+        Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
+
+        // When combining current assignment, we need to consider the member subscription in current assignment and
+        // the subscription being used for new assignment.
+        currentAssignmentByHash.forEach((targetPartition, members) -> members.forEach(member -> {
+            if (partitionToMemberSubscription.get(targetPartition).contains(member))
+                finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
+        }));
+        newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
+            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+
+        return groupAssignment(finalAssignment);
+    }
+
+    private GroupAssignment groupAssignment(
+        Map<String, Set<TargetPartition>> assignmentByMember) {
+        Map<String, MemberAssignment> members = new HashMap<>();
+        for (Map.Entry<String, Set<TargetPartition>> entry : assignmentByMember.entrySet()) {
+            Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
+            entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partition()));
+            members.put(entry.getKey(), new MemberAssignmentImpl(targetPartitions));
         }
         return new GroupAssignment(members);
     }
 
-    private Map<Uuid, Set<Integer>> computeTargetPartitions(
+    Map<TargetPartition, List<String>> computePartitionsAssignmentByHash(
+        Map<TargetPartition, List<String>> currentAssignment) {
+        List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
+        Set<String> members = new HashSet<>();
+        currentAssignment.values().forEach(members::addAll);
+        Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();
+        memberHashAssignment(targetPartitions, members, hashAssignment);
+        return hashAssignment;
+    }
+
+    private void memberHashAssignment(
+        List<TargetPartition> targetPartitions,
+        Collection<String> memberIds,
+        Map<TargetPartition, List<String>> assignment) {
+        for (String memberId : memberIds) {
+            int topicPartitionIndex = Math.abs(memberId.hashCode() % targetPartitions.size());
+            TargetPartition topicPartition = targetPartitions.get(topicPartitionIndex);
+            assignment.computeIfAbsent(topicPartition, k -> new ArrayList<>()).add(memberId);
+        }
+    }
+
+    private void roundRobinAssignment(
+        Collection<String> members,
+        List<TargetPartition> partitions,
+        Map<TargetPartition, List<String>> assignment) {
+        Iterator<String> memberIterator = members.iterator();
+        for (TargetPartition targetPartition : partitions) {
+            if (!memberIterator.hasNext()) {
+                memberIterator = members.iterator();
+            }
+            String member = memberIterator.next();
+            assignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(member);
+        }
+    }
+
+    private List<TargetPartition> computeTargetPartitions(
         Set<Uuid> subscribeTopicIds,
-        SubscribedTopicDescriber subscribedTopicDescriber
-    ) {
-        Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
+        SubscribedTopicDescriber subscribedTopicDescriber) {
+        List<TargetPartition> targetPartitions = new ArrayList<>();
         subscribeTopicIds.forEach(topicId -> {
             int numPartitions = subscribedTopicDescriber.numPartitions(topicId);
             if (numPartitions == -1) {
@@ -111,12 +252,41 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
                 );
             }
 
-            Set<Integer> partitions = new HashSet<>();
             for (int i = 0; i < numPartitions; i++) {
-                partitions.add(i);
+                targetPartitions.add(new TargetPartition(topicId, i));
             }
-            targetPartitions.put(topicId, partitions);
         });
         return targetPartitions;
+    }
+
+    static class TargetPartition {
+        Uuid topicId;
+        int partition;
+
+        TargetPartition(Uuid topicId, int partition) {
+            this.topicId = topicId;
+            this.partition = partition;
+        }
+
+        Uuid topicId() {
+            return topicId;
+        }
+
+        int partition() {
+            return partition;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TargetPartition that = (TargetPartition) o;
+            return topicId.equals(that.topicId) && partition == that.partition;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(topicId, partition);
+        }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -122,6 +122,14 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return assignment;
     }
 
+    /**
+     * This function computes the new assignment for a homogeneous group.
+     * @param groupSpec - The group metadata specifications.
+     * @param subscribedTopicIds - The set of all the subscribed topic ids for the group.
+     * @param targetPartitions - The list of all topic partitions that need assignment.
+     * @param currentAssignment - The current assignment for subscribed topic partitions to memberIds.
+     * @return the new partition assignment for the members of the group.
+     */
     private GroupAssignment newAssignmentHomogeneous(
         GroupSpec groupSpec,
         Set<Uuid> subscribedTopicIds,
@@ -166,6 +174,13 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
 
+    /**
+     * This function computes the new assignment for a heterogeneous group.
+     * @param groupSpec - The group metadata specifications.
+     * @param memberToPartitionsSubscription - The member to subscribed topic partitions map.
+     * @param currentAssignment - The current assignment for subscribed topic partitions to memberIds.
+     * @return the new partition assignment for the members of the group.
+     */
     private GroupAssignment newAssignmentHeterogeneous(
         GroupSpec groupSpec,
         Map<String, List<TopicIdPartition>> memberToPartitionsSubscription,
@@ -240,7 +255,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     /**
      * This function updates assignment by hashing the member IDs of the members and maps the partitions assigned to the
      * members based on the hash. This gives approximately even balance.
-     * @param unassignedPartitions - the subscribed topic partitions.
+     * @param unassignedPartitions - the subscribed topic partitions which needs assignment.
      * @param memberIds - the member ids to which the topic partitions need to be assigned.
      * @param assignment - the existing assignment by topic partition. We need to pass it as a parameter because this
      *                   function would be called multiple times for heterogeneous assignment.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -83,7 +83,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         // The current assignment from topic partition to members.
         Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
-        return newAssignmentHomogeneous(groupSpec, targetPartitions, currentAssignment);
+        return newAssignmentHomogeneous(groupSpec, subscribeTopicIds, targetPartitions, currentAssignment);
     }
 
     private GroupAssignment assignHeterogeneous(
@@ -122,6 +122,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
     private GroupAssignment newAssignmentHomogeneous(
         GroupSpec groupSpec,
+        Set<Uuid> subscribeTopicIds,
         List<TargetPartition> targetPartitions,
         Map<TargetPartition, List<String>> currentAssignment) {
 
@@ -138,12 +139,18 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         roundRobinAssignment(groupSpec.memberIds(), unassignedPartitions, newAssignment);
 
-        // Step 3: Combine current and new assignment and only consider the hash based assignment for the current assignment.
-        Map<TargetPartition, List<String>> currentAssignmentByHash = computePartitionsAssignmentByHash(currentAssignment);
+        // Step 3: We combine current assignment and new assignment.
+        // However, if any partitions are assigned members by step 1 in new assignment, and also have members in the current assignment assigned by 2,
+        // the members assigned in the current assignment by step 2 are ignored.
+        Map<TargetPartition, List<String>> currentAssignmentFiltered = filterCurrentAssignment(currentAssignment, assignedPartitions);
         Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
 
-        currentAssignmentByHash.forEach((targetPartition, members) -> members.forEach(member ->
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
+        // When combining current assignment, we need to only consider the topics in current assignment that are also being
+        // subscribed in the new assignment as well.
+        currentAssignmentFiltered.forEach((targetPartition, members) -> {
+            if (subscribeTopicIds.contains(targetPartition.topicId))
+                members.forEach(member -> finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition));
+        });
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
@@ -179,13 +186,15 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         unassignedPartitions.keySet().forEach(unassignedTopic ->
             roundRobinAssignment(topicToMemberSubscription.get(unassignedTopic), unassignedPartitions.get(unassignedTopic), newAssignment));
 
-        // Step 3: Combine current and new assignment and only consider the hash based assignment for the current assignment.
-        Map<TargetPartition, List<String>> currentAssignmentByHash = computePartitionsAssignmentByHash(currentAssignment);
+        // Step 3: We combine current assignment and new assignment.
+        // However, if any partitions are assigned members by step 1 in new assignment, and also have members in the current assignment assigned by 2,
+        // the members assigned in the current assignment by step 2 are ignored.
+        Map<TargetPartition, List<String>> currentAssignmentFiltered = filterCurrentAssignment(currentAssignment, assignedPartitions);
         Map<String, Set<TargetPartition>> finalAssignment = new HashMap<>();
 
-        // When combining current assignment, we need to consider the member subscription in current assignment and
-        // the subscription being used for new assignment.
-        currentAssignmentByHash.forEach((targetPartition, members) -> members.forEach(member -> {
+        // When combining current assignment, we need to only consider the member topic subscription in current assignment
+        // which is being subscribed in the new assignment as well.
+        currentAssignmentFiltered.forEach((targetPartition, members) -> members.forEach(member -> {
             if (topicToMemberSubscription.get(targetPartition.topicId()).contains(member))
                 finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
         }));
@@ -206,14 +215,31 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return new GroupAssignment(members);
     }
 
-    private Map<TargetPartition, List<String>> computePartitionsAssignmentByHash(
-        Map<TargetPartition, List<String>> currentAssignment) {
+    private Map<TargetPartition, List<String>> filterCurrentAssignment(
+        Map<TargetPartition, List<String>> currentAssignment,
+        Set<TargetPartition> assignedPartitions) {
+        // topic partitions which were a part of current assignment.
         List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
+        // members which were a part of current assignment.
         Set<String> members = new HashSet<>();
         currentAssignment.values().forEach(members::addAll);
+        // Computing hash based assignment that would have occurred for the current assignment.
         Map<TargetPartition, List<String>> hashAssignment = new HashMap<>();
         memberHashAssignment(targetPartitions, members, hashAssignment);
-        return hashAssignment;
+
+        Map<TargetPartition, List<String>> filteredCurrentAssignment = new HashMap<>();
+        currentAssignment.forEach((targetPartition, assignedMembers) -> {
+            if (!assignedPartitions.contains(targetPartition)) {
+                filteredCurrentAssignment.put(targetPartition, assignedMembers);
+            } else {
+                assignedMembers.forEach(assignedMember -> {
+                    // only adding members which were added by step 1 for the current assignment for the assigned partitions.
+                    if (hashAssignment.getOrDefault(targetPartition, Collections.emptyList()).contains(assignedMember))
+                        filteredCurrentAssignment.computeIfAbsent(targetPartition, k -> new ArrayList<>()).add(assignedMember);
+                });
+            }
+        });
+        return filteredCurrentAssignment;
     }
 
     // Visible for testing.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -143,6 +143,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         roundRobinAssignment(groupSpec.memberIds(), unassignedPartitions, newAssignment);
 
+        // Step 3: We combine current assignment and new assignment.
         Map<String, Set<TopicIdPartition>> finalAssignment = new HashMap<>();
 
         // When combining current assignment, we need to only consider the topics in current assignment that are also being
@@ -245,14 +246,21 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             }
     }
 
-    // Visible for testing.
+    /**
+     * This functions assigns topic partitions to members by round-robin approach and updates the existing assignment.
+     * @param memberIds - the member ids to which the topic partitions need to be assigned.
+     * @param targetPartitions - the subscribed topic partitions.
+     * @param assignment - the existing assignment by topic partition.
+     */
     void roundRobinAssignment(
         Collection<String> memberIds,
-        List<TopicIdPartition> partitions,
+        List<TopicIdPartition> targetPartitions,
         Map<TopicIdPartition, List<String>> assignment
     ) {
+        // We iterate through the target partitions and assign a memberId to them. In case we run out of members (members < targetPartitions),
+        // we again start from the starting index of memberIds.
         Iterator<String> memberIdIterator = memberIds.iterator();
-        for (TopicIdPartition targetPartition : partitions) {
+        for (TopicIdPartition targetPartition : targetPartitions) {
             if (!memberIdIterator.hasNext()) {
                 memberIdIterator = memberIds.iterator();
             }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -104,7 +104,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         // The current assignment from topic partition to members.
         Map<TargetPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
-        return newAssignmentHeterogeneous(memberToPartitionsSubscription, currentAssignment);
+        return newAssignmentHeterogeneous(groupSpec, memberToPartitionsSubscription, currentAssignment);
     }
 
     // Get the current assignment for subscribed topic partitions to share group members.
@@ -154,10 +154,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
-        return groupAssignment(finalAssignment);
+        return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
 
     private GroupAssignment newAssignmentHeterogeneous(
+        GroupSpec groupSpec,
         Map<String, List<TargetPartition>> memberToPartitionsSubscription,
         Map<TargetPartition, List<String>> currentAssignment) {
 
@@ -201,17 +202,23 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
 
-        return groupAssignment(finalAssignment);
+        return groupAssignment(finalAssignment, groupSpec.memberIds());
     }
 
     private GroupAssignment groupAssignment(
-        Map<String, Set<TargetPartition>> assignmentByMember) {
+        Map<String, Set<TargetPartition>> assignmentByMember,
+        Collection<String> allGroupMembers) {
         Map<String, MemberAssignment> members = new HashMap<>();
         for (Map.Entry<String, Set<TargetPartition>> entry : assignmentByMember.entrySet()) {
             Map<Uuid, Set<Integer>> targetPartitions = new HashMap<>();
             entry.getValue().forEach(targetPartition -> targetPartitions.computeIfAbsent(targetPartition.topicId(), k -> new HashSet<>()).add(targetPartition.partition()));
             members.put(entry.getKey(), new MemberAssignmentImpl(targetPartitions));
         }
+        allGroupMembers.forEach(member -> {
+            if (!members.containsKey(member))
+                members.put(member, new MemberAssignmentImpl(new HashMap<>()));
+        });
+
         return new GroupAssignment(members);
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -299,22 +299,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return targetPartitions;
     }
 
-    static class TargetPartition {
-        Uuid topicId;
-        int partition;
-
-        TargetPartition(Uuid topicId, int partition) {
-            this.topicId = topicId;
-            this.partition = partition;
-        }
-
-        Uuid topicId() {
-            return topicId;
-        }
-
-        int partition() {
-            return partition;
-        }
+    record TargetPartition(Uuid topicId, int partition) {
 
         @Override
         public boolean equals(Object o) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -153,14 +154,14 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         Map<String, List<TargetPartition>> memberToPartitionsSubscription,
         Map<TargetPartition, List<String>> currentAssignment) {
 
-        // exhaustive set of all subscribed topic partitions
-        Set<TargetPartition> targetPartitions = new HashSet<>();
+        // Exhaustive set of all subscribed topic partitions.
+        Set<TargetPartition> targetPartitions = new LinkedHashSet<>();
         memberToPartitionsSubscription.values().forEach(targetPartitions::addAll);
 
-        // Create an inverted map for partition to members subscription.
-        Map<TargetPartition, List<String>> partitionToMemberSubscription = new HashMap<>();
+        // Create a map for topic to members subscription.
+        Map<Uuid, Set<String>> topicToMemberSubscription = new HashMap<>();
         memberToPartitionsSubscription.forEach((member, partitions) ->
-            partitions.forEach(partition -> partitionToMemberSubscription.computeIfAbsent(partition, k -> new ArrayList<>()).add(member)));
+            partitions.forEach(partition -> topicToMemberSubscription.computeIfAbsent(partition.topicId(), k -> new LinkedHashSet<>()).add(member)));
 
         Map<TargetPartition, List<String>> newAssignment = new HashMap<>();
         // Step 1: Hash member IDs to partitions.
@@ -169,13 +170,14 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
         // Step 2: Round-robin assignment for unassigned partitions which do not have members already assigned in the current assignment.
         Set<TargetPartition> assignedPartitions = new HashSet<>(newAssignment.keySet());
-        List<TargetPartition> unassignedPartitions = targetPartitions.stream()
-            .filter(targetPartition -> !assignedPartitions.contains(targetPartition))
-            .filter(targetPartition -> !currentAssignment.containsKey(targetPartition))
-            .toList();
+        Map<Uuid, List<TargetPartition>> unassignedPartitions = new HashMap<>();
+        targetPartitions.forEach(targetPartition -> {
+            if (!assignedPartitions.contains(targetPartition) && !currentAssignment.containsKey(targetPartition))
+                unassignedPartitions.computeIfAbsent(targetPartition.topicId(), k -> new ArrayList<>()).add(targetPartition);
+        });
 
-        unassignedPartitions.forEach(unassignedPartition ->
-            roundRobinAssignment(partitionToMemberSubscription.get(unassignedPartition), Collections.singletonList(unassignedPartition), newAssignment));
+        unassignedPartitions.keySet().forEach(unassignedTopic ->
+            roundRobinAssignment(topicToMemberSubscription.get(unassignedTopic), unassignedPartitions.get(unassignedTopic), newAssignment));
 
         // Step 3: Combine current and new assignment and only consider the hash based assignment for the current assignment.
         Map<TargetPartition, List<String>> currentAssignmentByHash = computePartitionsAssignmentByHash(currentAssignment);
@@ -184,7 +186,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // When combining current assignment, we need to consider the member subscription in current assignment and
         // the subscription being used for new assignment.
         currentAssignmentByHash.forEach((targetPartition, members) -> members.forEach(member -> {
-            if (partitionToMemberSubscription.get(targetPartition).contains(member))
+            if (topicToMemberSubscription.get(targetPartition.topicId()).contains(member))
                 finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
         }));
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
@@ -204,7 +206,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return new GroupAssignment(members);
     }
 
-    Map<TargetPartition, List<String>> computePartitionsAssignmentByHash(
+    private Map<TargetPartition, List<String>> computePartitionsAssignmentByHash(
         Map<TargetPartition, List<String>> currentAssignment) {
         List<TargetPartition> targetPartitions = currentAssignment.keySet().stream().toList();
         Set<String> members = new HashSet<>();
@@ -214,7 +216,8 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return hashAssignment;
     }
 
-    private void memberHashAssignment(
+    // Visible for testing.
+    void memberHashAssignment(
         List<TargetPartition> targetPartitions,
         Collection<String> memberIds,
         Map<TargetPartition, List<String>> assignment) {
@@ -225,7 +228,8 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         }
     }
 
-    private void roundRobinAssignment(
+    // Visible for testing.
+    void roundRobinAssignment(
         Collection<String> members,
         List<TargetPartition> partitions,
         Map<TargetPartition, List<String>> assignment) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -149,7 +149,10 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // subscribed in the new assignment as well.
         currentAssignmentFiltered.forEach((targetPartition, members) -> {
             if (subscribeTopicIds.contains(targetPartition.topicId))
-                members.forEach(member -> finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition));
+                members.forEach(member -> {
+                    if (groupSpec.memberIds().contains(member))
+                        finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
+                });
         });
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
@@ -196,7 +199,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         // When combining current assignment, we need to only consider the member topic subscription in current assignment
         // which is being subscribed in the new assignment as well.
         currentAssignmentFiltered.forEach((targetPartition, members) -> members.forEach(member -> {
-            if (topicToMemberSubscription.get(targetPartition.topicId()).contains(member))
+            if (topicToMemberSubscription.getOrDefault(targetPartition.topicId(), Collections.emptySet()).contains(member))
                 finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
         }));
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -56,11 +56,9 @@ public class SimpleAssignorTest {
     private static final Uuid TOPIC_3_UUID = Uuid.randomUuid();
     private static final Uuid TOPIC_4_UUID = Uuid.randomUuid();
     private static final String TOPIC_1_NAME = "topic1";
-    private static final String TOPIC_2_NAME = "topic2";
     private static final String TOPIC_3_NAME = "topic3";
     private static final String MEMBER_A = "A";
     private static final String MEMBER_B = "B";
-    private static final String MEMBER_C = "C";
 
     private final SimpleAssignor assignor = new SimpleAssignor();
 
@@ -217,9 +215,8 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
-        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
-        // Step 2 -> T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
-        // Step 3 -> no new assignment gets added by current assignment since it is empty.
+        // T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 2),
@@ -274,10 +271,11 @@ public class SimpleAssignorTest {
             Assignment.EMPTY
         ));
 
+        String memberC = "C";
         Set<Uuid> memberCTopicsSubscription = new LinkedHashSet<>();
         memberCTopicsSubscription.add(TOPIC_2_UUID);
         memberCTopicsSubscription.add(TOPIC_3_UUID);
-        members.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
+        members.put(memberC, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
             memberCTopicsSubscription,
@@ -297,9 +295,8 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
-        // Step 1 -> T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
-        // Step 2 -> T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
-        // Step 3 -> no new assignment gets added by current assignment since it is empty.
+        // T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
+        // T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
@@ -308,7 +305,7 @@ public class SimpleAssignorTest {
         expectedAssignment.put(MEMBER_B, mkAssignment(
             mkTopicAssignment(TOPIC_3_UUID, 0, 1)
         ));
-        expectedAssignment.put(MEMBER_C, mkAssignment(
+        expectedAssignment.put(memberC, mkAssignment(
             mkTopicAssignment(TOPIC_2_UUID, 1, 2)
         ));
 
@@ -422,150 +419,6 @@ public class SimpleAssignorTest {
         expectedAssignment.put(partition4, Collections.singletonList(member1));
 
         assertAssignment(expectedAssignment, assignment);
-    }
-
-    @Test
-    public void testAssignWithCurrentAssignmentHomogeneous() {
-        // Current assignment setup
-        Map<Uuid, TopicMetadata> topicMetadata1 = new HashMap<>();
-        topicMetadata1.put(TOPIC_1_UUID, new TopicMetadata(
-            TOPIC_1_UUID,
-            TOPIC_1_NAME,
-            3
-        ));
-        topicMetadata1.put(TOPIC_2_UUID, new TopicMetadata(
-            TOPIC_2_UUID,
-            TOPIC_2_NAME,
-            2
-        ));
-
-        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
-
-        Set<Uuid> topicsSubscription1 = new LinkedHashSet<>();
-        topicsSubscription1.add(TOPIC_1_UUID);
-        topicsSubscription1.add(TOPIC_2_UUID);
-
-        members1.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
-            Optional.empty(),
-            Optional.empty(),
-            topicsSubscription1,
-            Assignment.EMPTY
-        ));
-
-        members1.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
-            Optional.empty(),
-            Optional.empty(),
-            topicsSubscription1,
-            Assignment.EMPTY
-        ));
-
-        GroupSpec groupSpec1 = new GroupSpecImpl(
-            members1,
-            HOMOGENEOUS,
-            Collections.emptyMap()
-        );
-        SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
-
-        GroupAssignment computedAssignment1 = assignor.assign(
-            groupSpec1,
-            subscribedTopicMetadata1
-        );
-
-        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
-        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
-        // Step 2 -> T1:2, T2:1 -> MEMBER_A and T2:0 -> MEMBER_B by round-robin assignment.
-        // Step 3 -> no new assignment gets added by current assignment since it is empty.
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment1 = new HashMap<>();
-        expectedAssignment1.put(MEMBER_A, mkAssignment(
-            mkTopicAssignment(TOPIC_1_UUID, 0, 2),
-            mkTopicAssignment(TOPIC_2_UUID, 1)
-        ));
-        expectedAssignment1.put(MEMBER_B, mkAssignment(
-            mkTopicAssignment(TOPIC_1_UUID, 1),
-            mkTopicAssignment(TOPIC_2_UUID, 0)
-        ));
-
-        // T1: 3 partitions + T2: 2 partitions = 5 partitions
-        assertEveryPartitionGetsAssignment(5, computedAssignment1);
-        assertAssignment(expectedAssignment1, computedAssignment1);
-
-        // New assignment setup
-        Map<Uuid, TopicMetadata> topicMetadata2 = new HashMap<>();
-        topicMetadata2.put(TOPIC_2_UUID, new TopicMetadata(
-            TOPIC_2_UUID,
-            TOPIC_2_NAME,
-            2
-        ));
-        topicMetadata2.put(TOPIC_3_UUID, new TopicMetadata(
-            TOPIC_3_UUID,
-            TOPIC_3_NAME,
-            3
-        ));
-
-        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
-
-        Set<Uuid> topicsSubscription2 = new LinkedHashSet<>();
-        topicsSubscription2.add(TOPIC_2_UUID);
-        topicsSubscription2.add(TOPIC_3_UUID);
-
-        members2.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
-            Optional.empty(),
-            Optional.empty(),
-            topicsSubscription2,
-            // Utilizing the assignment from current assignment
-            new Assignment(mkAssignment(
-                mkTopicAssignment(TOPIC_1_UUID, 0, 2),
-                mkTopicAssignment(TOPIC_2_UUID, 1)))
-        ));
-
-        members2.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
-            Optional.empty(),
-            Optional.empty(),
-            topicsSubscription2,
-            new Assignment(mkAssignment(
-                mkTopicAssignment(TOPIC_1_UUID, 1),
-                mkTopicAssignment(TOPIC_2_UUID, 0)))
-        ));
-
-        members2.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
-            Optional.empty(),
-            Optional.empty(),
-            topicsSubscription2,
-            Assignment.EMPTY
-        ));
-
-        GroupSpec groupSpec2 = new GroupSpecImpl(
-            members2,
-            HOMOGENEOUS,
-            Collections.emptyMap()
-        );
-        SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
-
-        GroupAssignment computedAssignment2 = assignor.assign(
-            groupSpec2,
-            subscribedTopicMetadata2
-        );
-
-        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
-        // Step 1 -> T2:0 -> MEMBER_A, T2:1 -> MEMBER_B, T3:0 -> MEMBER_C by hash assignment
-        // Step 2 -> T3:1 -> MEMBER_A, T3:2 -> MEMBER_B by round-robin assignment
-        // Step 3 -> no new assignment gets added by current assignment.
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment2 = new HashMap<>();
-        expectedAssignment2.put(MEMBER_A, mkAssignment(
-            mkTopicAssignment(TOPIC_2_UUID, 0),
-            mkTopicAssignment(TOPIC_3_UUID, 1)
-        ));
-        expectedAssignment2.put(MEMBER_B, mkAssignment(
-            mkTopicAssignment(TOPIC_2_UUID, 1),
-            mkTopicAssignment(TOPIC_3_UUID, 2)
-        ));
-        expectedAssignment2.put(MEMBER_C, mkAssignment(
-            mkTopicAssignment(TOPIC_3_UUID, 0)
-        ));
-
-        // T2: 2 partitions + T3: 3 partitions = 5 partitions
-        assertEveryPartitionGetsAssignment(5, computedAssignment2);
-        assertAssignment(expectedAssignment2, computedAssignment2);
     }
 
     private void assertAssignment(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.assignor;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
+import org.apache.kafka.coordinator.group.api.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.coordinator.group.modern.GroupSpecImpl;
@@ -28,8 +29,12 @@ import org.apache.kafka.coordinator.group.modern.TopicMetadata;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -37,16 +42,19 @@ import java.util.TreeMap;
 
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.TargetPartition;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleAssignorTest {
 
     private static final Uuid TOPIC_1_UUID = Uuid.randomUuid();
     private static final Uuid TOPIC_2_UUID = Uuid.randomUuid();
     private static final Uuid TOPIC_3_UUID = Uuid.randomUuid();
+    private static final Uuid TOPIC_4_UUID = Uuid.randomUuid();
     private static final String TOPIC_1_NAME = "topic1";
     private static final String TOPIC_3_NAME = "topic3";
     private static final String MEMBER_A = "A";
@@ -76,6 +84,17 @@ public class SimpleAssignorTest {
             subscribedTopicMetadata
         );
 
+        assertEquals(Collections.emptyMap(), groupAssignment.members());
+
+        groupSpec = new GroupSpecImpl(
+            Collections.emptyMap(),
+            HETEROGENEOUS,
+            Collections.emptyMap()
+        );
+        groupAssignment = assignor.assign(
+            groupSpec,
+            subscribedTopicMetadata
+        );
         assertEquals(Collections.emptyMap(), groupAssignment.members());
     }
 
@@ -165,17 +184,21 @@ public class SimpleAssignorTest {
 
         Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
 
+        Set<Uuid> topicsSubscription = new LinkedHashSet<>();
+        topicsSubscription.add(TOPIC_1_UUID);
+        topicsSubscription.add(TOPIC_3_UUID);
+
         members.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Set.of(TOPIC_1_UUID, TOPIC_3_UUID),
+            topicsSubscription,
             Assignment.EMPTY
         ));
 
         members.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Set.of(TOPIC_1_UUID, TOPIC_3_UUID),
+            topicsSubscription,
             Assignment.EMPTY
         ));
 
@@ -191,16 +214,21 @@ public class SimpleAssignorTest {
             subscribedTopicMetadata
         );
 
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
+        // T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
-            mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
-            mkTopicAssignment(TOPIC_3_UUID, 0, 1)
+            mkTopicAssignment(TOPIC_1_UUID, 0, 2),
+            mkTopicAssignment(TOPIC_3_UUID, 1)
         ));
         expectedAssignment.put(MEMBER_B, mkAssignment(
-            mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
-            mkTopicAssignment(TOPIC_3_UUID, 0, 1)
+            mkTopicAssignment(TOPIC_1_UUID, 1),
+            mkTopicAssignment(TOPIC_3_UUID, 0)
         ));
 
+        // T1: 3 partitions + T3: 2 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment);
         assertAssignment(expectedAssignment, computedAssignment);
     }
 
@@ -224,11 +252,15 @@ public class SimpleAssignorTest {
             2
         ));
 
+        Set<Uuid> memberATopicsSubscription = new LinkedHashSet<>();
+        memberATopicsSubscription.add(TOPIC_1_UUID);
+        memberATopicsSubscription.add(TOPIC_2_UUID);
+
         Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
         members.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Set.of(TOPIC_1_UUID, TOPIC_2_UUID),
+            memberATopicsSubscription,
             Assignment.EMPTY
         ));
 
@@ -240,10 +272,13 @@ public class SimpleAssignorTest {
         ));
 
         String memberC = "C";
+        Set<Uuid> memberCTopicsSubscription = new LinkedHashSet<>();
+        memberCTopicsSubscription.add(TOPIC_2_UUID);
+        memberCTopicsSubscription.add(TOPIC_3_UUID);
         members.put(memberC, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Set.of(TOPIC_2_UUID, TOPIC_3_UUID),
+            memberCTopicsSubscription,
             Assignment.EMPTY
         ));
 
@@ -259,19 +294,23 @@ public class SimpleAssignorTest {
             subscribedTopicMetadata
         );
 
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
+        // T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
+        // T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
-            mkTopicAssignment(TOPIC_2_UUID, 0, 1, 2)
+            mkTopicAssignment(TOPIC_2_UUID, 0, 2)
         ));
         expectedAssignment.put(MEMBER_B, mkAssignment(
             mkTopicAssignment(TOPIC_3_UUID, 0, 1)
         ));
         expectedAssignment.put(memberC, mkAssignment(
-            mkTopicAssignment(TOPIC_2_UUID, 0, 1, 2),
-            mkTopicAssignment(TOPIC_3_UUID, 0, 1)
+            mkTopicAssignment(TOPIC_2_UUID, 1, 2)
         ));
 
+        // T1: 3 partitions + T2: 3 partitions + T3: 2 partitions = 8 partitions
+        assertEveryPartitionGetsAssignment(8, computedAssignment);
         assertAssignment(expectedAssignment, computedAssignment);
     }
 
@@ -290,11 +329,14 @@ public class SimpleAssignorTest {
             2
         ));
 
+        Set<Uuid> memberATopicsSubscription = new LinkedHashSet<>();
+        memberATopicsSubscription.add(TOPIC_1_UUID);
+        memberATopicsSubscription.add(TOPIC_2_UUID);
         Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
         members.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Set.of(TOPIC_1_UUID, TOPIC_2_UUID),
+            memberATopicsSubscription,
             Assignment.EMPTY
         ));
 
@@ -326,6 +368,59 @@ public class SimpleAssignorTest {
         assertAssignment(expectedAssignment, computedAssignment);
     }
 
+    @Test
+    public void testMemberHashAssignment() {
+        // hashcode for "member1" is 948881623.
+        String member1 = "member1";
+        // hashcode for "member2" is 948881624.
+        String member2 = "member2";
+        // hashcode for "member3" is 948881625.
+        String member3 = "member3";
+        // hashcode for "member4" is 948881626.
+        String member4 = "member4";
+        // hashcode for "AaAaAaAa" is -540425984 to test with negative hashcode.
+        String member5 = "AaAaAaAa";
+        List<String> members = Arrays.asList(member1, member2, member3, member4, member5);
+
+        TargetPartition partition1 = new TargetPartition(TOPIC_1_UUID, 0);
+        TargetPartition partition2 = new TargetPartition(TOPIC_2_UUID, 0);
+        TargetPartition partition3 = new TargetPartition(TOPIC_3_UUID, 0);
+        List<TargetPartition> partitions = Arrays.asList(partition1, partition2, partition3);
+
+        Map<TargetPartition, List<String>> computedAssignment = new HashMap<>();
+        assignor.memberHashAssignment(partitions, members, computedAssignment);
+
+        Map<TargetPartition, List<String>> expectedAssignment = new HashMap<>();
+        expectedAssignment.put(partition1, Collections.singletonList(member3));
+        expectedAssignment.put(partition2, Arrays.asList(member1, member4));
+        expectedAssignment.put(partition3, Arrays.asList(member2, member5));
+        assertAssignment(expectedAssignment, computedAssignment);
+    }
+
+    @Test
+    public void testRoundRobinAssignment() {
+        String member1 = "member1";
+        String member2 = "member2";
+        List<String> members = Arrays.asList(member1, member2);
+        TargetPartition partition1 = new TargetPartition(TOPIC_1_UUID, 0);
+        TargetPartition partition2 = new TargetPartition(TOPIC_2_UUID, 0);
+        TargetPartition partition3 = new TargetPartition(TOPIC_3_UUID, 0);
+        TargetPartition partition4 = new TargetPartition(TOPIC_4_UUID, 0);
+        List<TargetPartition> unassignedPartitions = Arrays.asList(partition2, partition3, partition4);
+
+        Map<TargetPartition, List<String>> assignment = new HashMap<>();
+        assignment.put(partition1, Collections.singletonList(member1));
+
+        assignor.roundRobinAssignment(members, unassignedPartitions, assignment);
+        Map<TargetPartition, List<String>> expectedAssignment = new HashMap<>();
+        expectedAssignment.put(partition1, Collections.singletonList(member1));
+        expectedAssignment.put(partition2, Collections.singletonList(member1));
+        expectedAssignment.put(partition3, Collections.singletonList(member2));
+        expectedAssignment.put(partition4, Collections.singletonList(member1));
+
+        assertAssignment(expectedAssignment, assignment);
+    }
+
     private void assertAssignment(
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment,
         GroupAssignment computedGroupAssignment
@@ -335,5 +430,32 @@ public class SimpleAssignorTest {
             Map<Uuid, Set<Integer>> computedAssignmentForMember = computedGroupAssignment.members().get(memberId).partitions();
             assertEquals(expectedAssignment.get(memberId), computedAssignmentForMember);
         }
+    }
+
+    private void assertAssignment(
+        Map<TargetPartition, List<String>> expectedAssignment,
+        Map<TargetPartition, List<String>> computedAssignment
+    ) {
+        assertEquals(expectedAssignment.size(), computedAssignment.size());
+        expectedAssignment.forEach((targetPartition, members) -> {
+            List<String> computedMembers = computedAssignment.getOrDefault(targetPartition, Collections.emptyList());
+            assertEquals(members.size(), computedMembers.size());
+            members.forEach(member -> assertTrue(computedMembers.contains(member)));
+        });
+    }
+
+    private void assertEveryPartitionGetsAssignment(
+        int expectedPartitions,
+        GroupAssignment computedGroupAssignment
+    ) {
+        Map<String, MemberAssignment> memberAssignments = computedGroupAssignment.members();
+        Set<TargetPartition> topicPartitionAssignments = new HashSet<>();
+        memberAssignments.values().forEach(memberAssignment -> {
+            Map<Uuid, Set<Integer>> targetPartitions = memberAssignment.partitions();
+            targetPartitions.forEach((topicId, partitions) ->
+                partitions.forEach(partition -> topicPartitionAssignments.add(new TargetPartition(topicId, partition)))
+            );
+        });
+        assertEquals(expectedPartitions, topicPartitionAssignments.size());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -56,9 +56,12 @@ public class SimpleAssignorTest {
     private static final Uuid TOPIC_3_UUID = Uuid.randomUuid();
     private static final Uuid TOPIC_4_UUID = Uuid.randomUuid();
     private static final String TOPIC_1_NAME = "topic1";
+    private static final String TOPIC_2_NAME = "topic2";
     private static final String TOPIC_3_NAME = "topic3";
+    private static final String TOPIC_4_NAME = "topic4";
     private static final String MEMBER_A = "A";
     private static final String MEMBER_B = "B";
+    private static final String MEMBER_C = "C";
 
     private final SimpleAssignor assignor = new SimpleAssignor();
 
@@ -215,8 +218,9 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
-        // T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
-        // T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
+        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // Step 2 -> T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 2),
@@ -271,11 +275,10 @@ public class SimpleAssignorTest {
             Assignment.EMPTY
         ));
 
-        String memberC = "C";
         Set<Uuid> memberCTopicsSubscription = new LinkedHashSet<>();
         memberCTopicsSubscription.add(TOPIC_2_UUID);
         memberCTopicsSubscription.add(TOPIC_3_UUID);
-        members.put(memberC, new MemberSubscriptionAndAssignmentImpl(
+        members.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
             memberCTopicsSubscription,
@@ -295,8 +298,9 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
-        // T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
-        // T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
+        // Step 1 -> T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
+        // Step 2 -> T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
@@ -305,7 +309,7 @@ public class SimpleAssignorTest {
         expectedAssignment.put(MEMBER_B, mkAssignment(
             mkTopicAssignment(TOPIC_3_UUID, 0, 1)
         ));
-        expectedAssignment.put(memberC, mkAssignment(
+        expectedAssignment.put(MEMBER_C, mkAssignment(
             mkTopicAssignment(TOPIC_2_UUID, 1, 2)
         ));
 
@@ -365,6 +369,8 @@ public class SimpleAssignorTest {
             mkTopicAssignment(TOPIC_2_UUID, 0, 1)));
         expectedAssignment.put(MEMBER_B, mkAssignment());
 
+        // T1: 3 partitions + T2: 2 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment);
         assertAssignment(expectedAssignment, computedAssignment);
     }
 
@@ -419,6 +425,316 @@ public class SimpleAssignorTest {
         expectedAssignment.put(partition4, Collections.singletonList(member1));
 
         assertAssignment(expectedAssignment, assignment);
+    }
+
+    @Test
+    public void testAssignWithCurrentAssignmentHomogeneous() {
+        // Current assignment setup - Two members A, B subscribing to T1 and T2.
+        Map<Uuid, TopicMetadata> topicMetadata1 = new HashMap<>();
+        topicMetadata1.put(TOPIC_1_UUID, new TopicMetadata(
+            TOPIC_1_UUID,
+            TOPIC_1_NAME,
+            3
+        ));
+        topicMetadata1.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            2
+        ));
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
+
+        Set<Uuid> topicsSubscription1 = new LinkedHashSet<>();
+        topicsSubscription1.add(TOPIC_1_UUID);
+        topicsSubscription1.add(TOPIC_2_UUID);
+
+        members1.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        members1.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        GroupSpec groupSpec1 = new GroupSpecImpl(
+            members1,
+            HOMOGENEOUS,
+            Collections.emptyMap()
+        );
+        SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
+
+        GroupAssignment computedAssignment1 = assignor.assign(
+            groupSpec1,
+            subscribedTopicMetadata1
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
+        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // Step 2 -> T1:2, T2:1 -> MEMBER_A and T2:0 -> MEMBER_B by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment1 = new HashMap<>();
+        expectedAssignment1.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 0, 2),
+            mkTopicAssignment(TOPIC_2_UUID, 1)
+        ));
+        expectedAssignment1.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 1),
+            mkTopicAssignment(TOPIC_2_UUID, 0)
+        ));
+
+        // T1: 3 partitions + T2: 2 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment1);
+        assertAssignment(expectedAssignment1, computedAssignment1);
+
+        // New assignment setup - Three members A, B, C subscribing to T2 and T3.
+        Map<Uuid, TopicMetadata> topicMetadata2 = new HashMap<>();
+        topicMetadata2.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            2
+        ));
+        topicMetadata2.put(TOPIC_3_UUID, new TopicMetadata(
+            TOPIC_3_UUID,
+            TOPIC_3_NAME,
+            3
+        ));
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
+
+        Set<Uuid> topicsSubscription2 = new LinkedHashSet<>();
+        topicsSubscription2.add(TOPIC_2_UUID);
+        topicsSubscription2.add(TOPIC_3_UUID);
+
+        members2.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            // Utilizing the assignment from current assignment
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_1_UUID, 0, 2),
+                mkTopicAssignment(TOPIC_2_UUID, 1)))
+        ));
+
+        members2.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_1_UUID, 1),
+                mkTopicAssignment(TOPIC_2_UUID, 0)))
+        ));
+
+        members2.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            Assignment.EMPTY
+        ));
+
+        GroupSpec groupSpec2 = new GroupSpecImpl(
+            members2,
+            HOMOGENEOUS,
+            Collections.emptyMap()
+        );
+        SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
+
+        GroupAssignment computedAssignment2 = assignor.assign(
+            groupSpec2,
+            subscribedTopicMetadata2
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
+        // Step 1 -> T2:0 -> MEMBER_A, T2:1 -> MEMBER_B, T3:0 -> MEMBER_C by hash assignment
+        // Step 2 -> T3:1 -> MEMBER_A, T3:2 -> MEMBER_B by round-robin assignment
+        // Step 3 -> T2:1 -> MEMBER_A, T2:0 -> MEMBER_B by current assignment.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment2 = new HashMap<>();
+        expectedAssignment2.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_2_UUID, 0, 1),
+            mkTopicAssignment(TOPIC_3_UUID, 1)
+        ));
+        expectedAssignment2.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_2_UUID, 0, 1),
+            mkTopicAssignment(TOPIC_3_UUID, 2)
+        ));
+        expectedAssignment2.put(MEMBER_C, mkAssignment(
+            mkTopicAssignment(TOPIC_3_UUID, 0)
+        ));
+
+        // T2: 2 partitions + T3: 3 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment2);
+        assertAssignment(expectedAssignment2, computedAssignment2);
+    }
+
+    @Test
+    public void testAssignWithCurrentAssignmentHeterogeneous() {
+        // Current assignment setup - 3 members A - {T1, T2}, B - {T3}, C - {T2, T3}.
+        Map<Uuid, TopicMetadata> topicMetadata1 = new HashMap<>();
+        topicMetadata1.put(TOPIC_1_UUID, new TopicMetadata(
+            TOPIC_1_UUID,
+            TOPIC_1_NAME,
+            3
+        ));
+
+        topicMetadata1.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            3
+        ));
+        topicMetadata1.put(TOPIC_3_UUID, new TopicMetadata(
+            TOPIC_3_UUID,
+            TOPIC_3_NAME,
+            2
+        ));
+
+        Set<Uuid> memberATopicsSubscription1 = new LinkedHashSet<>();
+        memberATopicsSubscription1.add(TOPIC_1_UUID);
+        memberATopicsSubscription1.add(TOPIC_2_UUID);
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
+        members1.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            memberATopicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        members1.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            Set.of(TOPIC_3_UUID),
+            Assignment.EMPTY
+        ));
+
+        Set<Uuid> memberCTopicsSubscription1 = new LinkedHashSet<>();
+        memberCTopicsSubscription1.add(TOPIC_2_UUID);
+        memberCTopicsSubscription1.add(TOPIC_3_UUID);
+        members1.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            memberCTopicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        GroupSpec groupSpec1 = new GroupSpecImpl(
+            members1,
+            HETEROGENEOUS,
+            Collections.emptyMap()
+        );
+        SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
+
+        GroupAssignment computedAssignment1 = assignor.assign(
+            groupSpec1,
+            subscribedTopicMetadata1
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
+        // Step 1 -> T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
+        // Step 2 -> T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment1 = new HashMap<>();
+        expectedAssignment1.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
+            mkTopicAssignment(TOPIC_2_UUID, 0, 2)
+        ));
+        expectedAssignment1.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_3_UUID, 0, 1)
+        ));
+        expectedAssignment1.put(MEMBER_C, mkAssignment(
+            mkTopicAssignment(TOPIC_2_UUID, 1, 2)
+        ));
+
+        // T1: 3 partitions + T2: 3 partitions + T3: 2 partitions = 8 partitions
+        assertEveryPartitionGetsAssignment(8, computedAssignment1);
+        assertAssignment(expectedAssignment1, computedAssignment1);
+
+        // New assignment setup - 2 members A - {T1, T2, T3}, B - {T3, T4}.
+
+        Map<Uuid, TopicMetadata> topicMetadata2 = new HashMap<>();
+        topicMetadata2.put(TOPIC_1_UUID, new TopicMetadata(
+            TOPIC_1_UUID,
+            TOPIC_1_NAME,
+            3
+        ));
+        topicMetadata2.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            3
+        ));
+        topicMetadata2.put(TOPIC_3_UUID, new TopicMetadata(
+            TOPIC_3_UUID,
+            TOPIC_3_NAME,
+            2
+        ));
+        topicMetadata2.put(TOPIC_4_UUID, new TopicMetadata(
+            TOPIC_4_UUID,
+            TOPIC_4_NAME,
+            1
+        ));
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
+
+        Set<Uuid> memberATopicsSubscription2 = new LinkedHashSet<>();
+        memberATopicsSubscription2.add(TOPIC_1_UUID);
+        memberATopicsSubscription2.add(TOPIC_2_UUID);
+        memberATopicsSubscription2.add(TOPIC_3_UUID);
+
+        Set<Uuid> memberBTopicsSubscription2 = new LinkedHashSet<>();
+        memberBTopicsSubscription2.add(TOPIC_3_UUID);
+        memberBTopicsSubscription2.add(TOPIC_4_UUID);
+
+        members2.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            memberATopicsSubscription2,
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
+                mkTopicAssignment(TOPIC_2_UUID, 0, 2)))
+        ));
+
+        members2.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            memberBTopicsSubscription2,
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_3_UUID, 0, 1)))
+        ));
+
+        GroupSpec groupSpec2 = new GroupSpecImpl(
+            members2,
+            HETEROGENEOUS,
+            Collections.emptyMap()
+        );
+
+        SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
+
+        GroupAssignment computedAssignment2 = assignor.assign(
+            groupSpec2,
+            subscribedTopicMetadata2
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
+        // Step 1 -> T1:1 -> member_A, T3:0 -> member_B by hash assignment.
+        // Step 2 -> T2:1 -> member_A, T4:0 -> member_B by round-robin assignment.
+        // Step 3 -> T1:0, T1:2, T2:0 -> member_A,  T3:1 -> member_B by current assignment.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment2 = new HashMap<>();
+        expectedAssignment2.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
+            mkTopicAssignment(TOPIC_2_UUID, 0, 1, 2)
+        ));
+        expectedAssignment2.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_3_UUID, 0, 1),
+            mkTopicAssignment(TOPIC_4_UUID, 0)
+        ));
+
+        // T1: 3 partitions + T2: 3 partitions + T3: 2 partitions + T4: 1 partition = 9 partitions
+        assertEveryPartitionGetsAssignment(9, computedAssignment2);
+        assertAssignment(expectedAssignment2, computedAssignment2);
     }
 
     private void assertAssignment(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.server.common.TopicIdPartition;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -385,20 +384,20 @@ public class SimpleAssignorTest {
         String member4 = "member4";
         // hashcode for "AaAaAaAa" is -540425984 to test with negative hashcode.
         String member5 = "AaAaAaAa";
-        List<String> members = Arrays.asList(member1, member2, member3, member4, member5);
+        List<String> members = List.of(member1, member2, member3, member4, member5);
 
         TopicIdPartition partition1 = new TopicIdPartition(TOPIC_1_UUID, 0);
         TopicIdPartition partition2 = new TopicIdPartition(TOPIC_2_UUID, 0);
         TopicIdPartition partition3 = new TopicIdPartition(TOPIC_3_UUID, 0);
-        List<TopicIdPartition> partitions = Arrays.asList(partition1, partition2, partition3);
+        List<TopicIdPartition> partitions = List.of(partition1, partition2, partition3);
 
         Map<TopicIdPartition, List<String>> computedAssignment = new HashMap<>();
         assignor.memberHashAssignment(partitions, members, computedAssignment);
 
         Map<TopicIdPartition, List<String>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(partition1, List.of(member3));
-        expectedAssignment.put(partition2, Arrays.asList(member1, member4));
-        expectedAssignment.put(partition3, Arrays.asList(member2, member5));
+        expectedAssignment.put(partition2, List.of(member1, member4));
+        expectedAssignment.put(partition3, List.of(member2, member5));
         assertAssignment(expectedAssignment, computedAssignment);
     }
 
@@ -406,22 +405,23 @@ public class SimpleAssignorTest {
     public void testRoundRobinAssignment() {
         String member1 = "member1";
         String member2 = "member2";
-        List<String> members = Arrays.asList(member1, member2);
+        List<String> members = List.of(member1, member2);
         TopicIdPartition partition1 = new TopicIdPartition(TOPIC_1_UUID, 0);
         TopicIdPartition partition2 = new TopicIdPartition(TOPIC_2_UUID, 0);
         TopicIdPartition partition3 = new TopicIdPartition(TOPIC_3_UUID, 0);
         TopicIdPartition partition4 = new TopicIdPartition(TOPIC_4_UUID, 0);
-        List<TopicIdPartition> unassignedPartitions = Arrays.asList(partition2, partition3, partition4);
+        List<TopicIdPartition> unassignedPartitions = List.of(partition2, partition3, partition4);
 
         Map<TopicIdPartition, List<String>> assignment = new HashMap<>();
         assignment.put(partition1, List.of(member1));
 
         assignor.roundRobinAssignment(members, unassignedPartitions, assignment);
-        Map<TopicIdPartition, List<String>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(partition1, List.of(member1));
-        expectedAssignment.put(partition2, List.of(member1));
-        expectedAssignment.put(partition3, List.of(member2));
-        expectedAssignment.put(partition4, List.of(member1));
+        Map<TopicIdPartition, List<String>> expectedAssignment = Map.of(
+            partition1, List.of(member1),
+            partition2, List.of(member1),
+            partition3, List.of(member2),
+            partition4, List.of(member1)
+        );
 
         assertAssignment(expectedAssignment, assignment);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -56,9 +56,11 @@ public class SimpleAssignorTest {
     private static final Uuid TOPIC_3_UUID = Uuid.randomUuid();
     private static final Uuid TOPIC_4_UUID = Uuid.randomUuid();
     private static final String TOPIC_1_NAME = "topic1";
+    private static final String TOPIC_2_NAME = "topic2";
     private static final String TOPIC_3_NAME = "topic3";
     private static final String MEMBER_A = "A";
     private static final String MEMBER_B = "B";
+    private static final String MEMBER_C = "C";
 
     private final SimpleAssignor assignor = new SimpleAssignor();
 
@@ -215,8 +217,9 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
-        // T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
-        // T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
+        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // Step 2 -> T1:2, T3:1 -> MEMBER_A and T3:0 -> MEMBER_B by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 2),
@@ -271,11 +274,10 @@ public class SimpleAssignorTest {
             Assignment.EMPTY
         ));
 
-        String memberC = "C";
         Set<Uuid> memberCTopicsSubscription = new LinkedHashSet<>();
         memberCTopicsSubscription.add(TOPIC_2_UUID);
         memberCTopicsSubscription.add(TOPIC_3_UUID);
-        members.put(memberC, new MemberSubscriptionAndAssignmentImpl(
+        members.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
             memberCTopicsSubscription,
@@ -295,8 +297,9 @@ public class SimpleAssignorTest {
         );
 
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
-        // T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
-        // T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
+        // Step 1 -> T2:2 -> member_A, T3:0 -> member_B, T2:2 -> member_C by hash assignment.
+        // Step 2 -> T1:0, T1:1, T1:2, T2:0 -> member_A, T3:1, -> member_B, T2:1 -> member_C by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
@@ -305,7 +308,7 @@ public class SimpleAssignorTest {
         expectedAssignment.put(MEMBER_B, mkAssignment(
             mkTopicAssignment(TOPIC_3_UUID, 0, 1)
         ));
-        expectedAssignment.put(memberC, mkAssignment(
+        expectedAssignment.put(MEMBER_C, mkAssignment(
             mkTopicAssignment(TOPIC_2_UUID, 1, 2)
         ));
 
@@ -419,6 +422,150 @@ public class SimpleAssignorTest {
         expectedAssignment.put(partition4, Collections.singletonList(member1));
 
         assertAssignment(expectedAssignment, assignment);
+    }
+
+    @Test
+    public void testAssignWithCurrentAssignmentHomogeneous() {
+        // Current assignment setup
+        Map<Uuid, TopicMetadata> topicMetadata1 = new HashMap<>();
+        topicMetadata1.put(TOPIC_1_UUID, new TopicMetadata(
+            TOPIC_1_UUID,
+            TOPIC_1_NAME,
+            3
+        ));
+        topicMetadata1.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            2
+        ));
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
+
+        Set<Uuid> topicsSubscription1 = new LinkedHashSet<>();
+        topicsSubscription1.add(TOPIC_1_UUID);
+        topicsSubscription1.add(TOPIC_2_UUID);
+
+        members1.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        members1.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription1,
+            Assignment.EMPTY
+        ));
+
+        GroupSpec groupSpec1 = new GroupSpecImpl(
+            members1,
+            HOMOGENEOUS,
+            Collections.emptyMap()
+        );
+        SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
+
+        GroupAssignment computedAssignment1 = assignor.assign(
+            groupSpec1,
+            subscribedTopicMetadata1
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66.
+        // Step 1 -> T1:0 -> MEMBER_A and T1:1 -> MEMBER_B by hash assignment.
+        // Step 2 -> T1:2, T2:1 -> MEMBER_A and T2:0 -> MEMBER_B by round-robin assignment.
+        // Step 3 -> no new assignment gets added by current assignment since it is empty.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment1 = new HashMap<>();
+        expectedAssignment1.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 0, 2),
+            mkTopicAssignment(TOPIC_2_UUID, 1)
+        ));
+        expectedAssignment1.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_1_UUID, 1),
+            mkTopicAssignment(TOPIC_2_UUID, 0)
+        ));
+
+        // T1: 3 partitions + T2: 2 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment1);
+        assertAssignment(expectedAssignment1, computedAssignment1);
+
+        // New assignment setup
+        Map<Uuid, TopicMetadata> topicMetadata2 = new HashMap<>();
+        topicMetadata2.put(TOPIC_2_UUID, new TopicMetadata(
+            TOPIC_2_UUID,
+            TOPIC_2_NAME,
+            2
+        ));
+        topicMetadata2.put(TOPIC_3_UUID, new TopicMetadata(
+            TOPIC_3_UUID,
+            TOPIC_3_NAME,
+            3
+        ));
+
+        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
+
+        Set<Uuid> topicsSubscription2 = new LinkedHashSet<>();
+        topicsSubscription2.add(TOPIC_2_UUID);
+        topicsSubscription2.add(TOPIC_3_UUID);
+
+        members2.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            // Utilizing the assignment from current assignment
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_1_UUID, 0, 2),
+                mkTopicAssignment(TOPIC_2_UUID, 1)))
+        ));
+
+        members2.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            new Assignment(mkAssignment(
+                mkTopicAssignment(TOPIC_1_UUID, 1),
+                mkTopicAssignment(TOPIC_2_UUID, 0)))
+        ));
+
+        members2.put(MEMBER_C, new MemberSubscriptionAndAssignmentImpl(
+            Optional.empty(),
+            Optional.empty(),
+            topicsSubscription2,
+            Assignment.EMPTY
+        ));
+
+        GroupSpec groupSpec2 = new GroupSpecImpl(
+            members2,
+            HOMOGENEOUS,
+            Collections.emptyMap()
+        );
+        SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
+
+        GroupAssignment computedAssignment2 = assignor.assign(
+            groupSpec2,
+            subscribedTopicMetadata2
+        );
+
+        // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
+        // Step 1 -> T2:0 -> MEMBER_A, T2:1 -> MEMBER_B, T3:0 -> MEMBER_C by hash assignment
+        // Step 2 -> T3:1 -> MEMBER_A, T3:2 -> MEMBER_B by round-robin assignment
+        // Step 3 -> no new assignment gets added by current assignment.
+        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment2 = new HashMap<>();
+        expectedAssignment2.put(MEMBER_A, mkAssignment(
+            mkTopicAssignment(TOPIC_2_UUID, 0),
+            mkTopicAssignment(TOPIC_3_UUID, 1)
+        ));
+        expectedAssignment2.put(MEMBER_B, mkAssignment(
+            mkTopicAssignment(TOPIC_2_UUID, 1),
+            mkTopicAssignment(TOPIC_3_UUID, 2)
+        ));
+        expectedAssignment2.put(MEMBER_C, mkAssignment(
+            mkTopicAssignment(TOPIC_3_UUID, 0)
+        ));
+
+        // T2: 2 partitions + T3: 3 partitions = 5 partitions
+        assertEveryPartitionGetsAssignment(5, computedAssignment2);
+        assertAssignment(expectedAssignment2, computedAssignment2);
     }
 
     private void assertAssignment(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -362,8 +362,8 @@ public class SimpleAssignorTest {
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
         expectedAssignment.put(MEMBER_A, mkAssignment(
             mkTopicAssignment(TOPIC_1_UUID, 0, 1, 2),
-            mkTopicAssignment(TOPIC_2_UUID, 0, 1)
-        ));
+            mkTopicAssignment(TOPIC_2_UUID, 0, 1)));
+        expectedAssignment.put(MEMBER_B, mkAssignment());
 
         assertAssignment(expectedAssignment, computedAssignment);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -26,11 +26,11 @@ import org.apache.kafka.coordinator.group.modern.GroupSpecImpl;
 import org.apache.kafka.coordinator.group.modern.MemberSubscriptionAndAssignmentImpl;
 import org.apache.kafka.coordinator.group.modern.SubscribedTopicDescriberImpl;
 import org.apache.kafka.coordinator.group.modern.TopicMetadata;
+import org.apache.kafka.server.common.TopicIdPartition;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -44,7 +44,6 @@ import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.TargetPartition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,13 +72,13 @@ public class SimpleAssignorTest {
     @Test
     public void testAssignWithEmptyMembers() {
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(
-            Collections.emptyMap()
+            Map.of()
         );
 
         GroupSpec groupSpec = new GroupSpecImpl(
-            Collections.emptyMap(),
+            Map.of(),
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
 
         GroupAssignment groupAssignment = assignor.assign(
@@ -87,24 +86,24 @@ public class SimpleAssignorTest {
             subscribedTopicMetadata
         );
 
-        assertEquals(Collections.emptyMap(), groupAssignment.members());
+        assertEquals(Map.of(), groupAssignment.members());
 
         groupSpec = new GroupSpecImpl(
-            Collections.emptyMap(),
+            Map.of(),
             HETEROGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         groupAssignment = assignor.assign(
             groupSpec,
             subscribedTopicMetadata
         );
-        assertEquals(Collections.emptyMap(), groupAssignment.members());
+        assertEquals(Map.of(), groupAssignment.members());
     }
 
     @Test
     public void testAssignWithNoSubscribedTopic() {
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(
-            Collections.singletonMap(
+            Map.of(
                 TOPIC_1_UUID,
                 new TopicMetadata(
                     TOPIC_1_UUID,
@@ -114,12 +113,12 @@ public class SimpleAssignorTest {
             )
         );
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members = Collections.singletonMap(
+        Map<String, MemberSubscriptionAndAssignmentImpl> members = Map.of(
             MEMBER_A,
             new MemberSubscriptionAndAssignmentImpl(
                 Optional.empty(),
                 Optional.empty(),
-                Collections.emptySet(),
+                Set.of(),
                 Assignment.EMPTY
             )
         );
@@ -127,7 +126,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec = new GroupSpecImpl(
             members,
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
 
         GroupAssignment groupAssignment = assignor.assign(
@@ -135,13 +134,13 @@ public class SimpleAssignorTest {
             subscribedTopicMetadata
         );
 
-        assertEquals(Collections.emptyMap(), groupAssignment.members());
+        assertEquals(Map.of(), groupAssignment.members());
     }
 
     @Test
     public void testAssignWithSubscribedToNonExistentTopic() {
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(
-            Collections.singletonMap(
+            Map.of(
                 TOPIC_1_UUID,
                 new TopicMetadata(
                     TOPIC_1_UUID,
@@ -151,7 +150,7 @@ public class SimpleAssignorTest {
             )
         );
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members = Collections.singletonMap(
+        Map<String, MemberSubscriptionAndAssignmentImpl> members = Map.of(
             MEMBER_A,
             new MemberSubscriptionAndAssignmentImpl(
                 Optional.empty(),
@@ -164,7 +163,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec = new GroupSpecImpl(
             members,
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
 
         assertThrows(PartitionAssignorException.class,
@@ -208,7 +207,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec = new GroupSpecImpl(
             members,
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(topicMetadata);
 
@@ -288,7 +287,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec = new GroupSpecImpl(
             members,
             HETEROGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(topicMetadata);
 
@@ -347,14 +346,14 @@ public class SimpleAssignorTest {
         members.put(MEMBER_B, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
-            Collections.emptySet(),
+            Set.of(),
             Assignment.EMPTY
         ));
 
         GroupSpec groupSpec = new GroupSpecImpl(
             members,
             HETEROGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata = new SubscribedTopicDescriberImpl(topicMetadata);
 
@@ -388,16 +387,16 @@ public class SimpleAssignorTest {
         String member5 = "AaAaAaAa";
         List<String> members = Arrays.asList(member1, member2, member3, member4, member5);
 
-        TargetPartition partition1 = new TargetPartition(TOPIC_1_UUID, 0);
-        TargetPartition partition2 = new TargetPartition(TOPIC_2_UUID, 0);
-        TargetPartition partition3 = new TargetPartition(TOPIC_3_UUID, 0);
-        List<TargetPartition> partitions = Arrays.asList(partition1, partition2, partition3);
+        TopicIdPartition partition1 = new TopicIdPartition(TOPIC_1_UUID, 0);
+        TopicIdPartition partition2 = new TopicIdPartition(TOPIC_2_UUID, 0);
+        TopicIdPartition partition3 = new TopicIdPartition(TOPIC_3_UUID, 0);
+        List<TopicIdPartition> partitions = Arrays.asList(partition1, partition2, partition3);
 
-        Map<TargetPartition, List<String>> computedAssignment = new HashMap<>();
+        Map<TopicIdPartition, List<String>> computedAssignment = new HashMap<>();
         assignor.memberHashAssignment(partitions, members, computedAssignment);
 
-        Map<TargetPartition, List<String>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(partition1, Collections.singletonList(member3));
+        Map<TopicIdPartition, List<String>> expectedAssignment = new HashMap<>();
+        expectedAssignment.put(partition1, List.of(member3));
         expectedAssignment.put(partition2, Arrays.asList(member1, member4));
         expectedAssignment.put(partition3, Arrays.asList(member2, member5));
         assertAssignment(expectedAssignment, computedAssignment);
@@ -408,21 +407,21 @@ public class SimpleAssignorTest {
         String member1 = "member1";
         String member2 = "member2";
         List<String> members = Arrays.asList(member1, member2);
-        TargetPartition partition1 = new TargetPartition(TOPIC_1_UUID, 0);
-        TargetPartition partition2 = new TargetPartition(TOPIC_2_UUID, 0);
-        TargetPartition partition3 = new TargetPartition(TOPIC_3_UUID, 0);
-        TargetPartition partition4 = new TargetPartition(TOPIC_4_UUID, 0);
-        List<TargetPartition> unassignedPartitions = Arrays.asList(partition2, partition3, partition4);
+        TopicIdPartition partition1 = new TopicIdPartition(TOPIC_1_UUID, 0);
+        TopicIdPartition partition2 = new TopicIdPartition(TOPIC_2_UUID, 0);
+        TopicIdPartition partition3 = new TopicIdPartition(TOPIC_3_UUID, 0);
+        TopicIdPartition partition4 = new TopicIdPartition(TOPIC_4_UUID, 0);
+        List<TopicIdPartition> unassignedPartitions = Arrays.asList(partition2, partition3, partition4);
 
-        Map<TargetPartition, List<String>> assignment = new HashMap<>();
-        assignment.put(partition1, Collections.singletonList(member1));
+        Map<TopicIdPartition, List<String>> assignment = new HashMap<>();
+        assignment.put(partition1, List.of(member1));
 
         assignor.roundRobinAssignment(members, unassignedPartitions, assignment);
-        Map<TargetPartition, List<String>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(partition1, Collections.singletonList(member1));
-        expectedAssignment.put(partition2, Collections.singletonList(member1));
-        expectedAssignment.put(partition3, Collections.singletonList(member2));
-        expectedAssignment.put(partition4, Collections.singletonList(member1));
+        Map<TopicIdPartition, List<String>> expectedAssignment = new HashMap<>();
+        expectedAssignment.put(partition1, List.of(member1));
+        expectedAssignment.put(partition2, List.of(member1));
+        expectedAssignment.put(partition3, List.of(member2));
+        expectedAssignment.put(partition4, List.of(member1));
 
         assertAssignment(expectedAssignment, assignment);
     }
@@ -465,7 +464,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec1 = new GroupSpecImpl(
             members1,
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
 
@@ -540,7 +539,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec2 = new GroupSpecImpl(
             members2,
             HOMOGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
 
@@ -624,7 +623,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec1 = new GroupSpecImpl(
             members1,
             HETEROGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
         SubscribedTopicDescriberImpl subscribedTopicMetadata1 = new SubscribedTopicDescriberImpl(topicMetadata1);
 
@@ -708,7 +707,7 @@ public class SimpleAssignorTest {
         GroupSpec groupSpec2 = new GroupSpecImpl(
             members2,
             HETEROGENEOUS,
-            Collections.emptyMap()
+            Map.of()
         );
 
         SubscribedTopicDescriberImpl subscribedTopicMetadata2 = new SubscribedTopicDescriberImpl(topicMetadata2);
@@ -749,12 +748,12 @@ public class SimpleAssignorTest {
     }
 
     private void assertAssignment(
-        Map<TargetPartition, List<String>> expectedAssignment,
-        Map<TargetPartition, List<String>> computedAssignment
+        Map<TopicIdPartition, List<String>> expectedAssignment,
+        Map<TopicIdPartition, List<String>> computedAssignment
     ) {
         assertEquals(expectedAssignment.size(), computedAssignment.size());
-        expectedAssignment.forEach((targetPartition, members) -> {
-            List<String> computedMembers = computedAssignment.getOrDefault(targetPartition, Collections.emptyList());
+        expectedAssignment.forEach((topicIdPartition, members) -> {
+            List<String> computedMembers = computedAssignment.getOrDefault(topicIdPartition, List.of());
             assertEquals(members.size(), computedMembers.size());
             members.forEach(member -> assertTrue(computedMembers.contains(member)));
         });
@@ -765,11 +764,11 @@ public class SimpleAssignorTest {
         GroupAssignment computedGroupAssignment
     ) {
         Map<String, MemberAssignment> memberAssignments = computedGroupAssignment.members();
-        Set<TargetPartition> topicPartitionAssignments = new HashSet<>();
+        Set<TopicIdPartition> topicPartitionAssignments = new HashSet<>();
         memberAssignments.values().forEach(memberAssignment -> {
-            Map<Uuid, Set<Integer>> targetPartitions = memberAssignment.partitions();
-            targetPartitions.forEach((topicId, partitions) ->
-                partitions.forEach(partition -> topicPartitionAssignments.add(new TargetPartition(topicId, partition)))
+            Map<Uuid, Set<Integer>> topicIdPartitions = memberAssignment.partitions();
+            topicIdPartitions.forEach((topicId, partitions) ->
+                partitions.forEach(partition -> topicPartitionAssignments.add(new TopicIdPartition(topicId, partition)))
             );
         });
         assertEquals(expectedPartitions, topicPartitionAssignments.size());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -42,9 +42,9 @@ import java.util.TreeMap;
 
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.TargetPartition;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.HOMOGENEOUS;
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.TargetPartition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
@@ -183,7 +182,7 @@ public class SimpleAssignorTest {
             2
         ));
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members = new HashMap<>();
 
         Set<Uuid> topicsSubscription = new LinkedHashSet<>();
         topicsSubscription.add(TOPIC_1_UUID);
@@ -258,7 +257,7 @@ public class SimpleAssignorTest {
         memberATopicsSubscription.add(TOPIC_1_UUID);
         memberATopicsSubscription.add(TOPIC_2_UUID);
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members = new HashMap<>();
         members.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
@@ -334,7 +333,7 @@ public class SimpleAssignorTest {
         Set<Uuid> memberATopicsSubscription = new LinkedHashSet<>();
         memberATopicsSubscription.add(TOPIC_1_UUID);
         memberATopicsSubscription.add(TOPIC_2_UUID);
-        Map<String, MemberSubscriptionAndAssignmentImpl> members = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members = new HashMap<>();
         members.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
@@ -441,7 +440,7 @@ public class SimpleAssignorTest {
             2
         ));
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new HashMap<>();
 
         Set<Uuid> topicsSubscription1 = new LinkedHashSet<>();
         topicsSubscription1.add(TOPIC_1_UUID);
@@ -504,7 +503,7 @@ public class SimpleAssignorTest {
             3
         ));
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new HashMap<>();
 
         Set<Uuid> topicsSubscription2 = new LinkedHashSet<>();
         topicsSubscription2.add(TOPIC_2_UUID);
@@ -595,7 +594,7 @@ public class SimpleAssignorTest {
         memberATopicsSubscription1.add(TOPIC_1_UUID);
         memberATopicsSubscription1.add(TOPIC_2_UUID);
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members1 = new HashMap<>();
         members1.put(MEMBER_A, new MemberSubscriptionAndAssignmentImpl(
             Optional.empty(),
             Optional.empty(),
@@ -676,7 +675,7 @@ public class SimpleAssignorTest {
             1
         ));
 
-        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new TreeMap<>();
+        Map<String, MemberSubscriptionAndAssignmentImpl> members2 = new HashMap<>();
 
         Set<Uuid> memberATopicsSubscription2 = new LinkedHashSet<>();
         memberATopicsSubscription2.add(TOPIC_1_UUID);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignorTest.java
@@ -550,14 +550,14 @@ public class SimpleAssignorTest {
         // Hashcode of MEMBER_A is 65. Hashcode of MEMBER_B is 66. Hashcode of MEMBER_C is 67.
         // Step 1 -> T2:0 -> MEMBER_A, T2:1 -> MEMBER_B, T3:0 -> MEMBER_C by hash assignment
         // Step 2 -> T3:1 -> MEMBER_A, T3:2 -> MEMBER_B by round-robin assignment
-        // Step 3 -> T2:1 -> MEMBER_A, T2:0 -> MEMBER_B by current assignment.
+        // Step 3 -> no new addition by current assignment since T2:0 and T2:1 were already a part of new assignment.
         Map<String, Map<Uuid, Set<Integer>>> expectedAssignment2 = new HashMap<>();
         expectedAssignment2.put(MEMBER_A, mkAssignment(
-            mkTopicAssignment(TOPIC_2_UUID, 0, 1),
+            mkTopicAssignment(TOPIC_2_UUID, 0),
             mkTopicAssignment(TOPIC_3_UUID, 1)
         ));
         expectedAssignment2.put(MEMBER_B, mkAssignment(
-            mkTopicAssignment(TOPIC_2_UUID, 0, 1),
+            mkTopicAssignment(TOPIC_2_UUID, 1),
             mkTopicAssignment(TOPIC_3_UUID, 2)
         ));
         expectedAssignment2.put(MEMBER_C, mkAssignment(


### PR DESCRIPTION
### About
The current `SimpleAssignor` in AK assigned all subscribed topic partitions to all the share group members. This does not match the description given in [KIP-932](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=255070434#KIP932:QueuesforKafka-TheSimpleAssignor). Here are the rules as mentioned in the KIP by which the assignment should happen. We have changed the step 3 implementation here due to the reasons [described](https://github.com/apache/kafka/pull/18864#issuecomment-2659266502) -

1. The assignor hashes the member IDs of the members and maps the partitions assigned to the members based on the hash. This gives approximately even balance.
2. If any partitions were not assigned any members by (1) and do not have members already assigned in the current assignment, members are assigned round-robin until each partition has at least one member assigned to it.
3. We combine the current and new assignment. (Original rule - If any partitions were assigned members by (1) and also have members in the current assignment assigned by (2), the members assigned by (2) are removed.)

### Tests
The added code has been verified with unit tests and the already present integration tests.