### PR TITLE
KAFKA-18826: Add global thread metrics 

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -48,6 +48,11 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.tools.ClientMetricsCommand;
 
@@ -98,6 +103,8 @@ public class KafkaStreamsTelemetryIntegrationTest {
     private String outputTopicTwoPartitions;
     private String inputTopicOnePartition;
     private String outputTopicOnePartition;
+    private String globalStoreTopic;
+    private Uuid globalStoreConsumerInstanceId;
     private Properties streamsApplicationProperties = new Properties();
     private Properties streamsSecondApplicationProperties = new Properties();
 
@@ -125,10 +132,12 @@ public class KafkaStreamsTelemetryIntegrationTest {
         outputTopicTwoPartitions = appId + "-output-two";
         inputTopicOnePartition = appId + "-input-one";
         outputTopicOnePartition = appId + "-output-one";
+        globalStoreTopic = appId + "-global-store";
         cluster.createTopic(inputTopicTwoPartitions, 2, 1);
         cluster.createTopic(outputTopicTwoPartitions, 2, 1);
         cluster.createTopic(inputTopicOnePartition, 1, 1);
         cluster.createTopic(outputTopicOnePartition, 1, 1);
+        cluster.createTopic(globalStoreTopic, 2, 1);
     }
 
     @AfterAll
@@ -148,11 +157,49 @@ public class KafkaStreamsTelemetryIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"INFO", "DEBUG", "TRACE"})
+    public void shouldPushGlobalThreadMetricsToBroker(final String recordingLevel) throws Exception {
+        streamsApplicationProperties = props(true);
+        streamsApplicationProperties.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel);
+        final Topology topology = simpleTopology(true);
+        subscribeForStreamsMetrics();
+        try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+            final ClientInstanceIds clientInstanceIds = streams.clientInstanceIds(Duration.ofSeconds(60));
+            for (Map.Entry<String, Uuid> instanceId : clientInstanceIds.consumerInstanceIds().entrySet()) {
+                final String instanceIdKey = instanceId.getKey();
+                if (instanceIdKey.endsWith("GlobalStreamThread-global-consumer")) {
+                    globalStoreConsumerInstanceId = instanceId.getValue();
+                }
+            }
+
+            assertNotNull(globalStoreConsumerInstanceId);
+            LOG.info("Global consumer instance id {}", globalStoreConsumerInstanceId);
+            TestUtils.waitForCondition(
+                    () -> !TelemetryPlugin.SUBSCRIBED_METRICS.getOrDefault(globalStoreConsumerInstanceId, Collections.emptyList()).isEmpty(),
+                    30_000,
+                    "Never received subscribed metrics"
+            );
+
+            final List<String> expectedGlobalMetrics = streams.metrics().values().stream().map(Metric::metricName)
+                    .filter(metricName -> !metricName.name().contains("oldest") && metricName.tags().containsKey("thread-id") &&
+                            metricName.tags().get("thread-id").endsWith("-GlobalStreamThread")).map(mn -> {
+                        final String name = mn.name().replace('-', '.');
+                        final String group = mn.group().replace("-metrics", "").replace('-', '.');
+                        return "org.apache.kafka." + group + "." + name;
+                    }).filter(name -> !name.equals("org.apache.kafka.stream.thread.state"))// telemetry reporter filters out string metrics
+                    .sorted().toList();
+            final List<String> actualGlobalMetrics = new ArrayList<>(TelemetryPlugin.SUBSCRIBED_METRICS.get(globalStoreConsumerInstanceId));
+            assertEquals(expectedGlobalMetrics, actualGlobalMetrics);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"INFO", "DEBUG", "TRACE"})
     public void shouldPushMetricsToBroker(final String recordingLevel) throws Exception {
         // End-to-end test validating metrics pushed to broker
         streamsApplicationProperties  = props(true);
         streamsApplicationProperties.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel);
-        final Topology topology = simpleTopology();
+        final Topology topology = simpleTopology(false);
         subscribeForStreamsMetrics();
         try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
@@ -215,7 +262,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
     public void shouldPassMetrics(final String topologyType, final boolean stateUpdaterEnabled) throws Exception {
         // Streams metrics should get passed to Admin and Consumer
         streamsApplicationProperties = props(stateUpdaterEnabled);
-        final Topology topology = topologyType.equals("simple") ? simpleTopology() : complexTopology();
+        final Topology topology = topologyType.equals("simple") ? simpleTopology(false) : complexTopology();
        
         try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
@@ -419,8 +466,34 @@ public class KafkaStreamsTelemetryIntegrationTest {
         return builder.build();
     }
 
-    private Topology simpleTopology() {
+    private void addGlobalStore(final StreamsBuilder builder) {
+        builder.addGlobalStore(Stores.keyValueStoreBuilder(
+                Stores.inMemoryKeyValueStore("iq-test-store"),
+                Serdes.String(),
+                Serdes.String()
+        ),
+                globalStoreTopic,
+                Consumed.with(Serdes.String(), Serdes.String()),
+                () -> new Processor<>() {
+                    private KeyValueStore<String, String> store;
+
+                    @Override
+                    public void init(final ProcessorContext<Void, Void> context) {
+                        store = context.getStateStore("iq-test-store");
+                    }
+
+                    @Override
+                    public void process(final Record<String, String> record) {
+                        store.put(record.key(), record.value());
+                    }
+                });
+    }
+
+    private Topology simpleTopology(final boolean includeGlobalStore) {
         final StreamsBuilder builder = new StreamsBuilder();
+        if (includeGlobalStore) {
+            addGlobalStore(builder);
+        }
         builder.stream(inputTopicOnePartition, Consumed.with(Serdes.String(), Serdes.String()))
                 .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
                 .to(outputTopicOnePartition, Produced.with(Serdes.String(), Serdes.String()));
@@ -449,7 +522,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
 
         @Override
         public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
-            return new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+            return new TestingMetricsInterceptingConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
         }
 
         @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -491,7 +491,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
                     @SuppressWarnings("unchecked")
                     @Override
                     public void init(final ProcessorContext<Void, Void> context) {
-                        globalStoreIterator = ((KeyValueStore<String, String>)context.getStateStore("iq-test-store")).all();
+                        globalStoreIterator = ((KeyValueStore<String, String>) context.getStateStore("iq-test-store")).all();
                     }
 
                     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -168,7 +168,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
         streamsApplicationProperties = props(true);
         streamsApplicationProperties.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel);
         IntegrationTestUtils.produceKeyValuesSynchronously(globalStoreTopic,
-                List.of(KeyValue.pair("1", "one"),KeyValue.pair("2", "two"), KeyValue.pair("3","three")),
+                List.of(KeyValue.pair("1", "one"), KeyValue.pair("2", "two"), KeyValue.pair("3", "three")),
                 producerProperties(),
                 cluster.time);
         final Topology topology = simpleTopology(true);
@@ -176,7 +176,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
         try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
             final ClientInstanceIds clientInstanceIds = streams.clientInstanceIds(Duration.ofSeconds(60));
-            for (Map.Entry<String, Uuid> instanceId : clientInstanceIds.consumerInstanceIds().entrySet()) {
+            for (final Map.Entry<String, Uuid> instanceId : clientInstanceIds.consumerInstanceIds().entrySet()) {
                 final String instanceIdKey = instanceId.getKey();
                 if (instanceIdKey.endsWith("GlobalStreamThread-global-consumer")) {
                     globalStoreConsumerInstanceId = instanceId.getValue();
@@ -194,10 +194,10 @@ public class KafkaStreamsTelemetryIntegrationTest {
             final List<String> expectedGlobalMetrics = streams.metrics().values().stream().map(Metric::metricName)
                     .filter(metricName -> metricName.tags().containsKey("thread-id") &&
                             metricName.tags().get("thread-id").endsWith("-GlobalStreamThread")).map(mn -> {
-                        final String name = mn.name().replace('-', '.');
-                        final String group = mn.group().replace("-metrics", "").replace('-', '.');
-                        return "org.apache.kafka." + group + "." + name;
-                    }).filter(name -> !name.equals("org.apache.kafka.stream.thread.state"))// telemetry reporter filters out string metrics
+                                final String name = mn.name().replace('-', '.');
+                                final String group = mn.group().replace("-metrics", "").replace('-', '.');
+                                return "org.apache.kafka." + group + "." + name;
+                            }).filter(name -> !name.equals("org.apache.kafka.stream.thread.state"))// telemetry reporter filters out string metrics
                     .sorted().toList();
             final List<String> actualGlobalMetrics = new ArrayList<>(TelemetryPlugin.SUBSCRIBED_METRICS.get(globalStoreConsumerInstanceId));
             assertEquals(expectedGlobalMetrics, actualGlobalMetrics);
@@ -451,7 +451,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
 
     private Properties producerProperties() {
         final Properties properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());;
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
         return properties;
@@ -505,7 +505,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
                     public void process(final Record<String, String> record) {
                         store.put(record.key(), record.value());
                         globalStoreIterator = store.all();
-                        globalStoreIterator.forEachRemaining(kv -> System.out.printf("key %s value %s%n",kv.key, kv.value));
+                        globalStoreIterator.forEachRemaining(kv -> System.out.printf("key %s value %s%n", kv.key, kv.value));
                     }
                 });
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -471,6 +471,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
         return builder.build();
     }
 
+
     private void addGlobalStore(final StreamsBuilder builder) {
         builder.addGlobalStore(
             Stores.keyValueStoreBuilder(
@@ -481,22 +482,21 @@ public class KafkaStreamsTelemetryIntegrationTest {
                 globalStoreTopic,
                 Consumed.with(Serdes.String(), Serdes.String()),
                 () -> new Processor<>() {
-                    private KeyValueStore<String, String> store;
 
                     // The store iterator is intentionally not closed here as it needs
                     // to be open during the test, so the Streams app will emit the
                     // org.apache.kafka.stream.state.oldest.iterator.open.since.ms metric
                     // that is expected. So the globalStoreIterator is a global variable
                     // (pun not intended), so it can be closed in the tearDown method.
+                    @SuppressWarnings("unchecked")
                     @Override
                     public void init(final ProcessorContext<Void, Void> context) {
-                        store = context.getStateStore("iq-test-store");
-                        globalStoreIterator = store.all();
+                        globalStoreIterator = ((KeyValueStore<String, String>)context.getStateStore("iq-test-store")).all();
                     }
 
                     @Override
                     public void process(final Record<String, String> record) {
-                        store.put(record.key(), record.value());
+                        // no-op
                     }
                 });
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
@@ -41,6 +42,7 @@ import org.apache.kafka.shaded.io.opentelemetry.proto.metrics.v1.MetricsData;
 import org.apache.kafka.streams.ClientInstanceIds;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -51,6 +53,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.TestUtils;
@@ -107,6 +110,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
     private Uuid globalStoreConsumerInstanceId;
     private Properties streamsApplicationProperties = new Properties();
     private Properties streamsSecondApplicationProperties = new Properties();
+    private  KeyValueIterator<String, String> globalStoreIterator;
 
     private static EmbeddedKafkaCluster cluster;
     private static final List<TestingMetricsInterceptingConsumer<byte[], byte[]>> INTERCEPTING_CONSUMERS = new ArrayList<>();
@@ -153,6 +157,9 @@ public class KafkaStreamsTelemetryIntegrationTest {
         if (!streamsSecondApplicationProperties.isEmpty()) {
             IntegrationTestUtils.purgeLocalStreamsState(streamsSecondApplicationProperties);
         }
+        if (globalStoreIterator != null) {
+            globalStoreIterator.close();
+        }
     }
 
     @ParameterizedTest
@@ -160,6 +167,10 @@ public class KafkaStreamsTelemetryIntegrationTest {
     public void shouldPushGlobalThreadMetricsToBroker(final String recordingLevel) throws Exception {
         streamsApplicationProperties = props(true);
         streamsApplicationProperties.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel);
+        IntegrationTestUtils.produceKeyValuesSynchronously(globalStoreTopic,
+                List.of(KeyValue.pair("1", "one"),KeyValue.pair("2", "two"), KeyValue.pair("3","three")),
+                producerProperties(),
+                cluster.time);
         final Topology topology = simpleTopology(true);
         subscribeForStreamsMetrics();
         try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
@@ -181,7 +192,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
             );
 
             final List<String> expectedGlobalMetrics = streams.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> !metricName.name().contains("oldest") && metricName.tags().containsKey("thread-id") &&
+                    .filter(metricName -> metricName.tags().containsKey("thread-id") &&
                             metricName.tags().get("thread-id").endsWith("-GlobalStreamThread")).map(mn -> {
                         final String name = mn.name().replace('-', '.');
                         final String group = mn.group().replace("-metrics", "").replace('-', '.');
@@ -268,15 +279,15 @@ public class KafkaStreamsTelemetryIntegrationTest {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             final List<MetricName> streamsThreadMetrics = streams.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> metricName.tags().containsKey("thread-id")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.tags().containsKey("thread-id")).toList();
 
             final List<MetricName> streamsClientMetrics = streams.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> metricName.group().equals("stream-metrics")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.group().equals("stream-metrics")).toList();
 
 
 
-            final List<MetricName> consumerPassedStreamThreadMetricNames = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT).passedMetrics.stream().map(KafkaMetric::metricName).collect(Collectors.toList());
-            final List<MetricName> adminPassedStreamClientMetricNames = INTERCEPTING_ADMIN_CLIENTS.get(FIRST_INSTANCE_CLIENT).passedMetrics.stream().map(KafkaMetric::metricName).collect(Collectors.toList());
+            final List<MetricName> consumerPassedStreamThreadMetricNames = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT).passedMetrics.stream().map(KafkaMetric::metricName).toList();
+            final List<MetricName> adminPassedStreamClientMetricNames = INTERCEPTING_ADMIN_CLIENTS.get(FIRST_INSTANCE_CLIENT).passedMetrics.stream().map(KafkaMetric::metricName).toList();
 
 
             assertEquals(streamsThreadMetrics.size(), consumerPassedStreamThreadMetricNames.size());
@@ -306,10 +317,10 @@ public class KafkaStreamsTelemetryIntegrationTest {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streamsOne);
 
             final List<MetricName> streamsTaskMetricNames = streamsOne.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.tags().containsKey("task-id")).toList();
 
             final List<MetricName> consumerPassedStreamTaskMetricNames = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT).passedMetrics.stream().map(KafkaMetric::metricName)
-                    .filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.tags().containsKey("task-id")).toList();
 
             /*
              With only one instance, Kafka Streams should register task metrics for all tasks 0_0, 0_1, 1_0, 1_1
@@ -340,24 +351,24 @@ public class KafkaStreamsTelemetryIntegrationTest {
                 );
 
                 final List<MetricName> streamsOneTaskMetrics = streamsOne.metrics().values().stream().map(Metric::metricName)
-                        .filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                        .filter(metricName -> metricName.tags().containsKey("task-id")).toList();
                 final List<MetricName> streamsOneStateMetrics = streamsOne.metrics().values().stream().map(Metric::metricName)
-                        .filter(metricName -> metricName.group().equals("stream-state-metrics")).collect(Collectors.toList());
+                        .filter(metricName -> metricName.group().equals("stream-state-metrics")).toList();
                 
                 final List<MetricName> consumerOnePassedTaskMetrics = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT)
-                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.tags().containsKey("task-id")).toList();
                 final List<MetricName> consumerOnePassedStateMetrics = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT)
-                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.group().equals("stream-state-metrics")).collect(Collectors.toList());
+                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.group().equals("stream-state-metrics")).toList();
 
                 final List<MetricName> streamsTwoTaskMetrics = streamsTwo.metrics().values().stream().map(Metric::metricName)
-                        .filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                        .filter(metricName -> metricName.tags().containsKey("task-id")).toList();
                 final List<MetricName> streamsTwoStateMetrics = streamsTwo.metrics().values().stream().map(Metric::metricName)
-                        .filter(metricName -> metricName.group().equals("stream-state-metrics")).collect(Collectors.toList());
+                        .filter(metricName -> metricName.group().equals("stream-state-metrics")).toList();
                 
                 final List<MetricName> consumerTwoPassedTaskMetrics = INTERCEPTING_CONSUMERS.get(SECOND_INSTANCE_CLIENT)
-                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.tags().containsKey("task-id")).collect(Collectors.toList());
+                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.tags().containsKey("task-id")).toList();
                 final List<MetricName> consumerTwoPassedStateMetrics = INTERCEPTING_CONSUMERS.get(SECOND_INSTANCE_CLIENT)
-                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.group().equals("stream-state-metrics")).collect(Collectors.toList());
+                        .passedMetrics.stream().map(KafkaMetric::metricName).filter(metricName -> metricName.group().equals("stream-state-metrics")).toList();
                 /*
                  Confirm pre-existing KafkaStreams instance one only passes metrics for its tasks and has no metrics for previous tasks
                  */
@@ -397,10 +408,10 @@ public class KafkaStreamsTelemetryIntegrationTest {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             final List<MetricName> streamsThreadMetrics = streams.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> metricName.tags().containsKey("thread-id")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.tags().containsKey("thread-id")).toList();
 
             final List<MetricName> streamsClientMetrics = streams.metrics().values().stream().map(Metric::metricName)
-                    .filter(metricName -> metricName.group().equals("stream-metrics")).collect(Collectors.toList());
+                    .filter(metricName -> metricName.group().equals("stream-metrics")).toList();
 
             final Map<MetricName, ? extends Metric> embeddedConsumerMetrics = INTERCEPTING_CONSUMERS.get(FIRST_INSTANCE_CLIENT).metrics();
             final Map<MetricName, ? extends Metric> embeddedAdminMetrics = INTERCEPTING_ADMIN_CLIENTS.get(FIRST_INSTANCE_CLIENT).metrics();
@@ -436,6 +447,14 @@ public class KafkaStreamsTelemetryIntegrationTest {
     private static Stream<Arguments> multiTaskParameters() {
         return Stream.of(Arguments.of(true),
                 Arguments.of(false));
+    }
+
+    private Properties producerProperties() {
+        final Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());;
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
+        return properties;
     }
 
     private Properties props(final boolean stateUpdaterEnabled) {
@@ -485,6 +504,8 @@ public class KafkaStreamsTelemetryIntegrationTest {
                     @Override
                     public void process(final Record<String, String> record) {
                         store.put(record.key(), record.value());
+                        globalStoreIterator = store.all();
+                        globalStoreIterator.forEachRemaining(kv -> System.out.printf("key %s value %s%n",kv.key, kv.value));
                     }
                 });
     }
@@ -598,7 +619,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
                         .stream()
                         .flatMap(rm -> rm.getScopeMetricsList().stream())
                         .flatMap(sm -> sm.getMetricsList().stream())
-                        .map(metric -> metric.getGauge())
+                        .map(org.apache.kafka.shaded.io.opentelemetry.proto.metrics.v1.Metric::getGauge)
                         .flatMap(gauge -> gauge.getDataPointsList().stream())
                         .flatMap(numberDataPoint -> numberDataPoint.getAttributesList().stream())
                         .filter(keyValue -> keyValue.getKey().equals("process_id"))
@@ -612,7 +633,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
                         .stream()
                         .flatMap(rm -> rm.getScopeMetricsList().stream())
                         .flatMap(sm -> sm.getMetricsList().stream())
-                        .map(metric -> metric.getName())
+                        .map(org.apache.kafka.shaded.io.opentelemetry.proto.metrics.v1.Metric::getName)
                         .sorted()
                         .collect(Collectors.toList());
                 LOG.info("Found metrics {} for clientId={}", metricNames, clientId);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
@@ -42,7 +41,6 @@ import org.apache.kafka.shaded.io.opentelemetry.proto.metrics.v1.MetricsData;
 import org.apache.kafka.streams.ClientInstanceIds;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -167,10 +165,6 @@ public class KafkaStreamsTelemetryIntegrationTest {
     public void shouldPushGlobalThreadMetricsToBroker(final String recordingLevel) throws Exception {
         streamsApplicationProperties = props(true);
         streamsApplicationProperties.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel);
-        IntegrationTestUtils.produceKeyValuesSynchronously(globalStoreTopic,
-                List.of(KeyValue.pair("1", "one"), KeyValue.pair("2", "two"), KeyValue.pair("3", "three")),
-                producerProperties(),
-                cluster.time);
         final Topology topology = simpleTopology(true);
         subscribeForStreamsMetrics();
         try (final KafkaStreams streams = new KafkaStreams(topology, streamsApplicationProperties)) {
@@ -449,14 +443,6 @@ public class KafkaStreamsTelemetryIntegrationTest {
                 Arguments.of(false));
     }
 
-    private Properties producerProperties() {
-        final Properties properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
-        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serdes.String().serializer().getClass());
-        return properties;
-    }
-
     private Properties props(final boolean stateUpdaterEnabled) {
         return props(mkObjectProperties(mkMap(mkEntry(StreamsConfig.InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled))));
     }
@@ -486,7 +472,8 @@ public class KafkaStreamsTelemetryIntegrationTest {
     }
 
     private void addGlobalStore(final StreamsBuilder builder) {
-        builder.addGlobalStore(Stores.keyValueStoreBuilder(
+        builder.addGlobalStore(
+            Stores.keyValueStoreBuilder(
                 Stores.inMemoryKeyValueStore("iq-test-store"),
                 Serdes.String(),
                 Serdes.String()
@@ -496,16 +483,20 @@ public class KafkaStreamsTelemetryIntegrationTest {
                 () -> new Processor<>() {
                     private KeyValueStore<String, String> store;
 
+                    // The store iterator is intentionally not closed here as it needs
+                    // to be open during the test, so the Streams app will emit the
+                    // org.apache.kafka.stream.state.oldest.iterator.open.since.ms metric
+                    // that is expected. So the globalStoreIterator is a global variable
+                    // (pun not intended), so it can be closed in the tearDown method.
                     @Override
                     public void init(final ProcessorContext<Void, Void> context) {
                         store = context.getStateStore("iq-test-store");
+                        globalStoreIterator = store.all();
                     }
 
                     @Override
                     public void process(final Record<String, String> record) {
                         store.put(record.key(), record.value());
-                        globalStoreIterator = store.all();
-                        globalStoreIterator.forEachRemaining(kv -> System.out.printf("key %s value %s%n", kv.key, kv.value));
                     }
                 });
     }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
@@ -35,13 +35,13 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
     private static final String THREAD_ID_TAG = "thread-id";
     private final Consumer<byte[], byte[]> consumer;
     private final String threadId;
-    private final String stateUpdaterThreadId;
+    private final Optional<String> stateUpdaterThreadId;
 
 
     public StreamsThreadMetricsDelegatingReporter(final Consumer<byte[], byte[]> consumer, final String threadId, final Optional<String> stateUpdaterThreadId) {
         this.consumer = Objects.requireNonNull(consumer);
         this.threadId = Objects.requireNonNull(threadId);
-        this.stateUpdaterThreadId = stateUpdaterThreadId.orElse("");
+        this.stateUpdaterThreadId = stateUpdaterThreadId;
         log.debug("Creating MetricsReporter for threadId {} and stateUpdaterId {}", threadId, stateUpdaterThreadId);
     }
 
@@ -60,7 +60,8 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
 
     private boolean tagMatchStreamOrStateUpdaterThreadId(final KafkaMetric metric) {
         final Map<String, String> tags = metric.metricName().tags();
-        final boolean shouldInclude = tags.containsKey(THREAD_ID_TAG) && (tags.get(THREAD_ID_TAG).equals(threadId) || tags.get(THREAD_ID_TAG).equals(stateUpdaterThreadId));
+        final boolean shouldInclude = tags.containsKey(THREAD_ID_TAG) && (tags.get(THREAD_ID_TAG).equals(threadId) ||
+                Optional.of(tags.get(THREAD_ID_TAG)).equals(stateUpdaterThreadId));
         if (!shouldInclude) {
             log.trace("Rejecting metric {}", metric.metricName());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
@@ -61,7 +61,7 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
     private boolean tagMatchStreamOrStateUpdaterThreadId(final KafkaMetric metric) {
         final Map<String, String> tags = metric.metricName().tags();
         final boolean shouldInclude = tags.containsKey(THREAD_ID_TAG) && (tags.get(THREAD_ID_TAG).equals(threadId) ||
-                Optional.of(tags.get(THREAD_ID_TAG)).equals(stateUpdaterThreadId));
+                Optional.ofNullable(tags.get(THREAD_ID_TAG)).equals(stateUpdaterThreadId));
         if (!shouldInclude) {
             log.trace("Rejecting metric {}", metric.metricName());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
     
@@ -37,10 +38,10 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
     private final String stateUpdaterThreadId;
 
 
-    public StreamsThreadMetricsDelegatingReporter(final Consumer<byte[], byte[]> consumer, final String threadId, final String stateUpdaterThreadId) {
+    public StreamsThreadMetricsDelegatingReporter(final Consumer<byte[], byte[]> consumer, final String threadId, final Optional<String> stateUpdaterThreadId) {
         this.consumer = Objects.requireNonNull(consumer);
         this.threadId = Objects.requireNonNull(threadId);
-        this.stateUpdaterThreadId = Objects.requireNonNull(stateUpdaterThreadId);
+        this.stateUpdaterThreadId = stateUpdaterThreadId.orElse("");
         log.debug("Creating MetricsReporter for threadId {} and stateUpdaterId {}", threadId, stateUpdaterThreadId);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.metrics.StreamsThreadMetricsDelegatingReporter;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
@@ -43,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -390,6 +392,8 @@ public class GlobalStreamThread extends Thread {
                 time
             );
             stateMgr.setGlobalProcessorContext(globalProcessorContext);
+            final StreamsThreadMetricsDelegatingReporter globalMetricsReporter = new StreamsThreadMetricsDelegatingReporter(globalConsumer, getName(), Optional.empty());
+            streamsMetrics.metricsRegistry().addReporter(globalMetricsReporter);
 
             stateConsumer = new StateConsumer(
                 logContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -482,7 +482,7 @@ public class StreamThread extends Thread implements ProcessingThread {
         taskManager.setMainConsumer(mainConsumer);
         referenceContainer.mainConsumer = mainConsumer;
 
-        final StreamsThreadMetricsDelegatingReporter reporter = new StreamsThreadMetricsDelegatingReporter(mainConsumer, threadId, stateUpdaterId);
+        final StreamsThreadMetricsDelegatingReporter reporter = new StreamsThreadMetricsDelegatingReporter(mainConsumer, threadId, Optional.of(stateUpdaterId));
         streamsMetrics.metricsRegistry().addReporter(reporter);
 
         final StreamThread streamThread = new StreamThread(

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporterTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -63,7 +64,7 @@ class StreamsThreadMetricsDelegatingReporterTest {
         noThreadIdTagMap.put("client-id", "foo");
 
         mockConsumer = new MockConsumer<>(AutoOffsetResetStrategy.NONE.name());
-        streamsThreadMetricsDelegatingReporter = new StreamsThreadMetricsDelegatingReporter(mockConsumer, threadId, stateUpdaterId);
+        streamsThreadMetricsDelegatingReporter = new StreamsThreadMetricsDelegatingReporter(mockConsumer, threadId, Optional.of(stateUpdaterId));
 
         final MetricName metricNameOne = new MetricName("metric-one", "test-group-one", "foo bar baz", threadIdTagMap);
         final MetricName metricNameTwo = new MetricName("metric-two", "test-group-two", "description two", threadIdWithStateUpdaterTagMap);


### PR DESCRIPTION
When implementing [KIP-1091](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1091%3A+Improved+Kafka+Streams+operator+metrics) metrics for the Global Stream thread was overlooked. This ticket adds the Global Thread metrics so they are available via the KIP-1076 process of adding external Kafka metrics.

The existing integration test has been updated to confirm GlobalThread metrics are sent via the broker plugin.
