### PR TITLE
KAFKA-18813: [3/N] Client support for TopicAuthException in DescribeConsumerGroup path

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
@@ -333,6 +333,7 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
             case GROUP_AUTHORIZATION_FAILED:
             case TOPIC_AUTHORIZATION_FAILED:
                 log.debug("`{}` request for group id {} failed due to error {}.", apiName, groupId.idValue, error);
+                // The topic auth response received on DescribeConsumerGroup is a generic one not including topic names, so we just pass it on unchanged here.
                 failed.put(groupId, error.exception(errorMsg));
                 break;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
@@ -331,6 +331,7 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
 
         switch (error) {
             case GROUP_AUTHORIZATION_FAILED:
+            case TOPIC_AUTHORIZATION_FAILED:
                 log.debug("`{}` request for group id {} failed due to error {}.", apiName, groupId.idValue, error);
                 failed.put(groupId, error.exception(errorMsg));
                 break;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
@@ -321,6 +322,7 @@ public class DescribeConsumerGroupsHandlerTest {
     @Test
     public void testFailedHandleConsumerGroupResponse() {
         assertFailed(GroupAuthorizationException.class, handleConsumerGroupWithError(Errors.GROUP_AUTHORIZATION_FAILED));
+        assertFailed(TopicAuthorizationException.class, handleConsumerGroupWithError(Errors.TOPIC_AUTHORIZATION_FAILED));
         assertFailed(InvalidGroupIdException.class, handleConsumerGroupWithError(Errors.INVALID_GROUP_ID));
     }
 


### PR DESCRIPTION
Support TopicAuthorizationException received in DescribeConsumerGroup response. This is expected to be the case when the admin client does not have access to topics in the group and gets a generic auth error, no topic names.
