### PR TITLE
MINOR: admin client javadoc hotfix

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterStreamsGroupOffsetsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterStreamsGroupOffsetsOptions.java
@@ -18,9 +18,8 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
-
 /**
- * Options for the {@link Admin#alterStreamsGroupOffsets(String groupId, Map), AlterStreamsGroupOffsetsOptions)} call.
+ * Options for the {@link Admin#alterStreamsGroupOffsets(String, Map, AlterStreamsGroupOffsetsOptions)} call.
  * <p>
  * The API of this class is evolving, see {@link Admin} for details.
  */

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
@@ -43,7 +43,7 @@ public class ListStreamsGroupOffsetsResult {
     }
 
     /**
-     * Return a future which yields all Map<String, Map<TopicPartition, Long> objects, if requests for all the groups succeed.
+     * Return a future which yields all {@code Map<String, Map<TopicPartition, Long>} objects, if requests for all the groups succeed.
      */
     public KafkaFuture<Map<String, Map<TopicPartition, OffsetAndMetadata>>> all() {
         return delegate.all();


### PR DESCRIPTION
Seems like [017692e](https://github.com/apache/kafka/commit/017692e86c5e40402312ebdb4bdab82face30181) broke trunk, despite just having green checkmarks. This should fix it
