### PR TITLE
KAFKA-18798: The replica placement policy used by `ReassignPartitionsCommand` is not aligned with kraft controller 

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -38,7 +38,6 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.metadata.placement.ClusterDescriber;
-import org.apache.kafka.metadata.placement.PartitionAssignment;
 import org.apache.kafka.metadata.placement.PlacementSpec;
 import org.apache.kafka.metadata.placement.ReplicaPlacer;
 import org.apache.kafka.metadata.placement.StripedReplicaPlacer;
@@ -613,8 +612,8 @@ public class ReassignPartitionsCommand {
                         }
                     });
 
-            for (PartitionAssignment partitionAssignment : topicAssignment.assignments()) {
-                proposedAssignments.put(new TopicPartition(topic, partitionNum), partitionAssignment.replicas());
+            for (int i = 0; i < topicAssignment.assignments().size(); i++) {
+                proposedAssignments.put(new TopicPartition(topic, i), topicAssignment.assignments().get(i).replicas());
             }
         });
         return proposedAssignments;

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.tools.reassign;
 
-import org.apache.kafka.admin.AdminUtils;
 import org.apache.kafka.admin.BrokerMetadata;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -26,16 +25,25 @@ import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.PartitionReassignment;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionReplica;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.metadata.placement.ClusterDescriber;
+import org.apache.kafka.metadata.placement.PartitionAssignment;
+import org.apache.kafka.metadata.placement.PlacementSpec;
+import org.apache.kafka.metadata.placement.ReplicaPlacer;
+import org.apache.kafka.metadata.placement.StripedReplicaPlacer;
+import org.apache.kafka.metadata.placement.TopicAssignment;
+import org.apache.kafka.metadata.placement.UsableBroker;
 import org.apache.kafka.server.common.AdminCommandFailedException;
 import org.apache.kafka.server.common.AdminOperationException;
 import org.apache.kafka.server.config.QuotaConfig;
@@ -67,6 +75,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
@@ -74,7 +83,7 @@ import java.util.stream.Collectors;
 
 import joptsimple.OptionSpec;
 
-@SuppressWarnings("ClassDataAbstractionCoupling")
+@SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class ReassignPartitionsCommand {
     private static final String ANY_LOG_DIR = "any";
 
@@ -87,6 +96,8 @@ public class ReassignPartitionsCommand {
     private static final DecodeJson<List<Integer>> INT_LIST = DecodeJson.decodeList(INT);
 
     private static final DecodeJson<List<String>> STRING_LIST = DecodeJson.decodeList(STRING);
+
+    private static final ReplicaPlacer REPLICA_PLACER = new StripedReplicaPlacer(new Random());
 
     /**
      * The earliest version of the partition reassignment JSON.  We will default to this
@@ -582,10 +593,29 @@ public class ReassignPartitionsCommand {
         Map<TopicPartition, List<Integer>> proposedAssignments = new HashMap<>();
         groupedByTopic.forEach((topic, assignment) -> {
             List<Integer> replicas = assignment.get(0).getValue();
-            Map<Integer, List<Integer>> assignedReplicas = AdminUtils.
-                assignReplicasToBrokers(brokerMetadatas, assignment.size(), replicas.size());
-            assignedReplicas.forEach((partition, replicas0) ->
-                proposedAssignments.put(new TopicPartition(topic, partition), replicas0));
+            int partitionNum = assignment.size();
+            // generate topic assignments
+            TopicAssignment topicAssignment = REPLICA_PLACER.place(
+                    new PlacementSpec(0, partitionNum, (short) replicas.size()),
+                    new ClusterDescriber() {
+                        @Override
+                        public Iterator<UsableBroker> usableBrokers() {
+                            return brokerMetadatas.stream().map(brokerMetadata -> new UsableBroker(
+                                    brokerMetadata.id,
+                                    brokerMetadata.rack,
+                                    false
+                            )).iterator();
+                        }
+
+                        @Override
+                        public Uuid defaultDir(int brokerId) {
+                            return DirectoryId.MIGRATING;
+                        }
+                    });
+
+            for (PartitionAssignment partitionAssignment : topicAssignment.assignments()) {
+                proposedAssignments.put(new TopicPartition(topic, partitionNum), partitionAssignment.replicas());
+            }
         });
         return proposedAssignments;
     }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -359,7 +359,7 @@ public class ReassignPartitionsUnitTest {
     public void testGenerateAssignmentFailsWithoutEnoughReplicas() {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(4).build()) {
             addTopics(adminClient);
-            assertStartsWith("Replication factor: 3 larger than available brokers: 2",
+            assertStartsWith("The target replication factor of 3 cannot be reached because only 2 broker(s) are registered",
                 assertThrows(InvalidReplicationFactorException.class,
                     () -> generateAssignment(adminClient, "{\"topics\":[{\"topic\":\"foo\"},{\"topic\":\"bar\"}]}", "0,1", false),
                     "Expected generateAssignment to fail").getMessage());


### PR DESCRIPTION
As title.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
