### PR TITLE
KAFKA-18740: Remove BootstrapDirectory#ibp

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -181,7 +181,7 @@ object KafkaRaftServer {
     }
 
     // Load the BootstrapMetadata.
-    val bootstrapDirectory = new BootstrapDirectory(config.metadataLogDir, Optional.empty())
+    val bootstrapDirectory = new BootstrapDirectory(config.metadataLogDir)
     val bootstrapMetadata = bootstrapDirectory.read()
     (metaPropsEnsemble, bootstrapMetadata)
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -109,7 +109,7 @@ class KafkaRaftServerTest {
   }
 
   private def writeBootstrapMetadata(logDir: File, metadataVersion: MetadataVersion): Unit = {
-    val bootstrapDirectory = new BootstrapDirectory(logDir.toString, Optional.empty())
+    val bootstrapDirectory = new BootstrapDirectory(logDir.toString)
     bootstrapDirectory.writeBinaryFile(BootstrapMetadata.fromVersion(metadataVersion, "test"))
   }
 

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -712,7 +712,7 @@ Found problem:
 
     // Not doing full SCRAM record validation since that's covered elsewhere.
     // Just checking that we generate the correct number of records
-    val bootstrapMetadata = new BootstrapDirectory(availableDirs.head.toString, Optional.empty).read
+    val bootstrapMetadata = new BootstrapDirectory(availableDirs.head.toString).read
     val scramRecords = bootstrapMetadata.records().asScala
       .filter(apiMessageAndVersion => apiMessageAndVersion.message().isInstanceOf[UserScramCredentialRecord])
       .map(apiMessageAndVersion => apiMessageAndVersion.message().asInstanceOf[UserScramCredentialRecord])

--- a/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapDirectory.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapDirectory.java
@@ -31,11 +31,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION;
 
 
 /**
@@ -46,21 +44,16 @@ public class BootstrapDirectory {
     public static final String BINARY_BOOTSTRAP_FILENAME = "bootstrap.checkpoint";
 
     private final String directoryPath;
-    private final Optional<String> ibp;
 
     /**
      * Create a new BootstrapDirectory object.
      *
      * @param directoryPath     The path to the directory with the bootstrap file.
-     * @param ibp               The configured value of inter.broker.protocol, or the empty string
-     *                          if it is not configured.
      */
     public BootstrapDirectory(
-        String directoryPath,
-        Optional<String> ibp
+        String directoryPath
     ) {
         this.directoryPath = Objects.requireNonNull(directoryPath);
-        this.ibp = Objects.requireNonNull(ibp);
     }
 
     public BootstrapMetadata read() throws Exception {
@@ -75,23 +68,10 @@ public class BootstrapDirectory {
         }
         Path binaryBootstrapPath = Paths.get(directoryPath, BINARY_BOOTSTRAP_FILENAME);
         if (!Files.exists(binaryBootstrapPath)) {
-            return readFromConfiguration();
+            return BootstrapMetadata.fromVersion(MetadataVersion.latestProduction(), "the default bootstrap");
         } else {
             return readFromBinaryFile(binaryBootstrapPath.toString());
         }
-    }
-
-    BootstrapMetadata readFromConfiguration() {
-        if (ibp.isEmpty()) {
-            return BootstrapMetadata.fromVersion(MetadataVersion.latestProduction(), "the default bootstrap");
-        }
-        MetadataVersion version = MetadataVersion.fromVersionString(ibp.get());
-        if (version.isLessThan(MINIMUM_BOOTSTRAP_VERSION)) {
-            return BootstrapMetadata.fromVersion(MINIMUM_BOOTSTRAP_VERSION,
-                "the minimum version bootstrap with metadata.version " + MINIMUM_BOOTSTRAP_VERSION);
-        }
-        return BootstrapMetadata.fromVersion(version,
-            "the configured bootstrap with metadata.version " + version);
     }
 
     BootstrapMetadata readFromBinaryFile(String binaryPath) throws Exception {

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -435,7 +435,7 @@ public class Formatter {
                     directoryTypes.get(writeLogDir).description(), writeLogDir,
                     MetadataVersion.FEATURE_NAME, releaseVersion);
                 Files.createDirectories(Paths.get(writeLogDir));
-                BootstrapDirectory bootstrapDirectory = new BootstrapDirectory(writeLogDir, Optional.empty());
+                BootstrapDirectory bootstrapDirectory = new BootstrapDirectory(writeLogDir);
                 bootstrapDirectory.writeBinaryFile(bootstrapMetadata);
                 if (directoryTypes.get(writeLogDir).isDynamicMetadataDirectory()) {
                     writeDynamicQuorumSnapshot(writeLogDir,

--- a/metadata/src/test/java/org/apache/kafka/metadata/bootstrap/BootstrapDirectoryTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/bootstrap/BootstrapDirectoryTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,25 +73,7 @@ public class BootstrapDirectoryTest {
         try (BootstrapTestDirectory testDirectory = new BootstrapTestDirectory().createDirectory()) {
             assertEquals(BootstrapMetadata.fromVersion(MetadataVersion.latestProduction(),
                     "the default bootstrap"),
-                new BootstrapDirectory(testDirectory.path(), Optional.empty()).read());
-        }
-    }
-
-    @Test
-    public void testReadFromConfigurationWithAncientVersion() throws Exception {
-        try (BootstrapTestDirectory testDirectory = new BootstrapTestDirectory().createDirectory()) {
-            assertEquals(BootstrapMetadata.fromVersion(MetadataVersion.MINIMUM_BOOTSTRAP_VERSION,
-                    "the minimum version bootstrap with metadata.version 3.3-IV0"),
-                new BootstrapDirectory(testDirectory.path(), Optional.of("3.0")).read());
-        }
-    }
-
-    @Test
-    public void testReadFromConfiguration() throws Exception {
-        try (BootstrapTestDirectory testDirectory = new BootstrapTestDirectory().createDirectory()) {
-            assertEquals(BootstrapMetadata.fromVersion(MetadataVersion.IBP_3_3_IV2,
-                    "the configured bootstrap with metadata.version 3.3-IV2"),
-                new BootstrapDirectory(testDirectory.path(), Optional.of("3.3-IV2")).read());
+                new BootstrapDirectory(testDirectory.path()).read());
         }
     }
 
@@ -100,13 +81,13 @@ public class BootstrapDirectoryTest {
     public void testMissingDirectory() {
         assertEquals("No such directory as ./non/existent/directory",
             assertThrows(RuntimeException.class, () ->
-                new BootstrapDirectory("./non/existent/directory", Optional.empty()).read()).getMessage());
+                new BootstrapDirectory("./non/existent/directory").read()).getMessage());
     }
 
     @Test
     public void testReadFromConfigurationFile() throws Exception {
         try (BootstrapTestDirectory testDirectory = new BootstrapTestDirectory().createDirectory()) {
-            BootstrapDirectory directory = new BootstrapDirectory(testDirectory.path(), Optional.of("3.0-IV0"));
+            BootstrapDirectory directory = new BootstrapDirectory(testDirectory.path());
             BootstrapMetadata metadata = BootstrapMetadata.fromRecords(SAMPLE_RECORDS1,
                     "the binary bootstrap metadata file: " + testDirectory.binaryBootstrapPath());
             directory.writeBinaryFile(metadata);

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -143,7 +143,7 @@ public class FormatterTest {
             assertEquals(Optional.of(DEFAULT_CLUSTER_ID.toString()), ensemble.clusterId());
             assertEquals(new HashSet<>(testEnv.directories), ensemble.logDirProps().keySet());
             BootstrapMetadata bootstrapMetadata =
-                new BootstrapDirectory(testEnv.directory(0), Optional.empty()).read();
+                new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.latestProduction(), bootstrapMetadata.metadataVersion());
         }
     }
@@ -224,7 +224,7 @@ public class FormatterTest {
                 " with metadata.version " + MetadataVersion.IBP_3_5_IV0 + ".",
                     formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
-                new BootstrapDirectory(testEnv.directory(0), Optional.empty()).read();
+                new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.IBP_3_5_IV0, bootstrapMetadata.metadataVersion());
             assertEquals(1, bootstrapMetadata.records().size());
         }
@@ -251,7 +251,7 @@ public class FormatterTest {
                 " with metadata.version " + MetadataVersion.latestTesting() + ".",
                     formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
-                    new BootstrapDirectory(testEnv.directory(0), Optional.empty()).read();
+                    new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.latestTesting(), bootstrapMetadata.metadataVersion());
         }
     }
@@ -301,7 +301,7 @@ public class FormatterTest {
                 " with metadata.version " + MetadataVersion.IBP_3_8_IV0 + ".",
                     formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
-                new BootstrapDirectory(testEnv.directory(0), Optional.empty()).read();
+                new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.IBP_3_8_IV0, bootstrapMetadata.metadataVersion());
             List<ApiMessageAndVersion> scramRecords = bootstrapMetadata.records().stream().
                 filter(r -> r.message() instanceof UserScramCredentialRecord).
@@ -336,7 +336,7 @@ public class FormatterTest {
             formatter1.formatter.setFeatureLevel(TestFeatureVersion.FEATURE_NAME, version);
             formatter1.formatter.run();
             BootstrapMetadata bootstrapMetadata =
-                new BootstrapDirectory(testEnv.directory(0), Optional.empty()).read();
+                new BootstrapDirectory(testEnv.directory(0)).read();
             List<ApiMessageAndVersion> expected = new ArrayList<>();
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(MetadataVersion.FEATURE_NAME).


### PR DESCRIPTION
This PR removes the BootstrapDirectory#ibp. The follow-up of https://github.com/apache/kafka/pull/18566, which removed inter.broker.protocol.version, as it is not used in KRaft mode.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
