### PR TITLE
MINOR: Small refactor in GroupMetadataManager

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -195,4 +195,9 @@ public interface Group {
      * @return The number of members.
      */
     int numMembers();
+
+    /**
+     * Requests a metadata refresh.
+     */
+    void requestMetadataRefresh();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4780,11 +4780,8 @@ public class GroupMetadataManager {
         });
         allGroupIds.forEach(groupId -> {
             Group group = groups.get(groupId);
-            if (group != null && (group.type() == CONSUMER || group.type() == SHARE)) {
-                ((ModernGroup<?>) group).requestMetadataRefresh();
-            }
-            if (group != null && (group.type() == STREAMS)) {
-                ((StreamsGroup) group).requestMetadataRefresh();
+            if (group != null) {
+                group.requestMetadataRefresh();
             }
         });
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -343,6 +343,14 @@ public class ClassicGroup implements Group {
     }
 
     /**
+     * Requests a metadata refresh.
+     */
+    @Override
+    public void requestMetadataRefresh() {
+        // This does not apply to classic groups.
+    }
+
+    /**
      * Used to identify whether the given member is the leader of this group.
      *
      * @param memberId the member id.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java
@@ -414,6 +414,7 @@ public abstract class ModernGroup<T extends ModernGroupMember> implements Group 
     /**
      * Requests a metadata refresh.
      */
+    @Override
     public void requestMetadataRefresh() {
         this.metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -602,6 +602,7 @@ public class StreamsGroup implements Group {
     /**
      * Requests a metadata refresh.
      */
+    @Override
     public void requestMetadataRefresh() {
         this.metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
     }


### PR DESCRIPTION
The code in GroupMetadataManager to request metadata refresh got pretty ugly with the addition of share and stream groups.  It seems preferable to put the method in the base class.
