### PR TITLE
KAFKA-18944: Remove unused setters from ClusterConfig

### DIFF
--- a/core/src/test/java/kafka/test/api/AdminClientRebootstrapTest.java
+++ b/core/src/test/java/kafka/test/api/AdminClientRebootstrapTest.java
@@ -68,7 +68,6 @@ public class AdminClientRebootstrapTest {
         return ClusterConfig.defaultBuilder()
             .setTypes(Set.of(Type.KRAFT))
             .setBrokers(BROKER_COUNT)
-            .setAdminClientProperties(rebootstrapProperties)
             .setServerProperties(serverProperties).build();
     }
 

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterConfig.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterConfig.java
@@ -56,11 +56,6 @@ public class ClusterConfig {
     private final MetadataVersion metadataVersion;
 
     private final Map<String, String> serverProperties;
-    private final Map<String, String> producerProperties;
-    private final Map<String, String> consumerProperties;
-    private final Map<String, String> adminClientProperties;
-    private final Map<String, String> saslServerProperties;
-    private final Map<String, String> saslClientProperties;
     private final List<String> tags;
     private final Map<Integer, Map<String, String>> perServerProperties;
     private final Map<Feature, Short> features;
@@ -69,10 +64,8 @@ public class ClusterConfig {
     private ClusterConfig(Set<Type> types, int brokers, int controllers, int disksPerBroker, boolean autoStart,
                   SecurityProtocol brokerSecurityProtocol, ListenerName brokerListenerName,
                   SecurityProtocol controllerSecurityProtocol, ListenerName controllerListenerName, File trustStoreFile,
-                  MetadataVersion metadataVersion, Map<String, String> serverProperties, Map<String, String> producerProperties,
-                  Map<String, String> consumerProperties, Map<String, String> adminClientProperties, Map<String, String> saslServerProperties,
-                  Map<String, String> saslClientProperties, Map<Integer, Map<String, String>> perServerProperties, List<String> tags,
-                  Map<Feature, Short> features) {
+                  MetadataVersion metadataVersion, Map<String, String> serverProperties,
+                  Map<Integer, Map<String, String>> perServerProperties, List<String> tags, Map<Feature, Short> features) {
         // do fail fast. the following values are invalid for kraft modes.
         if (brokers < 0) throw new IllegalArgumentException("Number of brokers must be greater or equal to zero.");
         if (controllers < 0) throw new IllegalArgumentException("Number of controller must be greater or equal to zero.");
@@ -90,11 +83,6 @@ public class ClusterConfig {
         this.trustStoreFile = trustStoreFile;
         this.metadataVersion = Objects.requireNonNull(metadataVersion);
         this.serverProperties = Objects.requireNonNull(serverProperties);
-        this.producerProperties = Objects.requireNonNull(producerProperties);
-        this.consumerProperties = Objects.requireNonNull(consumerProperties);
-        this.adminClientProperties = Objects.requireNonNull(adminClientProperties);
-        this.saslServerProperties = Objects.requireNonNull(saslServerProperties);
-        this.saslClientProperties = Objects.requireNonNull(saslClientProperties);
         this.perServerProperties = Objects.requireNonNull(perServerProperties);
         this.tags = Objects.requireNonNull(tags);
         this.features = Objects.requireNonNull(features);
@@ -122,26 +110,6 @@ public class ClusterConfig {
 
     public Map<String, String> serverProperties() {
         return serverProperties;
-    }
-
-    public Map<String, String> producerProperties() {
-        return producerProperties;
-    }
-
-    public Map<String, String> consumerProperties() {
-        return consumerProperties;
-    }
-
-    public Map<String, String> adminClientProperties() {
-        return adminClientProperties;
-    }
-
-    public Map<String, String> saslServerProperties() {
-        return saslServerProperties;
-    }
-
-    public Map<String, String> saslClientProperties() {
-        return saslClientProperties;
     }
 
     public SecurityProtocol brokerSecurityProtocol() {
@@ -222,11 +190,6 @@ public class ClusterConfig {
                 .setTrustStoreFile(clusterConfig.trustStoreFile)
                 .setMetadataVersion(clusterConfig.metadataVersion)
                 .setServerProperties(clusterConfig.serverProperties)
-                .setProducerProperties(clusterConfig.producerProperties)
-                .setConsumerProperties(clusterConfig.consumerProperties)
-                .setAdminClientProperties(clusterConfig.adminClientProperties)
-                .setSaslServerProperties(clusterConfig.saslServerProperties)
-                .setSaslClientProperties(clusterConfig.saslClientProperties)
                 .setPerServerProperties(clusterConfig.perServerProperties)
                 .setTags(clusterConfig.tags)
                 .setFeatures(clusterConfig.features);
@@ -245,11 +208,6 @@ public class ClusterConfig {
         private File trustStoreFile;
         private MetadataVersion metadataVersion;
         private Map<String, String> serverProperties = Collections.emptyMap();
-        private Map<String, String> producerProperties = Collections.emptyMap();
-        private Map<String, String> consumerProperties = Collections.emptyMap();
-        private Map<String, String> adminClientProperties = Collections.emptyMap();
-        private Map<String, String> saslServerProperties = Collections.emptyMap();
-        private Map<String, String> saslClientProperties = Collections.emptyMap();
         private Map<Integer, Map<String, String>> perServerProperties = Collections.emptyMap();
         private List<String> tags = Collections.emptyList();
         private Map<Feature, Short> features = Collections.emptyMap();
@@ -316,31 +274,6 @@ public class ClusterConfig {
             return this;
         }
 
-        public Builder setConsumerProperties(Map<String, String> consumerProperties) {
-            this.consumerProperties = Map.copyOf(consumerProperties);
-            return this;
-        }
-
-        public Builder setProducerProperties(Map<String, String> producerProperties) {
-            this.producerProperties = Map.copyOf(producerProperties);
-            return this;
-        }
-
-        public Builder setAdminClientProperties(Map<String, String> adminClientProperties) {
-            this.adminClientProperties = Map.copyOf(adminClientProperties);
-            return this;
-        }
-
-        public Builder setSaslServerProperties(Map<String, String> saslServerProperties) {
-            this.saslServerProperties = Map.copyOf(saslServerProperties);
-            return this;
-        }
-
-        public Builder setSaslClientProperties(Map<String, String> saslClientProperties) {
-            this.saslClientProperties = Map.copyOf(saslClientProperties);
-            return this;
-        }
-
         public Builder setPerServerProperties(Map<Integer, Map<String, String>> perServerProperties) {
             this.perServerProperties = Collections.unmodifiableMap(
                     perServerProperties.entrySet().stream()
@@ -361,9 +294,7 @@ public class ClusterConfig {
         public ClusterConfig build() {
             return new ClusterConfig(types, brokers, controllers, disksPerBroker, autoStart,
                     brokerSecurityProtocol, brokerListenerName, controllerSecurityProtocol, controllerListenerName,
-                    trustStoreFile, metadataVersion, serverProperties, producerProperties, consumerProperties,
-                    adminClientProperties, saslServerProperties, saslClientProperties,
-                    perServerProperties, tags, features);
+                    trustStoreFile, metadataVersion, serverProperties, perServerProperties, tags, features);
         }
     }
 }

--- a/test-common/test-common-internal-api/src/test/java/org/apache/kafka/common/test/api/ClusterConfigTest.java
+++ b/test-common/test-common-internal-api/src/test/java/org/apache/kafka/common/test/api/ClusterConfigTest.java
@@ -68,11 +68,6 @@ public class ClusterConfigTest {
                 .setTrustStoreFile(trustStoreFile)
                 .setMetadataVersion(MetadataVersion.MINIMUM_VERSION)
                 .setServerProperties(Collections.singletonMap("broker", "broker_value"))
-                .setConsumerProperties(Collections.singletonMap("consumer", "consumer_value"))
-                .setProducerProperties(Collections.singletonMap("producer", "producer_value"))
-                .setAdminClientProperties(Collections.singletonMap("admin_client", "admin_client_value"))
-                .setSaslClientProperties(Collections.singletonMap("sasl_client", "sasl_client_value"))
-                .setSaslServerProperties(Collections.singletonMap("sasl_server", "sasl_server_value"))
                 .setPerServerProperties(Collections.singletonMap(0, Collections.singletonMap("broker_0", "broker_0_value")))
                 .build();
 


### PR DESCRIPTION
Remove unused `saslServerProperties`, `saslClientProperties`, `adminClientProperties`, `producerProperties`, and `consumerProperties` in ClusterConfig.

First, I quickly fixed the unused adminClientProperties, and then I will move on to https://github.com/apache/kafka/pull/19094 to fix the related issues.

Pass AdminClientRebootstrapTest
<img width="1398" alt="Screenshot 2025-03-09 at 12 54 57 PM" src="https://github.com/user-attachments/assets/73c50376-6602-493d-8abd-0eb2bb304114" />

Pass ClusterConfigTest
<img width="1117" alt="Screenshot 2025-03-09 at 12 55 28 PM" src="https://github.com/user-attachments/assets/b4da59da-dfdf-4698-9077-5086854360ab" />


