### PR TITLE
MINOR: Disable failing "Load Test Catalog" job on public forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
   load-catalog:
     needs: [configure]
     runs-on: ubuntu-latest
+    if: ${{ !github.event.repository.fork }}
     name: Load Test Catalog
     steps:
       - name: Checkout main


### PR DESCRIPTION
This change disables the "Load Test Catalog" job in the GitHub Actions workflow for public forks. 
The job requires repository authentication to be configured and fails outside of main repository without extra configuration on fork:
![image](https://github.com/user-attachments/assets/6eb7e7ef-19a7-4676-95ef-9aaeeb1fd11e)
**Checkout test-catalog**
```
Setting up auth
  /usr/bin/git config --local --name-only --get-regexp core\.sshCommand
  /usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
  /usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
  /usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
  /usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=100 origin +refs/heads/test-catalog*:refs/remotes/origin/test-catalog* +refs/tags/test-catalog*:refs/tags/test-catalog*
  The process '/usr/bin/git' failed with exit code 1
```


Change helps to avoid unnecessary errors/notifications on schedule builds and resource usage.

Tested on the fork trunk by applying the commit:

![image](https://github.com/user-attachments/assets/333fa467-bef7-40b0-9667-e99e72d0e851)
![image](https://github.com/user-attachments/assets/945e2972-1002-4bb3-a965-bbe5c6c25f03)
