### PR TITLE
MINOR : Add missing error code in ConsumerHeartbeatRequestManagerTest.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * - {@link Errors#INVALID_REQUEST}
  * - {@link Errors#INVALID_GROUP_ID}
  * - {@link Errors#GROUP_ID_NOT_FOUND}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class ConsumerGroupDescribeResponse extends AbstractResponse {
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
@@ -39,6 +39,7 @@ import java.util.Map;
  * - {@link Errors#UNRELEASED_INSTANCE_ID}
  * - {@link Errors#GROUP_MAX_SIZE_REACHED}
  * - {@link Errors#INVALID_REGULAR_EXPRESSION}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class ConsumerGroupHeartbeatResponse extends AbstractResponse {
     private final ConsumerGroupHeartbeatResponseData data;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -1029,7 +1029,8 @@ public class ConsumerHeartbeatRequestManagerTest {
             Arguments.of(Errors.UNSUPPORTED_VERSION, true),
             Arguments.of(Errors.UNRELEASED_INSTANCE_ID, true),
             Arguments.of(Errors.FENCED_INSTANCE_ID, true),
-            Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true));
+            Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true),
+            Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, true));
     }
 
     private ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -1030,7 +1030,7 @@ public class ConsumerHeartbeatRequestManagerTest {
             Arguments.of(Errors.UNRELEASED_INSTANCE_ID, true),
             Arguments.of(Errors.FENCED_INSTANCE_ID, true),
             Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true),
-            Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, true));
+            Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, false));
     }
 
     private ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,


### PR DESCRIPTION
***What***
PR fixes a minor bug in https://github.com/apache/kafka/pull/18986/files#diff-9fbddcb7950c03d236f3791df42fe4de0feb6d4ff25c7d8bec80545ff9378af3R585. 

The test was previously not taking in the intented error code (TOPIC_AUTHORIZATION_FAILED), now it would.

Updated javadocs for `ConsumerHeartbeatResponse` and `ConsumerDescribeResponse`.