### PR TITLE
KAFKA-18813: [2/N] Client consistent ack for assignment received

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -29,7 +29,7 @@
     <suppress checks="NPathComplexity"
               files="(FieldSpecPairIterator|MessageDataGenerator|FieldSpec|WorkerSinkTask).java"/>
     <suppress checks="JavaNCSS"
-              files="(ApiMessageType|FieldSpec|MessageDataGenerator|KafkaConsumerTest).java"/>
+              files="(ApiMessageType|FieldSpec|MessageDataGenerator|KafkaConsumerTest|ConsumerMembershipManagerTest).java"/>
     <suppress checks="MethodLength"
               files="(FieldSpec|MessageDataGenerator).java"/>
     <suppress id="dontUseSystemExit"

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -343,6 +343,9 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
             // broker), or JOINING (member joining received empty assignment).
             if (state == MemberState.RECONCILING || state == MemberState.JOINING) {
                 transitionTo(MemberState.STABLE);
+            } else {
+                // Send ack to the coordinator for the assignment received (even if it is already reconciled)
+                transitionTo(MemberState.ACKNOWLEDGING);
             }
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -54,9 +54,10 @@ public enum MemberState {
     RECONCILING,
 
     /**
-     * Member has completed reconciling an assignment received, and stays in this state only until
-     * the next heartbeat request is sent out to acknowledge the assignment to the server. This
-     * state indicates that the next heartbeat request must be sent without waiting for the
+     * Member has received and reconciled an assignment, and stays in this state only until
+     * the next heartbeat request is sent out to acknowledge the assignment to the server.
+     * Note that the member will acknowledge every assignment received (even if it is already reconciled).
+     * This state also indicates that the next heartbeat request must be sent without waiting for the
      * heartbeat interval to expire. Note that once the ack is sent, the member could go back to
      * {@link #RECONCILING} if it still has assignment waiting to be reconciled (assignments
      * waiting for metadata, assignments for which metadata was resolved, or new assignments
@@ -121,7 +122,7 @@ public enum MemberState {
 
         RECONCILING.previousValidStates = Arrays.asList(STABLE, JOINING, ACKNOWLEDGING, RECONCILING);
 
-        ACKNOWLEDGING.previousValidStates = Collections.singletonList(RECONCILING);
+        ACKNOWLEDGING.previousValidStates = Arrays.asList(RECONCILING, STABLE);
 
         FATAL.previousValidStates = Arrays.asList(JOINING, STABLE, RECONCILING, ACKNOWLEDGING,
                 PREPARE_LEAVING, LEAVING, UNSUBSCRIBED);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
@@ -1420,6 +1420,39 @@ public class ConsumerMembershipManagerTest {
         verify(membershipManager, never()).markReconciliationCompleted();
         verify(subscriptionState, never()).assignFromSubscribed(anyCollection());
 
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        mockAckSent(membershipManager);
+        assertEquals(MemberState.STABLE, membershipManager.state());
+
+        assertEquals(1.0d, getMetricValue(metrics, rebalanceMetricsManager.rebalanceTotal));
+        assertEquals(0.0d, getMetricValue(metrics, rebalanceMetricsManager.failedRebalanceTotal));
+    }
+
+    @Test
+    public void testAllAssignmentReceivedIsAcked() {
+        ConsumerMembershipManager membershipManager = createMembershipManagerJoiningGroup();
+        Uuid topicId = Uuid.randomUuid();
+        String topicName = "topic1";
+
+        // Receive assignment different from what the member owns - should reconcile and send ack
+        mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId, topicName, Collections.emptyList());
+        List<TopicIdPartition> expectedAssignmentReconciled = topicIdPartitions(topicId, topicName, 0, 1);
+        receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
+        membershipManager.poll(time.milliseconds());
+        verifyReconciliationTriggeredAndCompleted(membershipManager, expectedAssignmentReconciled);
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        mockAckSent(membershipManager);
+        assertEquals(MemberState.STABLE, membershipManager.state());
+
+        // Receive same assignment again - should not trigger reconciliation but should send ack to the coordinator.
+        clearInvocations(membershipManager);
+        mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId, topicName, expectedAssignmentReconciled);
+        receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
+        verifyReconciliationNotTriggered(membershipManager);
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        mockAckSent(membershipManager);
         assertEquals(MemberState.STABLE, membershipManager.state());
 
         assertEquals(1.0d, getMetricValue(metrics, rebalanceMetricsManager.rebalanceTotal));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -995,6 +995,8 @@ public class ShareMembershipManagerTest {
         verify(membershipManager, never()).markReconciliationCompleted();
         verify(subscriptionState, never()).assignFromSubscribed(anyCollection());
 
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        mockAckSent(membershipManager);
         assertEquals(MemberState.STABLE, membershipManager.state());
 
         assertEquals(1.0d, getMetricValue(metrics, rebalanceMetricsManager.rebalanceTotal));


### PR DESCRIPTION
Change to ensure the client always sends an ACK when it receives an assignment from the coordinator (even if it does not need to reconcile it because it already has).