### PR TITLE
HOTFIX Fix asf.yaml strict [2/n]

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,7 +49,7 @@ github:
   protected_branches:
     trunk:
       required_status_checks:
-        strict: true
+        strict: false
         contexts:
           - build / CI checks completed
       required_pull_request_reviews:


### PR DESCRIPTION
Change the `strict` value back to false. Follow-up of #19124

Reviewers: Andrew Schofield <aschofield@confluent.io>