### PR TITLE
MINOR: Mark IBP_4_0_IV3 as production ready!

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.server.common.Feature;
 import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.common.TestFeatureVersion;
+import org.apache.kafka.server.common.TransactionVersion;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -353,6 +354,9 @@ public class FormatterTest {
                     setName(TestFeatureVersion.FEATURE_NAME).
                     setFeatureLevel(version), (short) 0));
             }
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(TransactionVersion.FEATURE_NAME).
+                setFeatureLevel(TransactionVersion.TV_2.featureLevel()), (short) 0));
             assertEquals(expected, bootstrapMetadata.records());
         }
     }

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -118,17 +118,20 @@ public enum MetadataVersion {
     // ClearElrRecord is added.
     IBP_4_0_IV1(23, "4.0", "IV1", true),
 
+    // Bootstrap metadata version for transaction versions 1 and 2 (KIP-890)
+    IBP_4_0_IV2(24, "4.0", "IV2", false),
+
+    // Enables async remote LIST_OFFSETS support (KIP-1075)
+    IBP_4_0_IV3(25, "4.0", "IV3", false),
+
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
     // If users attempt to use an unstable MetadataVersion, they will get an error.
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // Bootstrap metadata version for transaction versions 1 and 2 (KIP-890)
-    IBP_4_0_IV2(24, "4.0", "IV2", false),
-
-    // Enables async remote LIST_OFFSETS support (KIP-1075)
-    IBP_4_0_IV3(25, "4.0", "IV3", false);
+    // Not used by anything yet.
+    IBP_4_1_IV0(26, "4.1", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -154,7 +157,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_0_IV1;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_0_IV3;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -95,10 +95,13 @@ class MetadataVersionTest {
         assertEquals(IBP_3_9_IV0, MetadataVersion.fromVersionString("3.9"));
         assertEquals(IBP_3_9_IV0, MetadataVersion.fromVersionString("3.9-IV0"));
 
+        // 4.0-IV3 is the latest production version in the 4.0 line
         assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0"));
         assertEquals(IBP_4_0_IV1, MetadataVersion.fromVersionString("4.0-IV1"));
         assertEquals(IBP_4_0_IV2, MetadataVersion.fromVersionString("4.0-IV2"));
         assertEquals(IBP_4_0_IV3, MetadataVersion.fromVersionString("4.0-IV3"));
+
+        assertEquals(IBP_4_1_IV0, MetadataVersion.fromVersionString("4.1-IV0"));
     }
 
     @Test
@@ -128,6 +131,7 @@ class MetadataVersionTest {
         assertEquals("4.0", IBP_4_0_IV1.shortVersion());
         assertEquals("4.0", IBP_4_0_IV2.shortVersion());
         assertEquals("4.0", IBP_4_0_IV3.shortVersion());
+        assertEquals("4.1", IBP_4_1_IV0.shortVersion());
     }
 
     @Test
@@ -157,6 +161,7 @@ class MetadataVersionTest {
         assertEquals("4.0-IV1", IBP_4_0_IV1.version());
         assertEquals("4.0-IV2", IBP_4_0_IV2.version());
         assertEquals("4.0-IV3", IBP_4_0_IV3.version());
+        assertEquals("4.1-IV0", IBP_4_1_IV0.version());
     }
 
     @Test

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
@@ -52,7 +52,7 @@ public @interface ClusterTest {
     String brokerListener() default DEFAULT_BROKER_LISTENER_NAME;
     SecurityProtocol controllerSecurityProtocol() default SecurityProtocol.PLAINTEXT;
     String controllerListener() default DEFAULT_CONTROLLER_LISTENER_NAME;
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_0_IV3;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_1_IV0;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -114,7 +114,7 @@ DEV_VERSION = KafkaVersion("4.1.0-SNAPSHOT")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "4.0-IV1"
+LATEST_STABLE_METADATA_VERSION = "4.0-IV3"
 
 # 0.11.0.x versions
 V_0_11_0_3 = KafkaVersion("0.11.0.3")

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -64,7 +64,7 @@ public class FeatureCommandTest {
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV3\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 4.1-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(features.get(3)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
     }
@@ -86,7 +86,7 @@ public class FeatureCommandTest {
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV3\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 4.1-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(3)));
         assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
     }
@@ -114,7 +114,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. The update failed for all features since the following " +
-                "feature had an error: Invalid update version 0 for feature metadata.version. Local controller 3000 only supports versions 1-25", commandOutput);
+                "feature had an error: Invalid update version 0 for feature metadata.version. Local controller 3000 only supports versions 1-26", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),


### PR DESCRIPTION
This patch marks IBP_4_0_IV3 as production ready for the Apache Kafka 4.0 release. It also introduced IBP_4_1_IV0 as the next development version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
