### PR TITLE
KAFKA-18755 Align timeout in kafka-share-groups.sh

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
@@ -118,7 +118,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
             .withRequiredArg()
             .describedAs("timeout (ms)")
             .ofType(Long.class)
-            .defaultsTo(5000L);
+            .defaultsTo(30000L);
         commandConfigOpt = parser.accepts("command-config", COMMAND_CONFIG_DOC)
             .withRequiredArg()
             .describedAs("command config property file")


### PR DESCRIPTION
Align timeout in kafka-share-groups.sh with kafka-group.sh to 30000ms.
JIRA: [Align timeout in kafka-share-groups.sh with other group-related tools](https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-18755?filter=myopenissues)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
