### PR TITLE
MINOR: Update LICENSE-binary

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,7 +205,6 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-- audience-annotations-0.12.0
 - caffeine-3.1.1
 - commons-beanutils-1.9.4
 - commons-collections-3.2.2
@@ -222,33 +221,25 @@ License Version 2.0:
 - jackson-datatype-jdk8-2.16.2
 - jackson-jakarta-rs-base-2.16.2
 - jackson-jakarta-rs-json-provider-2.16.2
-- jackson-jaxrs-base-2.16.2
-- jackson-jaxrs-json-provider-2.16.2
 - jackson-module-blackbird-2.16.2
 - jackson-module-jakarta-xmlbind-annotations-2.16.2
-- jackson-module-jaxb-annotations-2.16.2
 - jackson-module-scala_2.13-2.16.2
 - jakarta.inject-api-2.0.1
 - jakarta.validation-api-3.0.2
 - javassist-3.29.2-GA
 - jetty-alpn-client-12.0.15
 - jetty-client-12.0.15
-- jetty-continuation-9.4.56.v20240826
 - jetty-ee10-servlet-12.0.15
 - jetty-ee10-servlets-12.0.15
 - jetty-http-12.0.15
 - jetty-io-12.0.15
 - jetty-security-12.0.15
 - jetty-server-12.0.15
-- jetty-servlet-9.4.56.v20240826
-- jetty-servlets-9.4.56.v20240826
 - jetty-session-12.0.15
 - jetty-util-12.0.15
-- jetty-util-ajax-9.4.56.v20240826
 - jose4j-0.9.4
 - log4j-api-2.24.1
 - log4j-core-2.24.1
-- log4j-core-test-2.24.1
 - log4j-slf4j-impl-2.24.1
 - log4j-1.2-api-2.24.1
 - lz4-java-1.8.0
@@ -287,7 +278,6 @@ see: licenses/eclipse-public-license-2.0
 - hk2-utils-3.0.6
 - osgi-resource-locator-1.0.3
 - aopalliance-repackaged-3.0.6
-- jakarta.inject-2.6.1
 - jersey-client-3.1.9
 - jersey-common-3.1.9
 - jersey-container-servlet-3.1.9
@@ -302,7 +292,6 @@ see: licenses/CDDL+GPL-1.1
 - jakarta.servlet-api-6.0.0
 - javax.activation-api-1.2.0
 - javax.annotation-api-1.3.2
-- javax.servlet-api-3.1.0
 - jaxb-api-2.3.1
 - activation-1.1.1
 
@@ -325,7 +314,6 @@ BSD 2-Clause
 BSD 3-Clause
 
 - jline-3.25.1, see: licenses/jline-BSD-3-clause
-- jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 - paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause


### PR DESCRIPTION
Before the patch:
```
% python3 ./committer-tools/verify_license.py

...

All libs from ./libs are present in the LICENSE file.

The following entries are in the LICENSE file but not present in ./libs. These should be removed from the LICENSE-binary file:
 - audience-annotations-0.12.0
 - jackson-jaxrs-base-2.16.2
 - jackson-jaxrs-json-provider-2.16.2
 - jackson-module-jaxb-annotations-2.16.2
 - jakarta.inject-2.6.1
 - javax.servlet-api-3.1.0
 - jetty-continuation-9.4.56.v20240826
 - jetty-servlet-9.4.56.v20240826
 - jetty-servlets-9.4.56.v20240826
 - jetty-util-ajax-9.4.56.v20240826
 - jsr305-3.0.2
 - log4j-core-test-2.24.1
```

After the patch:
```
% python3 ./committer-tools/verify_license.py

...

All libs from ./libs are present in the LICENSE file.

No extra dependencies in the LICENSE file.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
