### PR TITLE
MINOR: add output formatting options for DumpLogSegments

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -59,6 +59,9 @@ import scala.collection.mutable.ArrayBuffer
 object DumpLogSegments {
   // visible for testing
   private[tools] val RecordIndent = "|"
+  private[tools] val DefaultFieldSep = " "
+  private[tools] val DefaultEntryCaption = ""
+  private[tools] val DefaultRecordCaption = "\n"+RecordIndent+DefaultFieldSep
 
   def main(args: Array[String]): Unit = {
     val opts = new DumpLogSegmentsOptions(args)
@@ -77,16 +80,16 @@ object DumpLogSegments {
       val suffix = filename.substring(filename.lastIndexOf("."))
       suffix match {
         case JUnifiedLog.LOG_FILE_SUFFIX | Snapshots.SUFFIX =>
-          dumpLog(file, opts.shouldPrintDataLog, nonConsecutivePairsForLogFilesMap, opts.isDeepIteration,
+          dumpLog(file, opts.shouldPrintDataLog, opts.fieldSep, opts.entryCaption, opts.recordCaption, opts.printKeyValues, nonConsecutivePairsForLogFilesMap, opts.isDeepIteration,
             opts.messageParser, opts.skipRecordMetadata, opts.maxBytes)
         case JUnifiedLog.INDEX_FILE_SUFFIX =>
-          dumpIndex(file, opts.indexSanityOnly, opts.verifyOnly, misMatchesForIndexFilesMap, opts.maxMessageSize)
+          dumpIndex(file, opts.indexSanityOnly, opts.verifyOnly, opts.fieldSep, opts.entryCaption, misMatchesForIndexFilesMap, opts.maxMessageSize)
         case JUnifiedLog.TIME_INDEX_FILE_SUFFIX =>
-          dumpTimeIndex(file, opts.indexSanityOnly, opts.verifyOnly, timeIndexDumpErrors)
+          dumpTimeIndex(file, opts.indexSanityOnly, opts.verifyOnly, opts.fieldSep, opts.entryCaption, timeIndexDumpErrors)
         case LogFileUtils.PRODUCER_SNAPSHOT_FILE_SUFFIX =>
-          dumpProducerIdSnapshot(file)
+          dumpProducerIdSnapshot(file, opts.fieldSep, opts.entryCaption)
         case JUnifiedLog.TXN_INDEX_FILE_SUFFIX =>
-          dumpTxnIndex(file)
+          dumpTxnIndex(file, opts.fieldSep, opts.entryCaption)
         case _ =>
           System.err.println(s"Ignoring unknown file $file")
       }
@@ -109,23 +112,23 @@ object DumpLogSegments {
     }
   }
 
-  private def dumpTxnIndex(file: File): Unit = {
+  private def dumpTxnIndex(file: File, fieldSep: String, entryCaption: String): Unit = {
     val index = new TransactionIndex(JUnifiedLog.offsetFromFile(file), file)
     for (abortedTxn <- index.allAbortedTxns.asScala) {
-      println(s"version: ${abortedTxn.version} producerId: ${abortedTxn.producerId} firstOffset: ${abortedTxn.firstOffset} " +
-        s"lastOffset: ${abortedTxn.lastOffset} lastStableOffset: ${abortedTxn.lastStableOffset}")
+      println(entryCaption + s"version: ${abortedTxn.version}" + fieldSep + s"producerId: ${abortedTxn.producerId}" + fieldSep + s"firstOffset: ${abortedTxn.firstOffset}" +
+        fieldSep + s"lastOffset: ${abortedTxn.lastOffset}" + fieldSep + s"lastStableOffset: ${abortedTxn.lastStableOffset}")
     }
   }
 
-  private def dumpProducerIdSnapshot(file: File): Unit = {
+  private def dumpProducerIdSnapshot(file: File, fieldSep: String, entryCaption: String): Unit = {
     try {
       ProducerStateManager.readSnapshot(file).forEach { entry =>
-        print(s"producerId: ${entry.producerId} producerEpoch: ${entry.producerEpoch} " +
-          s"coordinatorEpoch: ${entry.coordinatorEpoch} currentTxnFirstOffset: ${entry.currentTxnFirstOffset} " +
-          s"lastTimestamp: ${entry.lastTimestamp} ")
+        print(entryCaption + s"producerId: ${entry.producerId}" + fieldSep + s"producerEpoch: ${entry.producerEpoch}" +
+          fieldSep + s"coordinatorEpoch: ${entry.coordinatorEpoch}" + fieldSep + s"currentTxnFirstOffset: ${entry.currentTxnFirstOffset}" +
+          fieldSep + s"lastTimestamp: ${entry.lastTimestamp}")
         entry.batchMetadata.asScala.headOption.foreach { metadata =>
-          print(s"firstSequence: ${metadata.firstSeq} lastSequence: ${metadata.lastSeq} " +
-            s"lastOffset: ${metadata.lastOffset} offsetDelta: ${metadata.offsetDelta} timestamp: ${metadata.timestamp}")
+          print(fieldSep + s"firstSequence: ${metadata.firstSeq}" + fieldSep + s"lastSequence: ${metadata.lastSeq}" +
+            fieldSep + s"lastOffset: ${metadata.lastOffset}" + fieldSep + s"offsetDelta: ${metadata.offsetDelta}" + fieldSep + s"timestamp: ${metadata.timestamp}")
         }
         println()
       }
@@ -140,6 +143,8 @@ object DumpLogSegments {
   private[tools] def dumpIndex(file: File,
                                indexSanityOnly: Boolean,
                                verifyOnly: Boolean,
+                               fieldSep: String,
+                               entryCaption: String,
                                misMatchesForIndexFilesMap: mutable.Map[String, List[(Long, Long)]],
                                maxMessageSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
@@ -174,7 +179,7 @@ object DumpLogSegments {
         misMatchesForIndexFilesMap.put(file.getAbsolutePath, misMatchesSeq)
       }
       if (!verifyOnly)
-        println(s"offset: ${entry.offset} position: ${entry.position}")
+        println(entryCaption + s"offset: ${entry.offset}" +fieldSep + s"position: ${entry.position}")
     }
   }
 
@@ -182,6 +187,8 @@ object DumpLogSegments {
   private[tools] def dumpTimeIndex(file: File,
                                    indexSanityOnly: Boolean,
                                    verifyOnly: Boolean,
+                                   fieldSep: String,
+                                   entryCaption: String,
                                    timeIndexDumpErrors: TimeIndexDumpErrors): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     val logFile = new File(file.getAbsoluteFile.getParent, file.getName.split("\\.")(0) + JUnifiedLog.LOG_FILE_SUFFIX)
@@ -228,7 +235,7 @@ object DumpLogSegments {
               timeIndexDumpErrors.recordOutOfOrderIndexTimestamp(file, entry.timestamp, prevTimestamp)
         }
         if (!verifyOnly)
-          println(s"timestamp: ${entry.timestamp} offset: ${entry.offset}")
+          println(entryCaption + s"timestamp: ${entry.timestamp}" + fieldSep + s"offset: ${entry.offset}")
         prevTimestamp = entry.timestamp
       }
     } finally {
@@ -262,6 +269,10 @@ object DumpLogSegments {
   /* print out the contents of the log */
   private def dumpLog(file: File,
                       printContents: Boolean,
+                      fieldSep: String,
+                      entryCaption: String,
+                      recordCaption: String,
+                      printKeyValues: Boolean,
                       nonConsecutivePairsForLogFilesMap: mutable.Map[String, List[(Long, Long)]],
                       isDeepIteration: Boolean,
                       parser: MessageParser[_, _],
@@ -284,7 +295,8 @@ object DumpLogSegments {
       var lastOffset = -1L
 
       for (batch <- fileRecords.batches.asScala) {
-        printBatchLevel(batch, validBytes)
+        print(entryCaption)
+        printBatchLevel(batch, validBytes, fieldSep)
         if (isDeepIteration) {
           for (record <- batch.asScala) {
             if (lastOffset == -1)
@@ -296,17 +308,28 @@ object DumpLogSegments {
             }
             lastOffset = record.offset
 
-            var prefix = s"$RecordIndent "
+            var prefix = recordCaption
             if (!skipRecordMetadata) {
-              print(s"${prefix}offset: ${record.offset} ${batch.timestampType}: ${record.timestamp} " +
-                s"keySize: ${record.keySize} valueSize: ${record.valueSize}")
-              prefix = " "
+              print(s"${prefix}offset: ${record.offset}" + fieldSep + s"${batch.timestampType}: ${record.timestamp}" +
+                fieldSep + s"keySize: ${record.keySize}" + fieldSep + s"valueSize: ${record.valueSize}")
+              prefix = fieldSep
 
               if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
-                print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))
+                print(fieldSep + "sequence: " + record.sequence)
+                if(printKeyValues) {
+                  print(fieldSep + "numHeaders: "+record.headers.length)
+                  for(h <- record.headers) {
+                    val k = h.key
+                    val v = h.value.map(_.toChar).mkString
+                    print(fieldSep + "headerKey("+k.length+"): " + k)
+                    print(fieldSep + "headerVal("+v.length+"): " + v)
+                  }
+                } else {
+                  print(fieldSep + "headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))
+                }
               }
               record match {
-                case r: AbstractLegacyRecordBatch => print(s" isValid: ${r.isValid} crc: ${r.checksum}}")
+                case r: AbstractLegacyRecordBatch => print(fieldSep + s"isValid: ${r.isValid}" + fieldSep + s"crc: ${r.checksum}}")
                 case _ =>
               }
 
@@ -315,21 +338,21 @@ object DumpLogSegments {
                 ControlRecordType.fromTypeId(controlTypeId) match {
                   case ControlRecordType.ABORT | ControlRecordType.COMMIT =>
                     val endTxnMarker = EndTransactionMarker.deserialize(record)
-                    print(s" endTxnMarker: ${endTxnMarker.controlType} coordinatorEpoch: ${endTxnMarker.coordinatorEpoch}")
+                    print(fieldSep + s"endTxnMarker: ${endTxnMarker.controlType}" + fieldSep + s"coordinatorEpoch: ${endTxnMarker.coordinatorEpoch}")
                   case ControlRecordType.SNAPSHOT_HEADER =>
                     val header = ControlRecordUtils.deserializeSnapshotHeaderRecord(record)
-                    print(s" SnapshotHeader ${SnapshotHeaderRecordJsonConverter.write(header, header.version())}")
+                    print(fieldSep + s"SnapshotHeader ${SnapshotHeaderRecordJsonConverter.write(header, header.version())}")
                   case ControlRecordType.SNAPSHOT_FOOTER =>
                     val footer = ControlRecordUtils.deserializeSnapshotFooterRecord(record)
-                    print(s" SnapshotFooter ${SnapshotFooterRecordJsonConverter.write(footer, footer.version())}")
+                    print(fieldSep + s"SnapshotFooter ${SnapshotFooterRecordJsonConverter.write(footer, footer.version())}")
                   case ControlRecordType.KRAFT_VERSION =>
                     val kraftVersion = ControlRecordUtils.deserializeKRaftVersionRecord(record)
-                    print(s" KRaftVersion ${KRaftVersionRecordJsonConverter.write(kraftVersion, kraftVersion.version())}")
+                    print(fieldSep + s"KRaftVersion ${KRaftVersionRecordJsonConverter.write(kraftVersion, kraftVersion.version())}")
                   case ControlRecordType.KRAFT_VOTERS=>
                     val voters = ControlRecordUtils.deserializeVotersRecord(record)
-                    print(s" KRaftVoters ${VotersRecordJsonConverter.write(voters, voters.version())}")
+                    print(fieldSep + s"KRaftVoters ${VotersRecordJsonConverter.write(voters, voters.version())}")
                   case controlType =>
-                    print(s" controlType: $controlType($controlTypeId)")
+                    print(fieldSep + s"controlType: $controlType($controlTypeId)")
                 }
               }
             }
@@ -337,13 +360,13 @@ object DumpLogSegments {
               val (key, payload) = parser.parse(record)
               key.foreach { key =>
                 print(s"${prefix}key: $key")
-                prefix = " "
+                prefix = fieldSep
               }
-              payload.foreach(payload => print(s" payload: $payload"))
+              payload.foreach(payload => print(fieldSep + s"payload: $payload"))
             }
-            println()
           }
         }
+        println()
         validBytes += batch.sizeInBytes
       }
       val trailingBytes = fileRecords.sizeInBytes - validBytes
@@ -352,19 +375,19 @@ object DumpLogSegments {
     } finally fileRecords.closeHandlers()
   }
 
-  private def printBatchLevel(batch: FileLogInputStream.FileChannelRecordBatch, accumulativeBytes: Long): Unit = {
+  private def printBatchLevel(batch: FileLogInputStream.FileChannelRecordBatch, accumulativeBytes: Long, fieldSep: String): Unit = {
     if (batch.magic >= RecordBatch.MAGIC_VALUE_V2)
-      print("baseOffset: " + batch.baseOffset + " lastOffset: " + batch.lastOffset + " count: " + batch.countOrNull +
-        " baseSequence: " + batch.baseSequence + " lastSequence: " + batch.lastSequence +
-        " producerId: " + batch.producerId + " producerEpoch: " + batch.producerEpoch +
-        " partitionLeaderEpoch: " + batch.partitionLeaderEpoch + " isTransactional: " + batch.isTransactional +
-        " isControl: " + batch.isControlBatch + " deleteHorizonMs: " + batch.deleteHorizonMs)
+      print("baseOffset: " + batch.baseOffset + fieldSep + "lastOffset: " + batch.lastOffset + fieldSep + "count: " + batch.countOrNull +
+        fieldSep + "baseSequence: " + batch.baseSequence + fieldSep + "lastSequence: " + batch.lastSequence +
+        fieldSep + "producerId: " + batch.producerId + fieldSep + "producerEpoch: " + batch.producerEpoch +
+        fieldSep + "partitionLeaderEpoch: " + batch.partitionLeaderEpoch + fieldSep + "isTransactional: " + batch.isTransactional +
+        fieldSep + "isControl: " + batch.isControlBatch + fieldSep + "deleteHorizonMs: " + batch.deleteHorizonMs)
     else
       print("offset: " + batch.lastOffset)
 
-    println(" position: " + accumulativeBytes + " " + batch.timestampType + ": " + batch.maxTimestamp +
-      " size: " + batch.sizeInBytes + " magic: " + batch.magic +
-      " compresscodec: " + batch.compressionType.name + " crc: " + batch.checksum + " isvalid: " + batch.isValid)
+    print(fieldSep + "position: " + accumulativeBytes + fieldSep + batch.timestampType + ": " + batch.maxTimestamp +
+      fieldSep + "size: " + batch.sizeInBytes + fieldSep + "magic: " + batch.magic +
+      fieldSep + "compresscodec: " + batch.compressionType.name + fieldSep + "crc: " + batch.checksum + fieldSep + "isvalid: " + batch.isValid)
   }
 
   class TimeIndexDumpErrors {
@@ -596,6 +619,19 @@ object DumpLogSegments {
 
   private class DumpLogSegmentsOptions(args: Array[String]) extends CommandDefaultOptions(args) {
     private val printOpt = parser.accepts("print-data-log", "If set, printing the messages content when dumping data logs. Automatically set if any decoder option is specified.")
+    private val printKeyValuesOpt = parser.accepts("print-key-values", "If set, message header values are printed along with the keys.")
+    private val fieldSepOpt = parser.accepts("field-sep", "String to print between fields when dumping data logs.")
+      .withOptionalArg()
+      .ofType(classOf[java.lang.String])
+      .defaultsTo(DumpLogSegments.DefaultFieldSep)
+    private val entryCaptionOpt = parser.accepts("entry-caption", "String to print before each outputted entry when dumping data logs.")
+      .withOptionalArg()
+      .ofType(classOf[java.lang.String])
+      .defaultsTo(DumpLogSegments.DefaultEntryCaption)
+    private val recordCaptionOpt = parser.accepts("record-caption", "String to print before each record when dumping data logs.")
+      .withOptionalArg()
+      .ofType(classOf[java.lang.String])
+      .defaultsTo(DumpLogSegments.DefaultRecordCaption)
     private val verifyOpt = parser.accepts("verify-index-only", "If set, just verify the index log without printing its content.")
     private val indexSanityOpt = parser.accepts("index-sanity-check", "If set, just checks the index sanity without printing its content. " +
       "This is the same check that is executed on broker startup to determine if an index needs rebuilding or not.")
@@ -660,6 +696,10 @@ object DumpLogSegments {
       options.has(keyDecoderOpt) ||
       options.has(shareStateOpt)
 
+    lazy val printKeyValues: Boolean = options.has(printKeyValuesOpt)
+    lazy val fieldSep: String = StringContext.treatEscapes(options.valueOf(fieldSepOpt))
+    lazy val entryCaption: String = StringContext.treatEscapes(options.valueOf(entryCaptionOpt))
+    lazy val recordCaption: String = StringContext.treatEscapes(options.valueOf(recordCaptionOpt))
     lazy val skipRecordMetadata: Boolean = options.has(skipRecordMetadataOpt)
     lazy val isDeepIteration: Boolean = options.has(deepIterationOpt) || shouldPrintDataLog
     lazy val verifyOnly: Boolean = options.has(verifyOpt)

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -239,7 +239,8 @@ class DumpLogSegmentsTest {
     addSimpleRecords(log, batches)
     
     val offsetMismatches = mutable.Map[String, List[(Long, Long)]]()
-    DumpLogSegments.dumpIndex(new File(indexFilePath), indexSanityOnly = false, verifyOnly = true, offsetMismatches,
+    DumpLogSegments.dumpIndex(new File(indexFilePath), indexSanityOnly = false, verifyOnly = true,
+      DumpLogSegments.DefaultFieldSep, DumpLogSegments.DefaultEntryCaption, offsetMismatches,
       Int.MaxValue)
     assertEquals(Map.empty, offsetMismatches)
   }
@@ -251,7 +252,7 @@ class DumpLogSegmentsTest {
     addSimpleRecords(log, batches)
     
     val errors = new TimeIndexDumpErrors
-    DumpLogSegments.dumpTimeIndex(new File(timeIndexFilePath), indexSanityOnly = false, verifyOnly = true, errors)
+    DumpLogSegments.dumpTimeIndex(new File(timeIndexFilePath), indexSanityOnly = false, verifyOnly = true, DumpLogSegments.DefaultFieldSep, DumpLogSegments.DefaultEntryCaption, errors)
     assertEquals(Map.empty, errors.misMatchesForTimeIndexFilesMap)
     assertEquals(Map.empty, errors.outOfOrderTimestamp)
     assertEquals(Map.empty, errors.shallowOffsetNotFound)
@@ -603,6 +604,7 @@ class DumpLogSegmentsTest {
     val outContent = new ByteArrayOutputStream()
     Console.withOut(outContent) {
       DumpLogSegments.dumpIndex(indexFile, indexSanityOnly = false, verifyOnly = true,
+        DumpLogSegments.DefaultFieldSep, DumpLogSegments.DefaultEntryCaption,
         misMatchesForIndexFilesMap = mutable.Map[String, List[(Long, Long)]](), Int.MaxValue)
     }
     assertEquals(expectOutput, outContent.toString)


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

Currently the output of the `DumpLogSegments` tool is quite tricky to parse, making it difficult to use as part of disaster-recovery tooling. Here is an example output to demonstrate some of the issues:
```
Dumping 2.log
Log starting offset: 2
baseOffset: 0 lastOffset: 0 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: false deleteHorizonMs: OptionalLong.empty position: 0 CreateTime: 1739569505569 size: 131 magic: 2 compresscodec: none crc: 90285099 isvalid: true
| offset: 0 CreateTime: 1739569505569 keySize: -1 valueSize: 14 sequence: -1 headerKeys: [myheader,myotherheader,mythird:header] payload: This is a test
baseOffset: 1 lastOffset: 1 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: false deleteHorizonMs: OptionalLong.empty position: 131 CreateTime: 1739569599085 size: 149 magic: 2 compresscodec: none crc: 3989822952 isvalid: true
| offset: 1 CreateTime: 1739569599085 keySize: -1 valueSize: 14 sequence: -1 headerKeys: [myheader,myotherheader,mythird:header,fourth,header] payload: This is a test
```
Note that the actual stored header key/values look like this:
`myheader` -> `yes`
`myotherheader` -> `no`
`mythird:header` -> `ok`
`fourth,header` -> `wow`

Key issues:
1. The printed fields are _space_-separated, meaning a context-sensitive parser needs to be used (normally I would just split on a comma or newline to parse such fields).
2. Header keys that contain commas cause ambiguity in the output (e.g., in the above printout, it looks like there are 5 keys rather than 4.
3. Values for the header keys are not shown in the output.
4. There is not a clear designation of where one outputted record ends and another begins. In the above case, `baseOffset` marks the beginning of a new record, but when dumping indexes etc., different field names would need to be matched.

I have added four command-line options to address these issues:
```
/opt/kafka/bin/kafka-run-class.sh kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files 2.log --field-sep "; " --entry-caption "ENTRY\n" --record-caption "\nRECORD\n" --print-key-values
```
This gives the following output for the above example:
```
Dumping 2.log
Log starting offset: 2
ENTRY
baseOffset: 0; lastOffset: 0; count: 1; baseSequence: -1; lastSequence: -1; producerId: -1; producerEpoch: -1; partitionLeaderEpoch: 0; isTransactional: false; isControl: false; deleteHorizonMs: OptionalLong.empty; position: 0; CreateTime: 1739569505569; size: 131; magic: 2; compresscodec: none; crc: 90285099; isvalid: true
RECORD
offset: 0; CreateTime: 1739569505569; keySize: -1; valueSize: 14; sequence: -1; numHeaders: 3; headerKey(8): myheader; headerVal(3): yes; headerKey(13): myotherheader; headerVal(2): no; headerKey(14): mythird:header; headerVal(2): ok; payload: This is a test
ENTRY
baseOffset: 1; lastOffset: 1; count: 1; baseSequence: -1; lastSequence: -1; producerId: -1; producerEpoch: -1; partitionLeaderEpoch: 0; isTransactional: false; isControl: false; deleteHorizonMs: OptionalLong.empty; position: 131; CreateTime: 1739569599085; size: 149; magic: 2; compresscodec: none; crc: 3989822952; isvalid: true
RECORD
offset: 1; CreateTime: 1739569599085; keySize: -1; valueSize: 14; sequence: -1; numHeaders: 4; headerKey(8): myheader; headerVal(3): yes; headerKey(13): myotherheader; headerVal(2): no; headerKey(14): mythird:header; headerVal(2): ok; headerKey(13): fourth,header; headerVal(3): wow; payload: This is a test
```
Now the fields are semicolon-separated (any string can be used as a separator), and header keys/values are printed along with their lengths, allowing easy parsing.


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

The default values of the new command-line arguments are set to preserve the current functionality, so no existing tests should be affected.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
