### PR TITLE
HOTFIX: Revert "KAFKA-18067: Kafka Streams can leak Producer client under EOS (#17931)"

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -119,8 +119,7 @@ class ActiveTaskCreator {
     }
 
     public void reInitializeProducer() {
-        if (!streamsProducer.isClosed())
-            streamsProducer.resetProducer(producer());
+        streamsProducer.resetProducer(producer());
     }
 
     StreamsProducer streamsProducer() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -70,7 +70,6 @@ public class StreamsProducer {
     private Producer<byte[], byte[]> producer;
     private boolean transactionInFlight = false;
     private boolean transactionInitialized = false;
-    private boolean closed = false;
     private double oldProducerTotalBlockedTime = 0;
     // we have a single `StreamsProducer` per thread, and thus a single `sendException` instance,
     // which we share across all tasks, ie, all `RecordCollectorImpl`
@@ -97,10 +96,6 @@ public class StreamsProducer {
 
     boolean transactionInFlight() {
         return transactionInFlight;
-    }
-
-    boolean isClosed() {
-        return closed;
     }
 
     /**
@@ -325,7 +320,6 @@ public class StreamsProducer {
 
     void close() {
         producer.close();
-        closed = true;
         transactionInFlight = false;
         transactionInitialized = false;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -190,21 +190,7 @@ public class ActiveTaskCreatorTest {
 
         activeTaskCreator.close();
 
-        assertThat(activeTaskCreator.streamsProducer().isClosed(), is(true));
         assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
-    }
-
-    @Test
-    public void shouldNotReInitializeProducerOnClose() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-        createTasks();
-
-        activeTaskCreator.streamsProducer().close();
-        activeTaskCreator.reInitializeProducer();
-        // If streamsProducer is not closed, clientSupplier will recreate a producer,
-        // resulting in more than one producer being created.
-        assertThat(mockClientSupplier.producers.size(), is(1));
     }
 
     // error handling


### PR DESCRIPTION
This reverts commit e8837465a5fc478f1c79d1ad475b43e00a39a5d7.

The commit that is reverted prevents Kafka Streams from re-initializing its transactional producer. If an exception that fences the transactional producer occurs, the producer is not re-initialized during the handling of the exception. That causes an infinite loop of ProducerFencedExceptions with corresponding rebalances. 

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, David Jacot <djacot@confluent.io>