### PR TITLE
KAFKA-18777: add `PartitionsWithLateTransactionsCount` to BrokerMetricNamesTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/BrokerMetricNamesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerMetricNamesTest.scala
@@ -40,12 +40,7 @@ class BrokerMetricNamesTest(cluster: ClusterInstance) {
   def checkReplicaManagerMetrics(): Unit = {
     val metrics = KafkaYammerMetrics.defaultRegistry.allMetrics
     val expectedPrefix = "kafka.server:type=ReplicaManager,name"
-    val expectedMetricNames = Set(
-      "LeaderCount", "PartitionCount", "OfflineReplicaCount", "UnderReplicatedPartitions",
-      "UnderMinIsrPartitionCount", "AtMinIsrPartitionCount", "ReassigningPartitions",
-      "IsrExpandsPerSec", "IsrShrinksPerSec", "FailedIsrUpdatesPerSec",
-      "ProducerIdCount",
-    )
+    val expectedMetricNames = ReplicaManager.MetricNames
     expectedMetricNames.foreach { metricName =>
       assertEquals(1, metrics.keySet.asScala.count(_.getMBeanName == s"$expectedPrefix=$metricName"))
     }


### PR DESCRIPTION
Rewrite `BrokerMetricNamesTest` using `ReplicaManager.MetricNames`, ensuring that all metrics are always included. This helps prevent issues like `PartitionsWithLateTransactionsCount` not being correctly included in the test before.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
