### PR TITLE
KAFKA-18829: Added check before converting to IMPLICIT mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -1019,7 +1019,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                 // The first call to poll(Duration) moves into PENDING
                 acknowledgementMode = AcknowledgementMode.PENDING;
             } else if (acknowledgementMode == AcknowledgementMode.PENDING && !currentFetch.isEmpty()) {
-                // The second call to poll(Duration) if PENDING moves into IMPLICIT
+                // If there are records to acknowledge and PENDING, moves into IMPLICIT
                 acknowledgementMode = AcknowledgementMode.IMPLICIT;
             }
         } else {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -1018,7 +1018,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             if (acknowledgementMode == AcknowledgementMode.UNKNOWN) {
                 // The first call to poll(Duration) moves into PENDING
                 acknowledgementMode = AcknowledgementMode.PENDING;
-            } else if (acknowledgementMode == AcknowledgementMode.PENDING) {
+            } else if (acknowledgementMode == AcknowledgementMode.PENDING && !currentFetch.isEmpty()) {
                 // The second call to poll(Duration) if PENDING moves into IMPLICIT
                 acknowledgementMode = AcknowledgementMode.IMPLICIT;
             }

--- a/core/src/test/java/kafka/test/api/ShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/ShareConsumerTest.java
@@ -689,6 +689,41 @@ public class ShareConsumerTest {
     }
 
     @ClusterTest
+    public void testExplicitModeSwitchOnEmptyPoll() throws InterruptedException {
+        setup();
+        alterShareAutoOffsetReset("group1", "earliest");
+        try (Producer<byte[], byte[]> producer = createProducer();
+             ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer("group1")) {
+
+            shareConsumer.subscribe(Collections.singleton(tp.topic()));
+
+            Map<TopicPartition, Set<Long>> partitionOffsetsMap1 = new HashMap<>();
+            Map<TopicPartition, Exception> partitionExceptionMap1 = new HashMap<>();
+            shareConsumer.setAcknowledgementCommitCallback(new TestableAcknowledgementCommitCallback(partitionOffsetsMap1, partitionExceptionMap1));
+
+            ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+            assertEquals(0, records.count());
+            shareConsumer.commitAsync();
+
+            ProducerRecord<byte[], byte[]> record1 = new ProducerRecord<>(tp.topic(), tp.partition(), null, "key".getBytes(), "value".getBytes());
+            producer.send(record1);
+            producer.flush();
+
+            records = shareConsumer.poll(Duration.ofMillis(5000));
+            assertEquals(1, records.count());
+
+            shareConsumer.acknowledge(records.iterator().next());
+            shareConsumer.commitAsync();
+
+            TestUtils.waitForCondition(() -> {
+                shareConsumer.poll(Duration.ofMillis(500));
+                return partitionExceptionMap1.containsKey(tp);
+            }, 30000, 100L, () -> "Didn't receive call to callback");
+            verifyShareGroupStateTopicRecordsProduced();
+        }
+    }
+
+    @ClusterTest
     public void testExplicitAcknowledgementCommitAsyncPartialBatch() {
         setup();
         alterShareAutoOffsetReset("group1", "earliest");

--- a/core/src/test/java/kafka/test/api/ShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/ShareConsumerTest.java
@@ -689,7 +689,7 @@ public class ShareConsumerTest {
     }
 
     @ClusterTest
-    public void testImplicitModeNotTriggerByPollWhenNoAcksToSend() throws InterruptedException {
+    public void testImplicitModeNotTriggeredByPollWhenNoAcksToSend() throws InterruptedException {
         setup();
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();

--- a/core/src/test/java/kafka/test/api/ShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/ShareConsumerTest.java
@@ -689,7 +689,7 @@ public class ShareConsumerTest {
     }
 
     @ClusterTest
-    public void testExplicitModeSwitchOnEmptyPoll() throws InterruptedException {
+    public void testImplicitModeNotTriggerByPollWhenNoAcksToSend() throws InterruptedException {
         setup();
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -701,6 +701,7 @@ public class ShareConsumerTest {
             Map<TopicPartition, Exception> partitionExceptionMap1 = new HashMap<>();
             shareConsumer.setAcknowledgementCommitCallback(new TestableAcknowledgementCommitCallback(partitionOffsetsMap1, partitionExceptionMap1));
 
+            // The acknowledgement mode moves to PENDING from UNKNOWN.
             ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
             assertEquals(0, records.count());
             shareConsumer.commitAsync();
@@ -709,9 +710,11 @@ public class ShareConsumerTest {
             producer.send(record1);
             producer.flush();
 
+            // The acknowledgement mode remains in PENDING because no records were returned.
             records = shareConsumer.poll(Duration.ofMillis(5000));
             assertEquals(1, records.count());
 
+            // The acknowledgement mode now moves to EXPLICIT.
             shareConsumer.acknowledge(records.iterator().next());
             shareConsumer.commitAsync();
 


### PR DESCRIPTION
*What*
Addresses the bug raised in https://issues.apache.org/jira/browse/KAFKA-18829.
Now, we will only move to IMPLICIT mode in `ShareConsumerImpl`, if there were any records to be acknowledged, and the next `poll()`/`commitAsync()`/`commitSync()` is called.