### PR TITLE
MINOR: Align share group admin authz with consumer group

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3230,7 +3230,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         futures += CompletableFuture.completedFuture(new DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup()
           .setGroupId(groupDescribeOffsets.groupId)
           .setErrorCode(Errors.UNSUPPORTED_VERSION.code))
-      } else if (!authHelper.authorize(request.context, READ, GROUP, groupDescribeOffsets.groupId)) {
+      } else if (!authHelper.authorize(request.context, DESCRIBE, GROUP, groupDescribeOffsets.groupId)) {
         futures += CompletableFuture.completedFuture(new DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup()
           .setGroupId(groupDescribeOffsets.groupId)
           .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code))

--- a/docs/security.html
+++ b/docs/security.html
@@ -2269,7 +2269,8 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
             <td>DESCRIBE_SHARE_GROUP_OFFSETS (90)</td>
             <td>Describe</td>
             <td>Group</td>
-            <td></td>
+            <td>To describe the offset information for a partition in a share group, the application must have privileges on the
+                group and the topic. Group access is checked first, then topic access.</td>
         </tr>
         <tr>
             <td>DESCRIBE_SHARE_GROUP_OFFSETS (90)</td>
@@ -2281,7 +2282,8 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
             <td>ALTER_SHARE_GROUP_OFFSETS (91)</td>
             <td>Read</td>
             <td>Group</td>
-            <td></td>
+            <td>To alter the offset information for a partition in a share group, the application must have privileges on the
+                group and the topic. Group access is checked first, then topic access.</td>
         </tr>
         <tr>
             <td>ALTER_SHARE_GROUP_OFFSETS (91)</td>

--- a/docs/security.html
+++ b/docs/security.html
@@ -2267,14 +2267,26 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
         </tr>
         <tr>
             <td>DESCRIBE_SHARE_GROUP_OFFSETS (90)</td>
+            <td>Describe</td>
+            <td>Group</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>DESCRIBE_SHARE_GROUP_OFFSETS (90)</td>
+            <td>Describe</td>
+            <td>Topic</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>ALTER_SHARE_GROUP_OFFSETS (91)</td>
             <td>Read</td>
             <td>Group</td>
             <td></td>
         </tr>
         <tr>
             <td>ALTER_SHARE_GROUP_OFFSETS (91)</td>
-            <td>Alter</td>
-            <td>Group</td>
+            <td>Read</td>
+            <td>Topic</td>
             <td></td>
         </tr>
         </tbody>


### PR DESCRIPTION
As the share group admin operations are being implemented, I have noticed that consumer group operations and share group operations do not have the same authorisation requirements. This is not intentional.

I have updated KIP-932 to match consumer groups.

* `DescribeShareGroupOffsets` RPC - DESCRIBE GROUP and DESCRIBE TOPIC (matches `OffsetFetch`)
* `AlterShareGroupOffsets` RPC - READ GROUP and READ TOPIC (matches `OffsetCommit`)
* `DeleteShareGroupOffsets` RPC - DELETE GROUP and READ TOPIC (matches `OffsetDelete`)

This PR just changes the documentation to match the KIP and tweaks the group check for `DescribeShareGroupOffsets`. All other code changes are in progress or just about to be performed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
