### PR TITLE
KAFKA-18648: Make `records` in `FetchResponse` nullable again

### DIFF
--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -106,7 +106,7 @@
         ]},
         { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "default": "-1", "ignorable": false, "entityType": "brokerId",
           "about": "The preferred read replica for the consumer to use on its next fetch request."},
-        { "name": "Records", "type": "records", "versions": "0+", "about": "The record data."}
+        { "name": "Records", "type": "records", "versions": "0+", "nullableVersions": "0+", "about": "The record data."}
       ]}
     ]},
     { "name": "NodeEndpoints", "type": "[]NodeEndpoint", "versions": "16+", "taggedVersions": "16+", "tag": 0,


### PR DESCRIPTION
As Jun raised in https://github.com/apache/kafka/pull/18726#discussion_r1972525165,
we actually do have a few code paths where `records` remains `null`
in the FetchResponse with broker version 3.9 and older:

* Compression codec for topic is ZSTD and fetch version < 10: https://github.com/apache/kafka/blob/3.9/core/src/main/scala/kafka/server/KafkaApis.scala#L835
* Down-conversion of zstandard-compressed: https://github.com/apache/kafka/blob/3.9/core/src/main/scala/kafka/server/KafkaApis.scala#L884
* Generic uncaught exception through: https://github.com/apache/kafka/blob/3.9/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java#L365

To ensure 4.0 clients don't fail to deserialize fetch responses from brokers with the affected versions, we make `records` nullable again.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Jun Rao <junrao@gmail.com>