### PR TITLE
Clarification of topic configuration 'retention.bytes'

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -63,9 +63,10 @@ public class TopicConfig {
         "flush capabilities as it is more efficient.";
 
     public static final String RETENTION_BYTES_CONFIG = "retention.bytes";
-    public static final String RETENTION_BYTES_DOC = "This configuration controls the maximum size a partition " +
-        "(which consists of log segments) can grow to before we will discard old log segments to free up space if we " +
-        "are using the \"delete\" retention policy. By default there is no size limit only a time limit. " +
+    public static final String RETENTION_BYTES_DOC = "This configuration controls the desired maximum size of partition " +
+        "(which consists of log segments). Old log segments will be discarded to free up space so the partition size " + 
+        "will remain at least this value if we are using the \"delete\" retention policy. " +
+        "By default there is no size limit only a time limit. " +
         "Since this limit is enforced at the partition level, multiply it by the number of partitions to compute " +
         "the topic retention in bytes. Additionally, retention.bytes configuration " +
         "operates independently of \"segment.ms\" and \"segment.bytes\" configurations. " +
@@ -89,8 +90,9 @@ public class TopicConfig {
             "to `retention.ms` value.";
 
     public static final String LOCAL_LOG_RETENTION_BYTES_CONFIG = "local.retention.bytes";
-    public static final String LOCAL_LOG_RETENTION_BYTES_DOC = "The maximum size of local log segments that can grow for a partition before it " +
-            "deletes the old segments. Default value is -2, it represents `retention.bytes` value to be used. The effective value should always be " +
+    public static final String LOCAL_LOG_RETENTION_BYTES_DOC = "The desired maximum size of local log segments that can grow for a partition. " +
+            "Old log segments will be discarded to free up space so the partition size will remain at least this value. " +
+            "Default value is -2, it represents `retention.bytes` value to be used. The effective value should always be " +
             "less than or equal to `retention.bytes` value.";
 
     public static final String REMOTE_LOG_COPY_DISABLE_CONFIG = "remote.log.copy.disable";

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -145,7 +145,8 @@ public final class RemoteLogManagerConfig {
     public static final Long DEFAULT_LOG_LOCAL_RETENTION_MS = -2L;
 
     public static final String LOG_LOCAL_RETENTION_BYTES_PROP = "log.local.retention.bytes";
-    public static final String LOG_LOCAL_RETENTION_BYTES_DOC = "The maximum size of local log segments that can grow for a partition before it gets eligible for deletion. " +
+    public static final String LOG_LOCAL_RETENTION_BYTES_DOC = "The desired maximum size of local log segments that can grow for a partition before it gets eligible for deletion. " +
+            "Old log segments will be discarded to free up space so the partition size will remain at least this value. " +
             "Default value is -2, it represents `log.retention.bytes` value to be used. The effective value should always be " +
             "less than or equal to `log.retention.bytes` value.";
     public static final Long DEFAULT_LOG_LOCAL_RETENTION_BYTES = -2L;


### PR DESCRIPTION
The Kafka docs describes 'retention.bytes' configuration in a misleading way.
I believe that a clarification is required to ease the tuning of this configuration and for preventing severe confusion.

'retention.bytes' is depicted like this:
_This configuration controls the maximum size a partition (which consists of log segments) can grow to before we will discard old log segments to free up space..._

There are several problems in this description:
1. It seems like it's suppose to be the _minimum_ size of a partition, 
because old log segments won't be discarded before this size.
2. Even when the partition size reaches this size, old segments won't be automatically deleted like we would expect,
only if this "minimum" size could be guaranteed.

I will give an example for the differences and the misunderstanding:
A topic with only 1 partition, retention.bytes=1GB, and segment.bytes=512MB.

The behavior I EXPECTED: It would reserve about 1 GB of storage.
Once the topic reaches 1GB (or a bit more), 
old segments will be deleted as long as the total partition size is BIGGER THAN 1GB,
meaning the size of the partition will be approximately between 512MB-1GB+. 

The ACTUAL behavior: It would reserve about 1.5+ GB of storage.
There's a guarantee that our topic size won't be LESS THAN 1 GB,
meaning that when the partition reaches 1GB - segments won't be deleted, 
only when it reaches 1.5GB - allowing the deletion of 1 segment of 512MB, so we are left with size of 1GB+.

When the topic scale is bigger, we are talking about a difference of tens to hundred Gigabytes, which can cause storage exception and large confusion.

Therefore, I believe we can clarify that configuration very easily and perhaps prevent future issues.
