### PR TITLE
MINOR remove legacy branch protections from asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,12 +46,12 @@ github:
     merge: false
     rebase: false
 
+  # Disable legacy branch protections. We have manual rulesets which protect trunk
+  # and our release branches. See INFRA-26603
   protected_branches:
-    trunk: {}
-
-    # Disable force push on release branches
-    4.0: {}
-    3.9: {}
-    3.8: {}
-    3.7: {}
-    3.6: {}
+    trunk: ~
+    4.0: ~
+    3.9: ~
+    3.8: ~
+    3.7: ~
+    3.6: ~


### PR DESCRIPTION
Infra has manually setup rulesets for trunk and our release branches (INFRA-26603). We need to disable the legacy branch protections to avoid interfering with the new rulesets.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>