### PR TITLE
MINOR: Wrapping exceptions in usage for groups and metrics utility

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionException;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
 
@@ -260,7 +261,11 @@ public class ClientMetricsCommand {
                 .ofType(String.class)
                 .withValuesSeparatedBy(',');
 
-            options = parser.parse(args);
+            try {
+                options = parser.parse(args);
+            } catch (OptionException oe) {
+                CommandLineUtils.printUsageAndExit(parser, oe.getMessage());
+            }
 
             checkArgs();
         }

--- a/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionException;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
 
@@ -217,7 +218,11 @@ public class GroupsCommand {
                             + "This matches group type 'consumer', and group type 'classic' where the protocol type is 'consumer' or empty.");
             shareOpt = parser.accepts("share", "Filter the groups to show share groups.");
 
-            options = parser.parse(args);
+            try {
+                options = parser.parse(args);
+            } catch (OptionException oe) {
+                CommandLineUtils.printUsageAndExit(parser, oe.getMessage());
+            }
 
             checkArgs();
         }


### PR DESCRIPTION
If specified an invalid option then an exception trace appears with `kafka-client-metrics.sh` and `kafka-groups.sh` utilities. Then once has to explicitly remove the invalid argument and append `--help` to fetch correct options. The PR fixes below error message to one with `cause` and `usage`. This behaviour is similar to `kafka-console-consumer.sh` and `kafka-console-share-consumer.sh`

Before:

```
./bin/kafka-groups.sh --bootstrap-server 127.0.0.1:9092 --share --list --a --help

a is not a recognized option
joptsimple.UnrecognizedOptionException: a is not a recognized option
	at joptsimple.OptionException.unrecognizedOption(OptionException.java:108)
	at joptsimple.OptionParser.handleLongOptionToken(OptionParser.java:510)
	at joptsimple.OptionParserState$2.handleArgument(OptionParserState.java:56)
	at joptsimple.OptionParser.parse(OptionParser.java:396)
	at org.apache.kafka.tools.GroupsCommand$GroupsCommandOptions.<init>(GroupsCommand.java:220)
	at org.apache.kafka.tools.GroupsCommand.execute(GroupsCommand.java:65)
	at org.apache.kafka.tools.GroupsCommand.mainNoExit(GroupsCommand.java:55)
	at org.apache.kafka.tools.GroupsCommand.main(GroupsCommand.java:50)

./bin/kafka-client-metrics.sh --bootstrap-server localhost:9092 --alter --name all-metrics --metrics "*" --interval 10000 --abc

abc is not a recognized option
joptsimple.UnrecognizedOptionException: abc is not a recognized option
	at joptsimple.OptionException.unrecognizedOption(OptionException.java:108)
	at joptsimple.OptionParser.handleLongOptionToken(OptionParser.java:510)
	at joptsimple.OptionParserState$2.handleArgument(OptionParserState.java:56)
	at joptsimple.OptionParser.parse(OptionParser.java:396)
	at org.apache.kafka.tools.ClientMetricsCommand$ClientMetricsCommandOptions.<init>(ClientMetricsCommand.java:263)
	at org.apache.kafka.tools.ClientMetricsCommand.execute(ClientMetricsCommand.java:74)
	at org.apache.kafka.tools.ClientMetricsCommand.mainNoExit(ClientMetricsCommand.java:64)
	at org.apache.kafka.tools.ClientMetricsCommand.main(ClientMetricsCommand.java:59)
```

After:

```
./bin/kafka-groups.sh --bootstrap-server 127.0.0.1:9092 --share --list --random --help

random is not a recognized option
Option (* = required)                 Description
---------------------                 -----------
* --bootstrap-server <String: server  REQUIRED: The Kafka server to connect
  to connect to>                        to.
--command-config <String: command     Property file containing configs to be
  config property file>                 passed to Admin Client.
--consumer                            Filter the groups to show all kinds of
                                        consumer groups, including classic
                                        and simple consumer groups. This
                                        matches group type 'consumer', and
                                        group type 'classic' where the
                                        protocol type is 'consumer' or empty.
--group-type <String: type>           Filter the groups based on group type.
                                        Valid types are: 'classic',
                                        'consumer' and 'share'.
--help                                Print usage information.
--list                                List the groups.
--protocol <String: protocol>         Filter the groups based on protocol
                                        type.
--share                               Filter the groups to show share groups.
--version                             Display Kafka version.



./bin/kafka-client-metrics.sh --bootstrap-server localhost:9092 --alter --name all-metrics --metrics "*" --interval 10000 --abc

abc is not a recognized option
Option                                 Description
------                                 -----------
--alter                                Alter the configuration for the client
                                         metrics resource.
--bootstrap-server <String: server to  REQUIRED: The Kafka server to connect
  connect to>                            to.
--command-config <String: command      Property file containing configs to be
  config property file>                  passed to Admin Client.
--delete                               Delete the configuration for the
                                         client metrics resource.
--describe                             List configurations for the client
                                         metrics resource.
--generate-name                        Generate a UUID to use as the name.
--help                                 Print usage information.
--interval <Integer: push interval>    The metrics push interval in
                                         milliseconds.
--list                                 List the client metrics resources.
--match <String: k1=v1,k2=v2>          Matching selector 'k1=v1,k2=v2'. The
                                         following is a list of valid
                                         selector names:
                                       	client_id
                                       	client_instance_id
                                       	client_software_name
                                       	client_software_version
                                       	client_source_address
                                       	client_source_port
--metrics <String: m1,m2>              Telemetry metric name prefixes 'm1,m2'.
--name <String: name>                  Name of client metrics configuration
                                         resource.
--version                              Display Kafka version.
```