### PR TITLE
MINOR: Don't print cleaning group metadata log if empty

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -753,8 +753,11 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             }
         });
 
-        log.info("Generated {} tombstone records while cleaning up group metadata in {} milliseconds.",
-            records.size(), time.milliseconds() - startMs);
+        if (!records.isEmpty()) {
+            log.info("Generated {} tombstone records while cleaning up group metadata in {} milliseconds.",
+                records.size(), time.milliseconds() - startMs);
+        }
+
         // Reschedule the next cycle.
         scheduleGroupMetadataExpiration();
         return new CoordinatorResult<>(records, false);


### PR DESCRIPTION
The new group coordinator prints the following line at fixed interval even if no groups were deleted:

```
Generated 0 tombstone records while cleaning up group metadata in 0 milliseconds. (org.apache.kafka.coordinator.group.GroupCoordinatorShard)
```

The time component has some value in its own but it may be better to not print if when there are not records in order to reduce the spam in the logs.
