### PR TITLE
MINOR: Remove unused system test code and avoid misleading `quorum.zk` references

### DIFF
--- a/tests/kafkatest/sanity_checks/test_console_consumer.py
+++ b/tests/kafkatest/sanity_checks/test_console_consumer.py
@@ -40,7 +40,7 @@ class ConsoleConsumerTest(Test):
     @cluster(num_nodes=4)
     @matrix(security_protocol=['SASL_SSL'], sasl_mechanism=['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'], metadata_quorum=quorum.all_kraft)
     @matrix(security_protocol=['SASL_PLAINTEXT', 'SASL_SSL'], metadata_quorum=quorum.all_kraft)
-    def test_lifecycle(self, security_protocol, sasl_mechanism='GSSAPI', metadata_quorum=quorum.zk):
+    def test_lifecycle(self, security_protocol, sasl_mechanism='GSSAPI', metadata_quorum=quorum.isolated_kraft):
         """Check that console consumer starts/stops properly, and that we are capturing log output."""
 
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -32,7 +32,7 @@ class PerformanceServiceTest(Test):
 
     @cluster(num_nodes=5)
     @matrix(version=[str(LATEST_2_1), str(DEV_BRANCH)], metadata_quorum=quorum.all_kraft)
-    def test_version(self, version=str(LATEST_2_1), metadata_quorum=quorum.zk):
+    def test_version(self, version=str(LATEST_2_1), metadata_quorum=quorum.isolated_kraft):
         """
         Sanity check out producer performance service - verify that we can run the service with a small
         number of messages. The actual stats here are pretty meaningless since the number of messages is quite small.
@@ -47,7 +47,7 @@ class PerformanceServiceTest(Test):
         self.producer_perf = ProducerPerformanceService(
             self.test_context, 1, self.kafka, topic=self.topic,
             num_records=self.num_records, record_size=self.record_size,
-            throughput=1000000000,  # Set impossibly for no throttling for equivalent behavior between 0.8.X and 0.9.X
+            throughput=1000000000,  # Effectively no throttling
             version=version,
             settings={
                 'acks': 1,

--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -46,9 +46,9 @@ class TestVerifiableProducer(Test):
     @matrix(producer_version=[str(DEV_BRANCH)], security_protocol=['SASL_SSL'], sasl_mechanism=['PLAIN', 'GSSAPI'],
             metadata_quorum=quorum.all_kraft)
     def test_simple_run(self, producer_version, acks=None, enable_idempotence=False, security_protocol = 'PLAINTEXT',
-                        sasl_mechanism='PLAIN', metadata_quorum=quorum.zk):
+                        sasl_mechanism='PLAIN', metadata_quorum=quorum.isolated_kraft):
         """
-        Test that we can start VerifiableProducer on the current branch snapshot version or against the 0.8.2 jar, and
+        Test that we can start VerifiableProducer on the current branch snapshot version, and
         verify that we can produce a small number of messages.
         """
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1353,30 +1353,27 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Running alter message format command...\n%s" % cmd)
         node.account.ssh(cmd)
 
-    def kafka_acls_cmd_with_optional_security_settings(self, node, force_use_zk_connection, kafka_security_protocol = None, override_command_config = None):
+    def kafka_acls_cmd_with_optional_security_settings(self, node, kafka_security_protocol = None, override_command_config = None):
         if self.quorum_info.using_kraft and not self.quorum_info.has_brokers:
             raise Exception("Must invoke kafka-acls against a broker, not a KRaft controller")
-        force_use_zk_connection = force_use_zk_connection
-        if force_use_zk_connection:
-            bootstrap_server_or_authorizer_zk_props = "--authorizer-properties zookeeper.connect=%s" % (self.zk_connect_setting())
-            skip_optional_security_settings = True
-        else:
-            if kafka_security_protocol is None:
-                # it wasn't specified, so use the inter-broker security protocol if it is PLAINTEXT,
-                # otherwise use the client security protocol
-                if self.interbroker_security_protocol == SecurityConfig.PLAINTEXT:
-                    security_protocol_to_use = SecurityConfig.PLAINTEXT
-                else:
-                    security_protocol_to_use = self.security_protocol
+
+        if kafka_security_protocol is None:
+            # it wasn't specified, so use the inter-broker security protocol if it is PLAINTEXT,
+            # otherwise use the client security protocol
+            if self.interbroker_security_protocol == SecurityConfig.PLAINTEXT:
+                security_protocol_to_use = SecurityConfig.PLAINTEXT
             else:
-                security_protocol_to_use = kafka_security_protocol
-            bootstrap_server_or_authorizer_zk_props = "--bootstrap-server %s" % (self.bootstrap_servers(security_protocol_to_use))
-            skip_optional_security_settings = security_protocol_to_use == SecurityConfig.PLAINTEXT
-        if skip_optional_security_settings:
+                security_protocol_to_use = self.security_protocol
+        else:
+            security_protocol_to_use = kafka_security_protocol
+
+        bootstrap_server = "--bootstrap-server %s" % (self.bootstrap_servers(security_protocol_to_use))
+
+        if security_protocol_to_use == SecurityConfig.PLAINTEXT:
             optional_jass_krb_system_props_prefix = ""
             optional_command_config_suffix = ""
         else:
-            # we need security configs because aren't going to ZooKeeper and we aren't using PLAINTEXT
+            # we need security configs because we aren't using PLAINTEXT
             if (security_protocol_to_use == self.interbroker_security_protocol):
                 # configure JAAS to provide the broker's credentials
                 # since this is an authenticating cluster and we are going to use the inter-broker security protocol
@@ -1395,8 +1392,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 optional_command_config_suffix = " --command-config %s" % (override_command_config)
         kafka_acls_script = self.path.script("kafka-acls.sh", node)
         return "%s%s %s%s" % \
-               (optional_jass_krb_system_props_prefix, kafka_acls_script,
-                bootstrap_server_or_authorizer_zk_props, optional_command_config_suffix)
+               (optional_jass_krb_system_props_prefix, kafka_acls_script, bootstrap_server, optional_command_config_suffix)
 
     def run_cli_tool(self, node, cmd):
         output = ""

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1197,12 +1197,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 return False
         return True
 
-    def all_nodes_acl_command_supports_bootstrap_server(self):
-        for node in self.nodes:
-            if not node.version.acl_command_supports_bootstrap_server():
-                return False
-        return True
-
     def all_nodes_reassign_partitions_command_supports_bootstrap_server(self):
         for node in self.nodes:
             if not node.version.reassign_partitions_command_supports_bootstrap_server():
@@ -1362,7 +1356,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def kafka_acls_cmd_with_optional_security_settings(self, node, force_use_zk_connection, kafka_security_protocol = None, override_command_config = None):
         if self.quorum_info.using_kraft and not self.quorum_info.has_brokers:
             raise Exception("Must invoke kafka-acls against a broker, not a KRaft controller")
-        force_use_zk_connection = force_use_zk_connection or not self.all_nodes_acl_command_supports_bootstrap_server
+        force_use_zk_connection = force_use_zk_connection
         if force_use_zk_connection:
             bootstrap_server_or_authorizer_zk_props = "--authorizer-properties zookeeper.connect=%s" % (self.zk_connect_setting())
             skip_optional_security_settings = True

--- a/tests/kafkatest/services/kafka/quorum.py
+++ b/tests/kafkatest/services/kafka/quorum.py
@@ -14,14 +14,10 @@
 # limitations under the License.
 
 # the types of metadata quorums we support
-zk = 'ZK' # ZooKeeper, used before/during the KIP-500 bridge release(s)
-combined_kraft = 'COMBINED_KRAFT' # combined Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
-isolated_kraft = 'ISOLATED_KRAFT' # isolated Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
+zk = 'ZK' # ZooKeeper, supported from 0.11 to 3.9 (inclusive)
+combined_kraft = 'COMBINED_KRAFT' # combined Controllers in KRaft mode, production-ready from 3.3
+isolated_kraft = 'ISOLATED_KRAFT' # isolated Controllers in KRaft mode, production-ready from 3.3
 
-# How we will parameterize tests that exercise all quorum styles
-#   [“ZK”, “ISOLATED_KRAFT”, "COMBINED_KRAFT"] during the KIP-500 bridge release(s)
-#   [“ISOLATED_KRAFT”, "COMBINED_KRAFT”] after the KIP-500 bridge release(s)
-all = [zk, isolated_kraft, combined_kraft]
 # How we will parameterize tests that exercise all KRaft quorum styles
 all_kraft = [isolated_kraft, combined_kraft]
 # How we will parameterize tests that are unrelated to upgrades:
@@ -30,7 +26,7 @@ all_non_upgrade = [isolated_kraft]
 
 def for_test(test_context):
     # A test uses ZooKeeper if it doesn't specify a metadata quorum or if it explicitly specifies ZooKeeper
-    default_quorum_type = zk
+    default_quorum_type = isolated_kraft
     arg_name = 'metadata_quorum'
     retval = default_quorum_type if not test_context.injected_args else test_context.injected_args.get(arg_name, default_quorum_type)
     if retval not in all:

--- a/tests/kafkatest/services/security/kafka_acls.py
+++ b/tests/kafkatest/services/security/kafka_acls.py
@@ -19,13 +19,11 @@ class ACLs:
     def __init__(self, context):
         self.context = context
 
-    def add_cluster_acl(self, kafka, principal, force_use_zk_connection=False, additional_cluster_operations_to_grant = [], security_protocol=None):
+    def add_cluster_acl(self, kafka, principal, additional_cluster_operations_to_grant = [], security_protocol=None):
         """
         :param kafka: Kafka cluster upon which ClusterAction ACL is created
         :param principal: principal for which ClusterAction ACL is created
         :param node: Node to use when determining connection settings
-        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
-               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
         :param additional_cluster_operations_to_grant may be set to ['Alter', 'Create'] if the cluster is secured since these are required
                to create SCRAM credentials and topics, respectively
         :param security_protocol set it to explicitly determine whether we use client or broker credentials, otherwise
@@ -37,7 +35,7 @@ class ACLs:
 
         for operation in ['ClusterAction'] + additional_cluster_operations_to_grant:
             cmd = "%(cmd_prefix)s --add --cluster --operation=%(operation)s --allow-principal=%(principal)s" % {
-                'cmd_prefix': kafka.kafka_acls_cmd_with_optional_security_settings(node, force_use_zk_connection, security_protocol),
+                'cmd_prefix': kafka.kafka_acls_cmd_with_optional_security_settings(node, security_protocol),
                 'operation': operation,
                 'principal': principal
             }
@@ -59,7 +57,7 @@ class ACLs:
 
         for operation in ['ClusterAction'] + additional_cluster_operations_to_remove:
             cmd = "%(cmd_prefix)s --remove --force --cluster --operation=%(operation)s --allow-principal=%(principal)s" % {
-                'cmd_prefix': kafka.kafka_acls_cmd_with_optional_security_settings(node, False, security_protocol),
+                'cmd_prefix': kafka.kafka_acls_cmd_with_optional_security_settings(node, security_protocol),
                 'operation': operation,
                 'principal': principal
             }

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -124,7 +124,7 @@ class ClientCompatibilityFeaturesTest(Test):
     @parametrize(broker_version=str(LATEST_3_7), metadata_quorum=quorum.isolated_kraft)
     @parametrize(broker_version=str(LATEST_3_8), metadata_quorum=quorum.isolated_kraft)
     @parametrize(broker_version=str(LATEST_3_9), metadata_quorum=quorum.isolated_kraft)
-    def run_compatibility_test(self, broker_version, metadata_quorum=quorum.zk):
+    def run_compatibility_test(self, broker_version, metadata_quorum=quorum.isolated_kraft):
         if self.zk:
             self.zk.start()
         self.kafka.set_version(KafkaVersion(broker_version))

--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -84,7 +84,7 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     @parametrize(broker_version=str(LATEST_3_7), metadata_quorum=quorum.isolated_kraft)
     @parametrize(broker_version=str(LATEST_3_8), metadata_quorum=quorum.isolated_kraft)
     @parametrize(broker_version=str(LATEST_3_9), metadata_quorum=quorum.isolated_kraft)
-    def test_produce_consume(self, broker_version, metadata_quorum=quorum.zk):
+    def test_produce_consume(self, broker_version, metadata_quorum=quorum.isolated_kraft):
         print("running producer_consumer_compat with broker_version = %s" % broker_version, flush=True)
         self.kafka.set_version(KafkaVersion(broker_version))
         if metadata_quorum == quorum.isolated_kraft:

--- a/tests/kafkatest/tests/client/compression_test.py
+++ b/tests/kafkatest/tests/client/compression_test.py
@@ -57,7 +57,7 @@ class CompressionTest(ProduceConsumeValidateTest):
 
     @cluster(num_nodes=8)
     @matrix(compression_types=[COMPRESSION_TYPES], metadata_quorum=quorum.all_non_upgrade)
-    def test_compressed_topic(self, compression_types, metadata_quorum=quorum.zk):
+    def test_compressed_topic(self, compression_types, metadata_quorum=quorum.isolated_kraft):
         """Test produce => consume => validate for compressed topics
         Setup: 1 zk, 1 kafka node, 1 topic with partitions=10, replication-factor=1
 

--- a/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
@@ -52,7 +52,7 @@ class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True, False]
     )
-    def rolling_update_test(self, metadata_quorum=quorum.zk, use_new_coordinator=False):
+    def rolling_update_test(self, metadata_quorum=quorum.isolated_kraft, use_new_coordinator=False):
         """
         Verify rolling updates of partition assignment strategies works correctly. In this
         test, we use a rolling restart to change the group's assignment strategy from "range" 

--- a/tests/kafkatest/tests/client/pluggable_test.py
+++ b/tests/kafkatest/tests/client/pluggable_test.py
@@ -34,7 +34,7 @@ class PluggableConsumerTest(VerifiableConsumerTest):
 
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_start_stop(self, metadata_quorum=quorum.zk):
+    def test_start_stop(self, metadata_quorum=quorum.isolated_kraft):
         """
         Test that a pluggable VerifiableConsumer module load works
         """

--- a/tests/kafkatest/tests/client/share_consumer_test.py
+++ b/tests/kafkatest/tests/client/share_consumer_test.py
@@ -253,7 +253,7 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         metadata_quorum=[quorum.isolated_kraft, quorum.combined_kraft],
         use_share_groups=[True]
     )
-    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.zk, use_share_groups=True):
+    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.isolated_kraft, use_share_groups=True):
         """
         Verify correct share consumer behavior when the share consumers in the group are consecutively restarted.
 
@@ -295,7 +295,7 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         metadata_quorum=[quorum.isolated_kraft, quorum.combined_kraft],
         use_share_groups=[True]
     )
-    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.zk, num_failed_consumers=1, use_share_groups=True):
+    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_consumers=1, use_share_groups=True):
 
         producer = self.setup_producer(self.TOPIC2["name"])
         consumer = self.setup_share_group(self.TOPIC2["name"], offset_reset_strategy="earliest")

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -70,7 +70,7 @@ class ConnectStandaloneFileTest(Test):
     @cluster(num_nodes=6)
     @matrix(security_protocol=[SecurityConfig.SASL_SSL], metadata_quorum=quorum.all_non_upgrade)
     def test_file_source_and_sink(self, converter="org.apache.kafka.connect.json.JsonConverter", schemas=True, security_protocol='PLAINTEXT',
-                                  metadata_quorum=quorum.zk):
+                                  metadata_quorum=quorum.isolated_kraft):
         """
         Validates basic end-to-end functionality of Connect standalone using the file source and sink converters. Includes
         parameterizations to test different converters (which also test per-connector converter overrides), schema/schemaless

--- a/tests/kafkatest/tests/core/authorizer_test.py
+++ b/tests/kafkatest/tests/core/authorizer_test.py
@@ -98,8 +98,8 @@ class AuthorizerTest(Test):
 
         # add ACLs
         self.logger.info("Adding ACLs with broker credentials so that alter client quotas command will succeed")
-        self.acls.add_cluster_acl(self.kafka, client_principal, force_use_zk_connection=False,
-                                  additional_cluster_operations_to_grant=['AlterConfigs'], security_protocol=broker_security_protocol)
+        self.acls.add_cluster_acl(self.kafka, client_principal, additional_cluster_operations_to_grant=['AlterConfigs'],
+                                  security_protocol=broker_security_protocol)
 
         # the alter client quotas command should now succeed again
         self.logger.info(alter_client_quotas_cmd_log_msg)

--- a/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
+++ b/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
@@ -61,7 +61,7 @@ class ClientCompatibilityTestNewBroker(ProduceConsumeValidateTest):
     @matrix(producer_version=[str(LATEST_3_8)], consumer_version=[str(LATEST_3_8)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_3_9)], consumer_version=[str(LATEST_3_9)], compression_types=[["none"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
     @matrix(producer_version=[str(LATEST_2_1)], consumer_version=[str(LATEST_2_1)], compression_types=[["zstd"]], timestamp_type=[str("CreateTime")], metadata_quorum=quorum.all_non_upgrade)
-    def test_compatibility(self, producer_version, consumer_version, compression_types, timestamp_type=None, metadata_quorum=quorum.zk):
+    def test_compatibility(self, producer_version, consumer_version, compression_types, timestamp_type=None, metadata_quorum=quorum.isolated_kraft):
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=None, version=DEV_BRANCH, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,

--- a/tests/kafkatest/tests/core/get_offset_shell_test.py
+++ b/tests/kafkatest/tests/core/get_offset_shell_test.py
@@ -98,7 +98,7 @@ class GetOffsetShellTest(Test):
 
     @cluster(num_nodes=3)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_get_offset_shell_topic_name(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_get_offset_shell_topic_name(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests if GetOffsetShell handles --topic argument with a simple name correctly
         :return: None
@@ -112,7 +112,7 @@ class GetOffsetShellTest(Test):
 
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_get_offset_shell_topic_pattern(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_get_offset_shell_topic_pattern(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests if GetOffsetShell handles --topic argument with a pattern correctly
         :return: None
@@ -127,7 +127,7 @@ class GetOffsetShellTest(Test):
 
     @cluster(num_nodes=3)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_get_offset_shell_partitions(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_get_offset_shell_partitions(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests if GetOffsetShell handles --partitions argument correctly
         :return: None
@@ -149,7 +149,7 @@ class GetOffsetShellTest(Test):
 
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_get_offset_shell_topic_partitions(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_get_offset_shell_topic_partitions(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests if GetOffsetShell handles --topic-partitions argument correctly
         :return: None
@@ -201,7 +201,7 @@ class GetOffsetShellTest(Test):
 
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_get_offset_shell_internal_filter(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_get_offset_shell_internal_filter(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests if GetOffsetShell handles --exclude-internal-topics flag correctly
         :return: None

--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -143,7 +143,7 @@ class ReplicationTest(EndToEndTest):
     def test_replication_with_broker_failure(self, failure_mode, security_protocol, broker_type,
                                              client_sasl_mechanism="GSSAPI", interbroker_sasl_mechanism="GSSAPI",
                                              compression_type=None, enable_idempotence=False, tls_version=None,
-                                             metadata_quorum=quorum.zk, num_controllers=1):
+                                             metadata_quorum=quorum.isolated_kraft, num_controllers=1):
         """Replication tests.
         These tests verify that replication provides simple durability guarantees by checking that data acked by
         brokers is still available for consumption in the face of various failure scenarios.

--- a/tests/kafkatest/tests/tools/log_compaction_test.py
+++ b/tests/kafkatest/tests/tools/log_compaction_test.py
@@ -55,7 +55,7 @@ class LogCompactionTest(Test):
 
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_log_compaction(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_log_compaction(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
 
         self.start_kafka(security_protocol, security_protocol)
         self.start_test_log_compaction_tool(security_protocol)

--- a/tests/kafkatest/tests/tools/replica_verification_test.py
+++ b/tests/kafkatest/tests/tools/replica_verification_test.py
@@ -74,7 +74,7 @@ class ReplicaVerificationToolTest(Test):
 
     @cluster(num_nodes=6)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
-    def test_replica_lags(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.zk):
+    def test_replica_lags(self, security_protocol='PLAINTEXT', metadata_quorum=quorum.isolated_kraft):
         """
         Tests ReplicaVerificationTool
         :return: None

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -25,9 +25,9 @@ class KafkaVersion(LooseVersion):
 
     Example:
 
-        v10 = KafkaVersion("0.10.0")
-        v9 = KafkaVersion("0.9.0.1")
-        assert v10 > v9  # assertion passes!
+        v4 = KafkaVersion("4.0.0")
+        v3 = KafkaVersion("3.0.0")
+        assert v4 > v3  # assertion passes!
     """
     def __init__(self, version_string):
         self.is_dev = (version_string.lower() == "dev")
@@ -61,9 +61,6 @@ class KafkaVersion(LooseVersion):
             return 1
 
         return LooseVersion._cmp(self, other)
-
-    def acl_command_supports_bootstrap_server(self):
-        return self >= V_2_1_0
 
     def topic_command_supports_bootstrap_server(self):
         return self >= V_2_3_0


### PR DESCRIPTION
Also remove references to older versions that are no longer relevant.