### PR TITLE
KAFKA-18918: Correcting releasing of locks on exception

### DIFF
--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -277,9 +277,9 @@ public class DelayedShareFetch extends DelayedOperation {
             return false;
         } catch (Exception e) {
             log.error("Error processing delayed share fetch request", e);
+            releasePartitionLocks(topicPartitionData.keySet());
             partitionsAcquired.clear();
             partitionsAlreadyFetched.clear();
-            releasePartitionLocks(topicPartitionData.keySet());
             return forceComplete();
         }
     }


### PR DESCRIPTION
The PR corrects the way the locks are released on exception. As `partitionsAcquired` can be a reference to `topicPartitionData`, hence the locks should released prior clearing `partitionsAcquired`.