### PR TITLE
KAFKA-18816: Add KIP-877 support to KafkaPrincipalBuilder

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/Plugin.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/Plugin.java
@@ -44,6 +44,12 @@ public class Plugin<T> implements Supplier<T>, AutoCloseable {
         return wrapInstance(instance, metrics, () -> tags(key, instance));
     }
 
+    public static <T> Plugin<T> wrapInstance(T instance, Metrics metrics, String key, Map<String, String> extraTags) {
+        Map<String, String> tags = tags(key, instance);
+        tags.putAll(extraTags);
+        return wrapInstance(instance, metrics, () -> tags);
+    }
+
     private static <T> Map<String, String> tags(String key, T instance) {
         Map<String, String> tags = new LinkedHashMap<>();
         tags.put("config", key);

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
@@ -35,10 +35,11 @@ public interface ChannelBuilder extends AutoCloseable, Configurable {
      * @param  maxReceiveSize max size of a single receive buffer to allocate
      * @param  memoryPool memory pool from which to allocate buffers, or null for none
      * @param  metadataRegistry registry which stores the metadata about the channels
+     * @param  metrics the selector metrics
      * @return KafkaChannel
      */
     KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,
-                              MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry) throws KafkaException;
+                              MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry, Selector.SelectorMetrics metrics) throws KafkaException;
 
     /**
      * Closes ChannelBuilder

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.SslClientAuth;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
@@ -216,9 +217,10 @@ public class ChannelBuilders {
             throw new IllegalArgumentException("`mode` must be non-null if `securityProtocol` is `" + securityProtocol + "`");
     }
 
-    public static KafkaPrincipalBuilder createPrincipalBuilder(Map<String, ?> configs,
-                                                               KerberosShortNamer kerberosShortNamer,
-                                                               SslPrincipalMapper sslPrincipalMapper) {
+    public static Plugin<KafkaPrincipalBuilder> createPrincipalBuilderPlugin(Map<String, ?> configs,
+                                                                             KerberosShortNamer kerberosShortNamer,
+                                                                             SslPrincipalMapper sslPrincipalMapper,
+                                                                             Selector.SelectorMetrics metrics) {
         Class<?> principalBuilderClass = (Class<?>) configs.get(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG);
         final KafkaPrincipalBuilder builder;
 
@@ -234,7 +236,7 @@ public class ChannelBuilders {
         if (builder instanceof Configurable)
             ((Configurable) builder).configure(configs);
 
-        return builder;
+        return Plugin.wrapInstance(builder, metrics.metrics(), BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, metrics.metricTags());
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
@@ -24,7 +25,6 @@ import org.apache.kafka.common.security.auth.KafkaPrincipalSerde;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
 import org.apache.kafka.common.utils.Utils;
 
-import java.io.Closeable;
 import java.net.InetAddress;
 import java.nio.channels.SelectionKey;
 import java.util.Map;
@@ -49,12 +49,12 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
 
     @Override
     public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,
-                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry) throws KafkaException {
+                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry, Selector.SelectorMetrics metrics) throws KafkaException {
         PlaintextTransportLayer transportLayer = null;
         try {
             transportLayer = buildTransportLayer(key);
             final PlaintextTransportLayer finalTransportLayer = transportLayer;
-            Supplier<Authenticator> authenticatorCreator = () -> new PlaintextAuthenticator(configs, finalTransportLayer, listenerName);
+            Supplier<Authenticator> authenticatorCreator = () -> new PlaintextAuthenticator(configs, finalTransportLayer, listenerName, metrics);
             return buildChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
                     memoryPool != null ? memoryPool : MemoryPool.NONE, metadataRegistry);
         } catch (Exception e) {
@@ -80,12 +80,12 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
 
     private static class PlaintextAuthenticator implements Authenticator {
         private final PlaintextTransportLayer transportLayer;
-        private final KafkaPrincipalBuilder principalBuilder;
+        private final Plugin<KafkaPrincipalBuilder> principalBuilderPlugin;
         private final ListenerName listenerName;
 
-        private PlaintextAuthenticator(Map<String, ?> configs, PlaintextTransportLayer transportLayer, ListenerName listenerName) {
+        private PlaintextAuthenticator(Map<String, ?> configs, PlaintextTransportLayer transportLayer, ListenerName listenerName, Selector.SelectorMetrics metrics) {
             this.transportLayer = transportLayer;
-            this.principalBuilder = ChannelBuilders.createPrincipalBuilder(configs, null, null);
+            this.principalBuilderPlugin = ChannelBuilders.createPrincipalBuilderPlugin(configs, null, null, metrics);
             this.listenerName = listenerName;
         }
 
@@ -98,12 +98,12 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
             // listenerName should only be null in Client mode where principal() should not be called
             if (listenerName == null)
                 throw new IllegalStateException("Unexpected call to principal() when listenerName is null");
-            return principalBuilder.build(new PlaintextAuthenticationContext(clientAddress, listenerName.value()));
+            return principalBuilderPlugin.get().build(new PlaintextAuthenticationContext(clientAddress, listenerName.value()));
         }
 
         @Override
         public Optional<KafkaPrincipalSerde> principalSerde() {
-            return principalBuilder instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilder) : Optional.empty();
+            return principalBuilderPlugin.get() instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilderPlugin.get()) : Optional.empty();
         }
 
         @Override
@@ -113,8 +113,7 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
 
         @Override
         public void close() {
-            if (principalBuilder instanceof Closeable)
-                Utils.closeQuietly((Closeable) principalBuilder, "principal builder");
+            Utils.closeQuietly(principalBuilderPlugin, "principal builder plugin");
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -213,7 +213,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
 
     @Override
     public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,
-                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry) throws KafkaException {
+                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry, Selector.SelectorMetrics metrics) throws KafkaException {
         TransportLayer transportLayer = null;
         try {
             SocketChannel socketChannel = (SocketChannel) key.channel();
@@ -228,7 +228,8 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                         finalTransportLayer,
                         Collections.unmodifiableMap(subjects),
                         Collections.unmodifiableMap(connectionsMaxReauthMsByMechanism),
-                        metadataRegistry);
+                        metadataRegistry,
+                        metrics);
             } else {
                 LoginManager loginManager = loginManagers.get(clientSaslMechanism);
                 authenticatorCreator = () -> buildClientAuthenticator(configs,
@@ -278,10 +279,11 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                                                                TransportLayer transportLayer,
                                                                Map<String, Subject> subjects,
                                                                Map<String, Long> connectionsMaxReauthMsByMechanism,
-                                                               ChannelMetadataRegistry metadataRegistry) {
+                                                               ChannelMetadataRegistry metadataRegistry,
+                                                               Selector.SelectorMetrics metrics) {
         return new SaslServerAuthenticator(configs, callbackHandlers, id, subjects,
                 kerberosShortNamer, listenerName, securityProtocol, transportLayer,
-                connectionsMaxReauthMsByMechanism, metadataRegistry, time, apiVersionSupplier);
+                connectionsMaxReauthMsByMechanism, metadataRegistry, time, apiVersionSupplier, metrics);
     }
 
     // Visible to override for testing

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -338,7 +338,7 @@ public class Selector implements Selectable, AutoCloseable {
         ChannelMetadataRegistry metadataRegistry = null;
         try {
             metadataRegistry = new SelectorChannelMetadataRegistry();
-            KafkaChannel channel = channelBuilder.buildChannel(id, key, maxReceiveSize, memoryPool, metadataRegistry);
+            KafkaChannel channel = channelBuilder.buildChannel(id, key, maxReceiveSize, memoryPool, metadataRegistry, sensors);
             key.attach(channel);
             return channel;
         } catch (Exception e) {
@@ -1118,7 +1118,8 @@ public class Selector implements Selectable, AutoCloseable {
         }
     }
 
-    class SelectorMetrics implements AutoCloseable {
+    public class SelectorMetrics implements AutoCloseable {
+
         private final Metrics metrics;
         private final Map<String, String> metricTags;
         private final boolean metricsPerConnection;
@@ -1379,6 +1380,14 @@ public class Selector implements Selectable, AutoCloseable {
                 metrics.removeSensor(sensor.name());
             connectionsByCipher.close();
             connectionsByClient.close();
+        }
+
+        public Metrics metrics() {
+            return metrics;
+        }
+
+        public Map<String, String> metricTags() {
+            return metricTags;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.network;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
@@ -29,7 +30,6 @@ import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.channels.SelectionKey;
@@ -97,13 +97,13 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
 
     @Override
     public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,
-                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry) throws KafkaException {
+                                     MemoryPool memoryPool, ChannelMetadataRegistry metadataRegistry, Selector.SelectorMetrics metrics) throws KafkaException {
         SslTransportLayer transportLayer = null;
         try {
             transportLayer = buildTransportLayer(sslFactory, id, key, metadataRegistry);
             final SslTransportLayer finalTransportLayer = transportLayer;
             Supplier<Authenticator> authenticatorCreator = () ->
-                new SslAuthenticator(configs, finalTransportLayer, listenerName, sslPrincipalMapper);
+                new SslAuthenticator(configs, finalTransportLayer, listenerName, sslPrincipalMapper, metrics);
             return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
                     memoryPool != null ? memoryPool : MemoryPool.NONE, metadataRegistry);
         } catch (Exception e) {
@@ -131,12 +131,12 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
      */
     private static class SslAuthenticator implements Authenticator {
         private final SslTransportLayer transportLayer;
-        private final KafkaPrincipalBuilder principalBuilder;
+        private final Plugin<KafkaPrincipalBuilder> principalBuilderPlugin;
         private final ListenerName listenerName;
 
-        private SslAuthenticator(Map<String, ?> configs, SslTransportLayer transportLayer, ListenerName listenerName, SslPrincipalMapper sslPrincipalMapper) {
+        private SslAuthenticator(Map<String, ?> configs, SslTransportLayer transportLayer, ListenerName listenerName, SslPrincipalMapper sslPrincipalMapper, Selector.SelectorMetrics metrics) {
             this.transportLayer = transportLayer;
-            this.principalBuilder = ChannelBuilders.createPrincipalBuilder(configs, null, sslPrincipalMapper);
+            this.principalBuilderPlugin = ChannelBuilders.createPrincipalBuilderPlugin(configs, null, sslPrincipalMapper, metrics);
             this.listenerName = listenerName;
         }
         /**
@@ -159,18 +159,17 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
                     transportLayer.sslSession(),
                     clientAddress,
                     listenerName.value());
-            return principalBuilder.build(context);
+            return principalBuilderPlugin.get().build(context);
         }
 
         @Override
         public Optional<KafkaPrincipalSerde> principalSerde() {
-            return principalBuilder instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilder) : Optional.empty();
+            return principalBuilderPlugin.get() instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilderPlugin.get()) : Optional.empty();
         }
 
         @Override
         public void close() {
-            if (principalBuilder instanceof Closeable)
-                Utils.closeQuietly((Closeable) principalBuilder, "principal builder");
+            Utils.closeQuietly(principalBuilderPlugin, "principal builder plugin");
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipalBuilder.java
@@ -20,13 +20,22 @@ package org.apache.kafka.common.security.auth;
  * Pluggable principal builder interface which supports both SSL authentication through
  * {@link SslAuthenticationContext} and SASL through {@link SaslAuthenticationContext}.
  *
- * Note that the {@link org.apache.kafka.common.Configurable} and {@link java.io.Closeable}
+ * <p>Note that the {@link org.apache.kafka.common.Configurable} and {@link java.io.Closeable}
  * interfaces are respected if implemented. Additionally, implementations must provide a
  * default no-arg constructor.
  *
- * Note that custom implementations of {@link KafkaPrincipalBuilder}
+ * <p>Note that custom implementations of {@link KafkaPrincipalBuilder}
  * must also implement {@link KafkaPrincipalSerde}, otherwise brokers will not be able to
  * forward requests to the controller.
+ *
+ * <p>Implement {@link org.apache.kafka.common.metrics.Monitorable} to enable the principal builder to register metrics.
+ * The following tags are automatically added to all metrics registered:
+ * <ul>
+ *     <li><code>config</code> set to <code>principal.builder.class</code>
+ *     <li><code>class</code> set to the KafkaPrincipalBuilder class name
+ *     <li><code>listener</code> set to the listener name
+ *     <li><code>networkProcessor</code> set to the processor id
+ * </ul>
  */
 public interface KafkaPrincipalBuilder {
     /**

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.internals.SecurityManagerCompatibility;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
@@ -37,6 +38,7 @@ import org.apache.kafka.common.network.InvalidReceiveException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.ReauthenticationContext;
+import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.network.SslTransportLayer;
 import org.apache.kafka.common.network.TransportLayer;
@@ -69,7 +71,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -123,7 +124,7 @@ public class SaslServerAuthenticator implements Authenticator {
     private final TransportLayer transportLayer;
     private final List<String> enabledMechanisms;
     private final Map<String, ?> configs;
-    private final KafkaPrincipalBuilder principalBuilder;
+    private final Plugin<KafkaPrincipalBuilder> principalBuilderPlugin;
     private final Map<String, AuthenticateCallbackHandler> callbackHandlers;
     private final Map<String, Long> connectionsMaxReauthMsByMechanism;
     private final Time time;
@@ -159,7 +160,8 @@ public class SaslServerAuthenticator implements Authenticator {
                                    Map<String, Long> connectionsMaxReauthMsByMechanism,
                                    ChannelMetadataRegistry metadataRegistry,
                                    Time time,
-                                   Function<Short, ApiVersionsResponse> apiVersionSupplier) {
+                                   Function<Short, ApiVersionsResponse> apiVersionSupplier,
+                                   Selector.SelectorMetrics metrics) {
         this.callbackHandlers = callbackHandlers;
         this.connectionId = connectionId;
         this.subjects = subjects;
@@ -190,7 +192,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
         // Note that the old principal builder does not support SASL, so we do not need to pass the
         // authenticator or the transport layer
-        this.principalBuilder = ChannelBuilders.createPrincipalBuilder(configs, kerberosNameParser, null);
+        this.principalBuilderPlugin = ChannelBuilders.createPrincipalBuilderPlugin(configs, kerberosNameParser, null, metrics);
 
         saslAuthRequestMaxReceiveSize = (Integer) configs.get(BrokerSecurityConfigs.SASL_SERVER_MAX_RECEIVE_SIZE_CONFIG);
         if (saslAuthRequestMaxReceiveSize == null)
@@ -309,7 +311,7 @@ public class SaslServerAuthenticator implements Authenticator {
                 Optional.of(((SslTransportLayer) transportLayer).sslSession()) : Optional.empty();
         SaslAuthenticationContext context = new SaslAuthenticationContext(saslServer, securityProtocol,
                 clientAddress(), listenerName.value(), sslSession);
-        KafkaPrincipal principal = principalBuilder.build(context);
+        KafkaPrincipal principal = principalBuilderPlugin.get().build(context);
         if (ScramMechanism.isScram(saslMechanism) && Boolean.parseBoolean((String) saslServer.getNegotiatedProperty(ScramLoginModule.TOKEN_AUTH_CONFIG))) {
             principal.tokenAuthenticated(true);
         }
@@ -318,7 +320,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
     @Override
     public Optional<KafkaPrincipalSerde> principalSerde() {
-        return principalBuilder instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilder) : Optional.empty();
+        return principalBuilderPlugin.get() instanceof KafkaPrincipalSerde ? Optional.of((KafkaPrincipalSerde) principalBuilderPlugin.get()) : Optional.empty();
     }
 
     @Override
@@ -333,8 +335,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
     @Override
     public void close() throws IOException {
-        if (principalBuilder instanceof Closeable)
-            Utils.closeQuietly((Closeable) principalBuilder, "principal builder");
+        Utils.closeQuietly(principalBuilderPlugin, "principal builder plugin");
         if (saslServer != null)
             saslServer.dispose();
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
@@ -18,6 +18,10 @@ package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.internals.Plugin;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Monitorable;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.auth.AuthenticationContext;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -25,7 +29,6 @@ import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -34,16 +37,42 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ChannelBuildersTest {
 
     @Test
-    public void testCreateConfigurableKafkaPrincipalBuilder() {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, ConfigurableKafkaPrincipalBuilder.class);
-        KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null);
-        assertInstanceOf(ConfigurableKafkaPrincipalBuilder.class, builder);
-        assertTrue(((ConfigurableKafkaPrincipalBuilder) builder).configured);
+    public void testCreateConfigurableKafkaPrincipalBuilder() throws Exception {
+        Map<String, Object> configs = Map.of(
+                BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, ConfigurableKafkaPrincipalBuilder.class);
+        Selector.SelectorMetrics selectorMetrics = mock(Selector.SelectorMetrics.class);
+        when(selectorMetrics.metrics()).thenReturn(null);
+        when(selectorMetrics.metricTags()).thenReturn(Map.of("k1", "v1"));
+        try (Plugin<KafkaPrincipalBuilder> builderPlugin =
+                     ChannelBuilders.createPrincipalBuilderPlugin(configs, null, null, selectorMetrics)) {
+            assertInstanceOf(ConfigurableKafkaPrincipalBuilder.class, builderPlugin.get());
+            assertTrue(((ConfigurableKafkaPrincipalBuilder) builderPlugin.get()).configured);
+        }
+    }
+
+    @Test
+    public void testCreateMonitorableKafkaPrincipalBuilder() throws Exception {
+        Map<String, Object> configs = Map.of(
+            BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, MonitorableKafkaPrincipalBuilder.class);
+        Metrics metrics = new Metrics();
+        Selector.SelectorMetrics selectorMetrics = mock(Selector.SelectorMetrics.class);
+        when(selectorMetrics.metrics()).thenReturn(metrics);
+        when(selectorMetrics.metricTags()).thenReturn(Map.of("k1", "v1"));
+        try (Plugin<KafkaPrincipalBuilder> builderPlugin =
+                     ChannelBuilders.createPrincipalBuilderPlugin(configs, null, null, selectorMetrics)) {
+            assertInstanceOf(MonitorableKafkaPrincipalBuilder.class, builderPlugin.get());
+            assertTrue(((MonitorableKafkaPrincipalBuilder) builderPlugin.get()).pluginMetrics);
+            verify(selectorMetrics, times(1)).metrics();
+            verify(selectorMetrics, times(1)).metricTags();
+        }
     }
 
     @Test
@@ -62,10 +91,10 @@ public class ChannelBuildersTest {
         assertNull(configs.get("listener.name.listener1.gssapi.sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("listener.name.listener1.gssapi.sasl.kerberos.service.name"));
 
-        assertEquals(configs.get("gssapi.sasl.kerberos.service.name"), "testkafka");
+        assertEquals("testkafka", configs.get("gssapi.sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("gssapi.sasl.kerberos.service.name"));
 
-        assertEquals(configs.get("sasl.kerberos.service.name"), "testkafkaglobal");
+        assertEquals("testkafkaglobal", configs.get("sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("sasl.kerberos.service.name"));
 
         assertNull(configs.get("listener.name.listener1.sasl.kerberos.service.name"));
@@ -74,35 +103,35 @@ public class ChannelBuildersTest {
         assertNull(configs.get("plain.sasl.server.callback.handler.class"));
         assertFalse(securityConfig.unused().contains("plain.sasl.server.callback.handler.class"));
 
-        assertEquals(configs.get("listener.name.listener1.gssapi.config1.key"), "custom.config1");
+        assertEquals("custom.config1", configs.get("listener.name.listener1.gssapi.config1.key"));
         assertFalse(securityConfig.unused().contains("listener.name.listener1.gssapi.config1.key"));
 
-        assertEquals(configs.get("custom.config2.key"), "custom.config2");
+        assertEquals("custom.config2", configs.get("custom.config2.key"));
         assertFalse(securityConfig.unused().contains("custom.config2.key"));
 
         // test configs without listener prefix
         securityConfig = new TestSecurityConfig(props);
         configs = ChannelBuilders.channelBuilderConfigs(securityConfig, null);
 
-        assertEquals(configs.get("listener.name.listener1.gssapi.sasl.kerberos.service.name"), "testkafka");
+        assertEquals("testkafka", configs.get("listener.name.listener1.gssapi.sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("listener.name.listener1.gssapi.sasl.kerberos.service.name"));
 
         assertNull(configs.get("gssapi.sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("gssapi.sasl.kerberos.service.name"));
 
-        assertEquals(configs.get("listener.name.listener1.sasl.kerberos.service.name"), "testkafkaglobal");
+        assertEquals("testkafkaglobal", configs.get("listener.name.listener1.sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("listener.name.listener1.sasl.kerberos.service.name"));
 
         assertNull(configs.get("sasl.kerberos.service.name"));
         assertFalse(securityConfig.unused().contains("sasl.kerberos.service.name"));
 
-        assertEquals(configs.get("plain.sasl.server.callback.handler.class"), "callback");
+        assertEquals("callback", configs.get("plain.sasl.server.callback.handler.class"));
         assertFalse(securityConfig.unused().contains("plain.sasl.server.callback.handler.class"));
 
-        assertEquals(configs.get("listener.name.listener1.gssapi.config1.key"), "custom.config1");
+        assertEquals("custom.config1", configs.get("listener.name.listener1.gssapi.config1.key"));
         assertFalse(securityConfig.unused().contains("listener.name.listener1.gssapi.config1.key"));
 
-        assertEquals(configs.get("custom.config2.key"), "custom.config2");
+        assertEquals("custom.config2", configs.get("custom.config2.key"));
         assertFalse(securityConfig.unused().contains("custom.config2.key"));
     }
 
@@ -117,6 +146,20 @@ public class ChannelBuildersTest {
         @Override
         public KafkaPrincipal build(AuthenticationContext context) {
             return null;
+        }
+    }
+
+    public static class MonitorableKafkaPrincipalBuilder implements KafkaPrincipalBuilder, Monitorable {
+        private boolean pluginMetrics = false;
+
+        @Override
+        public KafkaPrincipal build(AuthenticationContext context) {
+            return null;
+        }
+
+        @Override
+        public void withPluginMetrics(PluginMetrics metrics) {
+            pluginMetrics = true;
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -433,7 +433,7 @@ public class SelectorTest {
         final ChannelBuilder channelBuilder = mock(ChannelBuilder.class);
 
         when(channelBuilder.buildChannel(eq(channelId), any(SelectionKey.class), anyInt(), any(MemoryPool.class),
-                any(ChannelMetadataRegistry.class))).thenThrow(new RuntimeException("Test exception"));
+                any(ChannelMetadataRegistry.class), any(Selector.SelectorMetrics.class))).thenThrow(new RuntimeException("Test exception"));
 
         try (MockedConstruction<Selector.SelectorChannelMetadataRegistry> mockedMetadataRegistry =
                      mockConstruction(Selector.SelectorChannelMetadataRegistry.class)) {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -2007,9 +2007,10 @@ public class SaslAuthenticatorTest {
                                                                        TransportLayer transportLayer,
                                                                        Map<String, Subject> subjects,
                                                                        Map<String, Long> connectionsMaxReauthMsByMechanism,
-                                                                       ChannelMetadataRegistry metadataRegistry) {
+                                                                       ChannelMetadataRegistry metadataRegistry,
+                                                                       Selector.SelectorMetrics metrics) {
                 return new SaslServerAuthenticator(configs, callbackHandlers, id, subjects, null, listenerName,
-                    securityProtocol, transportLayer, connectionsMaxReauthMsByMechanism, metadataRegistry, time, apiVersionSupplier) {
+                    securityProtocol, transportLayer, connectionsMaxReauthMsByMechanism, metadataRegistry, time, apiVersionSupplier, metrics) {
                     @Override
                     protected void enableKafkaSaslAuthenticateHeaders(boolean flag) {
                         // Don't enable Kafka SASL_AUTHENTICATE headers

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.security.authenticator;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.SaslAuthenticateRequestData;
@@ -28,6 +29,7 @@ import org.apache.kafka.common.network.ChannelMetadataRegistry;
 import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.DefaultChannelMetadataRegistry;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.AbstractRequest;
@@ -90,6 +92,7 @@ import static org.mockito.Mockito.when;
 public class SaslServerAuthenticatorTest {
 
     private final String clientId = "clientId";
+    private final Selector.SelectorMetrics metrics = mock(Selector.SelectorMetrics.class);
     
     @Test
     public void testOversizeRequest() throws IOException {
@@ -287,12 +290,15 @@ public class SaslServerAuthenticatorTest {
     }
 
     private MockedStatic<?> mockKafkaPrincipal(String principalType, String name) {
+
         KafkaPrincipalBuilder kafkaPrincipalBuilder = mock(KafkaPrincipalBuilder.class);
         when(kafkaPrincipalBuilder.build(any())).thenReturn(new KafkaPrincipal(principalType, name));
+        Plugin<KafkaPrincipalBuilder> kafkaPrincipalBuilderPlugin = mock(Plugin.class);
+        when(kafkaPrincipalBuilderPlugin.get()).thenReturn(kafkaPrincipalBuilder);
         MockedStatic<ChannelBuilders> channelBuilders = Mockito.mockStatic(ChannelBuilders.class, Answers.RETURNS_MOCKS);
         channelBuilders.when(() ->
-                ChannelBuilders.createPrincipalBuilder(anyMap(), any(KerberosShortNamer.class), any(SslPrincipalMapper.class))
-        ).thenReturn(kafkaPrincipalBuilder);
+                ChannelBuilders.createPrincipalBuilderPlugin(anyMap(), any(KerberosShortNamer.class), any(SslPrincipalMapper.class), any(Selector.SelectorMetrics.class))
+        ).thenReturn(kafkaPrincipalBuilderPlugin);
         return channelBuilders;
     }
 
@@ -407,7 +413,7 @@ public class SaslServerAuthenticatorTest {
 
         return new SaslServerAuthenticator(configs, callbackHandlers, "node", subjects, null,
                 new ListenerName("ssl"), SecurityProtocol.SASL_SSL, transportLayer, connectionsMaxReauthMsByMechanism,
-                metadataRegistry, time, version -> apiVersionsResponse);
+                metadataRegistry, time, version -> apiVersionsResponse, metrics);
     }
 
 }


### PR DESCRIPTION
This allows KafkaPrincipalBuilder implementations to implement the Monitorable interface to add custom metrics.
