### PR TITLE
KAFKA-18867: add tests to describe topic configs with empty name

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1626,6 +1626,11 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val existingTopic = new ConfigResource(ConfigResource.Type.TOPIC, topic)
     client.describeConfigs(Collections.singletonList(existingTopic)).values.get(existingTopic).get()
 
+    val defaultTopic = new ConfigResource(ConfigResource.Type.TOPIC, "")
+    val describeResult0 = client.describeConfigs(Collections.singletonList(defaultTopic))
+
+    assertTrue(assertThrows(classOf[ExecutionException], () => describeResult0.values.get(defaultTopic).get).getCause.isInstanceOf[InvalidTopicException])
+
     val nonExistentTopic = new ConfigResource(ConfigResource.Type.TOPIC, "unknown")
     val describeResult1 = client.describeConfigs(Collections.singletonList(nonExistentTopic))
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1624,22 +1624,19 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     client = createAdminClient
 
     val existingTopic = new ConfigResource(ConfigResource.Type.TOPIC, topic)
-    client.describeConfigs(Collections.singletonList(existingTopic)).values.get(existingTopic).get()
+    client.describeConfigs(util.List.of(existingTopic)).values.get(existingTopic).get()
 
     val defaultTopic = new ConfigResource(ConfigResource.Type.TOPIC, "")
-    val describeResult0 = client.describeConfigs(Collections.singletonList(defaultTopic))
-
-    assertTrue(assertThrows(classOf[ExecutionException], () => describeResult0.values.get(defaultTopic).get).getCause.isInstanceOf[InvalidTopicException])
+    var describeResult = client.describeConfigs(util.List.of(defaultTopic))
+    assertFutureThrows(classOf[InvalidTopicException], describeResult.all())
 
     val nonExistentTopic = new ConfigResource(ConfigResource.Type.TOPIC, "unknown")
-    val describeResult1 = client.describeConfigs(Collections.singletonList(nonExistentTopic))
-
-    assertTrue(assertThrows(classOf[ExecutionException], () => describeResult1.values.get(nonExistentTopic).get).getCause.isInstanceOf[UnknownTopicOrPartitionException])
+    describeResult = client.describeConfigs(util.List.of(nonExistentTopic))
+    assertFutureThrows(classOf[UnknownTopicOrPartitionException], describeResult.all())
 
     val invalidTopic = new ConfigResource(ConfigResource.Type.TOPIC, "(invalid topic)")
-    val describeResult2 = client.describeConfigs(Collections.singletonList(invalidTopic))
-
-    assertTrue(assertThrows(classOf[ExecutionException], () => describeResult2.values.get(invalidTopic).get).getCause.isInstanceOf[InvalidTopicException])
+    describeResult = client.describeConfigs(util.List.of(invalidTopic))
+    assertFutureThrows(classOf[InvalidTopicException], describeResult.all())
   }
 
   @Test


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-18867

Describing topic configs for default configs is disallowed, but we lack a test for this.

