### PR TITLE
KAFKA-18806: Resource leak in MemoryRecordsBuilder in RecordsUtil

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
@@ -89,10 +89,11 @@ public class RecordsUtil {
                 buffer = Utils.ensureCapacity(buffer, buffer.position() + recordBatchAndRecords.batch.sizeInBytes());
                 recordBatchAndRecords.batch.writeTo(buffer);
             } else {
-                MemoryRecordsBuilder builder = convertRecordBatch(toMagic, buffer, recordBatchAndRecords);
-                buffer = builder.buffer();
-                temporaryMemoryBytes += builder.uncompressedBytesWritten();
-                numRecordsConverted += builder.numRecords();
+                try (MemoryRecordsBuilder builder = convertRecordBatch(toMagic, buffer, recordBatchAndRecords)) {
+                    buffer = builder.buffer();
+                    temporaryMemoryBytes += builder.uncompressedBytesWritten();
+                    numRecordsConverted += builder.numRecords();
+                }
             }
         }
 


### PR DESCRIPTION
Tiny PR with MemoryRecordsBuilder not closed in RecordsUtil.
Closed implicitly with `try`

https://issues.apache.org/jira/browse/KAFKA-18806

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
