### PR TITLE
HOTFIX Fix asf.yaml strict [1/n]

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,7 +49,7 @@ github:
   protected_branches:
     trunk:
       required_status_checks:
-        strict: false
+        strict: true
         contexts:
           - build / CI checks completed
       required_pull_request_reviews:


### PR DESCRIPTION
Per ASF Infra's instructions, we need to reapply this .asf.yaml change. We'll do that by setting it to "true", then back to "false"

Reviewers: Andrew Schofield <aschofield@confluent.io>