### PR TITLE
KAFKA-18828: Update share group metrics per new init and call mechanism.

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4666,6 +4666,7 @@ public class GroupMetadataManager {
         Map<ClassicGroupState, Long> classicGroupSizeCounter = new HashMap<>();
         Map<ConsumerGroup.ConsumerGroupState, Long> consumerGroupSizeCounter = new HashMap<>();
         Map<StreamsGroup.StreamsGroupState, Long> streamsGroupSizeCounter = new HashMap<>();
+        Map<ShareGroup.ShareGroupState, Long> shareGroupSizeCounter = new HashMap<>();
         groups.forEach((__, group) -> {
             switch (group.type()) {
                 case CLASSIC:
@@ -4677,6 +4678,9 @@ public class GroupMetadataManager {
                 case STREAMS:
                     streamsGroupSizeCounter.compute(((StreamsGroup) group).state(), Utils::incValue);
                     break;
+                case SHARE:
+                    shareGroupSizeCounter.compute(((ShareGroup) group).state(), Utils::incValue);
+                    break;
                 default:
                     break;
             }
@@ -4684,6 +4688,7 @@ public class GroupMetadataManager {
         metrics.setClassicGroupGauges(classicGroupSizeCounter);
         metrics.setConsumerGroupGauges(consumerGroupSizeCounter);
         metrics.setStreamsGroupGauges(streamsGroupSizeCounter);
+        metrics.setShareGroupGauges(shareGroupSizeCounter);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -71,7 +71,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public static final String GROUP_COUNT_PROTOCOL_TAG = "protocol";
     public static final String SHARE_GROUP_PROTOCOL_TAG = GROUP_COUNT_PROTOCOL_TAG;
     public static final String CONSUMER_GROUP_COUNT_METRIC_NAME = "consumer-group-count";
-    public static final String SHARE_GROUP_COUNT_METRIC_NAME = "group-count";
+    public static final String SHARE_GROUP_COUNT_METRIC_NAME = "share-group-count";
     public static final String CONSUMER_GROUP_COUNT_STATE_TAG = "state";
     public static final String SHARE_GROUP_COUNT_STATE_TAG = CONSUMER_GROUP_COUNT_STATE_TAG;
     public static final String STREAMS_GROUP_COUNT_METRIC_NAME = "streams-group-count";
@@ -172,34 +172,31 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         );
 
         shareGroupCountMetricName = metrics.metricName(
-            SHARE_GROUP_COUNT_METRIC_NAME,
+            GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of share groups.",
-            Collections.singletonMap(SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString())
+            Map.of(SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString())
         );
 
         shareGroupCountEmptyMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in empty state.",
-            SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString(),
-            SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.EMPTY.toString()
+            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.EMPTY.toString())
         );
 
         shareGroupCountStableMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in stable state.",
-            SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString(),
-            SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.STABLE.toString()
+            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.STABLE.toString())
         );
 
         shareGroupCountDeadMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in dead state.",
-            SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString(),
-            SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString()
+            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString())
         );
 
         streamsGroupCountMetricName = metrics.metricName(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -18,11 +18,10 @@ package org.apache.kafka.coordinator.group.metrics;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
-import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
+import org.apache.kafka.coordinator.group.modern.share.ShareGroup.ShareGroupState;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineLong;
@@ -77,7 +76,7 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     /**
      * Share group size gauge counters keyed by the metric name.
      */
-    private final Map<ShareGroup.ShareGroupState, TimelineGaugeCounter> shareGroupGauges;
+    private volatile Map<ShareGroupState, Long> shareGroupGauges;
 
     /**
      * Streams group size gauge counters keyed by the metric name.
@@ -116,15 +115,7 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         this.classicGroupGauges = Collections.emptyMap();
         this.consumerGroupGauges = Collections.emptyMap();
         this.streamsGroupGauges = Collections.emptyMap();
-
-        this.shareGroupGauges = Utils.mkMap(
-            Utils.mkEntry(ShareGroup.ShareGroupState.EMPTY,
-                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ShareGroup.ShareGroupState.STABLE,
-                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ShareGroup.ShareGroupState.DEAD,
-                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
-        );
+        this.shareGroupGauges = Collections.emptyMap();
 
         this.globalSensors = Objects.requireNonNull(globalSensors);
         this.topicPartition = Objects.requireNonNull(topicPartition);
@@ -161,6 +152,18 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
      */
     public void setStreamsGroupGauges(Map<StreamsGroupState, Long> streamsGroupGauges) {
         this.streamsGroupGauges = streamsGroupGauges;
+    }
+
+    /**
+     * Set the number of share groups.
+     * This method should be the only way to update the map and is called by the scheduled task
+     * that updates the metrics in {@link org.apache.kafka.coordinator.group.GroupCoordinatorShard}.
+     * Breaking this will result in inconsistent behavior.
+     *
+     * @param shareGroupGauges The map counting the number of streams groups in each state.
+     */
+    public void setShareGroupGauges(Map<ShareGroupState, Long> shareGroupGauges) {
+        this.shareGroupGauges = shareGroupGauges;
     }
 
     /**
@@ -248,6 +251,29 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             .mapToLong(Long::longValue).sum();
     }
 
+    /**
+     * Get the number of streams groups in the specified state.
+     *
+     * @param state  the streams group state.
+     *
+     * @return   The number of streams groups in `state`.
+     */
+    public long numShareGroups(ShareGroupState state) {
+        Long counter = shareGroupGauges.get(state);
+        if (counter != null) {
+            return counter;
+        }
+        return 0L;
+    }
+
+    /**
+     * @return The total number of streams groups.
+     */
+    public long numShareGroups() {
+        return shareGroupGauges.values().stream()
+            .mapToLong(Long::longValue).sum();
+    }
+
     @Override
     public void record(String sensorName) {
         Sensor sensor = globalSensors.get(sensorName);
@@ -280,14 +306,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             long value = numOffsetsTimelineGaugeCounter.timelineLong.get(offset);
             numOffsetsTimelineGaugeCounter.atomicLong.set(value);
         }
-
-        this.shareGroupGauges.forEach((__, gaugeCounter) -> {
-            long value;
-            synchronized (gaugeCounter.timelineLong) {
-                value = gaugeCounter.timelineLong.get(offset);
-            }
-            gaugeCounter.atomicLong.set(value);
-        });
     }
 
     /**
@@ -302,74 +320,5 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         Map<ClassicGroupState, Long> classicGroupGauges
     ) {
         this.classicGroupGauges = classicGroupGauges;
-    }
-
-    public void incrementNumShareGroups(ShareGroup.ShareGroupState state) {
-        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
-        if (gaugeCounter != null) {
-            synchronized (gaugeCounter.timelineLong) {
-                gaugeCounter.timelineLong.increment();
-            }
-        }
-    }
-
-    public void decrementNumShareGroups(ShareGroup.ShareGroupState state) {
-        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
-        if (gaugeCounter != null) {
-            synchronized (gaugeCounter.timelineLong) {
-                gaugeCounter.timelineLong.decrement();
-            }
-        }
-    }
-
-    public long numShareGroups(ShareGroup.ShareGroupState state) {
-        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
-        if (gaugeCounter != null) {
-            return gaugeCounter.atomicLong.get();
-        }
-        return 0L;
-    }
-
-    public long numShareGroups() {
-        return shareGroupGauges.values().stream()
-            .mapToLong(timelineGaugeCounter -> timelineGaugeCounter.atomicLong.get()).sum();
-    }
-
-    // could be called from ShareGroup to indicate state transition
-    public void onShareGroupStateTransition(
-            ShareGroup.ShareGroupState oldState,
-            ShareGroup.ShareGroupState newState
-    ) {
-        if (newState != null) {
-            switch (newState) {
-                case EMPTY:
-                    incrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY);
-                    break;
-                case STABLE:
-                    incrementNumShareGroups(ShareGroup.ShareGroupState.STABLE);
-                    break;
-                case DEAD:
-                    incrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
-                    break;
-                default:
-                    log.warn("Unknown new share group state: {}", newState);
-            }
-        }
-
-        if (oldState != null) {
-            switch (oldState) {
-                case EMPTY:
-                    decrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY);
-                    break;
-                case STABLE:
-                    decrementNumShareGroups(ShareGroup.ShareGroupState.STABLE);
-                    break;
-                case DEAD:
-                    decrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
-                    break;
-                default:
-                    log.warn("Unknown previous share group state: {}", oldState);
-            }
-        }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -252,11 +252,11 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     }
 
     /**
-     * Get the number of streams groups in the specified state.
+     * Get the number of share groups in the specified state.
      *
-     * @param state  the streams group state.
+     * @param state  the share group state.
      *
-     * @return   The number of streams groups in `state`.
+     * @return   The number of share groups in `state`.
      */
     public long numShareGroups(ShareGroupState state) {
         Long counter = shareGroupGauges.get(state);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -115,22 +115,19 @@ public class GroupCoordinatorMetricsTest {
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("protocol", Group.GroupType.SHARE.toString())),
             metrics.metricName(
-                "group-count",
+                "share-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 "The number of share groups in empty state.",
-                "protocol", Group.GroupType.SHARE.toString(),
                 "state", GroupState.EMPTY.toString()),
             metrics.metricName(
-                "group-count",
+                "share-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 "The number of share groups in stable state.",
-                "protocol", Group.GroupType.SHARE.toString(),
                 "state", GroupState.STABLE.toString()),
             metrics.metricName(
-                "group-count",
+                "share-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 "The number of share groups in dead state.",
-                "protocol", Group.GroupType.SHARE.toString(),
                 "state", GroupState.DEAD.toString()),
             metrics.metricName(
                 "group-count",

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
-import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
+import org.apache.kafka.coordinator.group.modern.share.ShareGroup.ShareGroupState;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
@@ -227,13 +227,16 @@ public class GroupCoordinatorMetricsTest {
             StreamsGroupState.NOT_READY, 1L
         ));
 
+        shard0.setShareGroupGauges(Map.of(ShareGroupState.STABLE, 2L));
+        shard1.setShareGroupGauges(Map.of(
+            ShareGroupState.EMPTY, 2L,
+            ShareGroupState.STABLE, 3L,
+            ShareGroupState.DEAD, 1L
+        ));
+
         IntStream.range(0, 6).forEach(__ -> shard0.incrementNumOffsets());
         IntStream.range(0, 2).forEach(__ -> shard1.incrementNumOffsets());
         IntStream.range(0, 1).forEach(__ -> shard1.decrementNumOffsets());
-
-        IntStream.range(0, 5).forEach(__ -> shard0.incrementNumShareGroups(ShareGroup.ShareGroupState.STABLE));
-        IntStream.range(0, 5).forEach(__ -> shard1.incrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY));
-        IntStream.range(0, 3).forEach(__ -> shard1.decrementNumShareGroups(ShareGroup.ShareGroupState.DEAD));
 
         assertEquals(4, shard0.numClassicGroups());
         assertEquals(5, shard1.numClassicGroups());
@@ -261,12 +264,12 @@ public class GroupCoordinatorMetricsTest {
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);
 
-        assertEquals(5, shard0.numShareGroups());
-        assertEquals(2, shard1.numShareGroups());
+        assertEquals(2, shard0.numShareGroups());
+        assertEquals(6, shard1.numShareGroups());
         assertGaugeValue(
             metrics,
             metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("protocol", "share")),
-            7
+            8
         );
         
         assertEquals(2, shard0.numStreamsGroups());


### PR DESCRIPTION
* Due to recent changes in the way group count metrics are initialized and updated, the current share group count code has become obsolete as well as non-functional.
* The update method for the share group count which should be called from `ShareGroup` cannot be called either. This is because the constructor has been changed to NOT accept the `GroupCoordinatorShardMetrics` ref.
* In this PR, we remedy the situation by bringing share group count code at par with consumer and streams groups.
* Additionally the metric name for share groups with group state attributes was not aligned with streams and consumer groups as mentioned in https://github.com/apache/kafka/pull/17011#discussion_r1960309578. This PR aligns them too.

Ref:
KAFKA-18655: Implement the consumer group size counter with scheduled task (#18717)

![Screenshot 2025-02-19 at 4 49 46 PM](https://github.com/user-attachments/assets/e7ec3c92-69ae-4dcd-a10e-8ea96430dc18)


