### PR TITLE
KAFKA-18761: Complete listing of share group offsets [1/N]

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
@@ -37,7 +37,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
 
     private static final String BOOTSTRAP_SERVER_DOC = "REQUIRED: The server(s) to connect to.";
     private static final String GROUP_DOC = "The share group we wish to act on.";
-    private static final String TOPIC_DOC = "The topic whose share group information should be deleted or topic whose should be included in the reset offset process. " +
+    private static final String TOPIC_DOC = "The topic whose offset information should be deleted or included in the reset offset process. " +
         "When resetting offsets, partitions can be specified using this format: 'topic1:0,1,2', where 0,1,2 are the partitions to be included.";
     private static final String ALL_TOPICS_DOC = "Consider all topics assigned to a share group in the 'reset-offsets' process.";
     private static final String LIST_DOC = "List all share groups.";
@@ -177,8 +177,8 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
                 CommandLineUtils.printUsageAndExit(parser,
                     "Option " + deleteOpt + " takes the option: " + groupOpt);
             if (options.has(topicOpt))
-                CommandLineUtils.printUsageAndExit(parser, "The consumer does not support topic-specific offset " +
-                    "deletion from a share group.");
+                CommandLineUtils.printUsageAndExit(parser,
+                    "Option " + deleteOpt + " does not take the option: " + topicOpt);
         }
 
         if (options.has(deleteOffsetsOpt)) {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
@@ -64,7 +64,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
         "When specified with '--list', it displays the state of all groups. It can also be used to list groups with specific states. " +
         "Valid values are Empty, Stable and Dead.";
     private static final String VERBOSE_DOC = "Provide additional information, if any, when describing the group. This option may be used " +
-        "with the '--describe --state' and '--describe --members' options only.";
+        "with the '--describe' option only.";
     private static final String DELETE_OFFSETS_DOC = "Delete offsets of share group. Supports one share group at the time, and multiple topics.";
 
     final OptionSpec<String> bootstrapServerOpt;
@@ -142,8 +142,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
             .withOptionalArg()
             .ofType(String.class);
         verboseOpt = parser.accepts("verbose", VERBOSE_DOC)
-            .availableIf(membersOpt, stateOpt)
-            .availableUnless(listOpt);
+            .availableIf(describeOpt);
 
         allGroupSelectionScopeOpts = new HashSet<>(Arrays.asList(groupOpt, allGroupsOpt));
         allShareGroupLevelOpts = new HashSet<>(Arrays.asList(listOpt, describeOpt, deleteOpt, deleteOffsetsOpt, resetOffsetsOpt));


### PR DESCRIPTION
This is the first PR to complete list of share group offsets. Primarily, it adds support for receiving `null` back from the admin client when offsets cannot be retrieved. The`kafka-share-groups.sh` tool no longer throws an exception in this situation.

It also adds support for the final `--offsets --verbose` option for `kafka-share-groups.sh`.

Note that the leader epoch is just a placeholder for now and another PR in this sequence will add it to the admin client response (it's already in the Kafka protocol response).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
