### PR TITLE
MINOR: Fix fail e2e transactions_upgrade_test.py::TransactionsUpgradeTest.test_transactions_upgrade

### DIFF
--- a/tests/kafkatest/tests/core/transactions_upgrade_test.py
+++ b/tests/kafkatest/tests/core/transactions_upgrade_test.py
@@ -20,7 +20,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.transactional_message_copier import TransactionalMessageCopier
 from kafkatest.utils import is_int
 from kafkatest.utils.transactions_utils import create_and_start_copiers
-from kafkatest.version import LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, \
+from kafkatest.version import LATEST_3_3, LATEST_3_4, LATEST_3_5, \
     LATEST_3_6, LATEST_3_7, LATEST_3_8, LATEST_3_9, DEV_BRANCH, KafkaVersion, LATEST_STABLE_METADATA_VERSION, LATEST_STABLE_TRANSACTION_VERSION
 
 from ducktape.tests.test import Test
@@ -208,7 +208,7 @@ class TransactionsUpgradeTest(Test):
 
     @cluster(num_nodes=8)
     @matrix(
-        from_kafka_version=[str(LATEST_3_9), str(LATEST_3_8), str(LATEST_3_7), str(LATEST_3_6), str(LATEST_3_5), str(LATEST_3_4), str(LATEST_3_3), str(LATEST_3_2), str(LATEST_3_1)],
+        from_kafka_version=[str(LATEST_3_9), str(LATEST_3_8), str(LATEST_3_7), str(LATEST_3_6), str(LATEST_3_5), str(LATEST_3_4), str(LATEST_3_3)],
         metadata_quorum=[isolated_kraft],
         use_new_coordinator=[False],
         group_protocol=[None]


### PR DESCRIPTION
The main root cause is https://github.com/apache/kafka/commit/3dba3125e9c81fc9ba301416d708205a53e22aaa, this PR remove the metadata version which is older than 3.3, thus this test will fail when it use metadata version 3.2, 3.1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
