### PR TITLE
MINOR: Fix incorrect return value from upgradeFeatures

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -677,7 +677,7 @@ public class ConfigurationControlManager {
                 log.info("{}", logMessage);
             }
             records.addAll(result.records());
-            return ControllerResult.atomicOf(records, null);
+            return ControllerResult.atomicOf(records, ApiError.NONE);
         }
         return result;
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -64,7 +64,7 @@ import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.apache.kafka.server.config.ConfigSynonym.HOURS_TO_MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 @Timeout(value = 40)
@@ -472,7 +472,8 @@ public class ConfigurationControlManagerTest {
             Collections.singletonMap(EligibleLeaderReplicasVersion.FEATURE_NAME,
                 FeatureUpdate.UpgradeType.UPGRADE),
             false);
-        assertNull(result.response());
+        assertNotNull(result.response());
+        assertEquals(Errors.NONE, result.response().error());
         RecordTestUtils.replayAll(manager, result.records());
         RecordTestUtils.replayAll(featureManager, result.records());
 


### PR DESCRIPTION
Fix a null ptr problem when upgrading ELR. It does not affect the UTs because the upgrade is actually successful but it confuses the user with the following failure message.
```
Could not upgrade eligible.leader.replicas.version to 1. The server experienced an unexpected error when processing the request.
```

The nullptr error happens here. https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java#L2086
