### PR TITLE
KAFKA-18873: Fixed incorrect error message when exceeds 5 for transactional producers

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -471,7 +471,8 @@ public class KafkaProducerTest {
         assertThrows(
             ConfigException.class,
             () -> new ProducerConfig(invalidProps4),
-            "Must set retries to non-zero when using the idempotent producer.");
+            "Must set max.in.flight.requests.per.connection to at most 5 when using the \n" +
+                    "transactional producer.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -471,8 +471,7 @@ public class KafkaProducerTest {
         assertThrows(
             ConfigException.class,
             () -> new ProducerConfig(invalidProps4),
-            "Must set max.in.flight.requests.per.connection to at most 5 when using the \n" +
-                    "transactional producer.");
+            "Must set max.in.flight.requests.per.connection to at most 5 when using the transactional producer.");
     }
 
     @Test


### PR DESCRIPTION
The unit test `testInflightRequestsAndIdempotenceForIdempotentProducers` checks for configuration validation errors when instantiating a ProducerConfig with invalid properties. One of the assertions in this test is designed to validate the constraint that max.in.flight.requests.per.connection must be at most 5 when using a transactional producer. However, the error message thrown by the ProducerConfig constructor in this scenario is incorrect.

**Observed Behavior**:
When max.in.flight.requests.per.connection is set to 6 for a transactional producer, the test expects an exception with the message:
"Must set max.in.flight.requests.per.connection to at most 5 when using the transactional producer."
Instead, the error message states:
"Must set retries to non-zero when using the idempotent producer."

**Expected Behavio**r:
The error message should explicitly indicate the violation of the max.in.flight.requests.per.connection constraint for transactional producers:
"Must set max.in.flight.requests.per.connection to at most 5 when using the transactional producer."

The mismatch in the error message can lead to confusion for developers debugging the configuration error, as it incorrectly hints at a retries configuration issue instead of the actual max.in.flight.requests.per.connection issue.

Note: **the contribution is my original work and I license the work to the project under the project's open source license**