### PR TITLE
MINOR: Fix missing argument in kafka-features.sh upgrade doc

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -39,7 +39,7 @@
     </li>
     <li>Once the cluster's behavior and performance has been verified, finalize the upgrade by running
         <code>
-            bin/kafka-features.sh upgrade --release-version 4.0
+            bin/kafka-features.sh --bootstrap-server localhost:9092 upgrade --release-version 4.0
         </code>
     </li>
     <li>Note that cluster metadata downgrade is not supported in this version since it has metadata changes.


### PR DESCRIPTION
Running `bin/kafka-features.sh upgrade --release-version 4.0` results in the following error. This PR fixes the issue by adding the required argument.

`kafka-features: error: one of the arguments --bootstrap-server --bootstrap-controller is required.`

