### PR TITLE
KAFKA-18850: Fix the docs of org.apache.kafka.automatic.config.providers

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -451,6 +451,33 @@ public class AbstractConfigTest {
     }
 
     @Test
+    public void testAutomaticConfigProvidersWithFullClassName() {
+        Properties props = new Properties();
+        props.put("config.providers", "file");
+        props.put("config.providers.file.class", MockFileConfigProvider.class.getName());
+        String id = UUID.randomUUID().toString();
+        props.put("config.providers.file.param.testId", id);
+        props.put("test.key", "${file:/path:key}");
+
+        System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY, "file");
+        assertThrows(ConfigException.class, () -> new TestIndirectConfigResolution(props, Collections.emptyMap()));
+
+        System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY, MockFileConfigProvider.class.getName());
+        TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, Collections.emptyMap());
+        assertEquals("testKey", config.originals().get("test.key"));
+        MockFileConfigProvider.assertClosed(id);
+
+        System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY,
+                MockFileConfigProvider.class.getName() + "," +
+                        "org.apache.kafka.common.config.provider.EnvVarConfigProvider");
+        String id2 = UUID.randomUUID().toString();
+        props.put("config.providers.file.param.testId", id2);
+        TestIndirectConfigResolution config2 = new TestIndirectConfigResolution(props, Collections.emptyMap());
+        assertEquals("testKey", config2.originals().get("test.key"));
+        MockFileConfigProvider.assertClosed(id2);
+    }
+
+    @Test
     public void testImmutableOriginalsWithConfigProvidersProps() {
         // Test Case: Valid Test Case for ConfigProviders as a separate variable
         Properties providers = new Properties();

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.config;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.provider.EnvVarConfigProvider;
 import org.apache.kafka.common.config.provider.FileConfigProvider;
 import org.apache.kafka.common.config.provider.MockFileConfigProvider;
 import org.apache.kafka.common.config.provider.MockVaultConfigProvider;
@@ -468,8 +469,7 @@ public class AbstractConfigTest {
         MockFileConfigProvider.assertClosed(id);
 
         System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY,
-                MockFileConfigProvider.class.getName() + "," +
-                        "org.apache.kafka.common.config.provider.EnvVarConfigProvider");
+                MockFileConfigProvider.class.getName() + "," + EnvVarConfigProvider.class.getName());
         String id2 = UUID.randomUUID().toString();
         props.put("config.providers.file.param.testId", id2);
         TestIndirectConfigResolution config2 = new TestIndirectConfigResolution(props, Collections.emptyMap());

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -453,28 +453,24 @@ public class AbstractConfigTest {
 
     @Test
     public void testAutomaticConfigProvidersWithFullClassName() {
-        Properties props = new Properties();
-        props.put("config.providers", "file");
-        props.put("config.providers.file.class", MockFileConfigProvider.class.getName());
-        String id = UUID.randomUUID().toString();
-        props.put("config.providers.file.param.testId", id);
-        props.put("test.key", "${file:/path:key}");
-
+        // case0: MockFileConfigProvider is disallowed by org.apache.kafka.automatic.config.providers
         System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY, "file");
-        assertThrows(ConfigException.class, () -> new TestIndirectConfigResolution(props, Collections.emptyMap()));
+        assertThrows(ConfigException.class, () -> new TestIndirectConfigResolution(Map.of("config.providers", "file",
+                "config.providers.file.class", MockFileConfigProvider.class.getName()),
+                Map.of()));
 
+        // case1: MockFileConfigProvider is allowed by org.apache.kafka.automatic.config.providers
         System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY, MockFileConfigProvider.class.getName());
-        TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, Collections.emptyMap());
-        assertEquals("testKey", config.originals().get("test.key"));
-        MockFileConfigProvider.assertClosed(id);
+        Map<String, String> props = Map.of("config.providers", "file",
+                "config.providers.file.class", MockFileConfigProvider.class.getName(),
+                "config.providers.file.param.testId", UUID.randomUUID().toString(),
+                "test.key", "${file:/path:key}");
+        assertEquals("testKey", new TestIndirectConfigResolution(props, Map.of()).originals().get("test.key"));
 
+        // case2: MockFileConfigProvider and EnvVarConfigProvider are allowed by org.apache.kafka.automatic.config.providers
         System.setProperty(AbstractConfig.AUTOMATIC_CONFIG_PROVIDERS_PROPERTY,
                 MockFileConfigProvider.class.getName() + "," + EnvVarConfigProvider.class.getName());
-        String id2 = UUID.randomUUID().toString();
-        props.put("config.providers.file.param.testId", id2);
-        TestIndirectConfigResolution config2 = new TestIndirectConfigResolution(props, Collections.emptyMap());
-        assertEquals("testKey", config2.originals().get("test.key"));
-        MockFileConfigProvider.assertClosed(id2);
+        assertEquals("testKey", new TestIndirectConfigResolution(props, Map.of()).originals().get("test.key"));
     }
 
     @Test

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -282,10 +282,10 @@
       <p>This system property controls the automatic loading of ConfigProvider implementations in Apache Kafka. ConfigProviders are used to dynamically supply configuration values from sources such as files, directories, or environment variables. This property accepts a comma-separated list of ConfigProvider names. By default, all built-in ConfigProviders are enabled, including <b>FileConfigProvider</b>, <b>DirectoryConfigProvider</b>, and <b>EnvVarConfigProvider</b>.</p>
       <p>If users want to disable all automatic ConfigProviders, they need to explicitly set the system property as shown below. Disabling automatic ConfigProviders is recommended in environments where configuration data comes from untrusted sources or where increased security is required. For more details, see <a href="https://kafka.apache.org/cve-list#CVE-2024-31141">CVE-2024-31141</a>.</p>
       <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=none</code></pre>
-      <p>To allow specific ConfigProviders, update the system property with a comma-separated list of ConfigProvider names. For example, to enable only the <b>EnvVarConfigProvider</b>, set the property as follows:</p>
-      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=env</code></pre>
+      <p>To allow specific ConfigProviders, update the system property with a comma-separated list of fully qualified ConfigProvider class names. For example, to enable only the <b>EnvVarConfigProvider</b>, set the property as follows:</p>
+      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=org.apache.kafka.common.config.provider.EnvVarConfigProvider</code></pre>
       <p>To use multiple ConfigProviders, include their names in a comma-separated list as shown below:</p>
-      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=file,env</code></pre>
+      <pre><code class="language-bash">-Dorg.apache.kafka.automatic.config.providers=org.apache.kafka.common.config.provider.FileConfigProvider,org.apache.kafka.common.config.provider.EnvVarConfigProvider</code></pre>
       <table>
         <tbody>
         <tr><th>Since:</th><td>3.8.0</td></tr>


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-18850

`org.apache.kafka.automatic.config.providers = env` is incorrect. According to the source code, the correct value should be the [class name](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java#L616). 

fix the doc and add unit test to verify.

<img width="631" alt="11" src="https://github.com/user-attachments/assets/f3f0f19d-8ef5-4950-85e5-3c7c868447a9" />
