### PR TITLE
KAFKA-18780: Extend RetriableException related exceptions

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
@@ -18,8 +18,8 @@ package org.apache.kafka.common.errors;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionExceptionHierarchyTest {
 
@@ -48,4 +48,3 @@ public class TransactionExceptionHierarchyTest {
         assertRetriableExceptionInheritance(ConcurrentTransactionsException.class);
     }
 }
-

--- a/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
@@ -16,21 +16,20 @@
  */
 package org.apache.kafka.common.errors;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionExceptionHierarchyTest {
 
-    @Test
-    void testRetriableExceptionExceptionHierarchy() {
-        assertRetriableExceptionInheritance(TimeoutException.class);
-        assertRetriableExceptionInheritance(NotEnoughReplicasException.class);
-        assertRetriableExceptionInheritance(CoordinatorLoadInProgressException.class);
-        assertRetriableExceptionInheritance(CorruptRecordException.class);
-        assertRetriableExceptionInheritance(NotEnoughReplicasAfterAppendException.class);
-        assertRetriableExceptionInheritance(ConcurrentTransactionsException.class);
+    @ParameterizedTest
+    @MethodSource("retriableExceptionsProvider")
+    void testRetriableExceptionExceptionHierarchy(Class<? extends Exception> exceptionClass) {
+        assertRetriableExceptionInheritance(exceptionClass);
     }
 
     /**
@@ -46,5 +45,16 @@ public class TransactionExceptionHierarchyTest {
                 exceptionClass.getSimpleName() + " should extend RetriableException");
         assertFalse(RefreshRetriableException.class.isAssignableFrom(exceptionClass),
                 exceptionClass.getSimpleName() + " should NOT extend RefreshRetriableException");
+    }
+
+    private static Stream<Class<? extends Exception>> retriableExceptionsProvider() {
+        return Stream.of(
+                TimeoutException.class,
+                NotEnoughReplicasException.class,
+                CoordinatorLoadInProgressException.class,
+                CorruptRecordException.class,
+                NotEnoughReplicasAfterAppendException.class,
+                ConcurrentTransactionsException.class
+        );
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
@@ -17,44 +17,35 @@
 package org.apache.kafka.common.errors;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionExceptionHierarchyTest {
 
-    @ParameterizedTest
-    @MethodSource("retriableExceptionsProvider")
-    void testRetriableExceptionExceptionHierarchy(Class<? extends Exception> exceptionClass) {
-        assertRetriableExceptionInheritance(exceptionClass);
-    }
-
     /**
      * Verifies that the given exception class extends `RetriableException`
      * and does **not** extend `RefreshRetriableException`.
+     *
      * Using `RefreshRetriableException` changes the exception handling behavior,
-     * so only exceptions directly extending `RetriableException` are valid here.
+     * so only exceptions extending `RetriableException` directly are considered valid here.
      *
      * @param exceptionClass the exception class to check
      */
-    private void assertRetriableExceptionInheritance(Class<?> exceptionClass) {
+    @ParameterizedTest
+    @ValueSource(classes = {
+        TimeoutException.class,
+        NotEnoughReplicasException.class,
+        CoordinatorLoadInProgressException.class,
+        CorruptRecordException.class,
+        NotEnoughReplicasAfterAppendException.class,
+        ConcurrentTransactionsException.class
+    })
+    void testRetriableExceptionHierarchy(Class<? extends Exception> exceptionClass) {
         assertTrue(RetriableException.class.isAssignableFrom(exceptionClass),
                 exceptionClass.getSimpleName() + " should extend RetriableException");
         assertFalse(RefreshRetriableException.class.isAssignableFrom(exceptionClass),
                 exceptionClass.getSimpleName() + " should NOT extend RefreshRetriableException");
-    }
-
-    private static Stream<Class<? extends Exception>> retriableExceptionsProvider() {
-        return Stream.of(
-                TimeoutException.class,
-                NotEnoughReplicasException.class,
-                CoordinatorLoadInProgressException.class,
-                CorruptRecordException.class,
-                NotEnoughReplicasAfterAppendException.class,
-                ConcurrentTransactionsException.class
-        );
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
@@ -23,6 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionExceptionHierarchyTest {
 
+    @Test
+    void testRetriableExceptionExceptionHierarchy() {
+        assertRetriableExceptionInheritance(TimeoutException.class);
+        assertRetriableExceptionInheritance(NotEnoughReplicasException.class);
+        assertRetriableExceptionInheritance(CoordinatorLoadInProgressException.class);
+        assertRetriableExceptionInheritance(CorruptRecordException.class);
+        assertRetriableExceptionInheritance(NotEnoughReplicasAfterAppendException.class);
+        assertRetriableExceptionInheritance(ConcurrentTransactionsException.class);
+    }
+
     /**
      * Verifies that the given exception class extends `RetriableException`
      * and does **not** extend `RefreshRetriableException`.
@@ -36,15 +46,5 @@ public class TransactionExceptionHierarchyTest {
                 exceptionClass.getSimpleName() + " should extend RetriableException");
         assertFalse(RefreshRetriableException.class.isAssignableFrom(exceptionClass),
                 exceptionClass.getSimpleName() + " should NOT extend RefreshRetriableException");
-    }
-
-    @Test
-    void testRetriableExceptionExceptionHierarchy() {
-        assertRetriableExceptionInheritance(TimeoutException.class);
-        assertRetriableExceptionInheritance(NotEnoughReplicasException.class);
-        assertRetriableExceptionInheritance(CoordinatorLoadInProgressException.class);
-        assertRetriableExceptionInheritance(CorruptRecordException.class);
-        assertRetriableExceptionInheritance(NotEnoughReplicasAfterAppendException.class);
-        assertRetriableExceptionInheritance(ConcurrentTransactionsException.class);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/errors/TransactionExceptionHierarchyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TransactionExceptionHierarchyTest {
+
+    /**
+     * Verifies that the given exception class extends `RetriableException`
+     * and does **not** extend `RefreshRetriableException`.
+     * Using `RefreshRetriableException` changes the exception handling behavior,
+     * so only exceptions directly extending `RetriableException` are valid here.
+     *
+     * @param exceptionClass the exception class to check
+     */
+    private void assertRetriableExceptionInheritance(Class<?> exceptionClass) {
+        assertTrue(RetriableException.class.isAssignableFrom(exceptionClass),
+                exceptionClass.getSimpleName() + " should extend RetriableException");
+        assertFalse(RefreshRetriableException.class.isAssignableFrom(exceptionClass),
+                exceptionClass.getSimpleName() + " should NOT extend RefreshRetriableException");
+    }
+
+    @Test
+    void testRetriableExceptionExceptionHierarchy() {
+        assertRetriableExceptionInheritance(TimeoutException.class);
+        assertRetriableExceptionInheritance(NotEnoughReplicasException.class);
+        assertRetriableExceptionInheritance(CoordinatorLoadInProgressException.class);
+        assertRetriableExceptionInheritance(CorruptRecordException.class);
+        assertRetriableExceptionInheritance(NotEnoughReplicasAfterAppendException.class);
+        assertRetriableExceptionInheritance(ConcurrentTransactionsException.class);
+    }
+}
+


### PR DESCRIPTION
**Summary**
- Added a unit test to validate the exception hierarchy for all KIP-1050 transaction related exceptions.
- RetriableException is correctly extended by all child classes
- Included test for RetriableException exception with verification that all exceptions extending `RetriableException` do not inadvertently extend `RefreshRetriableException, preserving the intended behavior.