### PR TITLE
KAFKA-18955: Fix infinite loop and standardize options in MetadataSchemaCheckerTool

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
@@ -121,18 +121,34 @@ class CheckerUtils {
     }
 
     /**
-     * Read a MessageSpec file from remote git repo.
+     * Read the file from the specified git reference.
      *
-     * @param filePath The file to read from remote git repo.
-     * @param ref The specific git reference to be used for testing.
+     * @param filePath The fully qualified file path. The git directory will be derived from this.
+     * @param gitRef The specific git reference to be used for comparison.
      * @return The file contents.
      */
-    static String getDataFromGit(String filePath, Path gitPath, String ref) throws IOException {
-        Git git = Git.open(new File(gitPath + "/.git"));
+    static String readFileFromGitRef(String filePath, String gitRef) throws IOException {
+        Path fileAbsolutePath = Paths.get(filePath).toAbsolutePath();
+
+        // traverse up parent directories until .git directory is found
+        Path projectRoot = fileAbsolutePath.getParent();
+        if (projectRoot == null) {
+            throw new RuntimeException("The file path provided does not have a parent directory");
+        }
+        while (!Files.exists(projectRoot.resolve(".git"))) {
+            projectRoot = projectRoot.getParent();
+            if (projectRoot == null) {
+                throw new RuntimeException("Invalid path, need to be within a Git repository");
+            }
+        }
+
+        String pathFromProjectRoot = projectRoot.relativize(fileAbsolutePath).toString();
+
+        Git git = Git.open(new File(projectRoot + "/.git"));
         Repository repository = git.getRepository();
-        Ref head = repository.getRefDatabase().findRef(ref);
+        Ref head = repository.getRefDatabase().findRef(gitRef);
         if (head == null) {
-            throw new IllegalStateException("Cannot find " + ref + " in the repository.");
+            throw new IllegalStateException("Cannot find " + gitRef + " in the repository.");
         }
 
         try (RevWalk revWalk = new RevWalk(repository)) {
@@ -141,9 +157,9 @@ class CheckerUtils {
             try (TreeWalk treeWalk = new TreeWalk(repository)) {
                 treeWalk.addTree(tree);
                 treeWalk.setRecursive(true);
-                treeWalk.setFilter(PathFilter.create(String.valueOf(Paths.get(filePath.substring(1)))));
+                treeWalk.setFilter(PathFilter.create(String.valueOf(Paths.get(pathFromProjectRoot))));
                 if (!treeWalk.next()) {
-                    throw new IllegalStateException("Did not find expected file " + filePath.substring(1));
+                    throw new IllegalStateException("Did not find expected file " + pathFromProjectRoot);
                 }
                 ObjectId objectId = treeWalk.getObjectId(0);
                 ObjectLoader loader = repository.open(objectId);

--- a/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/CheckerUtils.java
@@ -144,7 +144,7 @@ class CheckerUtils {
 
         String pathFromProjectRoot = projectRoot.relativize(fileAbsolutePath).toString();
 
-        Git git = Git.open(new File(projectRoot + "/.git"));
+        Git git = Git.open(Paths.get(projectRoot.toString(), ".git").toFile());
         Repository repository = git.getRepository();
         Ref head = repository.getRefDatabase().findRef(gitRef);
         if (head == null) {

--- a/generator/src/main/java/org/apache/kafka/message/checker/FieldSpecPairIterator.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/FieldSpecPairIterator.java
@@ -72,6 +72,7 @@ class FieldSpecPairIterator implements Iterator<FieldSpecPair> {
                                     "message2, but should not be, based on its versions.");
                         }
                     }
+                    field1 = iterator1.hasNext() ? iterator1.next() : null;
                     break;
                 }
                 case MESSAGE2_ONLY:

--- a/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
@@ -25,11 +25,8 @@ import net.sourceforge.argparse4j.inf.Subparsers;
 import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import static org.apache.kafka.message.checker.CheckerUtils.getDataFromGit;
+import static org.apache.kafka.message.checker.CheckerUtils.readFileFromGitRef;
 
 public class MetadataSchemaCheckerTool {
     public static void main(String[] args) throws Exception {
@@ -54,18 +51,18 @@ public class MetadataSchemaCheckerTool {
             required(true).
             help("The path to a schema JSON file.");
         Subparser evolutionVerifierParser = subparsers.addParser("verify-evolution").
-            help("Verify that an evolution of a JSON file is valid.");
-        evolutionVerifierParser.addArgument("--path1", "-1").
+            help("Verify that a schema JSON file is a valid evolution of a parent schema.");
+        evolutionVerifierParser.addArgument("--path", "-1").
             required(true).
-            help("The initial schema JSON path.");
-        evolutionVerifierParser.addArgument("--path2", "-2").
+            help("The path to a schema JSON file.");
+        evolutionVerifierParser.addArgument("--parent_path", "-2").
             required(true).
-            help("The final schema JSON path.");
+            help("The path to the parent schema JSON file.");
         Subparser evolutionGitVerifierParser = subparsers.addParser("verify-evolution-git").
-            help(" Verify that an evolution of a JSON file is valid using git.");
-        evolutionGitVerifierParser.addArgument("--file", "-3").
+            help("Verify that a schema JSON file is a valid evolution of your local git master branch.");
+        evolutionGitVerifierParser.addArgument("--path", "-3").
             required(true).
-            help("The edited JSON file");
+            help("The path to your edited JSON file");
         evolutionGitVerifierParser.addArgument("--ref", "-4")
             .required(false)
             .setDefault("refs/heads/trunk")
@@ -85,31 +82,24 @@ public class MetadataSchemaCheckerTool {
                 break;
             }
             case "verify-evolution": {
-                String path1 = namespace.getString("path1");
-                String path2 = namespace.getString("path2");
+                String path = namespace.getString("path");
+                String parent = namespace.getString("parent_path");
                 EvolutionVerifier verifier = new EvolutionVerifier(
-                    CheckerUtils.readMessageSpecFromFile(path1),
-                    CheckerUtils.readMessageSpecFromFile(path2));
+                    CheckerUtils.readMessageSpecFromFile(path),
+                    CheckerUtils.readMessageSpecFromFile(parent));
                 verifier.verify();
-                writer.println("Successfully verified evolution of path1: " + path1 +
-                        ", and path2: " + path2);
+                writer.println("Successfully verified evolution of path: " + path +
+                        " from parent: " + parent);
                 break;
             }
             case "verify-evolution-git": {
-                String filePath = "/metadata/src/main/resources/common/metadata/" + namespace.getString("file");
-                Path rootKafkaDirectory = Paths.get("").toAbsolutePath();
-                while (!Files.exists(rootKafkaDirectory.resolve(".git"))) {
-                    rootKafkaDirectory = rootKafkaDirectory.getParent();
-                    if (rootKafkaDirectory == null) {
-                        throw new RuntimeException("Invalid directory, need to be within a Git repository");
-                    }
-                }
-                String gitContent = getDataFromGit(filePath, rootKafkaDirectory, namespace.getString("ref"));
+                String path = namespace.getString("path");
+                String gitContent = readFileFromGitRef(path, namespace.getString("ref"));
                 EvolutionVerifier verifier = new EvolutionVerifier(
-                        CheckerUtils.readMessageSpecFromFile(rootKafkaDirectory + filePath),
-                        CheckerUtils.readMessageSpecFromString(gitContent));
+                    CheckerUtils.readMessageSpecFromFile(path),
+                    CheckerUtils.readMessageSpecFromString(gitContent));
                 verifier.verify();
-                writer.println("Successfully verified evolution of file: " + namespace.getString("file"));
+                writer.println("Successfully verified evolution of file: " + namespace.getString("path"));
                 break;
             }
             default:

--- a/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
@@ -82,13 +82,13 @@ public class MetadataSchemaCheckerTool {
                 break;
             }
             case "verify-evolution": {
-                String path = namespace.getString("path");
+                String child = namespace.getString("path");
                 String parent = namespace.getString("parent_path");
                 EvolutionVerifier verifier = new EvolutionVerifier(
-                    CheckerUtils.readMessageSpecFromFile(path),
-                    CheckerUtils.readMessageSpecFromFile(parent));
+                    CheckerUtils.readMessageSpecFromFile(parent),
+                    CheckerUtils.readMessageSpecFromFile(child));
                 verifier.verify();
-                writer.println("Successfully verified evolution of path: " + path +
+                writer.println("Successfully verified evolution of path: " + child +
                         " from parent: " + parent);
                 break;
             }

--- a/generator/src/main/java/org/apache/kafka/message/checker/Unifier.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/Unifier.java
@@ -51,7 +51,7 @@ class Unifier {
         this.structRegistry1.register(topLevelMessage1);
         this.topLevelMessage2 = topLevelMessage2;
         this.structRegistry2 = new StructRegistry();
-        this.structRegistry1.register(topLevelMessage2);
+        this.structRegistry2.register(topLevelMessage2);
     }
 
     static FieldSpec structSpecToFieldSpec(StructSpec structSpec) {
@@ -146,11 +146,13 @@ class Unifier {
         }
         // Recursive step.
         if (field1.type().isStruct()) {
+            System.out.println("Field1 is struct: Unifying struct " + field1.name() + " and " + field2.name());
             unifyStructs(field1.name(),
                 field1.fields(),
                 field2.name(),
                 field2.fields());
         } else if (field2.type().isStructArray()) {
+            System.out.println("Field2 is struct: Unifying struct array " + field1.name() + " and " + field2.name());
             unifyStructs(((FieldType.ArrayType) field1.type()).elementName(),
                 field1.fields(),
                 ((FieldType.ArrayType) field2.type()).elementName(),
@@ -188,6 +190,7 @@ class Unifier {
             topLevelMessage2.validVersions());
         while (iterator.hasNext()) {
             FieldSpecPair pair = iterator.next();
+            System.out.println("Unifying " + pair.field1().name() + " and " + pair.field2().name());
             unify(pair.field1(), pair.field2());
         }
     }

--- a/generator/src/main/java/org/apache/kafka/message/checker/Unifier.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/Unifier.java
@@ -146,13 +146,11 @@ class Unifier {
         }
         // Recursive step.
         if (field1.type().isStruct()) {
-            System.out.println("Field1 is struct: Unifying struct " + field1.name() + " and " + field2.name());
             unifyStructs(field1.name(),
                 field1.fields(),
                 field2.name(),
                 field2.fields());
         } else if (field2.type().isStructArray()) {
-            System.out.println("Field2 is struct: Unifying struct array " + field1.name() + " and " + field2.name());
             unifyStructs(((FieldType.ArrayType) field1.type()).elementName(),
                 field1.fields(),
                 ((FieldType.ArrayType) field2.type()).elementName(),
@@ -190,7 +188,6 @@ class Unifier {
             topLevelMessage2.validVersions());
         while (iterator.hasNext()) {
             FieldSpecPair pair = iterator.next();
-            System.out.println("Unifying " + pair.field1().name() + " and " + pair.field2().name());
             unify(pair.field1(), pair.field2());
         }
     }


### PR DESCRIPTION
- fix infinite loop in FieldSpecPairIterator.java 
- fix bug in Unifier.java that was resulting in verify-evolution and verify-evolution-git to break in certain scenarios and probably generate false positives
- verify-evolution-git command takes an absolute path like the other commands
- verify-evolution arguments are more clear (path and parent_path)