### PR TITLE
KAFKA-10863: Convert ControRecordType schema to use auto-generated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -17,10 +17,9 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.InvalidRecordException;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
-import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.message.ControlRecordTypeSchema;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,46 +58,42 @@ public enum ControlRecordType {
 
     private static final Logger log = LoggerFactory.getLogger(ControlRecordType.class);
 
-    static final short CURRENT_CONTROL_RECORD_KEY_VERSION = 0;
-    static final int CURRENT_CONTROL_RECORD_KEY_SIZE = 4;
-    private static final Schema CONTROL_RECORD_KEY_SCHEMA_VERSION_V0 = new Schema(
-            new Field("version", Type.INT16),
-            new Field("type", Type.INT16));
-
     private final short type;
+    private final ByteBuffer buffer;
 
     ControlRecordType(short type) {
         this.type = type;
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema().setType(type);
+        buffer = MessageUtil.toVersionPrefixedByteBuffer(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION, schema);
     }
 
     public short type() {
         return type;
     }
 
-    public Struct recordKey() {
+    public ByteBuffer recordKey() {
         if (this == UNKNOWN)
             throw new IllegalArgumentException("Cannot serialize UNKNOWN control record type");
+        return buffer.duplicate();
+    }
 
-        Struct struct = new Struct(CONTROL_RECORD_KEY_SCHEMA_VERSION_V0);
-        struct.set("version", CURRENT_CONTROL_RECORD_KEY_VERSION);
-        struct.set("type", type);
-        return struct;
+    public int controlRecordKeySize() {
+        return buffer.remaining();
     }
 
     public static short parseTypeId(ByteBuffer key) {
-        if (key.remaining() < CURRENT_CONTROL_RECORD_KEY_SIZE)
-            throw new InvalidRecordException("Invalid value size found for end control record key. Must have " +
-                    "at least " + CURRENT_CONTROL_RECORD_KEY_SIZE + " bytes, but found only " + key.remaining());
-
-        short version = key.getShort(0);
-        if (version < 0)
+        short version = key.getShort();
+        if (version < ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION)
             throw new InvalidRecordException("Invalid version found for control record: " + version +
                     ". May indicate data corruption");
 
-        if (version != CURRENT_CONTROL_RECORD_KEY_VERSION)
+        if (version > ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION) {
             log.debug("Received unknown control record key version {}. Parsing as version {}", version,
-                    CURRENT_CONTROL_RECORD_KEY_VERSION);
-        return key.getShort(2);
+                    ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
+            version = ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION;
+        }
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema(new ByteBufferAccessor(key), version);
+        return schema.type();
     }
 
     public static ControlRecordType fromTypeId(short typeId) {

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.InvalidRecordException;
-import org.apache.kafka.common.message.ControlRecordTypeSchema;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
 
@@ -63,8 +62,8 @@ public enum ControlRecordType {
 
     ControlRecordType(short type) {
         this.type = type;
-        ControlRecordTypeSchema schema = new ControlRecordTypeSchema().setType(type);
-        buffer = MessageUtil.toVersionPrefixedByteBuffer(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION, schema);
+        org.apache.kafka.common.message.ControlRecordType schema = new org.apache.kafka.common.message.ControlRecordType().setType(type);
+        buffer = MessageUtil.toVersionPrefixedByteBuffer(org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION, schema);
     }
 
     public short type() {
@@ -82,17 +81,20 @@ public enum ControlRecordType {
     }
 
     public static short parseTypeId(ByteBuffer key) {
-        short version = key.getShort();
-        if (version < ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION)
+        // We should duplicate the original buffer since it will be read again in some test cases, for example,
+        // read by KafkaRaftClient and RaftClient.Listener
+        ByteBuffer buffer = key.duplicate();
+        short version = buffer.getShort();
+        if (version < org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION)
             throw new InvalidRecordException("Invalid version found for control record: " + version +
                     ". May indicate data corruption");
 
-        if (version > ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION) {
+        if (version > org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION) {
             log.debug("Received unknown control record key version {}. Parsing as version {}", version,
-                    ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
-            version = ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION;
+                    org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION);
+            version = org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION;
         }
-        ControlRecordTypeSchema schema = new ControlRecordTypeSchema(new ByteBufferAccessor(key), version);
+        org.apache.kafka.common.message.ControlRecordType schema = new org.apache.kafka.common.message.ControlRecordType(new ByteBufferAccessor(buffer), version);
         return schema.type();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.message.ControlRecordTypeSchema;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
 
@@ -62,8 +63,8 @@ public enum ControlRecordType {
 
     ControlRecordType(short type) {
         this.type = type;
-        org.apache.kafka.common.message.ControlRecordType schema = new org.apache.kafka.common.message.ControlRecordType().setType(type);
-        buffer = MessageUtil.toVersionPrefixedByteBuffer(org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION, schema);
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema().setType(type);
+        buffer = MessageUtil.toVersionPrefixedByteBuffer(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION, schema);
     }
 
     public short type() {
@@ -85,16 +86,16 @@ public enum ControlRecordType {
         // read by KafkaRaftClient and RaftClient.Listener
         ByteBuffer buffer = key.duplicate();
         short version = buffer.getShort();
-        if (version < org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION)
+        if (version < ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION)
             throw new InvalidRecordException("Invalid version found for control record: " + version +
                     ". May indicate data corruption");
 
-        if (version > org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION) {
+        if (version > ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION) {
             log.debug("Received unknown control record key version {}. Parsing as version {}", version,
-                    org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION);
-            version = org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION;
+                    ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
+            version = ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION;
         }
-        org.apache.kafka.common.message.ControlRecordType schema = new org.apache.kafka.common.message.ControlRecordType(new ByteBufferAccessor(buffer), version);
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema(new ByteBufferAccessor(buffer), version);
         return schema.type();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
@@ -104,7 +104,7 @@ public class EndTransactionMarker {
 
     public int endTxnMarkerValueSize() {
         return DefaultRecord.sizeInBytes(0, 0L,
-                ControlRecordType.CURRENT_CONTROL_RECORD_KEY_SIZE,
+                type.controlRecordKeySize(),
                 buffer.remaining(),
                 Record.EMPTY_HEADERS);
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.Utils;
 
@@ -611,10 +610,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
      * @param value The control record value
      */
     public void appendControlRecord(long timestamp, ControlRecordType type, ByteBuffer value) {
-        Struct keyStruct = type.recordKey();
-        ByteBuffer key = ByteBuffer.allocate(keyStruct.sizeOf());
-        keyStruct.writeTo(key);
-        key.flip();
+        ByteBuffer key = type.recordKey();
         appendWithOffset(nextSequentialOffset(), true, timestamp, key, value, Record.EMPTY_HEADERS);
     }
 

--- a/clients/src/main/resources/common/message/ControlRecordType.json
+++ b/clients/src/main/resources/common/message/ControlRecordType.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "ControlRecordTypeSchema",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "Type", "type": "int16", "versions": "0+",
+      "about": "The type of the control record, such as commit or abort"
+    }
+  ]
+}

--- a/clients/src/main/resources/common/message/ControlRecordType.json
+++ b/clients/src/main/resources/common/message/ControlRecordType.json
@@ -15,7 +15,7 @@
 
 {
   "type": "data",
-  "name": "ControlRecordTypeSchema",
+  "name": "ControlRecordType",
   "validVersions": "0",
   "flexibleVersions": "none",
   "fields": [

--- a/clients/src/main/resources/common/message/ControlRecordTypeSchema.json
+++ b/clients/src/main/resources/common/message/ControlRecordTypeSchema.json
@@ -15,7 +15,7 @@
 
 {
   "type": "data",
-  "name": "ControlRecordType",
+  "name": "ControlRecordTypeSchema",
   "validVersions": "0",
   "flexibleVersions": "none",
   "fields": [

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.message.ControlRecordTypeSchema;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -26,10 +32,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControlRecordTypeTest {
 
+    // Old hard-coded schema, used to validate old hard-coded schema format is exactly the same as new auto generated protocol format
+    private final Schema v0Schema = new Schema(
+            new Field("version", Type.INT16),
+            new Field("type", Type.INT16));
+
     @Test
     public void testParseUnknownType() {
         ByteBuffer buffer = ByteBuffer.allocate(32);
-        buffer.putShort(ControlRecordType.CURRENT_CONTROL_RECORD_KEY_VERSION);
+        buffer.putShort(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
         buffer.putShort((short) 337);
         buffer.flip();
         ControlRecordType type = ControlRecordType.parse(buffer);
@@ -50,11 +61,58 @@ public class ControlRecordTypeTest {
     @ParameterizedTest
     @EnumSource(value = ControlRecordType.class)
     public void testRoundTrip(ControlRecordType expected) {
-        ByteBuffer buffer = ByteBuffer.allocate(32);
-        buffer.putShort(ControlRecordType.CURRENT_CONTROL_RECORD_KEY_VERSION);
-        buffer.putShort(expected.type());
-        buffer.flip();
+        if (expected == ControlRecordType.UNKNOWN) {
+            return;
+        }
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+            ByteBuffer buffer = expected.recordKey();
+            ControlRecordType deserializedKey = ControlRecordType.parse(buffer);
+            assertEquals(expected, deserializedKey);
+        }
+    }
 
-        assertEquals(expected, ControlRecordType.parse(buffer));
+    @ParameterizedTest
+    @EnumSource(value = ControlRecordType.class)
+    public void testValueControlRecordKeySize(ControlRecordType type) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+            assertEquals(4, type.controlRecordKeySize());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ControlRecordType.class)
+    public void testBackwardDeserializeCompatibility(ControlRecordType type) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+            Struct struct = new Struct(v0Schema);
+            struct.set("version", version);
+            struct.set("type", type.type());
+
+            ByteBuffer oldVersionBuffer = ByteBuffer.allocate(struct.sizeOf());
+            struct.writeTo(oldVersionBuffer);
+            oldVersionBuffer.flip();
+
+            ControlRecordType deserializedType = ControlRecordType.parse(oldVersionBuffer);
+            assertEquals(type, deserializedType);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ControlRecordType.class)
+    public void testForwardDeserializeCompatibility(ControlRecordType type) {
+        if (type == ControlRecordType.UNKNOWN) {
+            return;
+        }
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+            ByteBuffer newVersionBuffer = type.recordKey();
+
+            Struct struct = v0Schema.read(newVersionBuffer);
+
+            ControlRecordType deserializedType = ControlRecordType.fromTypeId(struct.getShort("type"));
+            assertEquals(type, deserializedType);
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.message.ControlRecordTypeSchema;
 import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -39,7 +40,7 @@ public class ControlRecordTypeTest {
     @Test
     public void testParseUnknownType() {
         ByteBuffer buffer = ByteBuffer.allocate(32);
-        buffer.putShort(org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION);
+        buffer.putShort(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
         buffer.putShort((short) 337);
         buffer.flip();
         ControlRecordType type = ControlRecordType.parse(buffer);
@@ -63,8 +64,8 @@ public class ControlRecordTypeTest {
         if (expected == ControlRecordType.UNKNOWN) {
             return;
         }
-        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
-             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
             ByteBuffer buffer = expected.recordKey();
             ControlRecordType deserializedKey = ControlRecordType.parse(buffer);
             assertEquals(expected, deserializedKey);
@@ -74,8 +75,8 @@ public class ControlRecordTypeTest {
     @ParameterizedTest
     @EnumSource(value = ControlRecordType.class)
     public void testValueControlRecordKeySize(ControlRecordType type) {
-        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
-             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
             assertEquals(4, type.controlRecordKeySize());
         }
     }
@@ -83,8 +84,8 @@ public class ControlRecordTypeTest {
     @ParameterizedTest
     @EnumSource(value = ControlRecordType.class)
     public void testBackwardDeserializeCompatibility(ControlRecordType type) {
-        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
-             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
             Struct struct = new Struct(v0Schema);
             struct.set("version", version);
             struct.set("type", type.type());
@@ -104,8 +105,8 @@ public class ControlRecordTypeTest {
         if (type == ControlRecordType.UNKNOWN) {
             return;
         }
-        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
-             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
+             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
             ByteBuffer newVersionBuffer = type.recordKey();
 
             Struct struct = v0Schema.read(newVersionBuffer);

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.record;
 
-import org.apache.kafka.common.message.ControlRecordTypeSchema;
 import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -40,7 +39,7 @@ public class ControlRecordTypeTest {
     @Test
     public void testParseUnknownType() {
         ByteBuffer buffer = ByteBuffer.allocate(32);
-        buffer.putShort(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
+        buffer.putShort(org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION);
         buffer.putShort((short) 337);
         buffer.flip();
         ControlRecordType type = ControlRecordType.parse(buffer);
@@ -64,8 +63,8 @@ public class ControlRecordTypeTest {
         if (expected == ControlRecordType.UNKNOWN) {
             return;
         }
-        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
-             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
+             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
             ByteBuffer buffer = expected.recordKey();
             ControlRecordType deserializedKey = ControlRecordType.parse(buffer);
             assertEquals(expected, deserializedKey);
@@ -75,8 +74,8 @@ public class ControlRecordTypeTest {
     @ParameterizedTest
     @EnumSource(value = ControlRecordType.class)
     public void testValueControlRecordKeySize(ControlRecordType type) {
-        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
-             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
+             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
             assertEquals(4, type.controlRecordKeySize());
         }
     }
@@ -84,8 +83,8 @@ public class ControlRecordTypeTest {
     @ParameterizedTest
     @EnumSource(value = ControlRecordType.class)
     public void testBackwardDeserializeCompatibility(ControlRecordType type) {
-        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
-             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
+             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
             Struct struct = new Struct(v0Schema);
             struct.set("version", version);
             struct.set("type", type.type());
@@ -105,8 +104,8 @@ public class ControlRecordTypeTest {
         if (type == ControlRecordType.UNKNOWN) {
             return;
         }
-        for (short version = ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION;
-             version <= ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION; version++) {
+        for (short version = org.apache.kafka.common.message.ControlRecordType.LOWEST_SUPPORTED_VERSION;
+             version <= org.apache.kafka.common.message.ControlRecordType.HIGHEST_SUPPORTED_VERSION; version++) {
             ByteBuffer newVersionBuffer = type.recordKey();
 
             Struct struct = v0Schema.read(newVersionBuffer);

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -103,7 +103,7 @@ public class EndTransactionMarkerTest {
             EndTransactionMarker marker = new EndTransactionMarker(type, 1);
             int offsetSize = ByteUtils.sizeOfVarint(0);
             int timestampSize = ByteUtils.sizeOfVarlong(0);
-            int keySize = ControlRecordType.CURRENT_CONTROL_RECORD_KEY_SIZE;
+            int keySize = type.controlRecordKeySize();
             int valueSize = marker.serializeValue().remaining();
             int headerSize = ByteUtils.sizeOfVarint(Record.EMPTY_HEADERS.length);
             int totalSize = 1 + offsetSize + timestampSize + ByteUtils.sizeOfVarint(keySize) + keySize + ByteUtils.sizeOfVarint(valueSize) + valueSize + headerSize;

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1699,8 +1699,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         skippedMarkers += 1
       } else {
         val controlRecordType = marker.transactionResult match {
-          case TransactionResult.COMMIT => ControlRecordType.COMMIT
-          case TransactionResult.ABORT => ControlRecordType.ABORT
+          case TransactionResult.COMMIT => org.apache.kafka.common.record.ControlRecordType.COMMIT
+          case TransactionResult.ABORT => org.apache.kafka.common.record.ControlRecordType.ABORT
         }
 
         val markerResults = new ConcurrentHashMap[TopicPartition, Errors]()

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1128,11 +1128,7 @@ class LogCleanerTest extends Logging {
 
     // Now we append one transaction with a key which conflicts with the COMMIT marker appended above
     def commitRecordKey(): ByteBuffer = {
-      val keySize = ControlRecordType.COMMIT.recordKey().sizeOf()
-      val key = ByteBuffer.allocate(keySize)
-      ControlRecordType.COMMIT.recordKey().writeTo(key)
-      key.flip()
-      key
+      ControlRecordType.COMMIT.recordKey()
     }
 
     val producerId2 = 2L


### PR DESCRIPTION
1. Convert ControRecordType schema to use auto-generated protocol`ControRecordTypeSchema`
2. Substitute `CURRENT_CONTROL_RECORD_KEY_SIZE` with`controlRecordKeySize()` method since the size is accumulated from `ControRecordTypeSchema`.
3. Add buffer to `ControRecordType` to avoid twice compute from `recordKey()` and `controlRecordKeySize()`.
4. flexibleVersions is set to none.

