### PR TITLE
MINOR Run javadoc in check task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -709,7 +709,7 @@ subprojects {
 
   task docsJar(dependsOn: javadocJar)
 
-  test.dependsOn('javadoc')
+  check.dependsOn('javadoc')
 
   task systemTestLibs(dependsOn: jar)
 


### PR DESCRIPTION
We had a recent regression in the javadoc task on trunk. This happened because it caused a failure when running the `test` task. However, we assume any failure from the `test` task is due to test failures rather than some compilation/validation task. This patch moves the `javadoc` task as a dependency of `check` rather than `test`