### PR TITLE
KAFKA-18784: Fix ConsumerWithLegacyMessageFormatIntegrationTest

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -691,7 +691,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    *
    * Also see #appendAsLeader.
    */
-  private[log] def appendAsLeaderWithRecordVersion(records: MemoryRecords, leaderEpoch: Int, recordVersion: RecordVersion): LogAppendInfo = {
+  private[kafka] def appendAsLeaderWithRecordVersion(records: MemoryRecords, leaderEpoch: Int, recordVersion: RecordVersion): LogAppendInfo = {
     append(records, AppendOrigin.CLIENT, true, leaderEpoch, Some(RequestLocal.noCaching),
       VerificationGuard.SENTINEL, ignoreRecordSize = false, recordVersion.value)
   }


### PR DESCRIPTION
In PR https://github.com/apache/kafka/pull/18267, we removed old message format for cases in `ConsumerWithLegacyMessageFormatIntegrationTest`. Although test cases can pass, they don't fulfill original purpose. We can't send old message format since 4.0, so I change cases to append old records by `ReplicaManager` directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
