### PR TITLE
KAFKA-18817:[1/N] ShareGroupHeartbeat and ShareGroupDescribe API must check topic describe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
@@ -159,7 +159,9 @@ public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<Coordina
             Set<CoordinatorKey> groupsToUnmap) {
         switch (error) {
             case GROUP_AUTHORIZATION_FAILED:
+            case TOPIC_AUTHORIZATION_FAILED:
                 log.debug("`DescribeShareGroups` request for group id {} failed due to error {}", groupId.idValue, error);
+                // The topic auth response received on DescribeShareGroup is a generic one not including topic names, so we just pass it on unchanged here.
                 failed.put(groupId, error.exception(errorMsg));
                 break;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * - {@link Errors#INVALID_REQUEST}
  * - {@link Errors#INVALID_GROUP_ID}
  * - {@link Errors#GROUP_ID_NOT_FOUND}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class ShareGroupDescribeResponse extends AbstractResponse {
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * - {@link Errors#INVALID_REQUEST}
  * - {@link Errors#UNKNOWN_MEMBER_ID}
  * - {@link Errors#GROUP_MAX_SIZE_REACHED}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class ShareGroupHeartbeatResponse extends AbstractResponse {
     private final ShareGroupHeartbeatResponseData data;

--- a/clients/src/main/resources/common/message/ShareGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupDescribeResponse.json
@@ -27,6 +27,7 @@
   // - INVALID_REQUEST (version 0+)
   // - INVALID_GROUP_ID (version 0+)
   // - GROUP_ID_NOT_FOUND (version 0+)
+  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
@@ -21,12 +21,13 @@
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
-  // - NOT_COORDINATOR (version 0+) 
+  // - NOT_COORDINATOR (version 0+)
   // - COORDINATOR_NOT_AVAILABLE (version 0+)
   // - COORDINATOR_LOAD_IN_PROGRESS (version 0+)
   // - INVALID_REQUEST (version 0+)
   // - UNKNOWN_MEMBER_ID (version 0+)
   // - GROUP_MAX_SIZE_REACHED (version 0+)
+  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -402,12 +402,6 @@ public class ShareHeartbeatRequestManagerTest {
                 assertNextHeartbeatTiming(0);
                 break;
 
-            case TOPIC_AUTHORIZATION_FAILED:
-                verify(backgroundEventHandler).add(any(ErrorEvent.class));
-                assertNextHeartbeatTiming(DEFAULT_RETRY_BACKOFF_MS);
-                verify(membershipManager, never()).transitionToFatal();
-                break;
-
             default:
                 if (isFatal) {
                     when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
@@ -668,8 +662,7 @@ public class ShareHeartbeatRequestManagerTest {
                 Arguments.of(Errors.UNSUPPORTED_ASSIGNOR, true),
                 Arguments.of(Errors.UNSUPPORTED_VERSION, true),
                 Arguments.of(Errors.UNRELEASED_INSTANCE_ID, true),
-                Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true),
-                Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, false));
+                Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true));
     }
 
     private ClientResponse createHeartbeatResponse(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -402,6 +402,12 @@ public class ShareHeartbeatRequestManagerTest {
                 assertNextHeartbeatTiming(0);
                 break;
 
+            case TOPIC_AUTHORIZATION_FAILED:
+                verify(backgroundEventHandler).add(any(ErrorEvent.class));
+                assertNextHeartbeatTiming(DEFAULT_RETRY_BACKOFF_MS);
+                verify(membershipManager, never()).transitionToFatal();
+                break;
+
             default:
                 if (isFatal) {
                     when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
@@ -662,7 +668,8 @@ public class ShareHeartbeatRequestManagerTest {
                 Arguments.of(Errors.UNSUPPORTED_ASSIGNOR, true),
                 Arguments.of(Errors.UNSUPPORTED_VERSION, true),
                 Arguments.of(Errors.UNRELEASED_INSTANCE_ID, true),
-                Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true));
+                Arguments.of(Errors.GROUP_MAX_SIZE_REACHED, true),
+                Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, false));
     }
 
     private ClientResponse createHeartbeatResponse(


### PR DESCRIPTION
1、Client support for TopicAuthException in DescribeShareGroup and HB path
2、ShareConsumerImpl#sendAcknowledgementsAndLeaveGroup swallow TopicAuthorizationException and GroupAuthorizationException
