### PR TITLE
MINOR: Adjust javadoc to reflect the correct status of standby task 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsMetadata.java
@@ -49,9 +49,9 @@ public interface StreamsMetadata {
     Set<TopicPartition> topicPartitions();
 
     /**
-     * Changelog topic partitions for the state stores the standby tasks of the Streams client replicates.
+     * Source topic partitions for which the instance acts as standby.
      *
-     * @return set of changelog topic partitions of the standby tasks
+     * @return source topic partitions of the standby tasks
      */
     Set<TopicPartition> standbyTopicPartitions();
 


### PR DESCRIPTION
[KIP-744](https://cwiki.apache.org/confluence/display/KAFKA/KIP-744%3A+Migrate+TaskMetadata+and+ThreadMetadata+to+an+interface+with+internal+implementation) introduced the `StreamsMetadata` class as part of the [implementation](https://github.com/apache/kafka/pull/10840/files#diff-5b59e1e7e1efefa5832392880d20f6a846fe3154f314ed30470af44103622c0a).  In the KIP, the javadoc for the `standbyTopicPartitions` states that the method returns the set of source `TopicPartition` that it represents as a standby. The [current javadoc ](https://javadoc.io/static/org.apache.kafka/kafka-streams/3.9.0/org/apache/kafka/streams/StreamsMetadata.html#standbyTopicPartitions--)states that it represents the changelog `TopicPartition`(s).  While the partitions of the source and changelog topics will match, the javadoc needs to be updated to reflect the correct behavior.  

Note that the deprecated [o.a.k.streams.state.StreamsMetadata#standbyTopicPartitions](https://javadoc.io/static/org.apache.kafka/kafka-streams/3.9.0/org/apache/kafka/streams/state/StreamsMetadata.html#standbyTopicPartitions--) method also describes the set of `TopicPartition` being source `TopicPartition`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
