### PR TITLE
[MINOR] Clean up share-coordinator

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -59,7 +59,6 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -410,9 +409,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
                             Duration.ofMillis(config.shareCoordinatorWriteTimeoutMs()),
                             coordinator -> coordinator.writeState(new WriteShareGroupStateRequestData()
                                 .setGroupId(groupId)
-                                .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+                                .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                                     .setTopicId(topicData.topicId())
-                                    .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                                    .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                                         .setPartition(partitionData.partition())
                                         .setStartOffset(partitionData.startOffset())
                                         .setLeaderEpoch(partitionData.leaderEpoch())
@@ -528,9 +527,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
                 ReadShareGroupStateRequestData requestForCurrentPartition = new ReadShareGroupStateRequestData()
                     .setGroupId(groupId)
-                    .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+                    .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                         .setTopicId(topicId)
-                        .setPartitions(Collections.singletonList(partitionData))));
+                        .setPartitions(List.of(partitionData))));
 
                 // We are issuing a scheduleWriteOperation even though the request is of read type since
                 // we might want to update the leader epoch, if it is the highest seen so far for the specific

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -63,7 +63,6 @@ import org.apache.kafka.timeline.TimelineHashMap;
 
 import org.slf4j.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -86,7 +85,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     public static final Exception NEGATIVE_PARTITION_ID = new Exception("The partition id cannot be a negative number.");
 
     public static class Builder implements CoordinatorShardBuilder<ShareCoordinatorShard, CoordinatorRecord> {
-        private ShareCoordinatorConfig config;
+        private final ShareCoordinatorConfig config;
         private LogContext logContext;
         private SnapshotRegistry snapshotRegistry;
         private CoordinatorMetrics coordinatorMetrics;
@@ -319,16 +318,16 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         // build successful response if record is correctly created
         WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData()
             .setResults(
-                Collections.singletonList(
+                List.of(
                     WriteShareGroupStateResponse.toResponseWriteStateResult(key.topicId(),
-                        Collections.singletonList(
+                        List.of(
                             WriteShareGroupStateResponse.toResponsePartitionResult(
                                 key.partition()
                             ))
                     ))
             );
 
-        return new CoordinatorResult<>(Collections.singletonList(record), responseData);
+        return new CoordinatorResult<>(List.of(record), responseData);
     }
 
     /**
@@ -346,7 +345,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         // Only one key will be there in the request by design.
         Optional<ReadShareGroupStateResponseData> error = maybeGetReadStateError(request);
         if (error.isPresent()) {
-            return new CoordinatorResult<>(Collections.emptyList(), error.get());
+            return new CoordinatorResult<>(List.of(), error.get());
         }
 
         ReadShareGroupStateRequestData.ReadStateData topicData = request.topics().get(0);
@@ -366,7 +365,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 partitionId,
                 PartitionFactory.UNINITIALIZED_START_OFFSET,
                 PartitionFactory.DEFAULT_STATE_EPOCH,
-                Collections.emptyList()
+                List.of()
             );
         } else {
             // Leader epoch update might be needed
@@ -379,7 +378,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                             .setLastOffset(stateBatch.lastOffset())
                             .setDeliveryState(stateBatch.deliveryState())
                             .setDeliveryCount(stateBatch.deliveryCount())
-                    ).collect(Collectors.toList()) : Collections.emptyList();
+                    ).collect(Collectors.toList()) : List.of();
 
             responseData = ReadShareGroupStateResponse.toResponseData(
                 topicId,
@@ -393,7 +392,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         // Optimization in case leaderEpoch update is not required.
         if (leaderEpoch == -1 ||
             (leaderEpochMap.get(key) != null && leaderEpochMap.get(key) == leaderEpoch)) {
-            return new CoordinatorResult<>(Collections.emptyList(), responseData);
+            return new CoordinatorResult<>(List.of(), responseData);
         }
 
         // It is OK to info log this since this reaching this codepoint should be quite infrequent.
@@ -406,12 +405,12 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         WriteShareGroupStateRequestData.PartitionData writePartitionData = new WriteShareGroupStateRequestData.PartitionData()
             .setPartition(partitionId)
             .setLeaderEpoch(leaderEpoch)
-            .setStateBatches(Collections.emptyList())
+            .setStateBatches(List.of())
             .setStartOffset(responseData.results().get(0).partitions().get(0).startOffset())
             .setStateEpoch(responseData.results().get(0).partitions().get(0).stateEpoch());
 
         CoordinatorRecord record = generateShareStateRecord(writePartitionData, key);
-        return new CoordinatorResult<>(Collections.singletonList(record), responseData);
+        return new CoordinatorResult<>(List.of(record), responseData);
     }
 
     /**
@@ -471,7 +470,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             }
         }
 
-        return new CoordinatorResult<>(Collections.emptyList(), responseData);
+        return new CoordinatorResult<>(List.of(), responseData);
     }
 
     /**
@@ -482,7 +481,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
      */
     public CoordinatorResult<Optional<Long>, CoordinatorRecord> lastRedundantOffset() {
         return new CoordinatorResult<>(
-            Collections.emptyList(),
+            List.of(),
             this.offsetsManager.lastRedundantOffset()
         );
     }
@@ -527,7 +526,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 )
             );
 
-        return new CoordinatorResult<>(Collections.singletonList(record), responseData);
+        return new CoordinatorResult<>(List.of(record), responseData);
     }
 
     /**
@@ -555,7 +554,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                     .setStartOffset(partitionData.startOffset())
                     .setLeaderEpoch(partitionData.leaderEpoch())
                     .setStateEpoch(partitionData.stateEpoch())
-                    .setStateBatches(mergeBatches(Collections.emptyList(), partitionData))
+                    .setStateBatches(mergeBatches(List.of(), partitionData))
                     .build());
         } else if (snapshotUpdateCount.getOrDefault(key, 0) >= config.shareCoordinatorSnapshotUpdateRecordsPerSnapshot()) {
             ShareGroupOffset currentState = shareStateMap.get(key); // shareStateMap will have the entry as containsKey is true
@@ -587,7 +586,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                     .setSnapshotEpoch(currentState.snapshotEpoch()) // Use same snapshotEpoch as last share snapshot.
                     .setStartOffset(partitionData.startOffset())
                     .setLeaderEpoch(partitionData.leaderEpoch())
-                    .setStateBatches(mergeBatches(Collections.emptyList(), partitionData))
+                    .setStateBatches(mergeBatches(List.of(), partitionData))
                     .build());
         }
     }
@@ -772,7 +771,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     ) {
         String message = exception == null ? error.message() : exception.getMessage();
         WriteShareGroupStateResponseData responseData = WriteShareGroupStateResponse.toErrorResponseData(topicId, partitionId, error, message);
-        return new CoordinatorResult<>(Collections.emptyList(), responseData);
+        return new CoordinatorResult<>(List.of(), responseData);
     }
 
     private CoordinatorResult<DeleteShareGroupStateResponseData, CoordinatorRecord> getDeleteErrorResponse(
@@ -783,7 +782,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     ) {
         String message = exception == null ? error.message() : exception.getMessage();
         DeleteShareGroupStateResponseData responseData = DeleteShareGroupStateResponse.toErrorResponseData(topicId, partitionId, error, message);
-        return new CoordinatorResult<>(Collections.emptyList(), responseData);
+        return new CoordinatorResult<>(List.of(), responseData);
     }
 
     // Visible for testing

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -48,7 +48,7 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public static final String SHARE_COORDINATOR_WRITE_SENSOR_NAME = "ShareCoordinatorWrite";
     public static final String SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME = "ShareCoordinatorWriteLatency";
     public static final String SHARE_COORDINATOR_STATE_TOPIC_PRUNE_SENSOR_NAME = "ShareCoordinatorStateTopicPruneSensorName";
-    private Map<TopicPartition, ShareGroupPruneMetrics> pruneMetrics = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, ShareGroupPruneMetrics> pruneMetrics = new ConcurrentHashMap<>();
 
     /**
      * Global sensors. These are shared across all metrics shards.

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombinerTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/PersisterStateBatchCombinerTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.server.share.persister.PersisterStateBatch;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -70,7 +69,7 @@ public class PersisterStateBatchCombinerTest {
             int deliveryState,
             int deliveryCount
         ) {
-            return Collections.singletonList(
+            return List.of(
                 new PersisterStateBatch(firstOffset, lastOffset, (byte) deliveryState, (short) deliveryCount)
             );
         }
@@ -108,14 +107,14 @@ public class PersisterStateBatchCombinerTest {
             new BatchTestHolder(
                 "Current batches with start offset midway are pruned.",
                 BatchTestHolder.singleBatch(100, 130, 0, 1),
-                Collections.emptyList(),
+                List.of(),
                 BatchTestHolder.singleBatch(120, 130, 0, 1),
                 120
             ),
 
             new BatchTestHolder(
                 "New batches with start offset midway are pruned.",
-                Collections.emptyList(),
+                List.of(),
                 BatchTestHolder.singleBatch(100, 130, 0, 1),
                 BatchTestHolder.singleBatch(120, 130, 0, 1),
                 120
@@ -123,9 +122,9 @@ public class PersisterStateBatchCombinerTest {
 
             new BatchTestHolder(
                 "Both current and new batches empty.",
-                Collections.emptyList(),
-                Collections.emptyList(),
-                Collections.emptyList(),
+                List.of(),
+                List.of(),
+                List.of(),
                 120
             )
         );

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpersTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpersTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.server.share.persister.PersisterStateBatch;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -47,7 +47,7 @@ public class ShareCoordinatorRecordHelpersTest {
                 .setStateEpoch(1)
                 .setLeaderEpoch(5)
                 .setStartOffset(0)
-                .setStateBatches(Collections.singletonList(batch))
+                .setStateBatches(List.of(batch))
                 .build()
         );
 
@@ -62,7 +62,7 @@ public class ShareCoordinatorRecordHelpersTest {
                     .setStateEpoch(1)
                     .setLeaderEpoch(5)
                     .setStartOffset(0)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new ShareSnapshotValue.StateBatch()
                             .setFirstOffset(1L)
                             .setLastOffset(10L)
@@ -88,7 +88,7 @@ public class ShareCoordinatorRecordHelpersTest {
                 .setStateEpoch(-1)  // ignored for share update
                 .setLeaderEpoch(5)
                 .setStartOffset(0)
-                .setStateBatches(Collections.singletonList(batch))
+                .setStateBatches(List.of(batch))
                 .build()
         );
 
@@ -102,7 +102,7 @@ public class ShareCoordinatorRecordHelpersTest {
                     .setSnapshotEpoch(0)
                     .setLeaderEpoch(5)
                     .setStartOffset(0)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new ShareUpdateValue.StateBatch()
                             .setFirstOffset(1L)
                             .setLastOffset(10L)

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordSerdeTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordSerdeTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -221,7 +221,7 @@ public class ShareCoordinatorRecordSerdeTest {
                     .setLeaderEpoch(2)
                     .setStateEpoch(1)
                     .setSnapshotEpoch(1)
-                    .setStateBatches(Collections.singletonList(new ShareSnapshotValue.StateBatch()
+                    .setStateBatches(List.of(new ShareSnapshotValue.StateBatch()
                         .setFirstOffset(1)
                         .setLastOffset(10)
                         .setDeliveryState((byte) 0)

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -129,14 +129,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(leaderEpoch)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -169,7 +169,7 @@ class ShareCoordinatorShardTest {
                     .setSnapshotEpoch(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(leaderEpoch)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new ShareSnapshotValue.StateBatch()
                             .setFirstOffset(0)
                             .setLastOffset(10)
@@ -189,7 +189,7 @@ class ShareCoordinatorShardTest {
                     .setSnapshotEpoch(1)
                     .setStateEpoch(1)
                     .setLeaderEpoch(leaderEpoch + 1)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new ShareSnapshotValue.StateBatch()
                             .setFirstOffset(11)
                             .setLastOffset(12)
@@ -222,14 +222,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -240,7 +240,7 @@ class ShareCoordinatorShardTest {
         shard.replay(0L, 0L, (short) 0, result.records().get(0));
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request.topics().get(0).partitions().get(0))
         ));
 
@@ -262,14 +262,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -277,14 +277,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(11)
                         .setLastOffset(20)
                         .setDeliveryCount((short) 1)
@@ -295,7 +295,7 @@ class ShareCoordinatorShardTest {
         shard.replay(0L, 0L, (short) 0, result.records().get(0));
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0))
         ));
 
@@ -313,7 +313,7 @@ class ShareCoordinatorShardTest {
         expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
         // The snapshot epoch here will be 1 since this is a snapshot update record,
         // and it refers to parent share snapshot.
-        expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotUpdateRecord(
+        expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotUpdateRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request2.topics().get(0).partitions().get(0), 0)
         ));
 
@@ -326,7 +326,7 @@ class ShareCoordinatorShardTest {
         assertEquals(incrementalUpdate.leaderEpoch(), combinedState.leaderEpoch());
         assertEquals(incrementalUpdate.startOffset(), combinedState.startOffset());
         // The batches should have combined to 1 since same state.
-        assertEquals(Collections.singletonList(new PersisterStateBatch(0, 20, (byte) 0, (short) 1)),
+        assertEquals(List.of(new PersisterStateBatch(0, 20, (byte) 0, (short) 1)),
             combinedState.stateBatches());
         assertEquals(0, shard.getLeaderMapValue(shareCoordinatorKey));
     }
@@ -341,14 +341,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(partition)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -358,7 +358,7 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toErrorResponseData(
             TOPIC_ID, partition, Errors.INVALID_REQUEST, ShareCoordinatorShard.NEGATIVE_PARTITION_ID.getMessage());
-        List<CoordinatorRecord> expectedRecords = Collections.emptyList();
+        List<CoordinatorRecord> expectedRecords = List.of();
 
         assertEquals(expectedData, result.response());
         assertEquals(expectedRecords, result.records());
@@ -376,14 +376,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(0)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -393,7 +393,7 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toErrorResponseData(
             TOPIC_ID, 0, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.UNKNOWN_TOPIC_OR_PARTITION.message());
-        List<CoordinatorRecord> expectedRecords = Collections.emptyList();
+        List<CoordinatorRecord> expectedRecords = List.of();
 
         assertEquals(expectedData, result.response());
         assertEquals(expectedRecords, result.records());
@@ -410,14 +410,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(5)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -425,14 +425,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)
                     .setLeaderEpoch(3) // Lower leader epoch in the second request.
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(11)
                         .setLastOffset(20)
                         .setDeliveryCount((short) 1)
@@ -443,7 +443,7 @@ class ShareCoordinatorShardTest {
         shard.replay(0L, 0L, (short) 0, result.records().get(0));
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0))
         ));
 
@@ -459,7 +459,7 @@ class ShareCoordinatorShardTest {
         // Since the leader epoch in the second request was lower than the one in the first request, FENCED_LEADER_EPOCH error is expected.
         expectedData = WriteShareGroupStateResponse.toErrorResponseData(
             TOPIC_ID, PARTITION, Errors.FENCED_LEADER_EPOCH, Errors.FENCED_LEADER_EPOCH.message());
-        expectedRecords = Collections.emptyList();
+        expectedRecords = List.of();
 
         assertEquals(expectedData, result.response());
         assertEquals(expectedRecords, result.records());
@@ -476,14 +476,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(1)
                     .setLeaderEpoch(5)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(0)
                         .setLastOffset(10)
                         .setDeliveryCount((short) 1)
@@ -491,14 +491,14 @@ class ShareCoordinatorShardTest {
 
         WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(0)
                     .setStateEpoch(0)   // Lower state epoch in the second request.
                     .setLeaderEpoch(5)
-                    .setStateBatches(Collections.singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                    .setStateBatches(List.of(new WriteShareGroupStateRequestData.StateBatch()
                         .setFirstOffset(11)
                         .setLastOffset(20)
                         .setDeliveryCount((short) 1)
@@ -509,7 +509,7 @@ class ShareCoordinatorShardTest {
         shard.replay(0L, 0L, (short) 0, result.records().get(0));
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0))
         ));
 
@@ -525,7 +525,7 @@ class ShareCoordinatorShardTest {
         // Since the leader epoch in the second request was lower than the one in the first request, FENCED_LEADER_EPOCH error is expected.
         expectedData = WriteShareGroupStateResponse.toErrorResponseData(
             TOPIC_ID, PARTITION, Errors.FENCED_STATE_EPOCH, Errors.FENCED_STATE_EPOCH.message());
-        expectedRecords = Collections.emptyList();
+        expectedRecords = List.of();
 
         assertEquals(expectedData, result.response());
         assertEquals(expectedRecords, result.records());
@@ -544,9 +544,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(1)))));
 
@@ -557,7 +557,7 @@ class ShareCoordinatorShardTest {
             PARTITION,
             0,
             0,
-            Collections.singletonList(new ReadShareGroupStateResponseData.StateBatch()
+            List.of(new ReadShareGroupStateResponseData.StateBatch()
                 .setFirstOffset(0)
                 .setLastOffset(10)
                 .setDeliveryCount((short) 1)
@@ -578,9 +578,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateSummaryRequestData request = new ReadShareGroupStateSummaryRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateSummaryRequestData.ReadStateSummaryData()
+            .setTopics(List.of(new ReadShareGroupStateSummaryRequestData.ReadStateSummaryData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateSummaryRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateSummaryRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(1)))));
 
@@ -608,9 +608,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(partition)
                     .setLeaderEpoch(5)))));
 
@@ -637,9 +637,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateSummaryRequestData request = new ReadShareGroupStateSummaryRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateSummaryRequestData.ReadStateSummaryData()
+            .setTopics(List.of(new ReadShareGroupStateSummaryRequestData.ReadStateSummaryData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateSummaryRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateSummaryRequestData.PartitionData()
                     .setPartition(partition)
                     .setLeaderEpoch(5)))));
 
@@ -666,9 +666,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(0)
                     .setLeaderEpoch(5)))));
 
@@ -695,9 +695,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(3))))); // Lower leaderEpoch than the one stored in leaderMap.
 
@@ -750,9 +750,9 @@ class ShareCoordinatorShardTest {
         // Set initial state.
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(100)
                     .setStateEpoch(0)
@@ -781,7 +781,7 @@ class ShareCoordinatorShardTest {
         shard.replay(0L, 0L, (short) 0, result.records().get(0));
 
         WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request.topics().get(0).partitions().get(0))
         ));
 
@@ -797,14 +797,14 @@ class ShareCoordinatorShardTest {
         // Acknowledge b1.
         WriteShareGroupStateRequestData requestUpdateB1 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(-1)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new WriteShareGroupStateRequestData.StateBatch()    //b1
                             .setFirstOffset(100)
                             .setLastOffset(109)
@@ -819,14 +819,14 @@ class ShareCoordinatorShardTest {
         // Ack batch 3 and move start offset.
         WriteShareGroupStateRequestData requestUpdateStartOffsetAndB3 = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setStartOffset(110)    // 100 -> 110
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Collections.singletonList(
+                    .setStateBatches(List.of(
                         new WriteShareGroupStateRequestData.StateBatch()    //b3
                             .setFirstOffset(120)
                             .setLastOffset(129)
@@ -849,7 +849,7 @@ class ShareCoordinatorShardTest {
                 new PersisterStateBatch(120, 129, (byte) 2, (short) 1)
             ))
             .build();
-        List<CoordinatorRecord> expectedRecordsFinal = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+        List<CoordinatorRecord> expectedRecordsFinal = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, offsetFinal
         ));
 
@@ -871,7 +871,7 @@ class ShareCoordinatorShardTest {
             .build();
 
         when(manager.lastRedundantOffset()).thenReturn(Optional.of(10L));
-        assertEquals(new CoordinatorResult<>(Collections.emptyList(), Optional.of(10L)), shard.lastRedundantOffset());
+        assertEquals(new CoordinatorResult<>(List.of(), Optional.of(10L)), shard.lastRedundantOffset());
     }
 
     @Test
@@ -882,9 +882,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(2)
                 ))));
@@ -897,12 +897,12 @@ class ShareCoordinatorShardTest {
             TOPIC_ID, PARTITION,
             PartitionFactory.UNINITIALIZED_START_OFFSET,
             PartitionFactory.DEFAULT_STATE_EPOCH,
-            Collections.emptyList());
-        List<CoordinatorRecord> expectedRecords = Collections.singletonList(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
+            List.of());
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
             GROUP_ID, TOPIC_ID, PARTITION, new ShareGroupOffset.Builder()
                 .setStartOffset(PartitionFactory.UNINITIALIZED_START_OFFSET)
                 .setLeaderEpoch(2)
-                .setStateBatches(Collections.emptyList())
+                .setStateBatches(List.of())
                 .setSnapshotEpoch(0)
                 .setStateEpoch(PartitionFactory.DEFAULT_STATE_EPOCH)
                 .build()
@@ -922,9 +922,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request1 = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(2)
                 ))));
@@ -937,9 +937,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request2 = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(-1)
                 ))));
@@ -950,9 +950,9 @@ class ShareCoordinatorShardTest {
 
         ReadShareGroupStateRequestData request3 = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+            .setTopics(List.of(new ReadShareGroupStateRequestData.ReadStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new ReadShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)
                     .setLeaderEpoch(-1)
                 ))));
@@ -971,9 +971,9 @@ class ShareCoordinatorShardTest {
 
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new DeleteShareGroupStateRequestData.DeleteStateData()
+            .setTopics(List.of(new DeleteShareGroupStateRequestData.DeleteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new DeleteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new DeleteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)))));
 
         CoordinatorResult<DeleteShareGroupStateResponseData, CoordinatorRecord> result = shard.deleteState(request);
@@ -1028,9 +1028,9 @@ class ShareCoordinatorShardTest {
 
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
-            .setTopics(Collections.singletonList(new DeleteShareGroupStateRequestData.DeleteStateData()
+            .setTopics(List.of(new DeleteShareGroupStateRequestData.DeleteStateData()
                 .setTopicId(TOPIC_ID)
-                .setPartitions(Collections.singletonList(new DeleteShareGroupStateRequestData.PartitionData()
+                .setPartitions(List.of(new DeleteShareGroupStateRequestData.PartitionData()
                     .setPartition(PARTITION)))));
 
         CoordinatorResult<DeleteShareGroupStateResponseData, CoordinatorRecord> result = shard.deleteState(request);

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorTestConfig.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorTestConfig.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class ShareCoordinatorTestConfig {
 
-    private static final List<ConfigDef> CONFIG_DEF_LIST = Collections.singletonList(
+    private static final List<ConfigDef> CONFIG_DEF_LIST = List.of(
         ShareCoordinatorConfig.CONFIG_DEF
     );
 


### PR DESCRIPTION
Given that now we support Java 17 on our brokers, this PR replace the use of `Collections.singletonList()` and `Collections.emptyList()` with `List.of()`