### PR TITLE
KAFKA-18684: Add base exception classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/ApplicationRecoverableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ApplicationRecoverableException.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.errors;
 
 /**

--- a/clients/src/main/java/org/apache/kafka/common/errors/ApplicationRecoverableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ApplicationRecoverableException.java
@@ -1,0 +1,12 @@
+package org.apache.kafka.common.errors;
+
+/**
+ * Indicates that the error is fatal to the producer, and the application
+ * needs to restart the producer after handling the error. Depending on the application,
+ * different recovery strategies (e.g., re-balancing task, restoring from checkpoints) may be employed.
+ */
+public abstract class ApplicationRecoverableException extends ApiException {
+    public ApplicationRecoverableException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/RefreshRetriableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RefreshRetriableException.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.errors;
 
 /**

--- a/clients/src/main/java/org/apache/kafka/common/errors/RefreshRetriableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RefreshRetriableException.java
@@ -1,0 +1,12 @@
+package org.apache.kafka.common.errors;
+
+/**
+ * Indicates that an operation failed due to outdated or invalid metadata,
+ * requiring a refresh (e.g., refreshing producer metadata) before retrying the request.
+ * The request can be modified or updated with fresh metadata before being retried.
+ */
+public abstract class RefreshRetriableException extends RetriableException {
+    public RefreshRetriableException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
**Summary**
Introduced two new exception classes to the Kafka error handling framework:
- ApplicationRecoverableException: This exception signals that the error is recoverable, but the producer needs to be restarted. It helps in scenarios where recovery actions (like re-balancing or restoring from checkpoints) are needed.

- RefreshRetriableException: This exception occurs when metadata is outdated or invalid and needs to be refreshed before retrying the request. It helps handle retries that depend on updated metadata.

Both classes are abstract and in upcoming PRs they will be extended by relevant classes as mentioned in [KIP-1050:Exception Table](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=309496816#KIP1050:ConsistenterrorhandlingforTransactions-ExceptionTable).