### PR TITLE
KAFKA-18844: Stale features information in QuorumController#registerBroker

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2004,14 +2004,17 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         BrokerRegistrationRequestData request
     ) {
-        // populate finalized features map with latest known kraft version for validation
-        Map<String, Short> controllerFeatures = new HashMap<>(featureControl.finalizedFeatures(Long.MAX_VALUE).featureMap());
-        controllerFeatures.put(KRaftVersion.FEATURE_NAME, raftClient.kraftVersion().featureLevel());
         return appendWriteEvent("registerBroker", context.deadlineNs(),
-            () -> clusterControl.
-                registerBroker(request, offsetControl.nextWriteOffset(),
-                    new FinalizedControllerFeatures(controllerFeatures, Long.MAX_VALUE),
-                    context.requestHeader().requestApiVersion() >= 3),
+            () -> {
+                // Populate finalized features map with latest known kraft version for validation.
+                // Get the finalized features map in controller operation to avoid outdated features.
+                Map<String, Short> controllerFeatures = new HashMap<>(featureControl.finalizedFeatures(Long.MAX_VALUE).featureMap());
+                controllerFeatures.put(KRaftVersion.FEATURE_NAME, raftClient.kraftVersion().featureLevel());
+                return clusterControl.
+                    registerBroker(request, offsetControl.nextWriteOffset(),
+                        new FinalizedControllerFeatures(controllerFeatures, Long.MAX_VALUE),
+                        context.requestHeader().requestApiVersion() >= 3);
+            },
             EnumSet.noneOf(ControllerOperationFlag.class));
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2006,9 +2006,9 @@ public final class QuorumController implements Controller {
     ) {
         return appendWriteEvent("registerBroker", context.deadlineNs(),
             () -> {
-                // Populate finalized features map with latest known kraft version for validation.
-                // Get the finalized features map in controller operation to avoid outdated features.
+                // Read and write data in the controller event handling thread to avoid stale information.
                 Map<String, Short> controllerFeatures = new HashMap<>(featureControl.finalizedFeatures(Long.MAX_VALUE).featureMap());
+                // Populate finalized features map with latest known kraft version for validation.
                 controllerFeatures.put(KRaftVersion.FEATURE_NAME, raftClient.kraftVersion().featureLevel());
                 return clusterControl.
                     registerBroker(request, offsetControl.nextWriteOffset(),


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/16848, we added `kraft.version` to finalized features and got finalized features outside controller event handling thread. This may make finalized features stale when processing `registerBroker` event. Also, some cases like `QuorumControllerTest.testBalancePartitionLeaders` become flaky cause of outdated MV. This PR moves finalized features back to controller event handling thread to avoid the error.

Reviewers: Ismael Juma <ijuma@apache.org>, Jun Rao <junrao@gmail.com>, Colin P. McCabe <cmccabe@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>

---
Previous PR title: Fix flaky QuorumControllerTest.testBalancePartitionLeaders()
Previous PR description:
When we initialize `FeatureControlManager` in `QuorumController` [0], we don't set `bootstrapMetadata` for it, so it use `Metadata.latestProduction()` [1]. In the test case, we use `IBP_3_7_IV0` as `bootstrapMetadata` [2]. When initializing `QuorumController`, it takes time to replay record to overwrite `FeatureControlManager#metadataVersion`. If we add `Thread.sleep(1000L)` before `metadataVersion.set(mv)` [3], we can reproduce the flaky test steadily. 

I'm not sure whether setting `bootstrapMetadata` to `FeatureControlManager` is correct, so I  fix the case by waiting `metadataVersion` is overwrote. 

[0]
https://github.com/apache/kafka/blob/8f13e7c20737400a2b7b93449c20146089df00a6/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java#L1536-L1541

[1]
https://github.com/apache/kafka/blob/8f13e7c20737400a2b7b93449c20146089df00a6/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java#L57

[2]
https://github.com/apache/kafka/blob/8f13e7c20737400a2b7b93449c20146089df00a6/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java#L177-L178

[3]
https://github.com/apache/kafka/blob/8f13e7c20737400a2b7b93449c20146089df00a6/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java#L371-L379