### PR TITLE
MINOR: Removing share partition manager flaky annotation

### DIFF
--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -47,7 +47,6 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.requests.ShareRequestMetadata;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -1260,7 +1259,6 @@ public class SharePartitionManagerTest {
         );
     }
 
-    @Flaky("KAFKA-18657")
     @Test
     public void testReplicaManagerFetchShouldProceed() {
         String groupId = "grp";
@@ -2298,7 +2296,6 @@ public class SharePartitionManagerTest {
         shareGroupMetrics.close();
     }
 
-    @Flaky("KAFKA-18657")
     @Test
     public void testDelayedInitializationShouldCompleteFetchRequest() {
         String groupId = "grp";


### PR DESCRIPTION
There isn't any flaky test for SharePartitionManager in last 7 days, removing flaky annotation.

https://develocity.apache.org/scans/tests?search.timeZoneId=Europe%2FLondon&tests.container=kafka.server.share.SharePartitionManagerTest