### PR TITLE
MINOR: Add Append KRaft Version Record to BatchAccumulator

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -105,23 +105,22 @@ public class BatchAccumulator<T> implements Closeable {
     /**
      * Append to the accumulator.
      *
-     * @param epoch the leader epoch to append at
-     * @param records the records to append
+     * @param epoch      the leader epoch to append at
+     * @param records    the records to append
      * @param delayDrain whether the records could be drained
      * @return the offset of the last record
-     *
-     * @throws NotLeaderException indicates that an append operation cannot be completed because the
-     *         provided leader epoch was too old
+     * @throws NotLeaderException       indicates that an append operation cannot be completed because the
+     *                                  provided leader epoch was too old
      * @throws IllegalArgumentException indicates that an append operation cannot be completed
-     *         because the provided leader epoch was too new
-     * @throws IllegalStateException if the number of accumulated batches reaches the maximum
-     *         number of batches
+     *                                  because the provided leader epoch was too new
+     * @throws IllegalStateException    if the number of accumulated batches reaches the maximum
+     *                                  number of batches
      */
     public long append(int epoch, List<T> records, boolean delayDrain) {
         int numberOfCompletedBatches = completed.size();
         if (epoch < this.epoch) {
             throw new NotLeaderException("Append failed because the given epoch " + epoch + " is stale. " +
-                    "Current leader epoch = " + this.epoch());
+                "Current leader epoch = " + this.epoch());
         } else if (epoch > this.epoch) {
             throw new IllegalArgumentException("Attempt to append from epoch " + epoch +
                 " which is larger than the current epoch " + this.epoch);
@@ -222,12 +221,12 @@ public class BatchAccumulator<T> implements Closeable {
 
     /**
      * Append a control batch from a supplied memory record.
-     *
+     * <p>
      * See the {@code valueCreator} parameter description for requirements on this function.
      *
      * @param valueCreator a function that uses the passed buffer to create the control
-     *        batch that will be appended. The memory records returned must contain one
-     *        control batch and that control batch have at least one record.
+     *                     batch that will be appended. The memory records returned must contain one
+     *                     control batch and that control batch have at least one record.
      * @return the last of offset of the records created
      */
     public long appendControlMessages(MemoryRecordsCreator valueCreator) {
@@ -312,7 +311,7 @@ public class BatchAccumulator<T> implements Closeable {
     /**
      * Append a {@link VotersRecord} record to the batch
      *
-     * @param voters the record to append
+     * @param voters           the record to append
      * @param currentTimestamp the current time in milliseconds
      * @return the last of offset of the records created
      * @throws IllegalStateException on failure to allocate a buffer for the record
@@ -337,7 +336,7 @@ public class BatchAccumulator<T> implements Closeable {
      * Append a {@link LeaderChangeMessage} record to the batch
      *
      * @param leaderChangeMessage The message to append
-     * @param currentTimestamp The current time in milliseconds
+     * @param currentTimestamp    The current time in milliseconds
      * @throws IllegalStateException on failure to allocate a buffer for the record
      */
     public void appendLeaderChangeMessage(
@@ -359,21 +358,21 @@ public class BatchAccumulator<T> implements Closeable {
      * Append a {@link KRaftVersionRecord} record to the batch
      *
      * @param kraftVersionRecord The message to append
-     * @param currentTimestamp The current time in milliseconds
+     * @param currentTimestamp   The current time in milliseconds
      * @throws IllegalStateException on failure to allocate a buffer for the record
      */
     public void appendKRaftVersionRecord(
-            KRaftVersionRecord kraftVersionRecord,
-            long currentTimestamp
+        KRaftVersionRecord kraftVersionRecord,
+        long currentTimestamp
     ) {
         appendControlMessages((baseOffset, epoch, compression, buffer) ->
-                MemoryRecords.withKRaftVersionRecord(
-                        baseOffset,
-                        currentTimestamp,
-                        epoch,
-                        buffer,
-                        kraftVersionRecord
-                )
+            MemoryRecords.withKRaftVersionRecord(
+                baseOffset,
+                currentTimestamp,
+                epoch,
+                buffer,
+                kraftVersionRecord
+            )
         );
     }
 
@@ -381,7 +380,7 @@ public class BatchAccumulator<T> implements Closeable {
      * Append a {@link SnapshotHeaderRecord} record to the batch
      *
      * @param snapshotHeaderRecord The record to append
-     * @param currentTimestamp The current time in milliseconds
+     * @param currentTimestamp     The current time in milliseconds
      * @throws IllegalStateException on failure to allocate a buffer for the record
      */
     public void appendSnapshotHeaderRecord(
@@ -403,7 +402,7 @@ public class BatchAccumulator<T> implements Closeable {
      * Append a {@link SnapshotFooterRecord} record to the batch
      *
      * @param snapshotFooterRecord The record to append
-     * @param currentTimestamp The current time in milliseconds
+     * @param currentTimestamp     The current time in milliseconds
      * @throws IllegalStateException on failure to allocate a buffer for the record
      */
     public void appendSnapshotFooterRecord(
@@ -498,16 +497,16 @@ public class BatchAccumulator<T> implements Closeable {
     /**
      * Drain completed batches. The caller is expected to first check whether
      * {@link #needsDrain(long)} returns true in order to avoid unnecessary draining.
-     *
+     * <p>
      * Note on thread-safety: this method is safe in the presence of concurrent
      * appends, but it assumes a single thread is responsible for draining.
-     *
+     * <p>
      * This call will not block, but the drain may require multiple attempts before
      * it can be completed if the thread responsible for appending is holding the
      * append lock. In the worst case, the append will be completed on the next
      * call to {@link #append(int, List, boolean)} following the
      * initial call to this method.
-     *
+     * <p>
      * The caller should respect the time to the next flush as indicated by
      * {@link #timeUntilDrain(long)}.
      *

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft.internals;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.KRaftVersionRecord;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
@@ -354,6 +355,27 @@ public class BatchAccumulator<T> implements Closeable {
         );
     }
 
+    /**
+     * Append a {@link KRaftVersionRecord} record to the batch
+     *
+     * @param kraftVersionRecord The message to append
+     * @param currentTimestamp The current time in milliseconds
+     * @throws IllegalStateException on failure to allocate a buffer for the record
+     */
+    public void appendKRaftVersionRecord(
+            KRaftVersionRecord kraftVersionRecord,
+            long currentTimestamp
+    ) {
+        appendControlMessages((baseOffset, epoch, compression, buffer) ->
+                MemoryRecords.withKRaftVersionRecord(
+                        baseOffset,
+                        currentTimestamp,
+                        epoch,
+                        buffer,
+                        kraftVersionRecord
+                )
+        );
+    }
 
     /**
      * Append a {@link SnapshotHeaderRecord} record to the batch

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -111,13 +111,13 @@ class BatchAccumulatorTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
-                .thenReturn(buffer);
+            .thenReturn(buffer);
 
         BatchAccumulator<String> acc = buildAccumulator(
-                leaderEpoch,
-                baseOffset,
-                lingerMs,
-                maxBatchSize
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize
         );
 
         acc.appendKRaftVersionRecord(new KRaftVersionRecord(), time.milliseconds());
@@ -504,24 +504,24 @@ class BatchAccumulatorTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
-                .thenReturn(buffer);
+            .thenReturn(buffer);
 
         try (BatchAccumulator<String> acc = buildAccumulator(
-                leaderEpoch,
-                baseOffset,
-                lingerMs,
-                maxBatchSize
-            )
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize
+        )
         ) {
             acc.appendControlMessages((offset, epoch, compression, buf) -> {
                 long now = 1234;
                 try (MemoryRecordsBuilder builder = controlRecordsBuilder(
-                        offset,
-                        epoch,
-                        compression,
-                        now,
-                        buf
-                    )
+                    offset,
+                    epoch,
+                    compression,
+                    now,
+                    buf
+                )
                 ) {
                     builder.appendSnapshotHeaderMessage(
                         now,
@@ -562,17 +562,17 @@ class BatchAccumulatorTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
-                .thenReturn(buffer);
+            .thenReturn(buffer);
 
         BatchAccumulator.MemoryRecordsCreator creator = (offset, epoch, compression, buf) -> {
             long now = 1234;
             try (MemoryRecordsBuilder builder = controlRecordsBuilder(
-                    offset + 1,
-                    epoch,
-                    compression,
-                    now,
-                    buf
-                )
+                offset + 1,
+                epoch,
+                compression,
+                now,
+                buf
+            )
             ) {
                 builder.appendSnapshotHeaderMessage(
                     now,
@@ -586,11 +586,11 @@ class BatchAccumulatorTest {
         };
 
         try (BatchAccumulator<String> acc = buildAccumulator(
-                leaderEpoch,
-                baseOffset,
-                lingerMs,
-                maxBatchSize
-            )
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize
+        )
         ) {
             assertThrows(IllegalArgumentException.class, () -> acc.appendControlMessages(creator));
         }
@@ -605,17 +605,17 @@ class BatchAccumulatorTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
-                .thenReturn(buffer);
+            .thenReturn(buffer);
 
         BatchAccumulator.MemoryRecordsCreator creator = (offset, epoch, compression, buf) -> {
             long now = 1234;
             try (MemoryRecordsBuilder builder = controlRecordsBuilder(
-                    offset,
-                    epoch + 1,
-                    compression,
-                    now,
-                    buf
-                )
+                offset,
+                epoch + 1,
+                compression,
+                now,
+                buf
+            )
             ) {
                 builder.appendSnapshotHeaderMessage(
                     now,
@@ -629,11 +629,11 @@ class BatchAccumulatorTest {
         };
 
         try (BatchAccumulator<String> acc = buildAccumulator(
-                leaderEpoch,
-                baseOffset,
-                lingerMs,
-                maxBatchSize
-            )
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize
+        )
         ) {
             assertThrows(IllegalArgumentException.class, () -> acc.appendControlMessages(creator));
         }
@@ -648,17 +648,17 @@ class BatchAccumulatorTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
-                .thenReturn(buffer);
+            .thenReturn(buffer);
 
         BatchAccumulator.MemoryRecordsCreator creator = (offset, epoch, compression, buf) -> {
             long now = 1234;
             try (MemoryRecordsBuilder builder = controlRecordsBuilder(
-                    offset,
-                    epoch,
-                    compression,
-                    now,
-                    buf
-                )
+                offset,
+                epoch,
+                compression,
+                now,
+                buf
+            )
             ) {
                 // Create a control batch without any records
                 return builder.build();
@@ -666,11 +666,11 @@ class BatchAccumulatorTest {
         };
 
         try (BatchAccumulator<String> acc = buildAccumulator(
-                leaderEpoch,
-                baseOffset,
-                lingerMs,
-                maxBatchSize
-            )
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize
+        )
         ) {
             assertThrows(IllegalArgumentException.class, () -> acc.appendControlMessages(creator));
         }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -103,6 +103,35 @@ class BatchAccumulatorTest {
     }
 
     @Test
+    public void testKRaftVersionRecordWritten() {
+        int leaderEpoch = 17;
+        long baseOffset = 0;
+        int lingerMs = 50;
+        int maxBatchSize = 512;
+
+        ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
+        Mockito.when(memoryPool.tryAllocate(maxBatchSize))
+                .thenReturn(buffer);
+
+        BatchAccumulator<String> acc = buildAccumulator(
+                leaderEpoch,
+                baseOffset,
+                lingerMs,
+                maxBatchSize
+        );
+
+        acc.appendKRaftVersionRecord(new KRaftVersionRecord(), time.milliseconds());
+        assertTrue(acc.needsDrain(time.milliseconds()));
+
+        List<BatchAccumulator.CompletedBatch<String>> batches = acc.drain();
+        assertEquals(1, batches.size());
+
+        BatchAccumulator.CompletedBatch<String> batch = batches.get(0);
+        batch.release();
+        Mockito.verify(memoryPool).release(buffer);
+    }
+
+    @Test
     public void testForceDrain() {
         int leaderEpoch = 17;
         long baseOffset = 157;


### PR DESCRIPTION
### What
This minor PR adds a function to append the KRaft Version Record in BatchAccumulator. This is needed to implement KRaft upgrade (https://issues.apache.org/jira/browse/KAFKA-16538).

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
