### PR TITLE
MINOR: Prevent broker fencing by adjusting resendExponentialBackoff in BrokerLifecycleManager 

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -93,7 +93,7 @@ class BrokerLifecycleManager(
    * The exponential backoff to use for resending communication.
    */
   private val resendExponentialBackoff =
-    new ExponentialBackoff(100, 2, config.brokerSessionTimeoutMs.toLong, 0.02)
+    new ExponentialBackoff(100, 2, config.brokerSessionTimeoutMs.toLong / 2, 0.02)
 
   /**
    * The number of times we've tried and failed to communicate.  This variable can only be


### PR DESCRIPTION
This PR reduces `maxInterval` for `resendExponentialBackoff` in `BrokerLifecycleManager` class from `broker.session.timeout.ms` to half of its value. Setting `maxInterval` to `broker.session.timeout.ms` caused brokers to be fenced if a resend attempt occurred near the timeout threshold, leading to unnecessary broker fencing.