### PR TITLE
MINOR: Don't allow cloning a ProducerStateEntry with a different producer id

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -79,7 +79,7 @@ public class ProducerAppendInfo {
         this.origin = origin;
         this.verificationStateEntry = verificationStateEntry;
 
-        updatedEntry = currentEntry.withProducerIdAndBatchMetadata(producerId, Optional.empty());
+        updatedEntry = currentEntry.withEmptyBatchMetadata();
     }
 
     public long producerId() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
@@ -80,12 +80,11 @@ public class ProducerStateEntry {
     }
 
     /**
-     * Returns a new instance with the provided parameters (when present) and the values from the current instance
-     * otherwise.
+     * Returns a cloned instance except for an empty batch metadata deque is initialized for the new instance.
      */
-    public ProducerStateEntry withProducerIdAndBatchMetadata(long producerId, Optional<BatchMetadata> batchMetadata) {
-        return new ProducerStateEntry(producerId, this.producerEpoch(), this.coordinatorEpoch, this.lastTimestamp,
-            this.currentTxnFirstOffset, batchMetadata);
+    public ProducerStateEntry withEmptyBatchMetadata() {
+        return new ProducerStateEntry(this.producerId, this.producerEpoch, this.coordinatorEpoch, this.lastTimestamp,
+            this.currentTxnFirstOffset, Optional.empty());
     }
 
     public void addBatch(short producerEpoch, int lastSeq, long lastOffset, int offsetDelta, long timestamp) {


### PR DESCRIPTION
The `ProducerStateEntry` has been refactored several times and now `ProducerAppendInfo#updatedEntry` is created by calling the `withProducerIdAndBatchMetadata` on `currentEntry`. However, this method is confusing because the 1st parameter is the producer id, which means this method could be used to create `updatedEntry` with a different producer id  with `currentEntry`. However, this case should never happen.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
