### PR TITLE
KAFKA-18809: Set min in sync replicas for __share_group_state.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -235,6 +235,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         properties.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE); // as defined in KIP-932
         properties.put(TopicConfig.COMPRESSION_TYPE_CONFIG, BrokerCompressionType.PRODUCER.name);
         properties.put(TopicConfig.SEGMENT_BYTES_CONFIG, config.shareCoordinatorStateTopicSegmentBytes());
+        properties.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, config.shareCoordinatorStateTopicMinIsr());
         return properties;
     }
 


### PR DESCRIPTION
* The `share.coordinator.state.topic.min.isr` config defined in `ShareCoordinatorConfig` was not being used in the `AutoTopicCreationManager`. 
* The `AutoTopicCreationManager` calls the `ShareCoordinatorService.shareGroupStateTopicConfigs` to configs for the topic to create.
* The method `ShareCoordinatorService.shareGroupStateTopicConfigs` was not setting the supplied config value for `share.coordinator.state.topic.min.isr` to `min.insync.replicas`.
* In this PR, we remedy the situation by setting the value.
* A test has been added to `ShareCoordinatorServiceTest` so that this is not repeated for any configs.