### PR TITLE
MINOR: Using Java records for SnapshotPath

### DIFF
--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
@@ -20,4 +20,4 @@ import org.apache.kafka.raft.OffsetAndEpoch;
 
 import java.nio.file.Path;
 
-public record SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial, boolean deleted) {}
+public record SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial, boolean deleted) { }

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
@@ -20,21 +20,4 @@ import org.apache.kafka.raft.OffsetAndEpoch;
 
 import java.nio.file.Path;
 
-public final class SnapshotPath {
-    public final Path path;
-    public final OffsetAndEpoch snapshotId;
-    public final boolean partial;
-    public final boolean deleted;
-
-    public SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial, boolean deleted) {
-        this.path = path;
-        this.snapshotId = snapshotId;
-        this.partial = partial;
-        this.deleted = deleted;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("SnapshotPath(path=%s, snapshotId=%s, partial=%s)", path, snapshotId, partial);
-    }
-}
+public record SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial, boolean deleted) {}

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
@@ -56,8 +56,8 @@ public final class SnapshotWriterReaderTest {
         int recordsPerBatch = 1;
         int batches = 0;
         int delimiterCount = 2;
-        long magicTimestamp = 0xDEADBEEF;
-        OffsetAndEpoch id = new OffsetAndEpoch(recordsPerBatch * batches, 3);
+        long magicTimestamp = 0xDEADBEEFL;
+        OffsetAndEpoch id = new OffsetAndEpoch(0, 3);
 
         RaftClientTestContext.Builder contextBuilder = new RaftClientTestContext.Builder(localId, voters);
         RaftClientTestContext context = contextBuilder.build();
@@ -77,7 +77,7 @@ public final class SnapshotWriterReaderTest {
 
             RawSnapshotReader snapshot = context.log.readSnapshot(id).get();
             int recordCount = validateDelimiters(snapshot, magicTimestamp);
-            assertEquals((recordsPerBatch * batches) + delimiterCount, recordCount);
+            assertEquals((0) + delimiterCount, recordCount);
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
@@ -45,10 +45,10 @@ public final class SnapshotsTest {
         Path path = Snapshots.snapshotPath(TestUtils.tempDirectory().toPath(), snapshotId);
         SnapshotPath snapshotPath = Snapshots.parse(path).get();
 
-        assertEquals(path, snapshotPath.path);
-        assertEquals(snapshotId, snapshotPath.snapshotId);
-        assertFalse(snapshotPath.partial);
-        assertFalse(snapshotPath.deleted);
+        assertEquals(path, snapshotPath.path());
+        assertEquals(snapshotId, snapshotPath.snapshotId());
+        assertFalse(snapshotPath.partial());
+        assertFalse(snapshotPath.deleted());
     }
 
     @Test
@@ -64,9 +64,9 @@ public final class SnapshotsTest {
 
         SnapshotPath snapshotPath = Snapshots.parse(path).get();
 
-        assertEquals(path, snapshotPath.path);
-        assertEquals(snapshotId, snapshotPath.snapshotId);
-        assertTrue(snapshotPath.partial);
+        assertEquals(path, snapshotPath.path());
+        assertEquals(snapshotId, snapshotPath.snapshotId());
+        assertTrue(snapshotPath.partial());
     }
 
     @Test
@@ -79,8 +79,8 @@ public final class SnapshotsTest {
         Path deletedPath = Snapshots.deleteRenamePath(path, snapshotId);
         SnapshotPath snapshotPath = Snapshots.parse(deletedPath).get();
 
-        assertEquals(snapshotId, snapshotPath.snapshotId);
-        assertTrue(snapshotPath.deleted);
+        assertEquals(snapshotId, snapshotPath.snapshotId());
+        assertTrue(snapshotPath.deleted());
     }
 
     @Test


### PR DESCRIPTION
As title minor change to make the SnapshotPath class shorter and cleaner