### PR TITLE
MINOR: Use readable interface to parse requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -204,17 +204,13 @@ public final class MessageUtil {
         }
     }
 
-    public static ByteBufferAccessor toReadable(final Message message, final short version) {
+    public static ByteBufferAccessor toByteBufferAccessor(final Message message, final short version) {
         ObjectSerializationCache cache = new ObjectSerializationCache();
         int messageSize = message.size(cache, version);
         ByteBufferAccessor bytes = new ByteBufferAccessor(ByteBuffer.allocate(messageSize));
         message.write(bytes, cache, version);
         bytes.flip();
         return bytes;
-    }
-
-    public static ByteBuffer toByteBuffer(final Message message, final short version) {
-        return toReadable(message, version).buffer();
     }
 
     public static ByteBuffer toVersionPrefixedByteBuffer(final short version, final Message message) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -204,13 +204,17 @@ public final class MessageUtil {
         }
     }
 
-    public static ByteBuffer toByteBuffer(final Message message, final short version) {
+    public static Readable toReadable(final Message message, final short version) {
         ObjectSerializationCache cache = new ObjectSerializationCache();
         int messageSize = message.size(cache, version);
         ByteBufferAccessor bytes = new ByteBufferAccessor(ByteBuffer.allocate(messageSize));
         message.write(bytes, cache, version);
         bytes.flip();
-        return bytes.buffer();
+        return bytes;
+    }
+
+    public static ByteBuffer toByteBuffer(final Message message, final short version) {
+        return ((ByteBufferAccessor) toReadable(message, version)).buffer();
     }
 
     public static ByteBuffer toVersionPrefixedByteBuffer(final short version, final Message message) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -204,7 +204,7 @@ public final class MessageUtil {
         }
     }
 
-    private static ByteBufferAccessor toByteBufferAccessor(final Message message, final short version) {
+    public static ByteBufferAccessor toReadable(final Message message, final short version) {
         ObjectSerializationCache cache = new ObjectSerializationCache();
         int messageSize = message.size(cache, version);
         ByteBufferAccessor bytes = new ByteBufferAccessor(ByteBuffer.allocate(messageSize));
@@ -213,12 +213,8 @@ public final class MessageUtil {
         return bytes;
     }
 
-    public static Readable toReadable(final Message message, final short version) {
-        return toByteBufferAccessor(message, version);
-    }
-
     public static ByteBuffer toByteBuffer(final Message message, final short version) {
-        return toByteBufferAccessor(message, version).buffer();
+        return toReadable(message, version).buffer();
     }
 
     public static ByteBuffer toVersionPrefixedByteBuffer(final short version, final Message message) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -204,7 +204,7 @@ public final class MessageUtil {
         }
     }
 
-    public static Readable toReadable(final Message message, final short version) {
+    private static ByteBufferAccessor toByteBufferAccessor(final Message message, final short version) {
         ObjectSerializationCache cache = new ObjectSerializationCache();
         int messageSize = message.size(cache, version);
         ByteBufferAccessor bytes = new ByteBufferAccessor(ByteBuffer.allocate(messageSize));
@@ -213,8 +213,12 @@ public final class MessageUtil {
         return bytes;
     }
 
+    public static Readable toReadable(final Message message, final short version) {
+        return toByteBufferAccessor(message, version);
+    }
+
     public static ByteBuffer toByteBuffer(final Message message, final short version) {
-        return ((ByteBufferAccessor) toReadable(message, version)).buffer();
+        return toByteBufferAccessor(message, version).buffer();
     }
 
     public static ByteBuffer toVersionPrefixedByteBuffer(final short version, final Message message) {

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -634,7 +634,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
         appendControlRecord(
             timestamp,
             ControlRecordType.LEADER_CHANGE,
-            MessageUtil.toByteBuffer(leaderChangeMessage, ControlRecordUtils.LEADER_CHANGE_CURRENT_VERSION)
+            MessageUtil.toByteBufferAccessor(leaderChangeMessage, ControlRecordUtils.LEADER_CHANGE_CURRENT_VERSION).buffer()
         );
     }
 
@@ -642,7 +642,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
         appendControlRecord(
             timestamp,
             ControlRecordType.SNAPSHOT_HEADER,
-            MessageUtil.toByteBuffer(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_HEADER_CURRENT_VERSION)
+            MessageUtil.toByteBufferAccessor(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_HEADER_CURRENT_VERSION).buffer()
         );
     }
 
@@ -650,7 +650,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
         appendControlRecord(
             timestamp,
             ControlRecordType.SNAPSHOT_FOOTER,
-            MessageUtil.toByteBuffer(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_FOOTER_CURRENT_VERSION)
+            MessageUtil.toByteBufferAccessor(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_FOOTER_CURRENT_VERSION).buffer()
         );
     }
 
@@ -658,7 +658,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
         appendControlRecord(
             timestamp,
             ControlRecordType.KRAFT_VERSION,
-            MessageUtil.toByteBuffer(kraftVersionRecord, ControlRecordUtils.KRAFT_VERSION_CURRENT_VERSION)
+            MessageUtil.toByteBufferAccessor(kraftVersionRecord, ControlRecordUtils.KRAFT_VERSION_CURRENT_VERSION).buffer()
         );
     }
 
@@ -666,7 +666,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
         appendControlRecord(
             timestamp,
             ControlRecordType.KRAFT_VOTERS,
-            MessageUtil.toByteBuffer(votersRecord, ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION)
+            MessageUtil.toByteBufferAccessor(votersRecord, ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION).buffer()
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -124,8 +124,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
     }
 
     // Visible for testing
-    public final ByteBuffer serialize() {
-        return MessageUtil.toByteBuffer(data(), version);
+    public final Readable serialize() {
+        return MessageUtil.toReadable(data(), version);
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -125,7 +125,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
 
     // Visible for testing
     public final ByteBufferAccessor serialize() {
-        return MessageUtil.toReadable(data(), version);
+        return MessageUtil.toByteBufferAccessor(data(), version);
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -124,13 +124,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
     }
 
     // Visible for testing
-    public final Readable serialize() {
+    public final ByteBufferAccessor serialize() {
         return MessageUtil.toReadable(data(), version);
-    }
-
-    // Visible for testing
-    public final ByteBuffer serializeToByteBuffer() {
-        return MessageUtil.toByteBuffer(data(), version);
     }
 
     // Visible for testing
@@ -174,10 +169,6 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
     /**
      * Factory method for getting a request object based on ApiKey ID and a version
      */
-    public static RequestAndSize parseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer) {
-        return parseRequest(apiKey, apiVersion, new ByteBufferAccessor(buffer));
-    }
-
     public static RequestAndSize parseRequest(ApiKeys apiKey, short apiVersion, Readable readable) {
         int bufferSize = readable.remaining();
         return new RequestAndSize(doParseRequest(apiKey, apiVersion, readable), bufferSize);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -19,9 +19,11 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.SendBuilder;
 
 import java.nio.ByteBuffer;
@@ -168,190 +170,194 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
      * Factory method for getting a request object based on ApiKey ID and a version
      */
     public static RequestAndSize parseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer) {
-        int bufferSize = buffer.remaining();
-        return new RequestAndSize(doParseRequest(apiKey, apiVersion, buffer), bufferSize);
+        return parseRequest(apiKey, apiVersion, new ByteBufferAccessor(buffer));
     }
 
-    private static AbstractRequest doParseRequest(ApiKeys apiKey, short apiVersion, ByteBuffer buffer) {
+    public static RequestAndSize parseRequest(ApiKeys apiKey, short apiVersion, Readable readable) {
+        int bufferSize = readable.remaining();
+        return new RequestAndSize(doParseRequest(apiKey, apiVersion, readable), bufferSize);
+    }
+
+    private static AbstractRequest doParseRequest(ApiKeys apiKey, short apiVersion, Readable readable) {
         switch (apiKey) {
             case PRODUCE:
-                return ProduceRequest.parse(buffer, apiVersion);
+                return ProduceRequest.parse(readable, apiVersion);
             case FETCH:
-                return FetchRequest.parse(buffer, apiVersion);
+                return FetchRequest.parse(readable, apiVersion);
             case LIST_OFFSETS:
-                return ListOffsetsRequest.parse(buffer, apiVersion);
+                return ListOffsetsRequest.parse(readable, apiVersion);
             case METADATA:
-                return MetadataRequest.parse(buffer, apiVersion);
+                return MetadataRequest.parse(readable, apiVersion);
             case OFFSET_COMMIT:
-                return OffsetCommitRequest.parse(buffer, apiVersion);
+                return OffsetCommitRequest.parse(readable, apiVersion);
             case OFFSET_FETCH:
-                return OffsetFetchRequest.parse(buffer, apiVersion);
+                return OffsetFetchRequest.parse(readable, apiVersion);
             case FIND_COORDINATOR:
-                return FindCoordinatorRequest.parse(buffer, apiVersion);
+                return FindCoordinatorRequest.parse(readable, apiVersion);
             case JOIN_GROUP:
-                return JoinGroupRequest.parse(buffer, apiVersion);
+                return JoinGroupRequest.parse(readable, apiVersion);
             case HEARTBEAT:
-                return HeartbeatRequest.parse(buffer, apiVersion);
+                return HeartbeatRequest.parse(readable, apiVersion);
             case LEAVE_GROUP:
-                return LeaveGroupRequest.parse(buffer, apiVersion);
+                return LeaveGroupRequest.parse(readable, apiVersion);
             case SYNC_GROUP:
-                return SyncGroupRequest.parse(buffer, apiVersion);
+                return SyncGroupRequest.parse(readable, apiVersion);
             case DESCRIBE_GROUPS:
-                return DescribeGroupsRequest.parse(buffer, apiVersion);
+                return DescribeGroupsRequest.parse(readable, apiVersion);
             case LIST_GROUPS:
-                return ListGroupsRequest.parse(buffer, apiVersion);
+                return ListGroupsRequest.parse(readable, apiVersion);
             case SASL_HANDSHAKE:
-                return SaslHandshakeRequest.parse(buffer, apiVersion);
+                return SaslHandshakeRequest.parse(readable, apiVersion);
             case API_VERSIONS:
-                return ApiVersionsRequest.parse(buffer, apiVersion);
+                return ApiVersionsRequest.parse(readable, apiVersion);
             case CREATE_TOPICS:
-                return CreateTopicsRequest.parse(buffer, apiVersion);
+                return CreateTopicsRequest.parse(readable, apiVersion);
             case DELETE_TOPICS:
-                return DeleteTopicsRequest.parse(buffer, apiVersion);
+                return DeleteTopicsRequest.parse(readable, apiVersion);
             case DELETE_RECORDS:
-                return DeleteRecordsRequest.parse(buffer, apiVersion);
+                return DeleteRecordsRequest.parse(readable, apiVersion);
             case INIT_PRODUCER_ID:
-                return InitProducerIdRequest.parse(buffer, apiVersion);
+                return InitProducerIdRequest.parse(readable, apiVersion);
             case OFFSET_FOR_LEADER_EPOCH:
-                return OffsetsForLeaderEpochRequest.parse(buffer, apiVersion);
+                return OffsetsForLeaderEpochRequest.parse(readable, apiVersion);
             case ADD_PARTITIONS_TO_TXN:
-                return AddPartitionsToTxnRequest.parse(buffer, apiVersion);
+                return AddPartitionsToTxnRequest.parse(readable, apiVersion);
             case ADD_OFFSETS_TO_TXN:
-                return AddOffsetsToTxnRequest.parse(buffer, apiVersion);
+                return AddOffsetsToTxnRequest.parse(readable, apiVersion);
             case END_TXN:
-                return EndTxnRequest.parse(buffer, apiVersion);
+                return EndTxnRequest.parse(readable, apiVersion);
             case WRITE_TXN_MARKERS:
-                return WriteTxnMarkersRequest.parse(buffer, apiVersion);
+                return WriteTxnMarkersRequest.parse(readable, apiVersion);
             case TXN_OFFSET_COMMIT:
-                return TxnOffsetCommitRequest.parse(buffer, apiVersion);
+                return TxnOffsetCommitRequest.parse(readable, apiVersion);
             case DESCRIBE_ACLS:
-                return DescribeAclsRequest.parse(buffer, apiVersion);
+                return DescribeAclsRequest.parse(readable, apiVersion);
             case CREATE_ACLS:
-                return CreateAclsRequest.parse(buffer, apiVersion);
+                return CreateAclsRequest.parse(readable, apiVersion);
             case DELETE_ACLS:
-                return DeleteAclsRequest.parse(buffer, apiVersion);
+                return DeleteAclsRequest.parse(readable, apiVersion);
             case DESCRIBE_CONFIGS:
-                return DescribeConfigsRequest.parse(buffer, apiVersion);
+                return DescribeConfigsRequest.parse(readable, apiVersion);
             case ALTER_CONFIGS:
-                return AlterConfigsRequest.parse(buffer, apiVersion);
+                return AlterConfigsRequest.parse(readable, apiVersion);
             case ALTER_REPLICA_LOG_DIRS:
-                return AlterReplicaLogDirsRequest.parse(buffer, apiVersion);
+                return AlterReplicaLogDirsRequest.parse(readable, apiVersion);
             case DESCRIBE_LOG_DIRS:
-                return DescribeLogDirsRequest.parse(buffer, apiVersion);
+                return DescribeLogDirsRequest.parse(readable, apiVersion);
             case SASL_AUTHENTICATE:
-                return SaslAuthenticateRequest.parse(buffer, apiVersion);
+                return SaslAuthenticateRequest.parse(readable, apiVersion);
             case CREATE_PARTITIONS:
-                return CreatePartitionsRequest.parse(buffer, apiVersion);
+                return CreatePartitionsRequest.parse(readable, apiVersion);
             case CREATE_DELEGATION_TOKEN:
-                return CreateDelegationTokenRequest.parse(buffer, apiVersion);
+                return CreateDelegationTokenRequest.parse(readable, apiVersion);
             case RENEW_DELEGATION_TOKEN:
-                return RenewDelegationTokenRequest.parse(buffer, apiVersion);
+                return RenewDelegationTokenRequest.parse(readable, apiVersion);
             case EXPIRE_DELEGATION_TOKEN:
-                return ExpireDelegationTokenRequest.parse(buffer, apiVersion);
+                return ExpireDelegationTokenRequest.parse(readable, apiVersion);
             case DESCRIBE_DELEGATION_TOKEN:
-                return DescribeDelegationTokenRequest.parse(buffer, apiVersion);
+                return DescribeDelegationTokenRequest.parse(readable, apiVersion);
             case DELETE_GROUPS:
-                return DeleteGroupsRequest.parse(buffer, apiVersion);
+                return DeleteGroupsRequest.parse(readable, apiVersion);
             case ELECT_LEADERS:
-                return ElectLeadersRequest.parse(buffer, apiVersion);
+                return ElectLeadersRequest.parse(readable, apiVersion);
             case INCREMENTAL_ALTER_CONFIGS:
-                return IncrementalAlterConfigsRequest.parse(buffer, apiVersion);
+                return IncrementalAlterConfigsRequest.parse(readable, apiVersion);
             case ALTER_PARTITION_REASSIGNMENTS:
-                return AlterPartitionReassignmentsRequest.parse(buffer, apiVersion);
+                return AlterPartitionReassignmentsRequest.parse(readable, apiVersion);
             case LIST_PARTITION_REASSIGNMENTS:
-                return ListPartitionReassignmentsRequest.parse(buffer, apiVersion);
+                return ListPartitionReassignmentsRequest.parse(readable, apiVersion);
             case OFFSET_DELETE:
-                return OffsetDeleteRequest.parse(buffer, apiVersion);
+                return OffsetDeleteRequest.parse(readable, apiVersion);
             case DESCRIBE_CLIENT_QUOTAS:
-                return DescribeClientQuotasRequest.parse(buffer, apiVersion);
+                return DescribeClientQuotasRequest.parse(readable, apiVersion);
             case ALTER_CLIENT_QUOTAS:
-                return AlterClientQuotasRequest.parse(buffer, apiVersion);
+                return AlterClientQuotasRequest.parse(readable, apiVersion);
             case DESCRIBE_USER_SCRAM_CREDENTIALS:
-                return DescribeUserScramCredentialsRequest.parse(buffer, apiVersion);
+                return DescribeUserScramCredentialsRequest.parse(readable, apiVersion);
             case ALTER_USER_SCRAM_CREDENTIALS:
-                return AlterUserScramCredentialsRequest.parse(buffer, apiVersion);
+                return AlterUserScramCredentialsRequest.parse(readable, apiVersion);
             case VOTE:
-                return VoteRequest.parse(buffer, apiVersion);
+                return VoteRequest.parse(readable, apiVersion);
             case BEGIN_QUORUM_EPOCH:
-                return BeginQuorumEpochRequest.parse(buffer, apiVersion);
+                return BeginQuorumEpochRequest.parse(readable, apiVersion);
             case END_QUORUM_EPOCH:
-                return EndQuorumEpochRequest.parse(buffer, apiVersion);
+                return EndQuorumEpochRequest.parse(readable, apiVersion);
             case DESCRIBE_QUORUM:
-                return DescribeQuorumRequest.parse(buffer, apiVersion);
+                return DescribeQuorumRequest.parse(readable, apiVersion);
             case ALTER_PARTITION:
-                return AlterPartitionRequest.parse(buffer, apiVersion);
+                return AlterPartitionRequest.parse(readable, apiVersion);
             case UPDATE_FEATURES:
-                return UpdateFeaturesRequest.parse(buffer, apiVersion);
+                return UpdateFeaturesRequest.parse(readable, apiVersion);
             case ENVELOPE:
-                return EnvelopeRequest.parse(buffer, apiVersion);
+                return EnvelopeRequest.parse(readable, apiVersion);
             case FETCH_SNAPSHOT:
-                return FetchSnapshotRequest.parse(buffer, apiVersion);
+                return FetchSnapshotRequest.parse(readable, apiVersion);
             case DESCRIBE_CLUSTER:
-                return DescribeClusterRequest.parse(buffer, apiVersion);
+                return DescribeClusterRequest.parse(readable, apiVersion);
             case DESCRIBE_PRODUCERS:
-                return DescribeProducersRequest.parse(buffer, apiVersion);
+                return DescribeProducersRequest.parse(readable, apiVersion);
             case BROKER_REGISTRATION:
-                return BrokerRegistrationRequest.parse(buffer, apiVersion);
+                return BrokerRegistrationRequest.parse(readable, apiVersion);
             case BROKER_HEARTBEAT:
-                return BrokerHeartbeatRequest.parse(buffer, apiVersion);
+                return BrokerHeartbeatRequest.parse(readable, apiVersion);
             case UNREGISTER_BROKER:
-                return UnregisterBrokerRequest.parse(buffer, apiVersion);
+                return UnregisterBrokerRequest.parse(readable, apiVersion);
             case DESCRIBE_TRANSACTIONS:
-                return DescribeTransactionsRequest.parse(buffer, apiVersion);
+                return DescribeTransactionsRequest.parse(readable, apiVersion);
             case LIST_TRANSACTIONS:
-                return ListTransactionsRequest.parse(buffer, apiVersion);
+                return ListTransactionsRequest.parse(readable, apiVersion);
             case ALLOCATE_PRODUCER_IDS:
-                return AllocateProducerIdsRequest.parse(buffer, apiVersion);
+                return AllocateProducerIdsRequest.parse(readable, apiVersion);
             case CONSUMER_GROUP_HEARTBEAT:
-                return ConsumerGroupHeartbeatRequest.parse(buffer, apiVersion);
+                return ConsumerGroupHeartbeatRequest.parse(readable, apiVersion);
             case CONSUMER_GROUP_DESCRIBE:
-                return ConsumerGroupDescribeRequest.parse(buffer, apiVersion);
+                return ConsumerGroupDescribeRequest.parse(readable, apiVersion);
             case CONTROLLER_REGISTRATION:
-                return ControllerRegistrationRequest.parse(buffer, apiVersion);
+                return ControllerRegistrationRequest.parse(readable, apiVersion);
             case GET_TELEMETRY_SUBSCRIPTIONS:
-                return GetTelemetrySubscriptionsRequest.parse(buffer, apiVersion);
+                return GetTelemetrySubscriptionsRequest.parse(readable, apiVersion);
             case PUSH_TELEMETRY:
-                return PushTelemetryRequest.parse(buffer, apiVersion);
+                return PushTelemetryRequest.parse(readable, apiVersion);
             case ASSIGN_REPLICAS_TO_DIRS:
-                return AssignReplicasToDirsRequest.parse(buffer, apiVersion);
+                return AssignReplicasToDirsRequest.parse(readable, apiVersion);
             case LIST_CLIENT_METRICS_RESOURCES:
-                return ListClientMetricsResourcesRequest.parse(buffer, apiVersion);
+                return ListClientMetricsResourcesRequest.parse(readable, apiVersion);
             case DESCRIBE_TOPIC_PARTITIONS:
-                return DescribeTopicPartitionsRequest.parse(buffer, apiVersion);
+                return DescribeTopicPartitionsRequest.parse(readable, apiVersion);
             case SHARE_GROUP_HEARTBEAT:
-                return ShareGroupHeartbeatRequest.parse(buffer, apiVersion);
+                return ShareGroupHeartbeatRequest.parse(readable, apiVersion);
             case SHARE_GROUP_DESCRIBE:
-                return ShareGroupDescribeRequest.parse(buffer, apiVersion);
+                return ShareGroupDescribeRequest.parse(readable, apiVersion);
             case SHARE_FETCH:
-                return ShareFetchRequest.parse(buffer, apiVersion);
+                return ShareFetchRequest.parse(readable, apiVersion);
             case SHARE_ACKNOWLEDGE:
-                return ShareAcknowledgeRequest.parse(buffer, apiVersion);
+                return ShareAcknowledgeRequest.parse(readable, apiVersion);
             case ADD_RAFT_VOTER:
-                return AddRaftVoterRequest.parse(buffer, apiVersion);
+                return AddRaftVoterRequest.parse(readable, apiVersion);
             case REMOVE_RAFT_VOTER:
-                return RemoveRaftVoterRequest.parse(buffer, apiVersion);
+                return RemoveRaftVoterRequest.parse(readable, apiVersion);
             case UPDATE_RAFT_VOTER:
-                return UpdateRaftVoterRequest.parse(buffer, apiVersion);
+                return UpdateRaftVoterRequest.parse(readable, apiVersion);
             case INITIALIZE_SHARE_GROUP_STATE:
-                return InitializeShareGroupStateRequest.parse(buffer, apiVersion);
+                return InitializeShareGroupStateRequest.parse(readable, apiVersion);
             case READ_SHARE_GROUP_STATE:
-                return ReadShareGroupStateRequest.parse(buffer, apiVersion);
+                return ReadShareGroupStateRequest.parse(readable, apiVersion);
             case WRITE_SHARE_GROUP_STATE:
-                return WriteShareGroupStateRequest.parse(buffer, apiVersion);
+                return WriteShareGroupStateRequest.parse(readable, apiVersion);
             case DELETE_SHARE_GROUP_STATE:
-                return DeleteShareGroupStateRequest.parse(buffer, apiVersion);
+                return DeleteShareGroupStateRequest.parse(readable, apiVersion);
             case READ_SHARE_GROUP_STATE_SUMMARY:
-                return ReadShareGroupStateSummaryRequest.parse(buffer, apiVersion);
+                return ReadShareGroupStateSummaryRequest.parse(readable, apiVersion);
             case STREAMS_GROUP_HEARTBEAT:
-                return StreamsGroupHeartbeatRequest.parse(buffer, apiVersion);
+                return StreamsGroupHeartbeatRequest.parse(readable, apiVersion);
             case STREAMS_GROUP_DESCRIBE:
-                return StreamsGroupDescribeRequest.parse(buffer, apiVersion);
+                return StreamsGroupDescribeRequest.parse(readable, apiVersion);
             case DESCRIBE_SHARE_GROUP_OFFSETS:
-                return DescribeShareGroupOffsetsRequest.parse(buffer, apiVersion);
+                return DescribeShareGroupOffsetsRequest.parse(readable, apiVersion);
             case ALTER_SHARE_GROUP_OFFSETS:
-                return AlterShareGroupOffsetsRequest.parse(buffer, apiVersion);
+                return AlterShareGroupOffsetsRequest.parse(readable, apiVersion);
             case DELETE_SHARE_GROUP_OFFSETS:
-                return DeleteShareGroupOffsetsRequest.parse(buffer, apiVersion);
+                return DeleteShareGroupOffsetsRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -129,6 +129,11 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
     }
 
     // Visible for testing
+    public final ByteBuffer serializeToByteBuffer() {
+        return MessageUtil.toByteBuffer(data(), version);
+    }
+
+    // Visible for testing
     final int sizeInBytes() {
         return data().size(new ObjectSerializationCache(), version);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -52,7 +52,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
 
     // Visible for testing
     final ByteBuffer serialize(short version) {
-        return MessageUtil.toByteBuffer(data(), version);
+        return MessageUtil.toByteBufferAccessor(data(), version).buffer();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AddOffsetsToTxnRequestData;
 import org.apache.kafka.common.message.AddOffsetsToTxnResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class AddOffsetsToTxnRequest extends AbstractRequest {
 
@@ -64,7 +62,7 @@ public class AddOffsetsToTxnRequest extends AbstractRequest {
                                                .setThrottleTimeMs(throttleTimeMs));
     }
 
-    public static AddOffsetsToTxnRequest parse(ByteBuffer buffer, short version) {
-        return new AddOffsetsToTxnRequest(new AddOffsetsToTxnRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AddOffsetsToTxnRequest parse(Readable readable, short version) {
+        return new AddOffsetsToTxnRequest(new AddOffsetsToTxnRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnRequest.java
@@ -29,10 +29,9 @@ import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartiti
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnTopicResult;
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnTopicResultCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -198,7 +197,7 @@ public class AddPartitionsToTxnRequest extends AbstractRequest {
         return topicResults;
     }
 
-    public static AddPartitionsToTxnRequest parse(ByteBuffer buffer, short version) {
-        return new AddPartitionsToTxnRequest(new AddPartitionsToTxnRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AddPartitionsToTxnRequest parse(Readable readable, short version) {
+        return new AddPartitionsToTxnRequest(new AddPartitionsToTxnRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AddRaftVoterRequestData;
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class AddRaftVoterRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<AddRaftVoterRequest> {
@@ -67,9 +65,9 @@ public class AddRaftVoterRequest extends AbstractRequest {
             setThrottleTimeMs(throttleTimeMs));
     }
 
-    public static AddRaftVoterRequest parse(ByteBuffer buffer, short version) {
+    public static AddRaftVoterRequest parse(Readable readable, short version) {
         return new AddRaftVoterRequest(
-            new AddRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            new AddRaftVoterRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AllocateProducerIdsRequestData;
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class AllocateProducerIdsRequest extends AbstractRequest {
     private final AllocateProducerIdsRequestData data;
@@ -65,8 +63,8 @@ public class AllocateProducerIdsRequest extends AbstractRequest {
         }
     }
 
-    public static AllocateProducerIdsRequest parse(ByteBuffer buffer, short version) {
+    public static AllocateProducerIdsRequest parse(Readable readable, short version) {
         return new AllocateProducerIdsRequest(new AllocateProducerIdsRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
@@ -22,12 +22,11 @@ import org.apache.kafka.common.message.AlterClientQuotasRequestData.EntryData;
 import org.apache.kafka.common.message.AlterClientQuotasRequestData.OpData;
 import org.apache.kafka.common.message.AlterClientQuotasResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -138,7 +137,7 @@ public class AlterClientQuotasRequest extends AbstractRequest {
         return new AlterClientQuotasResponse(responseData);
     }
 
-    public static AlterClientQuotasRequest parse(ByteBuffer buffer, short version) {
-        return new AlterClientQuotasRequest(new AlterClientQuotasRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AlterClientQuotasRequest parse(Readable readable, short version) {
+        return new AlterClientQuotasRequest(new AlterClientQuotasRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsRequest.java
@@ -21,9 +21,8 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.AlterConfigsRequestData;
 import org.apache.kafka.common.message.AlterConfigsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -132,7 +131,7 @@ public class AlterConfigsRequest extends AbstractRequest {
 
     }
 
-    public static AlterConfigsRequest parse(ByteBuffer buffer, short version) {
-        return new AlterConfigsRequest(new AlterConfigsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AlterConfigsRequest parse(Readable readable, short version) {
+        return new AlterConfigsRequest(new AlterConfigsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsRequest.java
@@ -24,9 +24,8 @@ import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignablePartitionResponse;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignableTopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,9 +63,9 @@ public class AlterPartitionReassignmentsRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static AlterPartitionReassignmentsRequest parse(ByteBuffer buffer, short version) {
+    public static AlterPartitionReassignmentsRequest parse(Readable readable, short version) {
         return new AlterPartitionReassignmentsRequest(new AlterPartitionReassignmentsRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     public AlterPartitionReassignmentsRequestData data() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.message.AlterPartitionRequestData;
 import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
 import org.apache.kafka.common.message.AlterPartitionResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -54,8 +53,8 @@ public class AlterPartitionRequest extends AbstractRequest {
             .setErrorCode(Errors.forException(e).code()));
     }
 
-    public static AlterPartitionRequest parse(ByteBuffer buffer, short version) {
-        return new AlterPartitionRequest(new AlterPartitionRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AlterPartitionRequest parse(Readable readable, short version) {
+        return new AlterPartitionRequest(new AlterPartitionRequestData(readable, version), version);
     }
 
     public static class Builder extends AbstractRequest.Builder<AlterPartitionRequest> {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsRequest.java
@@ -23,10 +23,9 @@ import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -87,7 +86,7 @@ public class AlterReplicaLogDirsRequest extends AbstractRequest {
         return result;
     }
 
-    public static AlterReplicaLogDirsRequest parse(ByteBuffer buffer, short version) {
-        return new AlterReplicaLogDirsRequest(new AlterReplicaLogDirsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AlterReplicaLogDirsRequest parse(Readable readable, short version) {
+        return new AlterReplicaLogDirsRequest(new AlterReplicaLogDirsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AlterShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -76,9 +75,9 @@ public class AlterShareGroupOffsetsRequest extends AbstractRequest {
             .setResponses(results));
     }
 
-    public static AlterShareGroupOffsetsRequest parse(ByteBuffer buffer, short version) {
+    public static AlterShareGroupOffsetsRequest parse(Readable readable, short version) {
         return new AlterShareGroupOffsetsRequest(
-            new AlterShareGroupOffsetsRequestData(new ByteBufferAccessor(buffer), version),
+            new AlterShareGroupOffsetsRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsRequest.java
@@ -19,9 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,8 +54,8 @@ public class AlterUserScramCredentialsRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static AlterUserScramCredentialsRequest parse(ByteBuffer buffer, short version) {
-        return new AlterUserScramCredentialsRequest(new AlterUserScramCredentialsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static AlterUserScramCredentialsRequest parse(Readable readable, short version) {
+        return new AlterUserScramCredentialsRequest(new AlterUserScramCredentialsRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -20,11 +20,10 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.utils.AppInfoParser;
 
-import java.nio.ByteBuffer;
 import java.util.regex.Pattern;
 
 public class ApiVersionsRequest extends AbstractRequest {
@@ -128,8 +127,8 @@ public class ApiVersionsRequest extends AbstractRequest {
         return new ApiVersionsResponse(data);
     }
 
-    public static ApiVersionsRequest parse(ByteBuffer buffer, short version) {
-        return new ApiVersionsRequest(new ApiVersionsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static ApiVersionsRequest parse(Readable readable, short version) {
+        return new ApiVersionsRequest(new ApiVersionsRequestData(readable, version), version);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class AssignReplicasToDirsRequest extends AbstractRequest {
 
@@ -75,8 +73,8 @@ public class AssignReplicasToDirsRequest extends AbstractRequest {
         return data;
     }
 
-    public static AssignReplicasToDirsRequest parse(ByteBuffer buffer, short version) {
+    public static AssignReplicasToDirsRequest parse(Readable readable, short version) {
         return new AssignReplicasToDirsRequest(new AssignReplicasToDirsRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 
 public class BeginQuorumEpochRequest extends AbstractRequest {
@@ -64,8 +63,8 @@ public class BeginQuorumEpochRequest extends AbstractRequest {
             .setErrorCode(Errors.forException(e).code()));
     }
 
-    public static BeginQuorumEpochRequest parse(ByteBuffer buffer, short version) {
-        return new BeginQuorumEpochRequest(new BeginQuorumEpochRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static BeginQuorumEpochRequest parse(Readable readable, short version) {
+        return new BeginQuorumEpochRequest(new BeginQuorumEpochRequestData(readable, version), version);
     }
 
     public static BeginQuorumEpochRequestData singletonRequest(

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class BrokerHeartbeatRequest extends AbstractRequest {
 
@@ -65,8 +63,8 @@ public class BrokerHeartbeatRequest extends AbstractRequest {
                 .setErrorCode(error.code()));
     }
 
-    public static BrokerHeartbeatRequest parse(ByteBuffer buffer, short version) {
-        return new BrokerHeartbeatRequest(new BrokerHeartbeatRequestData(new ByteBufferAccessor(buffer), version),
+    public static BrokerHeartbeatRequest parse(Readable readable, short version) {
+        return new BrokerHeartbeatRequest(new BrokerHeartbeatRequestData(readable, version),
                 version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class BrokerRegistrationRequest extends AbstractRequest {
 
@@ -82,8 +80,8 @@ public class BrokerRegistrationRequest extends AbstractRequest {
                 .setErrorCode(error.code()));
     }
 
-    public static BrokerRegistrationRequest parse(ByteBuffer buffer, short version) {
-        return new BrokerRegistrationRequest(new BrokerRegistrationRequestData(new ByteBufferAccessor(buffer), version),
+    public static BrokerRegistrationRequest parse(Readable readable, short version) {
+        return new BrokerRegistrationRequest(new BrokerRegistrationRequestData(readable, version),
                 version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -79,9 +78,9 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
         return data;
     }
 
-    public static ConsumerGroupDescribeRequest parse(ByteBuffer buffer, short version) {
+    public static ConsumerGroupDescribeRequest parse(Readable readable, short version) {
         return new ConsumerGroupDescribeRequest(
-            new ConsumerGroupDescribeRequestData(new ByteBufferAccessor(buffer), version),
+            new ConsumerGroupDescribeRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
@@ -20,10 +20,8 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class ConsumerGroupHeartbeatRequest extends AbstractRequest {
 
@@ -97,8 +95,8 @@ public class ConsumerGroupHeartbeatRequest extends AbstractRequest {
         return data;
     }
 
-    public static ConsumerGroupHeartbeatRequest parse(ByteBuffer buffer, short version) {
+    public static ConsumerGroupHeartbeatRequest parse(Readable readable, short version) {
         return new ConsumerGroupHeartbeatRequest(new ConsumerGroupHeartbeatRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.ControllerRegistrationResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class ControllerRegistrationRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ControllerRegistrationRequest> {
@@ -65,9 +63,9 @@ public class ControllerRegistrationRequest extends AbstractRequest {
                 .setErrorMessage(error.message()));
     }
 
-    public static ControllerRegistrationRequest parse(ByteBuffer buffer, short version) {
+    public static ControllerRegistrationRequest parse(Readable readable, short version) {
         return new ControllerRegistrationRequest(
-            new ControllerRegistrationRequestData(new ByteBufferAccessor(buffer), version),
+            new ControllerRegistrationRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsRequest.java
@@ -27,12 +27,11 @@ import org.apache.kafka.common.message.CreateAclsRequestData.AclCreation;
 import org.apache.kafka.common.message.CreateAclsResponseData;
 import org.apache.kafka.common.message.CreateAclsResponseData.AclCreationResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -83,8 +82,8 @@ public class CreateAclsRequest extends AbstractRequest {
             .setResults(results));
     }
 
-    public static CreateAclsRequest parse(ByteBuffer buffer, short version) {
-        return new CreateAclsRequest(new CreateAclsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static CreateAclsRequest parse(Readable readable, short version) {
+        return new CreateAclsRequest(new CreateAclsRequestData(readable, version), version);
     }
 
     private void validate(CreateAclsRequestData data) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenRequest.java
@@ -18,11 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
-
-import java.nio.ByteBuffer;
 
 public class CreateDelegationTokenRequest extends AbstractRequest {
 
@@ -33,8 +31,8 @@ public class CreateDelegationTokenRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static CreateDelegationTokenRequest parse(ByteBuffer buffer, short version) {
-        return new CreateDelegationTokenRequest(new CreateDelegationTokenRequestData(new ByteBufferAccessor(buffer), version),
+    public static CreateDelegationTokenRequest parse(Readable readable, short version) {
+        return new CreateDelegationTokenRequest(new CreateDelegationTokenRequestData(readable, version),
             version);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
@@ -22,9 +22,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class CreatePartitionsRequest extends AbstractRequest {
 
@@ -76,7 +74,7 @@ public class CreatePartitionsRequest extends AbstractRequest {
         return new CreatePartitionsResponse(response);
     }
 
-    public static CreatePartitionsRequest parse(ByteBuffer buffer, short version) {
-        return new CreatePartitionsRequest(new CreatePartitionsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static CreatePartitionsRequest parse(Readable readable, short version) {
+        return new CreatePartitionsRequest(new CreatePartitionsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
@@ -22,9 +22,8 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -109,7 +108,7 @@ public class CreateTopicsRequest extends AbstractRequest {
         return new CreateTopicsResponse(response);
     }
 
-    public static CreateTopicsRequest parse(ByteBuffer buffer, short version) {
-        return new CreateTopicsRequest(new CreateTopicsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static CreateTopicsRequest parse(Readable readable, short version) {
+        return new CreateTopicsRequest(new CreateTopicsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsRequest.java
@@ -26,12 +26,11 @@ import org.apache.kafka.common.message.DeleteAclsRequestData.DeleteAclsFilter;
 import org.apache.kafka.common.message.DeleteAclsResponseData;
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsFilterResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -116,8 +115,8 @@ public class DeleteAclsRequest extends AbstractRequest {
             .setFilterResults(filterResults), version());
     }
 
-    public static DeleteAclsRequest parse(ByteBuffer buffer, short version) {
-        return new DeleteAclsRequest(new DeleteAclsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DeleteAclsRequest parse(Readable readable, short version) {
+        return new DeleteAclsRequest(new DeleteAclsRequestData(readable, version), version);
     }
 
     public static DeleteAclsFilter deleteAclsFilter(AclBindingFilter filter) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 public class DeleteGroupsRequest extends AbstractRequest {
@@ -60,8 +59,8 @@ public class DeleteGroupsRequest extends AbstractRequest {
         );
     }
 
-    public static DeleteGroupsRequest parse(ByteBuffer buffer, short version) {
-        return new DeleteGroupsRequest(new DeleteGroupsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DeleteGroupsRequest parse(Readable readable, short version) {
+        return new DeleteGroupsRequest(new DeleteGroupsRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
@@ -22,10 +22,8 @@ import org.apache.kafka.common.message.DeleteRecordsRequestData.DeleteRecordsTop
 import org.apache.kafka.common.message.DeleteRecordsResponseData;
 import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DeleteRecordsRequest extends AbstractRequest {
 
@@ -79,7 +77,7 @@ public class DeleteRecordsRequest extends AbstractRequest {
         return new DeleteRecordsResponse(result);
     }
 
-    public static DeleteRecordsRequest parse(ByteBuffer buffer, short version) {
-        return new DeleteRecordsRequest(new DeleteRecordsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DeleteRecordsRequest parse(Readable readable, short version) {
+        return new DeleteRecordsRequest(new DeleteRecordsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,9 +79,9 @@ public class DeleteShareGroupOffsetsRequest extends AbstractRequest {
         return data;
     }
 
-    public static DeleteShareGroupOffsetsRequest parse(ByteBuffer buffer, short version) {
+    public static DeleteShareGroupOffsetsRequest parse(Readable readable, short version) {
         return new DeleteShareGroupOffsetsRequest(
-            new DeleteShareGroupOffsetsRequestData(new ByteBufferAccessor(buffer), version),
+            new DeleteShareGroupOffsetsRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
 import org.apache.kafka.common.message.DeleteShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,9 +79,9 @@ public class DeleteShareGroupStateRequest extends AbstractRequest {
         return data;
     }
 
-    public static DeleteShareGroupStateRequest parse(ByteBuffer buffer, short version) {
+    public static DeleteShareGroupStateRequest parse(Readable readable, short version) {
         return new DeleteShareGroupStateRequest(
-                new DeleteShareGroupStateRequestData(new ByteBufferAccessor(buffer), version),
+                new DeleteShareGroupStateRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -22,9 +22,8 @@ import org.apache.kafka.common.message.DeleteTopicsRequestData.DeleteTopicState;
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
 import org.apache.kafka.common.message.DeleteTopicsResponseData.DeletableTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -114,8 +113,8 @@ public class DeleteTopicsRequest extends AbstractRequest {
         return data.topicNames().stream().map(name -> new DeleteTopicState().setName(name)).collect(Collectors.toList()); 
     }
 
-    public static DeleteTopicsRequest parse(ByteBuffer buffer, short version) {
-        return new DeleteTopicsRequest(new DeleteTopicsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DeleteTopicsRequest parse(Readable readable, short version) {
+        return new DeleteTopicsRequest(new DeleteTopicsRequestData(readable, version), version);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsRequest.java
@@ -24,12 +24,10 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.DescribeAclsRequestData;
 import org.apache.kafka.common.message.DescribeAclsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-
-import java.nio.ByteBuffer;
 
 public class DescribeAclsRequest extends AbstractRequest {
 
@@ -104,8 +102,8 @@ public class DescribeAclsRequest extends AbstractRequest {
         return new DescribeAclsResponse(response, version());
     }
 
-    public static DescribeAclsRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeAclsRequest(new DescribeAclsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeAclsRequest parse(Readable readable, short version) {
+        return new DescribeAclsRequest(new DescribeAclsRequestData(readable, version), version);
     }
 
     public AclBindingFilter filter() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasRequest.java
@@ -20,11 +20,10 @@ import org.apache.kafka.common.message.DescribeClientQuotasRequestData;
 import org.apache.kafka.common.message.DescribeClientQuotasRequestData.ComponentData;
 import org.apache.kafka.common.message.DescribeClientQuotasResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,8 +119,8 @@ public class DescribeClientQuotasRequest extends AbstractRequest {
             .setEntries(null));
     }
 
-    public static DescribeClientQuotasRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeClientQuotasRequest(new DescribeClientQuotasRequestData(new ByteBufferAccessor(buffer), version),
+    public static DescribeClientQuotasRequest parse(Readable readable, short version) {
+        return new DescribeClientQuotasRequest(new DescribeClientQuotasRequestData(readable, version),
             version);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterRequest.java
@@ -20,9 +20,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeClusterRequestData;
 import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DescribeClusterRequest extends AbstractRequest {
 
@@ -71,7 +69,7 @@ public class DescribeClusterRequest extends AbstractRequest {
         return data.toString();
     }
 
-    public static DescribeClusterRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeClusterRequest(new DescribeClusterRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeClusterRequest parse(Readable readable, short version) {
+        return new DescribeClusterRequest(new DescribeClusterRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.stream.Collectors;
 
 public class DescribeConfigsRequest extends AbstractRequest {
@@ -67,7 +66,7 @@ public class DescribeConfigsRequest extends AbstractRequest {
         ));
     }
 
-    public static DescribeConfigsRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeConfigsRequest(new DescribeConfigsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeConfigsRequest parse(Readable readable, short version) {
+        return new DescribeConfigsRequest(new DescribeConfigsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenRequest.java
@@ -18,11 +18,10 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DescribeDelegationTokenRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -74,8 +73,8 @@ public class DescribeDelegationTokenRequest extends AbstractRequest {
         return new DescribeDelegationTokenResponse(version(), throttleTimeMs, Errors.forException(e));
     }
 
-    public static DescribeDelegationTokenRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeDelegationTokenRequest parse(Readable readable, short version) {
         return new DescribeDelegationTokenRequest(new DescribeDelegationTokenRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeGroupsRequestData;
 import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -74,8 +73,8 @@ public class DescribeGroupsRequest extends AbstractRequest {
         return new DescribeGroupsResponse(describeGroupsResponseData);
     }
 
-    public static DescribeGroupsRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeGroupsRequest(new DescribeGroupsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeGroupsRequest parse(Readable readable, short version) {
+        return new DescribeGroupsRequest(new DescribeGroupsRequestData(readable, version), version);
     }
 
     public static List<DescribeGroupsResponseData.DescribedGroup> getErrorDescribedGroupList(

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DescribeLogDirsRequest extends AbstractRequest {
 
@@ -69,7 +67,7 @@ public class DescribeLogDirsRequest extends AbstractRequest {
         return data.topics() == null;
     }
 
-    public static DescribeLogDirsRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeLogDirsRequest(new DescribeLogDirsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeLogDirsRequest parse(Readable readable, short version) {
+        return new DescribeLogDirsRequest(new DescribeLogDirsRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
@@ -22,10 +22,8 @@ import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.message.DescribeProducersResponseData.PartitionResponse;
 import org.apache.kafka.common.message.DescribeProducersResponseData.TopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DescribeProducersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DescribeProducersRequest> {
@@ -85,9 +83,9 @@ public class DescribeProducersRequest extends AbstractRequest {
         return new DescribeProducersResponse(response);
     }
 
-    public static DescribeProducersRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeProducersRequest parse(Readable readable, short version) {
         return new DescribeProducersRequest(new DescribeProducersRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,8 +55,8 @@ public class DescribeQuorumRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static DescribeQuorumRequest parse(ByteBuffer buffer, short version) {
-        return new DescribeQuorumRequest(new DescribeQuorumRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeQuorumRequest parse(Readable readable, short version) {
+        return new DescribeQuorumRequest(new DescribeQuorumRequestData(readable, version), version);
     }
 
     public static DescribeQuorumRequestData singletonRequest(TopicPartition topicPartition) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsRequest.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.message.DescribeShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup;
 import org.apache.kafka.common.message.DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,9 +81,9 @@ public class DescribeShareGroupOffsetsRequest extends AbstractRequest {
         return data;
     }
 
-    public static DescribeShareGroupOffsetsRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeShareGroupOffsetsRequest parse(Readable readable, short version) {
         return new DescribeShareGroupOffsetsRequest(
-                new DescribeShareGroupOffsetsRequestData(new ByteBufferAccessor(buffer), version),
+                new DescribeShareGroupOffsetsRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -91,9 +90,9 @@ public class DescribeTopicPartitionsRequest extends AbstractRequest {
         return new DescribeTopicPartitionsResponse(responseData);
     }
 
-    public static DescribeTopicPartitionsRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeTopicPartitionsRequest parse(Readable readable, short version) {
         return new DescribeTopicPartitionsRequest(
-            new DescribeTopicPartitionsRequestData(new ByteBufferAccessor(buffer), version),
+            new DescribeTopicPartitionsRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeTransactionsRequestData;
 import org.apache.kafka.common.message.DescribeTransactionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DescribeTransactionsRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DescribeTransactionsRequest> {
@@ -72,9 +70,9 @@ public class DescribeTransactionsRequest extends AbstractRequest {
         return new DescribeTransactionsResponse(response);
     }
 
-    public static DescribeTransactionsRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeTransactionsRequest parse(Readable readable, short version) {
         return new DescribeTransactionsRequest(new DescribeTransactionsRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsRequest.java
@@ -19,9 +19,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class DescribeUserScramCredentialsRequest extends AbstractRequest {
 
@@ -51,9 +49,9 @@ public class DescribeUserScramCredentialsRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static DescribeUserScramCredentialsRequest parse(ByteBuffer buffer, short version) {
+    public static DescribeUserScramCredentialsRequest parse(Readable readable, short version) {
         return new DescribeUserScramCredentialsRequest(new DescribeUserScramCredentialsRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
@@ -25,10 +25,9 @@ import org.apache.kafka.common.message.ElectLeadersRequestData.TopicPartitions;
 import org.apache.kafka.common.message.ElectLeadersResponseData.PartitionResult;
 import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -147,7 +146,7 @@ public class ElectLeadersRequest extends AbstractRequest {
         return new ElectLeadersResponse(throttleTimeMs, apiError.error().code(), electionResults, version());
     }
 
-    public static ElectLeadersRequest parse(ByteBuffer buffer, short version) {
-        return new ElectLeadersRequest(new ElectLeadersRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static ElectLeadersRequest parse(Readable readable, short version) {
+        return new ElectLeadersRequest(new ElectLeadersRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -67,8 +66,8 @@ public class EndQuorumEpochRequest extends AbstractRequest {
             .setErrorCode(Errors.forException(e).code()));
     }
 
-    public static EndQuorumEpochRequest parse(ByteBuffer buffer, short version) {
-        return new EndQuorumEpochRequest(new EndQuorumEpochRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static EndQuorumEpochRequest parse(Readable readable, short version) {
+        return new EndQuorumEpochRequest(new EndQuorumEpochRequestData(readable, version), version);
     }
 
     public static EndQuorumEpochRequestData singletonRequest(TopicPartition topicPartition,

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndTxnRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndTxnRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.EndTxnRequestData;
 import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class EndTxnRequest extends AbstractRequest {
     public static final short LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2 = 4;
@@ -81,7 +79,7 @@ public class EndTxnRequest extends AbstractRequest {
         );
     }
 
-    public static EndTxnRequest parse(ByteBuffer buffer, short version) {
-        return new EndTxnRequest(new EndTxnRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static EndTxnRequest parse(Readable readable, short version) {
+        return new EndTxnRequest(new EndTxnRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeRequest.java
@@ -19,8 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.EnvelopeRequestData;
 import org.apache.kafka.common.message.EnvelopeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import java.nio.ByteBuffer;
 
@@ -76,8 +76,8 @@ public class EnvelopeRequest extends AbstractRequest {
                                         .setErrorCode(Errors.forException(e).code()));
     }
 
-    public static EnvelopeRequest parse(ByteBuffer buffer, short version) {
-        return new EnvelopeRequest(new EnvelopeRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static EnvelopeRequest parse(Readable readable, short version) {
+        return new EnvelopeRequest(new EnvelopeRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenRequest.java
@@ -19,8 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import java.nio.ByteBuffer;
 
@@ -33,9 +33,9 @@ public class ExpireDelegationTokenRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static ExpireDelegationTokenRequest parse(ByteBuffer buffer, short version) {
+    public static ExpireDelegationTokenRequest parse(Readable readable, short version) {
         return new ExpireDelegationTokenRequest(
-            new ExpireDelegationTokenRequestData(new ByteBufferAccessor(buffer), version), version);
+            new ExpireDelegationTokenRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -25,11 +25,10 @@ import org.apache.kafka.common.message.FetchRequestData.ForgottenTopic;
 import org.apache.kafka.common.message.FetchRequestData.ReplicaState;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.RecordBatch;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -453,8 +452,8 @@ public class FetchRequest extends AbstractRequest {
         return data.rackId();
     }
 
-    public static FetchRequest parse(ByteBuffer buffer, short version) {
-        return new FetchRequest(new FetchRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static FetchRequest parse(Readable readable, short version) {
+        return new FetchRequest(new FetchRequestData(readable, version), version);
     }
 
     // Broker ids are non-negative int.

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FetchSnapshotRequestData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Optional;
 
 public final class FetchSnapshotRequest extends AbstractRequest {
@@ -68,8 +67,8 @@ public final class FetchSnapshotRequest extends AbstractRequest {
             .findAny();
     }
 
-    public static FetchSnapshotRequest parse(ByteBuffer buffer, short version) {
-        return new FetchSnapshotRequest(new FetchSnapshotRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static FetchSnapshotRequest parse(Readable readable, short version) {
+        return new FetchSnapshotRequest(new FetchSnapshotRequestData(readable, version), version);
     }
 
     public static class Builder extends AbstractRequest.Builder<FetchSnapshotRequest> {

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 
 public class FindCoordinatorRequest extends AbstractRequest {
@@ -105,8 +104,8 @@ public class FindCoordinatorRequest extends AbstractRequest {
         }
     }
 
-    public static FindCoordinatorRequest parse(ByteBuffer buffer, short version) {
-        return new FindCoordinatorRequest(new FindCoordinatorRequestData(new ByteBufferAccessor(buffer), version),
+    public static FindCoordinatorRequest parse(Readable readable, short version) {
+        return new FindCoordinatorRequest(new FindCoordinatorRequestData(readable, version),
             version);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsRequestData;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class GetTelemetrySubscriptionsRequest extends AbstractRequest {
 
@@ -71,8 +69,8 @@ public class GetTelemetrySubscriptionsRequest extends AbstractRequest {
         return data;
     }
 
-    public static GetTelemetrySubscriptionsRequest parse(ByteBuffer buffer, short version) {
+    public static GetTelemetrySubscriptionsRequest parse(Readable readable, short version) {
         return new GetTelemetrySubscriptionsRequest(new GetTelemetrySubscriptionsRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -20,10 +20,8 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class HeartbeatRequest extends AbstractRequest {
 
@@ -67,8 +65,8 @@ public class HeartbeatRequest extends AbstractRequest {
         return new HeartbeatResponse(responseData);
     }
 
-    public static HeartbeatRequest parse(ByteBuffer buffer, short version) {
-        return new HeartbeatRequest(new HeartbeatRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static HeartbeatRequest parse(Readable readable, short version) {
+        return new HeartbeatRequest(new HeartbeatRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
@@ -24,9 +24,8 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.AlterC
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
 
@@ -84,9 +83,9 @@ public class IncrementalAlterConfigsRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static IncrementalAlterConfigsRequest parse(ByteBuffer buffer, short version) {
+    public static IncrementalAlterConfigsRequest parse(Readable readable, short version) {
         return new IncrementalAlterConfigsRequest(new IncrementalAlterConfigsRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
@@ -19,11 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.RecordBatch;
-
-import java.nio.ByteBuffer;
 
 public class InitProducerIdRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<InitProducerIdRequest> {
@@ -68,8 +66,8 @@ public class InitProducerIdRequest extends AbstractRequest {
         return new InitProducerIdResponse(response);
     }
 
-    public static InitProducerIdRequest parse(ByteBuffer buffer, short version) {
-        return new InitProducerIdRequest(new InitProducerIdRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static InitProducerIdRequest parse(Readable readable, short version) {
+        return new InitProducerIdRequest(new InitProducerIdRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.InitializeShareGroupStateRequestData;
 import org.apache.kafka.common.message.InitializeShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,9 +79,9 @@ public class InitializeShareGroupStateRequest extends AbstractRequest {
         return data;
     }
 
-    public static InitializeShareGroupStateRequest parse(ByteBuffer buffer, short version) {
+    public static InitializeShareGroupStateRequest parse(Readable readable, short version) {
         return new InitializeShareGroupStateRequest(
-            new InitializeShareGroupStateRequestData(new ByteBufferAccessor(buffer), version),
+            new InitializeShareGroupStateRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 
 public class JoinGroupRequest extends AbstractRequest {
@@ -208,7 +207,7 @@ public class JoinGroupRequest extends AbstractRequest {
         return new JoinGroupResponse(data, version());
     }
 
-    public static JoinGroupRequest parse(ByteBuffer buffer, short version) {
-        return new JoinGroupRequest(new JoinGroupRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static JoinGroupRequest parse(Readable readable, short version) {
+        return new JoinGroupRequest(new JoinGroupRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
@@ -21,11 +21,10 @@ import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -121,7 +120,7 @@ public class LeaveGroupRequest extends AbstractRequest {
         return new LeaveGroupResponse(responseData);
     }
 
-    public static LeaveGroupRequest parse(ByteBuffer buffer, short version) {
-        return new LeaveGroupRequest(new LeaveGroupRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static LeaveGroupRequest parse(Readable readable, short version) {
+        return new LeaveGroupRequest(new LeaveGroupRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListClientMetricsResourcesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListClientMetricsResourcesRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ListClientMetricsResourcesRequestData;
 import org.apache.kafka.common.message.ListClientMetricsResourcesResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class ListClientMetricsResourcesRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ListClientMetricsResourcesRequest> {
@@ -64,9 +62,9 @@ public class ListClientMetricsResourcesRequest extends AbstractRequest {
         return new ListClientMetricsResourcesResponse(response);
     }
 
-    public static ListClientMetricsResourcesRequest parse(ByteBuffer buffer, short version) {
+    public static ListClientMetricsResourcesRequest parse(Readable readable, short version) {
         return new ListClientMetricsResourcesRequest(new ListClientMetricsResourcesRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 
 /**
@@ -81,8 +80,8 @@ public class ListGroupsRequest extends AbstractRequest {
         return new ListGroupsResponse(listGroupsResponseData);
     }
 
-    public static ListGroupsRequest parse(ByteBuffer buffer, short version) {
-        return new ListGroupsRequest(new ListGroupsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static ListGroupsRequest parse(Readable readable, short version) {
+        return new ListGroupsRequest(new ListGroupsRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -25,10 +25,9 @@ import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -184,8 +183,8 @@ public class ListOffsetsRequest extends AbstractRequest {
         return data.timeoutMs();
     }
 
-    public static ListOffsetsRequest parse(ByteBuffer buffer, short version) {
-        return new ListOffsetsRequest(new ListOffsetsRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static ListOffsetsRequest parse(Readable readable, short version) {
+        return new ListOffsetsRequest(new ListOffsetsRequestData(readable, version), version);
     }
 
     public static List<ListOffsetsTopic> toListOffsetsTopics(Map<TopicPartition, ListOffsetsPartition> timestampsToSearch) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsRequest.java
@@ -21,9 +21,8 @@ import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingPartitionReassignment;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingTopicReassignment;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -58,9 +57,9 @@ public class ListPartitionReassignmentsRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static ListPartitionReassignmentsRequest parse(ByteBuffer buffer, short version) {
+    public static ListPartitionReassignmentsRequest parse(Readable readable, short version) {
         return new ListPartitionReassignmentsRequest(new ListPartitionReassignmentsRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
@@ -20,10 +20,8 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class ListTransactionsRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ListTransactionsRequest> {
@@ -69,9 +67,9 @@ public class ListTransactionsRequest extends AbstractRequest {
         return new ListTransactionsResponse(response);
     }
 
-    public static ListTransactionsRequest parse(ByteBuffer buffer, short version) {
+    public static ListTransactionsRequest parse(Readable readable, short version) {
         return new ListTransactionsRequest(new ListTransactionsRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -192,8 +191,8 @@ public class MetadataRequest extends AbstractRequest {
         return data.allowAutoTopicCreation();
     }
 
-    public static MetadataRequest parse(ByteBuffer buffer, short version) {
-        return new MetadataRequest(new MetadataRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static MetadataRequest parse(Readable readable, short version) {
+        return new MetadataRequest(new MetadataRequestData(readable, version), version);
     }
 
     public static List<MetadataRequestTopic> convertToMetadataRequestTopic(final Collection<String> topics) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -24,10 +24,9 @@ import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponsePartition;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -121,7 +120,7 @@ public class OffsetCommitRequest extends AbstractRequest {
         return getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, e);
     }
 
-    public static OffsetCommitRequest parse(ByteBuffer buffer, short version) {
-        return new OffsetCommitRequest(new OffsetCommitRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static OffsetCommitRequest parse(Readable readable, short version) {
+        return new OffsetCommitRequest(new OffsetCommitRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class OffsetDeleteRequest extends AbstractRequest {
 
@@ -66,8 +64,8 @@ public class OffsetDeleteRequest extends AbstractRequest {
         return getErrorResponse(throttleTimeMs, Errors.forException(e));
     }
 
-    public static OffsetDeleteRequest parse(ByteBuffer buffer, short version) {
-        return new OffsetDeleteRequest(new OffsetDeleteRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static OffsetDeleteRequest parse(Readable readable, short version) {
+        return new OffsetDeleteRequest(new OffsetDeleteRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -23,13 +23,12 @@ import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequest
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopic;
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -329,8 +328,8 @@ public class OffsetFetchRequest extends AbstractRequest {
         return getErrorResponse(throttleTimeMs, Errors.forException(e));
     }
 
-    public static OffsetFetchRequest parse(ByteBuffer buffer, short version) {
-        return new OffsetFetchRequest(new OffsetFetchRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static OffsetFetchRequest parse(Readable readable, short version) {
+        return new OffsetFetchRequest(new OffsetFetchRequestData(readable, version), version);
     }
 
     public boolean isAllPartitions() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -23,10 +23,8 @@ import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET;
@@ -101,8 +99,8 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         return data.replicaId();
     }
 
-    public static OffsetsForLeaderEpochRequest parse(ByteBuffer buffer, short version) {
-        return new OffsetsForLeaderEpochRequest(new OffsetForLeaderEpochRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static OffsetsForLeaderEpochRequest parse(Readable readable, short version) {
+        return new OffsetsForLeaderEpochRequest(new OffsetForLeaderEpochRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -22,15 +22,14 @@ import org.apache.kafka.common.errors.UnsupportedCompressionTypeException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.Utils;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -227,8 +226,8 @@ public class ProduceRequest extends AbstractRequest {
         }
     }
 
-    public static ProduceRequest parse(ByteBuffer buffer, short version) {
-        return new ProduceRequest(new ProduceRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static ProduceRequest parse(Readable readable, short version) {
+        return new ProduceRequest(new ProduceRequestData(readable, version), version);
     }
 
     public static boolean isTransactionV2Requested(short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryRequest.java
@@ -19,8 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.PushTelemetryRequestData;
 import org.apache.kafka.common.message.PushTelemetryResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetryUtils;
 
@@ -91,8 +91,8 @@ public class PushTelemetryRequest extends AbstractRequest {
             this.data.metrics() : ClientTelemetryUtils.decompress(this.data.metrics(), cType);
     }
 
-    public static PushTelemetryRequest parse(ByteBuffer buffer, short version) {
+    public static PushTelemetryRequest parse(Readable readable, short version) {
         return new PushTelemetryRequest(new PushTelemetryRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,9 +80,9 @@ public class ReadShareGroupStateRequest extends AbstractRequest {
         return data;
     }
 
-    public static ReadShareGroupStateRequest parse(ByteBuffer buffer, short version) {
+    public static ReadShareGroupStateRequest parse(Readable readable, short version) {
         return new ReadShareGroupStateRequest(
-                new ReadShareGroupStateRequestData(new ByteBufferAccessor(buffer), version),
+                new ReadShareGroupStateRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateSummaryRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateSummaryRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,9 +80,9 @@ public class ReadShareGroupStateSummaryRequest extends AbstractRequest {
         return data;
     }
 
-    public static ReadShareGroupStateSummaryRequest parse(ByteBuffer buffer, short version) {
+    public static ReadShareGroupStateSummaryRequest parse(Readable readable, short version) {
         return new ReadShareGroupStateSummaryRequest(
-            new ReadShareGroupStateSummaryRequestData(new ByteBufferAccessor(buffer), version),
+            new ReadShareGroupStateSummaryRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterRequest.java
@@ -20,10 +20,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
 import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class RemoveRaftVoterRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<RemoveRaftVoterRequest> {
@@ -67,9 +65,9 @@ public class RemoveRaftVoterRequest extends AbstractRequest {
             setThrottleTimeMs(throttleTimeMs));
     }
 
-    public static RemoveRaftVoterRequest parse(ByteBuffer buffer, short version) {
+    public static RemoveRaftVoterRequest parse(Readable readable, short version) {
         return new RemoveRaftVoterRequest(
-            new RemoveRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            new RemoveRaftVoterRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class RenewDelegationTokenRequest extends AbstractRequest {
 
@@ -33,9 +31,9 @@ public class RenewDelegationTokenRequest extends AbstractRequest {
         this.data = data;
     }
 
-    public static RenewDelegationTokenRequest parse(ByteBuffer buffer, short version) {
+    public static RenewDelegationTokenRequest parse(Readable readable, short version) {
         return new RenewDelegationTokenRequest(new RenewDelegationTokenRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalSerde;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -117,7 +118,7 @@ public class RequestContext implements AuthorizableRequestContext {
             ApiKeys apiKey = header.apiKey();
             try {
                 short apiVersion = header.apiVersion();
-                return AbstractRequest.parseRequest(apiKey, apiVersion, buffer);
+                return AbstractRequest.parseRequest(apiKey, apiVersion, new ByteBufferAccessor(buffer));
             } catch (Throwable ex) {
                 throw new InvalidRequestException("Error getting request for apiKey: " + apiKey +
                         ", apiVersion: " + header.apiVersion() +

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateRequest.java
@@ -19,9 +19,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 
 /**
@@ -74,8 +72,8 @@ public class SaslAuthenticateRequest extends AbstractRequest {
         return new SaslAuthenticateResponse(response);
     }
 
-    public static SaslAuthenticateRequest parse(ByteBuffer buffer, short version) {
-        return new SaslAuthenticateRequest(new SaslAuthenticateRequestData(new ByteBufferAccessor(buffer), version),
+    public static SaslAuthenticateRequest parse(Readable readable, short version) {
+        return new SaslAuthenticateRequest(new SaslAuthenticateRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
@@ -20,9 +20,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 /**
  * Request from SASL client containing client SASL mechanism.
@@ -73,7 +71,7 @@ public class SaslHandshakeRequest extends AbstractRequest {
         return new SaslHandshakeResponse(response);
     }
 
-    public static SaslHandshakeRequest parse(ByteBuffer buffer, short version) {
-        return new SaslHandshakeRequest(new SaslHandshakeRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static SaslHandshakeRequest parse(Readable readable, short version) {
+        return new SaslHandshakeRequest(new SaslHandshakeRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -118,9 +117,9 @@ public class ShareAcknowledgeRequest extends AbstractRequest {
                 .setErrorCode(error.code()));
     }
 
-    public static ShareAcknowledgeRequest parse(ByteBuffer buffer, short version) {
+    public static ShareAcknowledgeRequest parse(Readable readable, short version) {
         return new ShareAcknowledgeRequest(
-                new ShareAcknowledgeRequestData(new ByteBufferAccessor(buffer), version),
+                new ShareAcknowledgeRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -166,9 +165,9 @@ public class ShareFetchRequest extends AbstractRequest {
                 .setErrorCode(error.code()));
     }
 
-    public static ShareFetchRequest parse(ByteBuffer buffer, short version) {
+    public static ShareFetchRequest parse(Readable readable, short version) {
         return new ShareFetchRequest(
-                new ShareFetchRequestData(new ByteBufferAccessor(buffer), version),
+                new ShareFetchRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
 import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,9 +79,9 @@ public class ShareGroupDescribeRequest extends AbstractRequest {
         return data;
     }
 
-    public static ShareGroupDescribeRequest parse(ByteBuffer buffer, short version) {
+    public static ShareGroupDescribeRequest parse(Readable readable, short version) {
         return new ShareGroupDescribeRequest(
-                new ShareGroupDescribeRequestData(new ByteBufferAccessor(buffer), version),
+                new ShareGroupDescribeRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class ShareGroupHeartbeatRequest extends AbstractRequest {
     /**
@@ -79,8 +77,8 @@ public class ShareGroupHeartbeatRequest extends AbstractRequest {
         return data;
     }
 
-    public static ShareGroupHeartbeatRequest parse(ByteBuffer buffer, short version) {
+    public static ShareGroupHeartbeatRequest parse(Readable readable, short version) {
         return new ShareGroupHeartbeatRequest(new ShareGroupHeartbeatRequestData(
-                new ByteBufferAccessor(buffer), version), version);
+                readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeRequest.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.StreamsGroupDescribeRequestData;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -79,9 +78,9 @@ public class StreamsGroupDescribeRequest extends AbstractRequest {
         return data;
     }
 
-    public static StreamsGroupDescribeRequest parse(ByteBuffer buffer, short version) {
+    public static StreamsGroupDescribeRequest parse(Readable readable, short version) {
         return new StreamsGroupDescribeRequest(
-            new StreamsGroupDescribeRequestData(new ByteBufferAccessor(buffer), version),
+            new StreamsGroupDescribeRequestData(readable, version),
             version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class StreamsGroupHeartbeatRequest extends AbstractRequest {
 
@@ -81,8 +79,8 @@ public class StreamsGroupHeartbeatRequest extends AbstractRequest {
         return data;
     }
 
-    public static StreamsGroupHeartbeatRequest parse(ByteBuffer buffer, short version) {
+    public static StreamsGroupHeartbeatRequest parse(Readable readable, short version) {
         return new StreamsGroupHeartbeatRequest(new StreamsGroupHeartbeatRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -20,8 +20,8 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -87,8 +87,8 @@ public class SyncGroupRequest extends AbstractRequest {
             return true;
     }
 
-    public static SyncGroupRequest parse(ByteBuffer buffer, short version) {
-        return new SyncGroupRequest(new SyncGroupRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static SyncGroupRequest parse(Readable readable, short version) {
+        return new SyncGroupRequest(new SyncGroupRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
@@ -25,11 +25,10 @@ import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData.TxnOffsetCommitResponsePartition;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData.TxnOffsetCommitResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.RecordBatch;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -217,9 +216,9 @@ public class TxnOffsetCommitRequest extends AbstractRequest {
         return response;
     }
 
-    public static TxnOffsetCommitRequest parse(ByteBuffer buffer, short version) {
+    public static TxnOffsetCommitRequest parse(Readable readable, short version) {
         return new TxnOffsetCommitRequest(new TxnOffsetCommitRequestData(
-            new ByteBufferAccessor(buffer), version), version);
+            readable, version), version);
     }
 
     public static class CommittedOffset {

--- a/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerRequest.java
@@ -19,10 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.UnregisterBrokerRequestData;
 import org.apache.kafka.common.message.UnregisterBrokerResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-
-import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.Readable;
 
 public class UnregisterBrokerRequest extends AbstractRequest {
 
@@ -61,8 +59,8 @@ public class UnregisterBrokerRequest extends AbstractRequest {
                 .setErrorMessage(e.getMessage()));
     }
 
-    public static UnregisterBrokerRequest parse(ByteBuffer buffer, short version) {
-        return new UnregisterBrokerRequest(new UnregisterBrokerRequestData(new ByteBufferAccessor(buffer), version),
+    public static UnregisterBrokerRequest parse(Readable readable, short version) {
+        return new UnregisterBrokerRequest(new UnregisterBrokerRequestData(readable, version),
                 version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesRequest.java
@@ -19,9 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.clients.admin.FeatureUpdate;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -116,7 +115,7 @@ public class UpdateFeaturesRequest extends AbstractRequest {
         return data;
     }
 
-    public static UpdateFeaturesRequest parse(ByteBuffer buffer, short version) {
-        return new UpdateFeaturesRequest(new UpdateFeaturesRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static UpdateFeaturesRequest parse(Readable readable, short version) {
+        return new UpdateFeaturesRequest(new UpdateFeaturesRequestData(readable, version), version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterRequest.java
@@ -20,12 +20,10 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.UpdateRaftVoterRequestData;
 import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
-
-public class UpdateRaftVoterRequest extends AbstractRequest {
+public class    UpdateRaftVoterRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<UpdateRaftVoterRequest> {
         private final UpdateRaftVoterRequestData data;
 
@@ -65,9 +63,9 @@ public class UpdateRaftVoterRequest extends AbstractRequest {
             setThrottleTimeMs(throttleTimeMs));
     }
 
-    public static UpdateRaftVoterRequest parse(ByteBuffer buffer, short version) {
+    public static UpdateRaftVoterRequest parse(Readable readable, short version) {
         return new UpdateRaftVoterRequest(
-            new UpdateRaftVoterRequestData(new ByteBufferAccessor(buffer), version),
+            new UpdateRaftVoterRequestData(readable, version),
             version);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 
 public class VoteRequest extends AbstractRequest {
@@ -65,8 +64,8 @@ public class VoteRequest extends AbstractRequest {
             .setErrorCode(Errors.forException(e).code()));
     }
 
-    public static VoteRequest parse(ByteBuffer buffer, short version) {
-        return new VoteRequest(new VoteRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static VoteRequest parse(Readable readable, short version) {
+        return new VoteRequest(new VoteRequestData(readable, version), version);
     }
 
     public static VoteRequestData singletonRequest(TopicPartition topicPartition,

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateRequest.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,9 +80,9 @@ public class WriteShareGroupStateRequest extends AbstractRequest {
         return data;
     }
 
-    public static WriteShareGroupStateRequest parse(ByteBuffer buffer, short version) {
+    public static WriteShareGroupStateRequest parse(Readable readable, short version) {
         return new WriteShareGroupStateRequest(
-                new WriteShareGroupStateRequestData(new ByteBufferAccessor(buffer), version),
+                new WriteShareGroupStateRequestData(readable, version),
                 version
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.message.WriteTxnMarkersRequestData;
 import org.apache.kafka.common.message.WriteTxnMarkersRequestData.WritableTxnMarker;
 import org.apache.kafka.common.message.WriteTxnMarkersRequestData.WritableTxnMarkerTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -189,8 +188,8 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
         return markers;
     }
 
-    public static WriteTxnMarkersRequest parse(ByteBuffer buffer, short version) {
-        return new WriteTxnMarkersRequest(new WriteTxnMarkersRequestData(new ByteBufferAccessor(buffer), version), version);
+    public static WriteTxnMarkersRequest parse(Readable readable, short version) {
+        return new WriteTxnMarkersRequest(new WriteTxnMarkersRequestData(readable, version), version);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -209,7 +209,7 @@ public class MetadataTest {
                 .setBrokers(new MetadataResponseBrokerCollection());
 
         for (short version = ApiKeys.METADATA.oldestVersion(); version < 9; version++) {
-            ByteBuffer buffer = MessageUtil.toByteBuffer(data, version);
+            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
             MetadataResponse response = MetadataResponse.parse(buffer, version);
             assertFalse(response.hasReliableLeaderEpochs());
             metadata.updateWithCurrentRequestVersion(response, false, 100);
@@ -219,7 +219,7 @@ public class MetadataTest {
         }
 
         for (short version = 9; version <= ApiKeys.METADATA.latestVersion(); version++) {
-            ByteBuffer buffer = MessageUtil.toByteBuffer(data, version);
+            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
             MetadataResponse response = MetadataResponse.parse(buffer, version);
             assertTrue(response.hasReliableLeaderEpochs());
             metadata.updateWithCurrentRequestVersion(response, false, 100);

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -944,7 +944,7 @@ public final class MessageTest {
     @Test
     public void defaultValueShouldBeWritable() {
         for (short version = SimpleExampleMessageData.LOWEST_SUPPORTED_VERSION; version <= SimpleExampleMessageData.HIGHEST_SUPPORTED_VERSION; ++version) {
-            MessageUtil.toByteBuffer(new SimpleExampleMessageData(), version);
+            MessageUtil.toByteBufferAccessor(new SimpleExampleMessageData(), version).buffer();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/message/NullableStructMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/NullableStructMessageTest.java
@@ -129,7 +129,7 @@ public class NullableStructMessageTest {
     }
 
     private ByteBuffer serialize(NullableStructMessageData message, short version) {
-        return MessageUtil.toByteBuffer(message, version);
+        return MessageUtil.toByteBufferAccessor(message, version).buffer();
     }
 
     private NullableStructMessageData roundTrip(NullableStructMessageData message, short version) {

--- a/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
@@ -70,7 +70,7 @@ public class RecordsSerdeTest {
     }
 
     private void testRoundTrip(SimpleRecordsMessageData message, short version) {
-        ByteBuffer buf = MessageUtil.toByteBuffer(message, version);
+        ByteBuffer buf = MessageUtil.toByteBufferAccessor(message, version).buffer();
         SimpleRecordsMessageData message2 = deserialize(buf.duplicate(), version);
         assertEquals(message, message2);
         assertEquals(message.hashCode(), message2.hashCode());

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -84,7 +84,7 @@ public class SimpleExampleMessageTest {
         out.setProcessId(uuid);
         out.setZeroCopyByteBuffer(buf);
 
-        final ByteBuffer buffer = MessageUtil.toByteBuffer(out, (short) 1);
+        final ByteBuffer buffer = MessageUtil.toByteBufferAccessor(out, (short) 1).buffer();
 
         final SimpleExampleMessageData in = new SimpleExampleMessageData();
         in.read(new ByteBufferAccessor(buffer), (short) 1);
@@ -106,7 +106,7 @@ public class SimpleExampleMessageTest {
         out.setZeroCopyByteBuffer(buf1);
         out.setNullableZeroCopyByteBuffer(buf2);
 
-        final ByteBuffer buffer = MessageUtil.toByteBuffer(out, (short) 1);
+        final ByteBuffer buffer = MessageUtil.toByteBufferAccessor(out, (short) 1).buffer();
 
         final SimpleExampleMessageData in = new SimpleExampleMessageData();
         in.read(new ByteBufferAccessor(buffer), (short) 1);
@@ -359,7 +359,7 @@ public class SimpleExampleMessageTest {
         SimpleExampleMessageData message,
         short version
     ) {
-        ByteBuffer buf = MessageUtil.toByteBuffer(message, version);
+        ByteBuffer buf = MessageUtil.toByteBufferAccessor(message, version).buffer();
         // Check size calculation
         assertEquals(buf.remaining(), message.size(new ObjectSerializationCache(), version));
         return deserialize(buf.duplicate(), version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.CreateAclsRequestData;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,9 +66,9 @@ public class CreateAclsRequestTest {
     @Test
     public void shouldRoundTripV1() {
         final CreateAclsRequest original = new CreateAclsRequest(data(LITERAL_ACL1, PREFIXED_ACL1), V1);
-        final ByteBuffer buffer = original.serialize();
+        final Readable readable = original.serialize();
 
-        final CreateAclsRequest result = CreateAclsRequest.parse(buffer, V1);
+        final CreateAclsRequest result = CreateAclsRequest.parse(readable, V1);
 
         assertRequestEquals(original, result);
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsRequestTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.DeleteAclsRequestData;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -67,9 +67,9 @@ public class DeleteAclsRequestTest {
         final DeleteAclsRequest original = new DeleteAclsRequest.Builder(
                 requestData(LITERAL_FILTER, PREFIXED_FILTER, ANY_FILTER)
         ).build(V1);
-        final ByteBuffer buffer = original.serialize();
+        final Readable readable = original.serialize();
 
-        final DeleteAclsRequest result = DeleteAclsRequest.parse(buffer, V1);
+        final DeleteAclsRequest result = DeleteAclsRequest.parse(readable, V1);
 
         assertRequestEquals(original, result);
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
@@ -111,9 +111,9 @@ public class LeaveGroupResponseTest {
                 .setThrottleTimeMs(throttleTimeMs);
         for (short version : ApiKeys.LEAVE_GROUP.allVersions()) {
             LeaveGroupResponse primaryResponse = LeaveGroupResponse.parse(
-                MessageUtil.toByteBuffer(responseData, version), version);
+                MessageUtil.toByteBufferAccessor(responseData, version).buffer(), version);
             LeaveGroupResponse secondaryResponse = LeaveGroupResponse.parse(
-                MessageUtil.toByteBuffer(responseData, version), version);
+                MessageUtil.toByteBufferAccessor(responseData, version).buffer(), version);
 
             assertEquals(primaryResponse, primaryResponse);
             assertEquals(primaryResponse, secondaryResponse);
@@ -130,7 +130,7 @@ public class LeaveGroupResponseTest {
             .setThrottleTimeMs(throttleTimeMs);
 
         for (short version : ApiKeys.LEAVE_GROUP.allVersions()) {
-            ByteBuffer buffer = MessageUtil.toByteBuffer(data, version);
+            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
             LeaveGroupResponse leaveGroupResponse = LeaveGroupResponse.parse(buffer, version);
             assertEquals(expectedErrorCounts, leaveGroupResponse.errorCounts());
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -54,7 +54,7 @@ public class ListOffsetsRequestTest {
         ListOffsetsRequestData data = new ListOffsetsRequestData()
                 .setTopics(topics)
                 .setReplicaId(-1);
-        ListOffsetsRequest request = ListOffsetsRequest.parse(MessageUtil.toByteBuffer(data, (short) 1), (short) 1);
+        ListOffsetsRequest request = ListOffsetsRequest.parse(MessageUtil.toReadable(data, (short) 1), (short) 1);
         assertEquals(Collections.singleton(new TopicPartition("topic", 0)), request.duplicatePartitions());
         assertEquals(0, data.timeoutMs()); // default value
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -54,7 +54,7 @@ public class ListOffsetsRequestTest {
         ListOffsetsRequestData data = new ListOffsetsRequestData()
                 .setTopics(topics)
                 .setReplicaId(-1);
-        ListOffsetsRequest request = ListOffsetsRequest.parse(MessageUtil.toReadable(data, (short) 1), (short) 1);
+        ListOffsetsRequest request = ListOffsetsRequest.parse(MessageUtil.toByteBufferAccessor(data, (short) 1), (short) 1);
         assertEquals(Collections.singleton(new TopicPartition("topic", 0)), request.duplicatePartitions());
         assertEquals(0, data.timeoutMs()); // default value
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
@@ -87,7 +87,7 @@ public class OffsetCommitResponseTest {
             .setThrottleTimeMs(throttleTimeMs);
 
         for (short version : ApiKeys.OFFSET_COMMIT.allVersions()) {
-            ByteBuffer buffer = MessageUtil.toByteBuffer(data, version);
+            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
             OffsetCommitResponse response = OffsetCommitResponse.parse(buffer, version);
             assertEquals(expectedErrorCounts, response.errorCounts());
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -251,6 +251,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -1937,11 +1938,14 @@ public class RequestResponseTest {
         // Check for equality of the ByteBuffer only if indicated (it is likely to fail if any of the fields
         // in the request is a HashMap with multiple elements since ordering of the elements may vary)
         try {
-            ByteBuffer serializedBytes = req.serialize();
-            AbstractRequest deserialized = AbstractRequest.parseRequest(req.apiKey(), req.version(), serializedBytes).request;
-            ByteBuffer serializedBytes2 = deserialized.serialize();
-            serializedBytes.rewind();
-            assertEquals(serializedBytes, serializedBytes2, "Request " + req + "failed equality test");
+            Readable readable = req.serialize();
+            AbstractRequest deserialized = AbstractRequest.parseRequest(req.apiKey(), req.version(), readable).request;
+            Readable readable2 = deserialized.serialize();
+
+            ByteBufferAccessor buffer = (ByteBufferAccessor) readable;
+            ByteBufferAccessor buffer2 = (ByteBufferAccessor) readable2;
+            buffer.buffer().rewind();
+            assertEquals(buffer.buffer(), buffer2.buffer(), "Request " + req + "failed equality test");
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize request " + req + " with type " + req.getClass(), e);
         }
@@ -3816,12 +3820,12 @@ public class RequestResponseTest {
     public void testInvalidSaslHandShakeRequest() {
         AbstractRequest request = new SaslHandshakeRequest.Builder(
                 new SaslHandshakeRequestData().setMechanism("PLAIN")).build();
-        ByteBuffer serializedBytes = request.serialize();
+        Readable readable = request.serialize();
         // corrupt the length of the sasl mechanism string
-        serializedBytes.putShort(0, Short.MAX_VALUE);
+        ((ByteBufferAccessor) readable).buffer().putShort(0, Short.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
-            parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
+            parseRequest(request.apiKey(), request.version(), readable)).getMessage();
         assertEquals("Error reading byte array of 32767 byte(s): only 5 byte(s) available", msg);
     }
 
@@ -3837,13 +3841,13 @@ public class RequestResponseTest {
         };
         SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(b);
         AbstractRequest request = new SaslAuthenticateRequest(data, version);
-        ByteBuffer serializedBytes = request.serialize();
+        Readable readable = request.serialize();
 
         // corrupt the length of the bytes array
-        serializedBytes.putInt(0, Integer.MAX_VALUE);
+        ((ByteBufferAccessor) readable).buffer().putInt(0, Integer.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
-                parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
+                parseRequest(request.apiKey(), request.version(), readable)).getMessage();
         assertEquals("Error reading byte array of 2147483647 byte(s): only 20 byte(s) available", msg);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -251,7 +251,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -1938,14 +1937,11 @@ public class RequestResponseTest {
         // Check for equality of the ByteBuffer only if indicated (it is likely to fail if any of the fields
         // in the request is a HashMap with multiple elements since ordering of the elements may vary)
         try {
-            Readable readable = req.serialize();
-            AbstractRequest deserialized = AbstractRequest.parseRequest(req.apiKey(), req.version(), readable).request;
-            Readable readable2 = deserialized.serialize();
-
-            ByteBufferAccessor buffer = (ByteBufferAccessor) readable;
-            ByteBufferAccessor buffer2 = (ByteBufferAccessor) readable2;
-            buffer.buffer().rewind();
-            assertEquals(buffer.buffer(), buffer2.buffer(), "Request " + req + "failed equality test");
+            ByteBuffer serializedBytes = req.serializeToByteBuffer();
+            AbstractRequest deserialized = AbstractRequest.parseRequest(req.apiKey(), req.version(), serializedBytes).request;
+            ByteBuffer serializedBytes2 = deserialized.serializeToByteBuffer();
+            serializedBytes.rewind();
+            assertEquals(serializedBytes, serializedBytes2, "Request " + req + "failed equality test");
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize request " + req + " with type " + req.getClass(), e);
         }
@@ -3820,12 +3816,12 @@ public class RequestResponseTest {
     public void testInvalidSaslHandShakeRequest() {
         AbstractRequest request = new SaslHandshakeRequest.Builder(
                 new SaslHandshakeRequestData().setMechanism("PLAIN")).build();
-        Readable readable = request.serialize();
+        ByteBuffer serializedBytes = request.serializeToByteBuffer();
         // corrupt the length of the sasl mechanism string
-        ((ByteBufferAccessor) readable).buffer().putShort(0, Short.MAX_VALUE);
+        serializedBytes.putShort(0, Short.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
-            parseRequest(request.apiKey(), request.version(), readable)).getMessage();
+            parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
         assertEquals("Error reading byte array of 32767 byte(s): only 5 byte(s) available", msg);
     }
 
@@ -3841,13 +3837,13 @@ public class RequestResponseTest {
         };
         SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(b);
         AbstractRequest request = new SaslAuthenticateRequest(data, version);
-        Readable readable = request.serialize();
+        ByteBuffer serializedBytes = request.serializeToByteBuffer();
 
         // corrupt the length of the bytes array
-        ((ByteBufferAccessor) readable).buffer().putInt(0, Integer.MAX_VALUE);
+        serializedBytes.putInt(0, Integer.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
-                parseRequest(request.apiKey(), request.version(), readable)).getMessage();
+                parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
         assertEquals("Error reading byte array of 2147483647 byte(s): only 20 byte(s) available", msg);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -695,7 +695,7 @@ public class RequestResponseTest {
         assertEquals(requestHeader, parsedHeader);
 
         RequestAndSize parsedRequest = AbstractRequest.parseRequest(
-            CREATE_TOPICS, requestVersion, serializedRequest);
+            CREATE_TOPICS, requestVersion, new ByteBufferAccessor(serializedRequest));
 
         assertEquals(createTopicsRequest.data(), parsedRequest.request.data());
     }
@@ -1937,11 +1937,11 @@ public class RequestResponseTest {
         // Check for equality of the ByteBuffer only if indicated (it is likely to fail if any of the fields
         // in the request is a HashMap with multiple elements since ordering of the elements may vary)
         try {
-            ByteBuffer serializedBytes = req.serializeToByteBuffer();
+            ByteBufferAccessor serializedBytes = req.serialize();
             AbstractRequest deserialized = AbstractRequest.parseRequest(req.apiKey(), req.version(), serializedBytes).request;
-            ByteBuffer serializedBytes2 = deserialized.serializeToByteBuffer();
-            serializedBytes.rewind();
-            assertEquals(serializedBytes, serializedBytes2, "Request " + req + "failed equality test");
+            ByteBufferAccessor serializedBytes2 = deserialized.serialize();
+            serializedBytes.buffer().rewind();
+            assertEquals(serializedBytes.buffer(), serializedBytes2.buffer(), "Request " + req + "failed equality test");
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize request " + req + " with type " + req.getClass(), e);
         }
@@ -3816,9 +3816,9 @@ public class RequestResponseTest {
     public void testInvalidSaslHandShakeRequest() {
         AbstractRequest request = new SaslHandshakeRequest.Builder(
                 new SaslHandshakeRequestData().setMechanism("PLAIN")).build();
-        ByteBuffer serializedBytes = request.serializeToByteBuffer();
+        ByteBufferAccessor serializedBytes = request.serialize();
         // corrupt the length of the sasl mechanism string
-        serializedBytes.putShort(0, Short.MAX_VALUE);
+        serializedBytes.buffer().putShort(0, Short.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
             parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
@@ -3837,10 +3837,10 @@ public class RequestResponseTest {
         };
         SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(b);
         AbstractRequest request = new SaslAuthenticateRequest(data, version);
-        ByteBuffer serializedBytes = request.serializeToByteBuffer();
+        ByteBufferAccessor serializedBytes = request.serialize();
 
         // corrupt the length of the bytes array
-        serializedBytes.putInt(0, Integer.MAX_VALUE);
+        serializedBytes.buffer().putInt(0, Integer.MAX_VALUE);
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
                 parseRequest(request.apiKey(), request.version(), serializedBytes)).getMessage();
@@ -3869,7 +3869,7 @@ public class RequestResponseTest {
         accessor.flip();
 
         SaslAuthenticateRequest saslAuthenticateRequest = (SaslAuthenticateRequest) AbstractRequest.
-                parseRequest(SASL_AUTHENTICATE, SASL_AUTHENTICATE.latestVersion(), accessor.buffer()).request;
+                parseRequest(SASL_AUTHENTICATE, SASL_AUTHENTICATE.latestVersion(), accessor).request;
         Assertions.assertArrayEquals(authBytes, saslAuthenticateRequest.data().authBytes());
         assertEquals(1, saslAuthenticateRequest.data().unknownTaggedFields().size());
         assertEquals(taggedField, saslAuthenticateRequest.data().unknownTaggedFields().get(0));
@@ -3897,7 +3897,7 @@ public class RequestResponseTest {
         accessor.flip();
 
         String msg = assertThrows(RuntimeException.class, () -> AbstractRequest.
-                parseRequest(SASL_AUTHENTICATE, SASL_AUTHENTICATE.latestVersion(), accessor.buffer())).getMessage();
+                parseRequest(SASL_AUTHENTICATE, SASL_AUTHENTICATE.latestVersion(), accessor)).getMessage();
         assertEquals("Error reading byte array of 32767 byte(s): only 3 byte(s) available", msg);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
@@ -57,7 +57,7 @@ public class TxnOffsetCommitResponseTest extends OffsetCommitResponseTest {
 
         for (short version : ApiKeys.TXN_OFFSET_COMMIT.allVersions()) {
             TxnOffsetCommitResponse response = TxnOffsetCommitResponse.parse(
-                MessageUtil.toByteBuffer(data, version), version);
+                MessageUtil.toByteBufferAccessor(data, version).buffer(), version);
             assertEquals(expectedErrorCounts, response.errorCounts());
             assertEquals(throttleTimeMs, response.throttleTimeMs());
             assertEquals(version >= 1, response.shouldClientThrottle(version));

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesRequestTest.java
@@ -21,10 +21,10 @@ import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,8 +80,8 @@ public class UpdateFeaturesRequestTest {
             new UpdateFeaturesRequestData().setFeatureUpdates(features),
             UpdateFeaturesRequestData.LOWEST_SUPPORTED_VERSION
         );
-        ByteBuffer buffer = request.serialize();
-        request = UpdateFeaturesRequest.parse(buffer, UpdateFeaturesRequestData.LOWEST_SUPPORTED_VERSION);
+        Readable readable = request.serialize();
+        request = UpdateFeaturesRequest.parse(readable, UpdateFeaturesRequestData.LOWEST_SUPPORTED_VERSION);
 
         List<UpdateFeaturesRequest.FeatureUpdateItem> updates = new ArrayList<>(request.featureUpdates());
         assertEquals(updates.size(), 2);
@@ -110,8 +110,8 @@ public class UpdateFeaturesRequestTest {
             UpdateFeaturesRequestData.HIGHEST_SUPPORTED_VERSION
         );
 
-        ByteBuffer buffer = request.serialize();
-        request = UpdateFeaturesRequest.parse(buffer, UpdateFeaturesRequestData.HIGHEST_SUPPORTED_VERSION);
+        Readable readable = request.serialize();
+        request = UpdateFeaturesRequest.parse(readable, UpdateFeaturesRequestData.HIGHEST_SUPPORTED_VERSION);
 
         List<UpdateFeaturesRequest.FeatureUpdateItem> updates = new ArrayList<>(request.featureUpdates());
         assertEquals(updates.size(), 2);

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.network.DefaultChannelMetadataRegistry;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
@@ -354,7 +355,7 @@ public class SaslServerAuthenticatorTest {
     private void mockRequest(RequestHeader header, AbstractRequest request, TransportLayer transportLayer) throws IOException {
         ByteBuffer headerBuffer = RequestTestUtils.serializeRequestHeader(header);
 
-        ByteBuffer requestBuffer = request.serialize();
+        ByteBuffer requestBuffer = ((ByteBufferAccessor) request.serialize()).buffer();
         requestBuffer.rewind();
 
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.network.DefaultChannelMetadataRegistry;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
@@ -355,7 +354,7 @@ public class SaslServerAuthenticatorTest {
     private void mockRequest(RequestHeader header, AbstractRequest request, TransportLayer transportLayer) throws IOException {
         ByteBuffer headerBuffer = RequestTestUtils.serializeRequestHeader(header);
 
-        ByteBuffer requestBuffer = ((ByteBufferAccessor) request.serialize()).buffer();
+        ByteBuffer requestBuffer = request.serializeToByteBuffer();
         requestBuffer.rewind();
 
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -354,7 +354,7 @@ public class SaslServerAuthenticatorTest {
     private void mockRequest(RequestHeader header, AbstractRequest request, TransportLayer transportLayer) throws IOException {
         ByteBuffer headerBuffer = RequestTestUtils.serializeRequestHeader(header);
 
-        ByteBuffer requestBuffer = request.serializeToByteBuffer();
+        ByteBuffer requestBuffer = request.serialize().buffer();
         requestBuffer.rewind();
 
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {

--- a/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
@@ -505,7 +505,7 @@ class AlterPartitionManagerTest {
       null,
       // Response is serialized and deserialized to ensure that its does
       // not contain ignorable fields used by other versions.
-      AlterPartitionResponse.parse(MessageUtil.toByteBuffer(response.data, version), version)
+      AlterPartitionResponse.parse(MessageUtil.toByteBufferAccessor(response.data, version).buffer(), version)
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.message.{ApiVersionsResponseData, CreateTopicsReq
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreatableTopicConfig, CreatableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.utils.{SecurityUtils, Utils}
@@ -252,7 +252,8 @@ class AutoTopicCreationManagerTest {
 
     val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
     assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer));
-    assertEquals(requestBody.data(), CreateTopicsRequest.parse(forwardedRequestBuffer, ApiKeys.CREATE_TOPICS.latestVersion()).data())
+    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
+      ApiKeys.CREATE_TOPICS.latestVersion()).data())
   }
 
   @Test
@@ -307,7 +308,8 @@ class AutoTopicCreationManagerTest {
       .build(ApiKeys.CREATE_TOPICS.latestVersion())
     val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
     assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer));
-    assertEquals(requestBody.data(), CreateTopicsRequest.parse(forwardedRequestBuffer, ApiKeys.CREATE_TOPICS.latestVersion()).data())
+    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
+      ApiKeys.CREATE_TOPICS.latestVersion()).data())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
@@ -141,7 +141,7 @@ class EdgeCaseRequestTest extends KafkaServerTestHarness {
         .setTimeoutMs(10000)
         .setTransactionalId(null))
         .build()
-      val bodyBytes = request.serializeToByteBuffer
+      val bodyBytes = request.serialize.buffer
       val byteBuffer = ByteBuffer.allocate(headerBytes.length + bodyBytes.remaining())
       byteBuffer.put(headerBytes)
       byteBuffer.put(bodyBytes)

--- a/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.message.ProduceRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.types.Type
-import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.{ProduceResponse, ResponseHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -141,10 +141,10 @@ class EdgeCaseRequestTest extends KafkaServerTestHarness {
         .setTimeoutMs(10000)
         .setTransactionalId(null))
         .build()
-      val bodyBytes = request.serialize
+      val bodyBytes = request.serializeToByteBuffer
       val byteBuffer = ByteBuffer.allocate(headerBytes.length + bodyBytes.remaining())
       byteBuffer.put(headerBytes)
-      byteBuffer.put(bodyBytes.asInstanceOf[ByteBufferAccessor].buffer())
+      byteBuffer.put(bodyBytes)
       (byteBuffer.array(), request.apiKey.responseHeaderVersion(version))
     }
 

--- a/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.message.ProduceRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.types.Type
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, Errors}
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.{ProduceResponse, ResponseHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -144,7 +144,7 @@ class EdgeCaseRequestTest extends KafkaServerTestHarness {
       val bodyBytes = request.serialize
       val byteBuffer = ByteBuffer.allocate(headerBytes.length + bodyBytes.remaining())
       byteBuffer.put(headerBytes)
-      byteBuffer.put(bodyBytes)
+      byteBuffer.put(bodyBytes.asInstanceOf[ByteBufferAccessor].buffer())
       (byteBuffer.array(), request.apiKey.responseHeaderVersion(version))
     }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -9042,7 +9042,7 @@ class KafkaApisTest extends Logging {
     })
 
     val data = new ListOffsetsRequestData().setTopics(targetTimes).setReplicaId(ListOffsetsRequest.CONSUMER_REPLICA_ID)
-    val listOffsetRequest = ListOffsetsRequest.parse(MessageUtil.toReadable(data, version), version)
+    val listOffsetRequest = ListOffsetsRequest.parse(MessageUtil.toByteBufferAccessor(data, version), version)
     val request = buildRequest(listOffsetRequest)
 
     kafkaApis = createKafkaApis()
@@ -9142,10 +9142,10 @@ class KafkaApisTest extends Logging {
       any()
     )
     val response = capturedResponse.getValue
-    val buffer = MessageUtil.toByteBuffer(
+    val buffer = MessageUtil.toByteBufferAccessor(
       response.data,
       request.context.header.apiVersion
-    )
+    ).buffer()
     AbstractResponse.parseResponse(
       request.context.header.apiKey,
       buffer,
@@ -9163,10 +9163,10 @@ class KafkaApisTest extends Logging {
       any()
     )
     val response = capturedResponse.getValue
-    val buffer = MessageUtil.toByteBuffer(
+    val buffer = MessageUtil.toByteBufferAccessor(
       response.data,
       request.context.header.apiVersion
-    )
+    ).buffer()
 
     // Create the RequestChannel.Response that is created when sendResponse is called in order to update the metrics.
     val sendResponse = new RequestChannel.SendResponse(

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -9042,7 +9042,7 @@ class KafkaApisTest extends Logging {
     })
 
     val data = new ListOffsetsRequestData().setTopics(targetTimes).setReplicaId(ListOffsetsRequest.CONSUMER_REPLICA_ID)
-    val listOffsetRequest = ListOffsetsRequest.parse(MessageUtil.toByteBuffer(data, version), version)
+    val listOffsetRequest = ListOffsetsRequest.parse(MessageUtil.toReadable(data, version), version)
     val request = buildRequest(listOffsetRequest)
 
     kafkaApis = createKafkaApis()

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FetchRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FetchRequestBenchmark.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ByteBufferChannel;
 import org.apache.kafka.common.requests.FetchRequest;
@@ -41,7 +42,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -71,7 +71,7 @@ public class FetchRequestBenchmark {
 
     FetchRequest replicaRequest;
 
-    ByteBuffer requestBuffer;
+    Readable serializedRequest;
 
     @Setup(Level.Trial)
     public void setup() {
@@ -93,13 +93,13 @@ public class FetchRequestBenchmark {
             .build(ApiKeys.FETCH.latestVersion());
         this.replicaRequest = FetchRequest.Builder.forReplica(ApiKeys.FETCH.latestVersion(), 1, 1, 0, 0, fetchData)
             .build(ApiKeys.FETCH.latestVersion());
-        this.requestBuffer = this.consumerRequest.serialize();
+        this.serializedRequest = this.consumerRequest.serialize();
 
     }
 
     @Benchmark
     public short testFetchRequestFromBuffer() {
-        return AbstractRequest.parseRequest(ApiKeys.FETCH, ApiKeys.FETCH.latestVersion(), requestBuffer).request.version();
+        return AbstractRequest.parseRequest(ApiKeys.FETCH, ApiKeys.FETCH.latestVersion(), serializedRequest).request.version();
     }
 
     @Benchmark

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -44,7 +44,6 @@ import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -219,7 +218,7 @@ public class KRaftMetadataRequestBenchmark {
     private RequestChannel.Request buildAllTopicMetadataRequest() {
         MetadataRequest metadataRequest = MetadataRequest.Builder.allTopics().build();
         RequestHeader header = new RequestHeader(metadataRequest.apiKey(), metadataRequest.version(), "", 0);
-        ByteBuffer bodyBuffer = ((ByteBufferAccessor) metadataRequest.serialize()).buffer();
+        ByteBuffer bodyBuffer = metadataRequest.serializeToByteBuffer();
 
         RequestContext context = new RequestContext(header, "1", null, principal,
                 ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -218,7 +218,7 @@ public class KRaftMetadataRequestBenchmark {
     private RequestChannel.Request buildAllTopicMetadataRequest() {
         MetadataRequest metadataRequest = MetadataRequest.Builder.allTopics().build();
         RequestHeader header = new RequestHeader(metadataRequest.apiKey(), metadataRequest.version(), "", 0);
-        ByteBuffer bodyBuffer = metadataRequest.serializeToByteBuffer();
+        ByteBuffer bodyBuffer = metadataRequest.serialize().buffer();
 
         RequestContext context = new RequestContext(header, "1", null, principal,
                 ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -218,7 +219,7 @@ public class KRaftMetadataRequestBenchmark {
     private RequestChannel.Request buildAllTopicMetadataRequest() {
         MetadataRequest metadataRequest = MetadataRequest.Builder.allTopics().build();
         RequestHeader header = new RequestHeader(metadataRequest.apiKey(), metadataRequest.version(), "", 0);
-        ByteBuffer bodyBuffer = metadataRequest.serialize();
+        ByteBuffer bodyBuffer = ((ByteBufferAccessor) metadataRequest.serialize()).buffer();
 
         RequestContext context = new RequestContext(header, "1", null, principal,
                 ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),

--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
@@ -389,10 +390,11 @@ public final class RecordsIteratorTest {
                 buffer.capacity()
             )
         ) {
+            final Message message = defaultControlRecord(type);
             builder.appendControlRecord(
                 0,
                 type,
-                MessageUtil.toByteBuffer(defaultControlRecord(type), defaultControlRecordVersion(type))
+                MessageUtil.toByteBufferAccessor(message, defaultControlRecordVersion(type)).buffer()
             );
         }
 

--- a/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
+++ b/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
@@ -60,7 +60,7 @@ public class RequestConvertToJsonTest {
                 } else {
                     message = ApiMessageType.fromApiKey(key.id).newRequest();
                 }
-                Readable bytes = MessageUtil.toReadable(message, version);
+                Readable bytes = MessageUtil.toByteBufferAccessor(message, version);
                 AbstractRequest req = AbstractRequest.parseRequest(key, version, bytes).request;
                 try {
                     RequestConvertToJson.request(req);
@@ -88,7 +88,7 @@ public class RequestConvertToJsonTest {
                     message = ApiMessageType.fromApiKey(key.id).newResponse();
                 }
 
-                ByteBuffer bytes = MessageUtil.toByteBuffer(message, version);
+                ByteBuffer bytes = MessageUtil.toByteBufferAccessor(message, version).buffer();
                 AbstractResponse response = AbstractResponse.parseResponse(key, bytes, version);
                 try {
                     RequestConvertToJson.response(response, version);
@@ -107,7 +107,7 @@ public class RequestConvertToJsonTest {
             if (key.hasValidVersion()) {
                 short version = key.latestVersion();
                 ApiMessage message = ApiMessageType.fromApiKey(key.id).newResponse();
-                ByteBuffer bytes = MessageUtil.toByteBuffer(message, version);
+                ByteBuffer bytes = MessageUtil.toByteBufferAccessor(message, version).buffer();
                 AbstractResponse res = AbstractResponse.parseResponse(key, bytes, version);
                 try {
                     RequestConvertToJson.response(res, version);

--- a/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
+++ b/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 
@@ -59,7 +60,7 @@ public class RequestConvertToJsonTest {
                 } else {
                     message = ApiMessageType.fromApiKey(key.id).newRequest();
                 }
-                ByteBuffer bytes = MessageUtil.toByteBuffer(message, version);
+                Readable bytes = MessageUtil.toReadable(message, version);
                 AbstractRequest req = AbstractRequest.parseRequest(key, version, bytes).request;
                 try {
                     RequestConvertToJson.request(req);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -324,7 +324,7 @@ public class SubscriptionInfo {
                 "Should never try to encode a SubscriptionInfo with version [" +
                     data.version() + "] > LATEST_SUPPORTED_VERSION [" + LATEST_SUPPORTED_VERSION + "]"
             );
-        } else return MessageUtil.toByteBuffer(data, (short) data.version());
+        } else return MessageUtil.toByteBufferAccessor(data, (short) data.version()).buffer();
     }
 
     /**


### PR DESCRIPTION
The generated `*RequestData` java file constructors take `Readable` as an input. However, the `parse` method in the `AbstractRequest` takes a `ByteBuffer` as input. So to create the corresponding `*RequestData` objects, each individual concrete Request classes wraps the `ByteBuffer` into a `ByteBufferAccessor`.

This is a boilerplate code present in all the concrete Request classes. This change pulls it into `AbstractRequest` so that subclasses can simply pass the `Readable` they get from the superclass directly to `*RequestData` classes. 

The same change is made to the `serialize` method to maintain symmetry.

A simple mechanical refactoring that touches many files, but reduced a lot of duplicated and boilerplate code.

Reviewers: Ismael Juma <ismael@juma.me.uk>, José Armando García Sancio <jsancio@apache.org>, Artem Livshits <alivshits@confluent.io>, Truc Nguyen <trnguyen@confluent.io>