### PR TITLE
Revert "KAFKA-16803: Change fork, update ShadowJavaPlugin to 8.1.7 (#16295)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ plugins {
 
   id "com.github.spotbugs" version '6.0.25' apply false
   id 'org.scoverage' version '8.0.3' apply false
-  id 'io.github.goooler.shadow' version '8.1.3' apply false
+  // Updating the shadow plugin version to 8.1.1 causes issue with signing and publishing the shadowed
+  // artifacts - see https://github.com/johnrengelman/shadow/issues/901
+  id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
   id 'com.diffplug.spotless' version "6.25.0"
 }
 
@@ -364,7 +366,7 @@ subprojects {
           if (!shouldPublishWithShadow) {
             from components.java
           } else {
-            apply plugin: 'io.github.goooler.shadow'
+            apply plugin: 'com.github.johnrengelman.shadow'
             project.shadow.component(mavenJava)
 
             // Fix for avoiding inclusion of runtime dependencies marked as 'shadow' in MANIFEST Class-Path.
@@ -3276,7 +3278,7 @@ project(':streams:upgrade-system-tests-39') {
 
 project(':jmh-benchmarks') {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.github.johnrengelman.shadow'
 
   shadowJar {
     archiveBaseName = 'kafka-jmh-benchmarks'


### PR DESCRIPTION
The PR: https://github.com/apache/kafka/pull/16295 which changed the shadow plugin version has re-introduced the issue with publication of signed jars, fixed in: https://github.com/apache/kafka/pull/15308.

This PR reverts https://github.com/apache/kafka/pull/16295  to unblock Kafka 4.0 release. And we should aim for fixing the issue permanently as being discussed here: https://github.com/apache/kafka/pull/18018.

Seems same issue was encountered during `Kafka-3.9` release and same commit was reverted in 3.9 as well: https://github.com/apache/kafka/pull/17218.

