### PR TITLE
MINOR: fix flaky TruncationTest.test_offset_truncate

### DIFF
--- a/tests/kafkatest/tests/client/truncation_test.py
+++ b/tests/kafkatest/tests/client/truncation_test.py
@@ -80,7 +80,7 @@ class TruncationTest(VerifiableConsumerTest):
         isr = self.kafka.isr_idx_list(self.TOPIC, 0)
         node1 = self.kafka.get_node(isr[0])
         self.kafka.stop_node(node1)
-        self.logger.info("Reduced ISR to one node, consumer is at %s", consumer.current_position(tp))
+        self.logger.info("Reduced ISR to one node, stop node %s, consumer is at %s", node1, consumer.current_position(tp))
 
         # Ensure remaining ISR member has a little bit of data
         current_total = consumer.total_consumed()
@@ -91,7 +91,7 @@ class TruncationTest(VerifiableConsumerTest):
         # Kill last ISR member
         node2 = self.kafka.get_node(isr[1])
         self.kafka.stop_node(node2)
-        self.logger.info("No members in ISR, consumer is at %s", consumer.current_position(tp))
+        self.logger.info("No members in ISR, stop node %s, consumer is at %s", node2, consumer.current_position(tp))
 
         # Keep consuming until we've caught up to HW
         def none_consumed(this, consumer):
@@ -121,12 +121,12 @@ class TruncationTest(VerifiableConsumerTest):
                    timeout_sec=30,
                    err_msg="Timed out waiting for truncation")
 
+        producer.stop()
+        consumer.stop()
+
         # Make sure we didn't reset to beginning of log
         total_records_consumed = len(self.all_values_consumed)
         assert total_records_consumed == len(set(self.all_values_consumed)), "Received duplicate records"
-
-        consumer.stop()
-        producer.stop()
 
         # Re-consume all the records
         consumer2 = VerifiableConsumer(self.test_context, 1, self.kafka, self.TOPIC, group_id="group2",
@@ -145,6 +145,6 @@ class TruncationTest(VerifiableConsumerTest):
                err_msg="Timed out waiting for the consumer to fully consume data")
 
         second_total_consumed = consumer2.total_consumed()
-        assert second_total_consumed < total_records_consumed, "Expected fewer records with new consumer since we truncated"
+        assert second_total_consumed < total_records_consumed, ("Expected fewer records with new consumer since we truncated, total_records_consumed is %s, second_total_consumed is %s" % total_records_consumed, second_total_consumed)
         self.logger.info("Second consumer saw only %s, meaning %s were truncated",
                          second_total_consumed, total_records_consumed - second_total_consumed)


### PR DESCRIPTION
The case `TruncationTest.test_offset_truncate` is flaky some time on my laptop. I can reproduce the error once every ten attempts. The production code is fine, because in both successful and failed cases, I can see log like `Truncating partition test_topic-0 with TruncationState(offset=xx, completed=true) due to leader epoch and offset EpochEndOffset`. That means truncation is really happened.

The tricky part is that in VerifiableConsumer-0 log, I can see consumer commit offset at 191. However, when I print `total_records_consumed`, it's only 83. We got `total_records_consumed` before stopping the consumer, so there is time gap that the consumer may keep consuming other data. The fix is to stop the consumer before getting `total_records_consumed`. With this fix, I can't reproduce the error.

[failed-TruncationTest-test_offset_truncate.zip](https://github.com/user-attachments/files/18927058/failed-TruncationTest-test_offset_truncate.zip)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
