### PR TITLE
MINOR: add docs for "org.apache.kafka.sasl.oauthbearer.allowed.urls" in v3.8

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -291,6 +291,16 @@
   Below are the supported system properties.
   <ul class="config-list">
     <li>
+      <h4><a id="org.apache.kafka.sasl.oauthbearer.allowed.urls"></a><a id="systemproperties_org.apache.kafka.sasl.oauthbearer.allowed.urls" href="#systemproperties_org.apache.kafka.sasl.oauthbearer.allowed.urls">org.apache.kafka.sasl.oauthbearer.allowed.urls</a></h4>
+      <p>This system property is used to set the allowed URLs as SASL OAUTHBEARER token or jwks endpoints. This property accepts comma-separated list of URLs. By default all URLs are allowed.
+      <p>If users want to only enable some URLs, users need to explicitly set the system property like below.
+      <p><pre><code class="language-bash">-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=https://www.example.com,file:///tmp/token</code></pre>
+      <table><tbody>
+      <tr><th>Since:</th><td>3.8.2</td></tr>
+      <tr><th>Default Value:</th><td>All URLs are allowed</td></tr>
+      </tbody></table>
+    </li>
+    <li>
       <h4><a id="org.apache.kafka.disallowed.login.modules"></a><a id="systemproperties_org.apache.kafka.disallowed.login.modules" href="#systemproperties_org.apache.kafka.disallowed.login.modules">org.apache.kafka.disallowed.login.modules</a></h4>
       <p>This system property is used to disable the problematic login modules usage in SASL JAAS configuration. This property accepts comma-separated list of loginModule names. By default <b>com.sun.security.auth.module.JndiLoginModule</b> loginModule is disabled.
       <p>If users want to enable JndiLoginModule, users need to explicitly reset the system property like below. We advise the users to validate configurations and only allow trusted JNDI configurations. For more details <a href="https://kafka.apache.org/cve-list#CVE-2023-25194">CVE-2023-25194</a>.

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -84,6 +84,11 @@
 
     <h5><a id="upgrade_382_notable" href="#upgrade_382_notable">Notable changes in 3.8.2</a></h5>
     <ul>
+        <li>
+            We have added a system property ("org.apache.kafka.sasl.oauthbearer.allowed.urls") to
+            set the allowed URLs as SASL OAUTHBEARER token or jwks endpoints. By default all URLs are allowed.
+            Users should explicitly set the desired allowed list if necessary.
+        </li>
         <li>Request logging for deprecated protocol api versions was changed from <code>DEBUG</code> to <code>INFO</code> level. This makes it possible to enable request
             logging for deprecated requests without enabling it for regular requests (which are still logged at <code>DEBUG</code> level). The relevant logger is
             <code>log4j.logger.kafka.request.logger</code> and it can be adjusted statically via the <code>log4j.properties</code> file or dynamically via <code>kafka-configs.sh</code>.


### PR DESCRIPTION
add docs for "org.apache.kafka.sasl.oauthbearer.allowed.urls" in v3.8.
The v4.0 change PR is here: https://github.com/apache/kafka/pull/18938

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
