### PR TITLE
KAFKA-18929: Log a warning when time based segment delete is blocked by a future timestamp

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1522,6 +1522,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     val startMs = time.milliseconds
 
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
+      if (startMs < segment.largestTimestamp()) {
+        warn(s"Segment with base offset $segment contains future timestamp")
+      }
       val shouldDelete = startMs - segment.largestTimestamp > retentionMs
       debug(s"$segment retentionMs breached: $shouldDelete, startMs=$startMs, retentionMs=$retentionMs")
       shouldDelete

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1524,7 +1524,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
       if (startMs < segment.largestTimestamp()) {
-        futureTimestampLogger.warn(s"Segment with base offset $segment contains future timestamp")
+        futureTimestampLogger.warn(s"$segment contains future timestamp(s), making it ineligible to be deleted")
       }
       val shouldDelete = startMs - segment.largestTimestamp > retentionMs
       debug(s"$segment retentionMs breached: $shouldDelete, startMs=$startMs, retentionMs=$retentionMs")

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -100,6 +100,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   private val metricsGroup = new KafkaMetricsGroup(getClass.getPackage.getName, "Log")
 
   this.logIdent = s"[UnifiedLog partition=$topicPartition, dir=$parentDir] "
+  private val futureTimestampLogger = new LogFutureTimestampLogger(logIdent)
 
   /* A lock that guards all modifications to the log */
   private val lock = new Object
@@ -1523,7 +1524,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
       if (startMs < segment.largestTimestamp()) {
-        warn(s"Segment with base offset $segment contains future timestamp")
+        futureTimestampLogger.warn(s"Segment with base offset $segment contains future timestamp")
       }
       val shouldDelete = startMs - segment.largestTimestamp > retentionMs
       debug(s"$segment retentionMs breached: $shouldDelete, startMs=$startMs, retentionMs=$retentionMs")
@@ -1994,6 +1995,10 @@ object UnifiedLog extends Logging {
       None
   }
 
+}
+
+class LogFutureTimestampLogger(parentLogIdent: String) extends Logging {
+  this.logIdent = parentLogIdent
 }
 
 case class RetentionMsBreach(log: UnifiedLog, remoteLogEnabledAndRemoteCopyEnabled: Boolean) extends SegmentDeletionReason {


### PR DESCRIPTION
When producers send future timestamps, time retention based log segments may get blocked from removal for an extended period of time. Log cleaning should should warn in the logs when this scenario occurs.