### PR TITLE
MINOR Auto-approve Pull Request Reviewed with ci-approved label

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,7 +101,7 @@ There are two files related to this workflow:
 
 * [pr-labeled.yml](pr-labeled.yml) approves a pending approval for PRs that have
 been labeled with `ci-approved`
-* [ci-requested.yml](ci-requested.yml) approves future workflow requests automatically
+* [workflow-requested.yml](workflow-requested.yml) approves future workflow requests automatically
 if the PR has the `ci-approved` label
 
 _The pr-labeled.yml workflow includes pull_request_target!_
@@ -118,6 +118,9 @@ or body edited. This workflow simply captures the PR number into a text file
 * [pr-linter.yml](pr-linter.yml) runs after pr-reviewed.yml and loads the PR
 using the saved text file. This workflow runs the linter script that checks the
 structure of the PR
+
+Note that the pr-reviewed.yml workflow uses the `ci-approved` mechanism described
+above.
 
 ### Stale PRs
 

--- a/.github/workflows/workflow-requested.yml
+++ b/.github/workflows/workflow-requested.yml
@@ -13,22 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI Requested
+name: Workflow Requested
 
 on:
   workflow_run:
-    workflows: [CI]
+    workflows: [CI, Pull Request Reviewed]
     types:
       - requested
 
-run-name: CI Requested for ${{ github.event.workflow_run.display_title}}
+run-name: Workflow Requested for ${{ github.event.workflow_run.display_title}}
 
 jobs:
   check-pr-labels:
     # Even though job conditionals are difficult to debug, this will reduce the number of unnecessary runs
     if: |
       github.event_name == 'workflow_run' && 
-      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_review') &&
       github.event.workflow_run.status == 'completed' && 
       github.event.workflow_run.conclusion == 'action_required'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The "pull_request_review" event has similar permissions to "pull_request". Due to our repo config, we require approvals for non-committer PRs. This patch allows the `ci-approved` label to approve the "Pull Request Reviewed" workflow as well as the "CI" workflow.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>