### PR TITLE
KAFKA-18803: The acls would appear at the wrong level of the metadata shell "tree"

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/AclsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/AclsImage.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.image.node.AclsImageByIdNode;
+import org.apache.kafka.image.node.AclsImageNode;
 import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.authorizer.StandardAcl;
@@ -75,6 +75,6 @@ public final class AclsImage {
 
     @Override
     public String toString() {
-        return new AclsImageByIdNode(this).stringify();
+        return new AclsImageNode(this).stringify();
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/node/MetadataImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/MetadataImageNode.java
@@ -43,7 +43,7 @@ public class MetadataImageNode implements MetadataNode {
         ConfigurationsImageNode.NAME, image -> new ConfigurationsImageNode(image.configs()),
         ClientQuotasImageNode.NAME, image -> new ClientQuotasImageNode(image.clientQuotas()),
         ProducerIdsImageNode.NAME, image -> new ProducerIdsImageNode(image.producerIds()),
-        AclsImageNode.NAME, image -> new AclsImageByIdNode(image.acls()),
+        AclsImageNode.NAME, image -> new AclsImageNode(image.acls()),
         ScramImageNode.NAME, image -> new ScramImageNode(image.scram()),
         DelegationTokenImageNode.NAME, image -> new DelegationTokenImageNode(image.delegationTokens())
     );

--- a/metadata/src/test/java/org/apache/kafka/image/node/MetadataImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/MetadataImageNodeTest.java
@@ -46,9 +46,9 @@ public class MetadataImageNodeTest {
     public void shouldGetAclsImageNode() {
         when(mockMetadataImage.acls()).thenReturn(mockAclsImage);
 
-        MetadataNode aclsNode = metadataImageNode.child("acls");
+        MetadataNode aclsNode = metadataImageNode.child(AclsImageNode.NAME);
 
-        assertNotNull(aclsNode, "aclsNode should not be null");
-        assertEquals(AclsImageNode.class, aclsNode.getClass(), "aclsNode should be AclsImageNode");
+        assertNotNull(aclsNode);
+        assertEquals(AclsImageNode.class, aclsNode.getClass());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/node/MetadataImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/MetadataImageNodeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image.node;
+
+import org.apache.kafka.image.AclsImage;
+import org.apache.kafka.image.MetadataImage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Timeout(value = 40)
+public class MetadataImageNodeTest {
+    private MetadataImageNode metadataImageNode;
+    private MetadataImage mockMetadataImage;
+    private AclsImage mockAclsImage;
+
+    @BeforeEach
+    public void setup() {
+        mockMetadataImage = mock(MetadataImage.class);
+        mockAclsImage = mock(AclsImage.class);
+        metadataImageNode = new MetadataImageNode(mockMetadataImage);
+    }
+
+    @Test
+    public void shouldGetAclsImageNode() {
+        when(mockMetadataImage.acls()).thenReturn(mockAclsImage);
+
+        MetadataNode aclsNode = metadataImageNode.child("acls");
+
+        assertNotNull(aclsNode, "aclsNode should not be null");
+        assertEquals(AclsImageNode.class, aclsNode.getClass(), "aclsNode should be AclsImageNode");
+    }
+}


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/18845#discussion_r1956525411

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
