### PR TITLE
MINOR: Update log4j2 to 2.24.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -237,10 +237,10 @@ License Version 2.0:
 - jetty-session-12.0.15
 - jetty-util-12.0.15
 - jose4j-0.9.4
-- log4j-api-2.24.1
-- log4j-core-2.24.1
-- log4j-slf4j-impl-2.24.1
-- log4j-1.2-api-2.24.1
+- log4j-api-2.24.3
+- log4j-core-2.24.3
+- log4j-slf4j-impl-2.24.3
+- log4j-1.2-api-2.24.3
 - lz4-java-1.8.0
 - maven-artifact-3.9.6
 - metrics-core-2.2.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ versions += [
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
   kafka_39: "3.9.0",
-  log4j2: "2.24.1",
+  log4j2: "2.24.3",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   lz4: "1.8.0",
   mavenArtifact: "3.9.6",


### PR DESCRIPTION
2.24.2 includes a critical fix:

"This release fixes a critical bug in Log4j API initialization code, which can cause LogManager.getLogger() to return null under certain conditions. See https://github.com/apache/logging-log4j2/issues/3143 for details."

2.24.3 includes an important fix for our usage:

"Fix ConcurrentModificationException, if multiple threads modify loggers concurrently.
This bug affects users that modify logger levels programmatically."

Release notes:
* https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.24.2
* https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.24.3

Reviewers: David Jacot <djacot@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com