### PR TITLE
KAFKA-3987: Replace MD5  for FIPS 140-3 compliance in Log Cleaner.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/CleanerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/CleanerConfig.java
@@ -32,7 +32,7 @@ import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
  * Configuration parameters for the log cleaner.
  */
 public class CleanerConfig {
-    public static final String HASH_ALGORITHM = "MD5";
+    public static final String HASH_ALGORITHM = "SHA-256";
     public static final int LOG_CLEANER_THREADS = 1;
     public static final double LOG_CLEANER_IO_MAX_BYTES_PER_SECOND = Double.MAX_VALUE;
     public static final long LOG_CLEANER_DEDUPE_BUFFER_SIZE = 128 * 1024 * 1024L;


### PR DESCRIPTION
Replace MD5 with SHA-256 for FIPS 140-3 compliance in Log Cleaner.